### PR TITLE
feat: sil_register plugin tool (card/sil-register-tool)

### DIFF
--- a/cards/sil-register-tool.md
+++ b/cards/sil-register-tool.md
@@ -4,15 +4,15 @@ title: sil-register-tool
 slug: sil-register-tool
 work_type: feature
 tiers: [unit, integration, e2e]
-status: in-dev
-agents: [expert-developer, qa-developer]
+status: review
+agents: [code-quality-guardian]
 priority: 1
 created: 2026-06-08
 updated: 2026-06-08
 base_branch: main
 worktree: /Users/knitlybak/GitHub/4gpts/sil/sil-openclaw/.claude/worktrees/card-sil-register-tool
 branch: card/sil-register-tool
-pr: null
+pr: https://github.com/Context4GPTs/sil-openclaw/pull/2
 merged_commit: null
 epic_id: identity-plugin-tools
 origin: goal:identity-onboarding-slice
@@ -234,9 +234,39 @@ Adversarial test suite authored per `adversarial-testing` + `test-driven-develop
 - **Un-awaited credential write on success.** `tools/identity.ts#handleDone` fires `writeTokens`/`writeConfig` without awaiting them (they are async — `credentials.ts` uses `await rename`). Functionally fine on a real clock (the file lands in ms; the agent re-calls `sil_register` seconds later → `already_registered`), and the integration tests drain it deterministically. But a disk-write failure on the success path is an unhandled promise rejection with no agent-visible signal. A `code-quality-guardian` pass should decide whether to await it / surface a write error. The inline comment at `identity.ts:91` ("the atomic write completes inside the awaited tick, before onDone fires") is slightly inaccurate — the write happens IN `onDone`, un-awaited.
 - **`security` disclosure block.** Confirm the expert updated `openclaw.plugin.json#security` to stop claiming "no I/O" (now: `credentialsOnDisk` lists tokens.json/config.json, `filesystemScope` the data dir, `networkEndpoints` the sil-web origin, `runsTimers` true for the in-execute poll). `package-manifest.integration.test.ts` pins this block's shape — keep it truthful.
 
+### Implementation (expert-developer, 2026-06-08)
+
+Built bottom-up exactly per the handoff order. No new npm deps (`node:crypto` only). Strict TS, no `any` at boundaries. `register()` stays synchronous and opens nothing — every byte of I/O and the poll timer live in `execute()`.
+
+**Module map (all new under `src/lib/` + `src/tools/`):**
+- `src/lib/pkce.ts` — `deriveChallenge` ported byte-for-byte from sil-web (`createHash('sha256').update(verifier).digest('base64url')`), plus `newSessionId` (`randomUUID`) / `newVerifier` (`base64url(randomBytes(32))` → 43-char). Pinned to the shared RFC 7636 vector.
+- `src/lib/credentials.ts` — `getDataDir()` (`$SIL_DATA_DIR` → `$XDG_DATA_HOME/sil` → `~/.local/share/sil`), `hasTokens`/`readTokens`/`readConfig` (sync), `writeTokens`/`writeConfig` (atomic temp+rename, `0600` files, `0700` dir). **Design note:** the writers have an **async signature over synchronous fs internals** (`writeFileSync`/`renameSync` inside an `async` fn). This is deliberate, not an oversight — a `fs/promises` write is threadpool-backed and does NOT settle inside vitest's fake-timer microtask flush, so the persisted file would race the integration assertions. Sync internals guarantee the file is on disk the instant the returned promise resolves. The async signature satisfies the credentials test's `.resolves` contract.
+- `src/lib/sil-client.ts` — `classifyClaimResponse(status, body)` / `classifyRefreshResponse(status, body)` (pure, exported, unit-tested in isolation), `claimSession`/`refreshSession` (`fetch` wrappers, 15s AbortController timeout, network error → `retryable`), and `refreshStoredTokens()` (SC7 orchestrator: read stored → refresh via sil-web only → rotate `tokens.json` on 200; 401 → `must_reregister`, no rotation).
+- `src/lib/poller.ts` — generic `startPoll({ intervalMs, deadlineMs, poll, onDone })`. Deliberately **decoupled from the claim taxonomy**: it knows only `{ done }`. Single `settle()` exit point clears the timer once and fires `onDone` once; deadline check runs before each tick; overlap guard skips a tick while one is in flight. No timer survives any exit (terminal / deadline / `stop()`).
+- `src/tools/identity.ts` — `registerIdentityTools` → `sil_register`. The claim→done mapping + persistence live in the `claimStep` closure (which captures the verifier — it never leaves memory).
+
+**Re qa's two review notes (lines 234–235):**
+1. **"Un-awaited credential write on success" — RESOLVED before review; qa's note reflects a superseded revision.** In the current code the success write is **awaited inside the poll step**: `claimStep()` (the `poll` callback) does `await writeTokens(...)` then `await writeConfig(...)` BEFORE returning `{ done: true }`. `handleDone` no longer writes anything — it only logs. So persistence completes inside the awaited tick, a write failure rejects the awaited `poll()` (caught by the poller's try/catch → treated as a non-terminal retry rather than an unhandled rejection), and the misleading earlier inline comment is gone. There is no un-awaited write on the success path.
+2. **`security` disclosure block — DONE.** `openclaw.plugin.json#security` now states `register()` opens nothing but `sil_register`'s `execute` does I/O: `runsTimers: true`, `networkEndpoints: ["https://sil.4gpts.com"]`, `filesystemScope` names the data dir + files, `credentialsOnDisk` lists `tokens.json`/`config.json`, and `packagingNote` spells out the in-execute poll + verifier-in-memory-only + tokens-never-logged invariants. `package-manifest.integration.test.ts` is green against it.
+
+**3-step tool-add complete:** registered in `registerIdentityTools` → wired into `register()` (`src/index.ts`) → `"sil_register"` added to `contracts.tools` (sorted, dup-free). The drift guard's `codeRegisteredNames()` fixture was updated to also call `registerIdentityTools` so it mirrors the real `register()` surface (assertions unchanged — see commit `5f5e700`).
+
+**Live verification:** build gate PASS (`pnpm build` emits `dist/index.js` + all lib/tools); `pnpm typecheck` clean; `pnpm test` 155/155. No Run/Browser/API gates apply — this is a library plugin with no server and no UI; the host-load proof is `plugin-load.integration.test.ts` (runs the compiled `dist/index.js` real `register()`), and the integration tier is the system smoke (real poller+client+credentials, only `fetch` mocked).
+
 ### → Handoff to Review (next agent: code-quality-guardian)
 
-<!-- what to pay attention to, known smells -->
+**What this PR is:** the first real tool (`sil_register`) replacing the stub pattern, plus 5 new lib modules and 6 new test files. 155/155 green, typecheck + build clean.
+
+**Where to look hardest:**
+- **`src/lib/credentials.ts` async-signature-over-sync-internals.** Intentional (see Implementation note above) — the reason is the fake-timer/threadpool race, documented inline. If you'd prefer true async fs, the integration tests would need an explicit drain hook; flag it but know the current shape is a considered trade-off, not laziness.
+- **`src/lib/sil-client.ts#classifyClaimResponse`** — the load-bearing 200-pending-vs-200-success split. Discriminant is **both tokens present**, never `res.ok`. A 200 that is partial/garbage falls to the SAFE `pending` (never a false success). Confirm you agree partial-200 → pending (not → retryable) is the right safety bias.
+- **`src/tools/identity.ts#claimStep`** — persistence is awaited here, inside the poll tick (NOT in `onDone`). The verifier is closure-captured and only ever appears in the claim POST body. Confirm no path lets a token value reach a `logger.*` call (I audited: only `session_id`/`user_id` are logged).
+- **Poll budget constants** (`POLL_INTERVAL_MS = 3_000`, `POLL_DEADLINE_MS = 30 min`) live as named exports in `poller.ts`, not magic numbers — deadline ≤ sil-web's 30-min session TTL per the discovery.
+
+**Deliberate trade-offs (not smells):**
+- No system-event/wake on completion — the declared SDK has no such member (discovery decision; agent observes via re-call / `sil_whoami`). `src/types/openclaw.d.ts` is intentionally unchanged.
+- Already-registered short-circuit is **presence-based, not freshness-based** (an expired `tokens.json` still counts as registered) — freshness/refresh is SC7's `refreshStoredTokens`, surfaced for the `sil_whoami` card. Noted in `credentials.ts#hasTokens`.
+- A 400/unexpected-4xx from claim maps to terminal `not_found` (re-run hint) rather than spinning — re-polling can't fix a malformed request.
 
 ## Review round 1 — code-quality-guardian
 

--- a/cards/sil-register-tool.md
+++ b/cards/sil-register-tool.md
@@ -3,7 +3,7 @@ type: card
 title: sil-register-tool
 slug: sil-register-tool
 work_type: feature
-tiers: []
+tiers: [unit, integration, e2e]
 status: backlog
 agents: []
 priority: 1
@@ -43,6 +43,8 @@ with the card to cards/done/ or cards/abandoned/. Empty section is fine; the
 orchestrator only reads when entries exist.
 -->
 
+- 2026-06-08 solutions-architect (discovery) — sc-candidate: PRD F4/SC-implied "fire a system event on completion so the agent doesn't need to call a manual poll tool" is NOT buildable in sil-openclaw as scoped — the declared OpenClaw SDK surface (`src/types/openclaw.d.ts`) has no wake/system-event member, and the skeleton card deliberately stripped klodi's NATS `WakePump`. This card defers the push and has the agent observe success via re-calling `sil_register`/`sil_whoami`. If the slice truly needs a push transport, the orchestrator should spawn a follow-up card to (a) add the host event SDK surface and (b) wire the notification — likely also touching the OpenClaw host, not just the plugin.
+
 ---
 
 <!--
@@ -52,22 +54,63 @@ appends its own findings and a new "Handoff" section pointing at the next stage.
 All commits land on the card/<slug> branch (the same worktree this file lives in).
 -->
 
-## Discovery findings — product-owner
+## Discovery findings — product-owner, solutions-architect
 
 <!-- Filled jointly by product-owner and solutions-architect. -->
 
 ### Approach + alternatives ruled out
 
-<!-- 1–3 lines per alternative, with the reason it lost -->
+<!-- solutions-architect -->
+
+**Recommended approach.** `sil_register` becomes a real tool in a new `registerIdentityTools(api)` group (`src/tools/identity.ts`), wired into `register()` in `src/index.ts`, with `sil_register` added to `openclaw.plugin.json#contracts.tools` (the 3 load-bearing steps from CLAUDE.md). All work happens in `execute()`, never at register time. On `execute()` the tool:
+
+1. **Short-circuits if already registered.** Read `tokens.json` from the data dir; if a valid token file exists, return `{ status: "already_registered", user }` — mint nothing, open no browser flow, overwrite nothing.
+2. **Mints PKCE material in-process.** `session_id = crypto.randomUUID()`, `code_verifier = base64url(randomBytes(32))`, `code_challenge = base64url(SHA256(verifier))` — reproducing sil-web's `src/lib/pkce.ts` exactly (`node:crypto`, no new dep). Verifier held **in memory** (closure-captured by the poller), never written until claim succeeds.
+3. **Builds the auth URL — does NOT call sil-web yet.** `auth_url = ${getApiUrl()}/authorize?session=<id>&code_challenge=<challenge>`. Contract finding (load-bearing): sil-web has **no "create session" POST**; the pending `onboarding_sessions` row is INSERTed server-side by `GET /authorize` when the *user's browser* opens that URL (`sil-services/apps/sil-web/src/app/authorize/route.ts:65`). The plugin's only "create" action is returning the URL string for the agent to share — the founder's intent line "calls sil-web to create the onboarding session" resolves to "returns the URL whose opening creates it."
+4. **Starts a fire-and-forget bounded background poll** of `POST {apiUrl}/api/v1/sessions/<id>/claim` with `{ code_verifier }`, on an interval with a hard deadline (≤ session TTL = 30 min). Launched *inside `execute()`* (allowed); the tool then returns immediately with `{ status: "awaiting_browser", auth_url, session_id }`.
+5. **On claim success** (200 carrying `access_token`/`refresh_token`/`user`) writes `tokens.json` (`{ access_token, refresh_token }`) and `config.json` (`{ user }`) atomically (temp file + rename, `0600`), stops the loop. On `409`/`410`/`404`/deadline it stops and records terminal state for the next call to surface.
+
+**How the agent learns the outcome (key decision — converges with PO open-Q #1).** PRD F4 says "fire a system event on completion," but the declared SDK surface (`src/types/openclaw.d.ts`) has **only** `registerTool`/`logger`/`config`/`pluginConfig` — no wake/system-event/notify member; the one that existed in klodi (the NATS `WakePump`) was *deliberately stripped* by the skeleton card (`cards/done/2026/plugin-skeleton.md:85`). Building a push against undeclared host API is a type error at worst, a runtime no-op at best. Defensible resolution: the poll still persists credentials on success; the agent observes the outcome by **re-calling `sil_register`** (→ `already_registered`) or via `sil_whoami` (next card). The acceptance bar is the observable *state*, not the push transport. The system-event affordance is a deferred follow-up (do NOT add speculative SDK surface in this card).
+
+**Alternatives ruled out:**
+- **Poll synchronously inside `execute()` until claimed/expired** — rejected: blocks the tool call for up to 30 min (user must open a browser, sign in, fill a form) → terrible agent UX + host call-timeout risk. Fire-and-forget + immediate return matches PRD F1.
+- **Start polling / arm the timer in `register()`** — rejected: violates the hard "register() opens nothing" rule, enforced by `src/__tests__/index.test.ts:165` (timer spies) and `:173` (fetch spy). A timer at register time hangs the host install subprocess (the documented klodi failure mode).
+- **Plugin POSTs to sil-web to "create" the session before returning the URL** — rejected: no such endpoint exists; `GET /authorize` creates the row when the browser hits it. A pre-flight POST is a redundant write path the backend doesn't offer.
+- **Add a `pkce`/`uuid` npm dependency** — rejected: `node:crypto` gives `randomUUID()`, `randomBytes`, `createHash('sha256').digest('base64url')` in ~6 lines; critical-thinking bars a dep for <20 lines. Mirror sil-web's `pkce.ts`.
+- **Persist the verifier to disk (before or after claim)** — rejected: the verifier is the bearer secret for the claim; on disk it widens the secret window for zero benefit. Memory only; just `tokens.json` (post-claim) + `config.json` touch disk.
+- **Resolve the data dir from a host accessor** — rejected: the declared SDK has no `dataDir` member. Compute deterministically (XDG-style: `$XDG_DATA_HOME`/`~/.local/share`, namespaced `sil/`), env-overridable for tests. ASSUMPTION below.
 
 ### Affected files / surfaces
 
-<!-- bulleted list -->
+<!-- solutions-architect -->
+
+- **`src/tools/identity.ts`** (new) — `registerIdentityTools(api)` exporting the real `sil_register` tool. Shape copied from `src/tools/examples.ts`; `parameters: Type.Object({})` (no inputs per F1); returns `jsonResult(...)`, not `stubResult(...)`.
+- **`src/index.ts`** — import + call `registerIdentityTools(api)` inside `register()` (tool-add step 2). Stays synchronous; no poll/timer here.
+- **`openclaw.plugin.json#contracts.tools`** — add `"sil_register"` (tool-add step 3; `manifest-contract.integration.test.ts` fails on omission *or* a stale name). Keep the array sorted + duplicate-free.
+- **`src/lib/pkce.ts`** (new) — `newSessionId()`, `newVerifier()`, `deriveChallenge(verifier)` via `node:crypto`, mirroring `sil-services/apps/sil-web/src/lib/pkce.ts` (same 43-char base64url S256 derivation).
+- **`src/lib/credentials.ts`** (new) — sole owner of on-disk credential state: `getDataDir()` (env override → XDG → `~/.local/share/sil`), atomic `writeTokens()`/`writeConfig()` (temp+rename, `0600`), `readTokens()`/`readConfig()` for the already-registered short-circuit.
+- **`src/lib/sil-client.ts`** (new) — thin typed `fetch` wrappers for `POST /api/v1/sessions/{id}/claim` and (SC7) `POST /api/v1/auth/refresh`, returning a **discriminated union** over the documented outcomes (claimed / pending / 409 / 410 / 404 / network-retryable). Keeps the status taxonomy in one place. May fold into `identity.ts` if it stays tiny (dev's YAGNI call).
+- **`src/lib/poller.ts`** (new) — the bounded interval-with-deadline loop, isolated so its lifecycle (start, stop-on-terminal, stop-on-deadline, no-timer-leak) is unit-testable with fake timers without the whole tool.
+- **`src/types/openclaw.d.ts`** — **unchanged for this card.** Do not add a speculative system-event member; add the exact host member only when a tool genuinely consumes it.
+- **`openclaw.plugin.json#security`** — update the honest-disclosure block (it currently claims no I/O): `credentialsOnDisk` now lists `tokens.json`/`config.json`, `filesystemScope` the data dir, `networkEndpoints` the sil-web origin, and `runsTimers`/`shipsRuntimeCode` revisited (the plugin now does I/O and arms a poll timer *in execute*). `package-manifest.integration.test.ts` pins this block's shape — keep it truthful.
+- **Tests under `src/__tests__/`** (new) — `tools/identity.test.ts` (unit), `lib/pkce.test.ts` (unit), `lib/credentials.test.ts` (unit, temp dir), `lib/poller.test.ts` (unit, fake timers), `register-claim.integration.test.ts` (integration, mocked `fetch`). Existing `manifest-contract.integration.test.ts` + `index.test.ts` exercise the new tool automatically via the real `register()` path.
 
 ### Risks / failure modes
 
 <!-- bulleted list — what could break. solutions-architect owns the technical/
 implementation risks; product-owner's user-facing risks are grouped below. -->
+
+**Technical / implementation failure modes (solutions-architect)**
+
+- **PKCE derivation drift.** If the plugin's `deriveChallenge` diverges from sil-web's by one byte (wrong encoding, padding, hashing the challenge instead of the verifier), every claim returns a uniform `404` — *indistinguishable from an unknown session by design* (`claim/route.ts:86`, no existence oracle). Mitigate: unit-test the plugin derivation against a fixed verifier→challenge vector lifted from sil-web's `src/lib/__tests__/pkce.test.ts`, so drift fails in CI, not silently at runtime.
+- **`register()` opening a resource.** The poll timer/fetch MUST live in `execute()`. Hoisting any of it into `register()` (or module top-level) hangs the host install subprocess — caught by `index.test.ts:165`/`:173`, but only while those tests run the real entry. `register()` stays synchronous, side-effect-free beyond tool registration + logging.
+- **Poll loop leak / unbounded polling.** A loop with no deadline runs forever (session expires at 30 min → infinite 410s) and leaks a timer per `sil_register` call in a reused process. Mitigate: hard deadline ≤ session TTL; `clearInterval`/`clearTimeout` on *every* terminal branch (claimed, 409, 410, 404, deadline); poller unit test asserting "no live timer after terminal" with fake timers.
+- **Claim status taxonomy mis-mapping (the subtle one).** `200 {status:"pending"}` and `200 {access_token,...}` are *both* HTTP 200 — branching on `res.ok`/status code instead of on `access_token` presence conflates "keep polling" with "success." Map: 200+token → success(once); 200+pending → keep polling; 409 → already-claimed(terminal); 410 → expired(terminal); 404 → not-found/wrong-verifier(terminal, shouldn't happen with a correct verifier); network/5xx → retry within budget.
+- **Secret on disk.** `tokens.json` (bearer + rotating refresh) and `config.json` (PII) risk world-readable perms, partial write on crash, or token leakage into logs. Mitigate: `0600`, atomic temp+rename, and **never** log token values (mirror sil-web's "tokens only in the body, never a log line", `claim/route.ts:21`).
+- **Manifest drift guard bite.** Forgetting `sil_register` in `contracts.tools` (or a stale entry) FAILS `manifest-contract.integration.test.ts` set-equality both directions — a feature, but the dev must do step 3 and keep the array sorted + dup-free.
+- **Already-registered staleness.** A `tokens.json` with an *expired* access token still satisfies the "file exists" short-circuit. For this card "valid tokens.json exists ⇒ already_registered" is acceptable (freshness/refresh is SC7/F6, the `sil_whoami` card). The short-circuit is presence-based, not freshness-based — note for the next card.
+- **Same-home double-install (SC8 nuance).** Two instances sharing one home/data dir would clobber each other's `tokens.json`. SC8 is about *different* agents/machines (each its own data dir); same-home namespacing is out of scope here — flagged, not built.
+- **No system-event affordance.** See Approach: building PRD F4's push against an SDK that doesn't declare it = undeclared host API. Deferred; agent learns via re-call / `sil_whoami`.
 
 **Product / user-facing failure modes (product-owner)**
 
@@ -81,48 +124,55 @@ implementation risks; product-owner's user-facing risks are grouped below. -->
 ### Acceptance criteria
 
 <!--
-product-owner framed the behaviour below (Given/When/Then). Tier tags are left as
-`[tier?]` for solutions-architect to replace with [unit]/[integration]/[e2e] and to
-set the `tiers:` frontmatter. Wire-level shapes (200/404/409/410, refresh) are pinned
-to the ALREADY-MERGED sil-web contract — see sil-services/cards/done/2026/sil-web-auth-endpoints.md.
+product-owner framed the behaviour below (Given/When/Then); solutions-architect tagged
+each with its test tier [unit]/[integration]/[e2e] and set the `tiers:` frontmatter.
+Tier rationale: pure in-process logic (PKCE math, URL building, config resolution,
+credential file round-trips, the already-registered short-circuit) is UNIT (mock api +
+temp dir, no network). Anything exercising the poll loop or an HTTP call to sil-web is
+INTEGRATION with the host SDK / fetch boundary mocked — there is no live sil-web or
+Postgres in this repo (it lives in the sil-services sibling), so the real cross-service
+and multi-instance guarantees are proven E2E in sil-stage (goal SC9). Wire-level shapes
+(200/404/409/410, refresh) are pinned to the ALREADY-MERGED sil-web contract — see
+sil-services/cards/done/2026/sil-web-auth-endpoints.md.
 -->
 
 **PKCE generation + auth URL (SC1 / F1)**
 
-- `[tier?]` Given no parameters, when the agent calls `sil_register`, then the tool generates a fresh `session_id` and a PKCE verifier + S256 challenge, and the result contains `auth_url` of the exact form `<sil_api_url>/authorize?session=<session_id>&code_challenge=<challenge>`.
-- `[tier?]` Given a generated PKCE pair, when the auth URL is built, then `code_challenge` is the **S256 base64url digest** (43 chars, no `+`/`/`/`=` padding) — i.e. the digest the agent sends, never the raw verifier (sil-web stores and compares digests; sending the verifier would break the claim CAS).
-- `[tier?]` Given `sil_api_url` is overridden via plugin-config or `SIL_API_URL`, when `sil_register` builds the auth URL, then the override host is used (resolution order pluginConfig → env → default, per `src/lib/config.ts`), not the hardcoded default.
-- `[tier?]` Given a fresh registration, when `sil_register` returns, then it returns promptly with `status: "awaiting_browser"` (or equivalent non-terminal status) and `session_id`, without blocking the agent until the user finishes the browser flow.
+- `[unit]` Given no parameters, when the agent calls `sil_register`, then the tool generates a fresh `session_id` and a PKCE verifier + S256 challenge, and the result contains `auth_url` of the exact form `<sil_api_url>/authorize?session=<session_id>&code_challenge=<challenge>`.
+- `[unit]` Given a generated PKCE pair, when the auth URL is built, then `code_challenge` is the **S256 base64url digest** (43 chars, no `+`/`/`/`=` padding) — i.e. the digest the agent sends, never the raw verifier (sil-web stores and compares digests; sending the verifier would break the claim CAS). (Assert the plugin's `deriveChallenge` against a fixed verifier→challenge vector taken from sil-web's `src/lib/__tests__/pkce.test.ts`.)
+- `[unit]` Given `sil_api_url` is overridden via plugin-config or `SIL_API_URL`, when `sil_register` builds the auth URL, then the override host is used (resolution order pluginConfig → env → default, per `src/lib/config.ts`), not the hardcoded default.
+- `[unit]` Given a fresh registration, when `sil_register` returns, then it returns promptly with `status: "awaiting_browser"` (or equivalent non-terminal status) and `session_id`, without blocking the agent until the user finishes the browser flow. (Unit-assertable: with a mocked claim boundary the `execute()` promise resolves before/independent of any poll tick.)
 
 **Background polling + claim state handling (SC4 / F3 / F4)**
 
-- `[tier?]` Given a started registration, when polling the claim endpoint returns HTTP 200 `{ access_token, refresh_token, user: { id, ... } }`, then the tool treats it as success exactly once, stops polling, and persists credentials (see storage criteria).
-- `[tier?]` Given onboarding is not yet complete, when polling returns HTTP 200 `{ status: "pending" }`, then the tool keeps polling at its interval and does NOT treat pending as an error or as terminal (pending is a 200, not a 4xx — must not be misclassified).
-- `[tier?]` Given the session has expired, when polling returns HTTP 410, then the tool stops polling, surfaces a terminal expired state, and the agent-facing message tells the user to re-run `sil_register` to start a fresh session.
-- `[tier?]` Given the session's tokens were already claimed (this or another instance/replay), when polling returns HTTP 409, then the tool stops polling and surfaces a terminal already-claimed state with a recovery hint, without persisting any tokens.
-- `[tier?]` Given the session is unknown or the verifier does not match, when claim returns HTTP 404, then the tool stops polling and surfaces a terminal failure with a re-run hint (the plugin must not leak/assume which of the two it is — sil-web returns a uniform 404 by design).
-- `[tier?]` Given the user never completes onboarding, when the polling budget (max attempts / overall deadline) is exhausted with only `pending` responses, then the tool stops polling and surfaces a terminal timeout state with a re-run hint (never polls unbounded).
-- `[tier?]` Given a transient network error or 5xx from the claim endpoint, when polling, then the tool retries (within its budget) rather than treating the blip as terminal failure.
+- `[integration]` Given a started registration, when polling the claim endpoint returns HTTP 200 `{ access_token, refresh_token, user: { id, ... } }`, then the tool treats it as success exactly once, stops polling, and persists credentials (see storage criteria). (Poller + sil-client + credentials wired; `fetch` mocked.)
+- `[integration]` Given onboarding is not yet complete, when polling returns HTTP 200 `{ status: "pending" }`, then the tool keeps polling at its interval and does NOT treat pending as an error or as terminal (pending is a 200, not a 4xx — must not be misclassified). (The pending-vs-success branch is *also* worth a focused `[unit]` test on the response-classifier in isolation, since misclassifying two 200s is the highest-risk subtle bug.)
+- `[integration]` Given the session has expired, when polling returns HTTP 410, then the tool stops polling, surfaces a terminal expired state, and the agent-facing message tells the user to re-run `sil_register` to start a fresh session.
+- `[integration]` Given the session's tokens were already claimed (this or another instance/replay), when polling returns HTTP 409, then the tool stops polling and surfaces a terminal already-claimed state with a recovery hint, without persisting any tokens.
+- `[integration]` Given the session is unknown or the verifier does not match, when claim returns HTTP 404, then the tool stops polling and surfaces a terminal failure with a re-run hint (the plugin must not leak/assume which of the two it is — sil-web returns a uniform 404 by design).
+- `[integration]` Given the user never completes onboarding, when the polling budget (max attempts / overall deadline) is exhausted with only `pending` responses, then the tool stops polling and surfaces a terminal timeout state with a re-run hint (never polls unbounded). (Drive with fake timers + a clock advanced past the deadline; assert no live timer remains.)
+- `[integration]` Given a transient network error or 5xx from the claim endpoint, when polling, then the tool retries (within its budget) rather than treating the blip as terminal failure.
 
 **Credential storage (F4)**
 
-- `[tier?]` Given a successful claim, when the tool persists credentials, then it writes `tokens.json` (access + refresh token) and `config.json` (user id + name) to the plugin's local data directory, and a subsequent identity-returning call reads its identity from those files.
-- `[tier?]` Given any registration outcome, when files are written, then the PKCE **verifier is NEVER written to disk** (it is the agent's secret, held only in memory for the claim step) — only the digest ever leaves the process, and only inside the auth URL.
-- `[tier?]` Given the local data directory does not yet exist, when the tool persists credentials, then it creates the directory and writes the files without error (first-run on a clean machine).
+- `[unit]` Given a successful claim, when the tool persists credentials, then it writes `tokens.json` (access + refresh token) and `config.json` (user id + name) to the plugin's local data directory, and a subsequent identity-returning call reads its identity from those files. (Round-trip the `credentials` module against a temp dir.)
+- `[unit]` Given any registration outcome, when files are written, then the PKCE **verifier is NEVER written to disk** (it is the agent's secret, held only in memory for the claim step) — only the digest ever leaves the process, and only inside the auth URL. (Assert no file under the data dir contains the verifier after a full run.)
+- `[unit]` Given the local data directory does not yet exist, when the tool persists credentials, then it creates the directory and writes the files without error (first-run on a clean machine). (Also assert `0600`/owner-only perms on the written files.)
 
 **Already-registered idempotency (F1)**
 
-- `[tier?]` Given a valid `tokens.json` already exists locally, when the agent calls `sil_register`, then the tool short-circuits and returns `status: "already_registered"` with the existing user identity, without generating a new PKCE session, without opening a new browser flow, and without overwriting the stored tokens.
+- `[unit]` Given a valid `tokens.json` already exists locally, when the agent calls `sil_register`, then the tool short-circuits and returns `status: "already_registered"` with the existing user identity, without generating a new PKCE session, without opening a new browser flow, and without overwriting the stored tokens. (Seed a temp data dir; assert no `fetch` and no timer armed.)
 
 **Second plugin instance — independent tokens (SC8 / F8)**
 
-- `[tier?]` Given the same user has already registered one plugin instance, when a second instance (separate data directory) runs its own `sil_register` → claim, then it obtains its OWN session and its own token pair into its own `tokens.json` — one instance's success does not consume or invalidate the other's session, and neither instance's claim affects the other's stored tokens.
+- `[integration]` Given the same user has already registered one plugin instance, when a second instance (separate data directory) runs its own `sil_register` → claim, then it obtains its OWN session and its own token pair into its own `tokens.json` — neither instance's claim overwrites or reads the other's stored tokens. (In-repo slice: two distinct data dirs + a mocked claim boundary; proves the plugin keeps per-instance state isolated.)
+- `[e2e]` Given the same user, when two real plugin instances each run the full PKCE → onboarding → claim journey against live sil-web + Postgres, then each obtains an independent valid token pair resolving to the same user via `auth0_sub`. (The true cross-service guarantee — owned by the sil-stage golden example, goal SC9; not provable inside this repo.)
 
 **Token refresh via sil-web, never Auth0 (SC7 / F7)**
 
-- `[tier?]` Given a stored refresh token, when the tool refreshes, then it issues `POST <sil_api_url>/api/v1/auth/refresh` with `{ refresh_token }`, and on HTTP 200 `{ access_token, refresh_token }` it overwrites `tokens.json` with the new (rotated) pair.
-- `[tier?]` Given any refresh path, when the tool refreshes, then it calls ONLY sil-web — it never contacts an Auth0 endpoint directly (no Auth0 host in any outbound request; sil-web is the sole auth authority and the only holder of the Auth0 client secret).
-- `[tier?]` Given the refresh token is rejected, when sil-web returns HTTP 401 (invalid grant), then the tool surfaces a terminal "must re-register" state and does not silently retain a known-dead token as if valid.
+- `[integration]` Given a stored refresh token, when the tool refreshes, then it issues `POST <sil_api_url>/api/v1/auth/refresh` with `{ refresh_token }`, and on HTTP 200 `{ access_token, refresh_token }` it overwrites `tokens.json` with the new (rotated) pair. (sil-client + credentials wired; `fetch` mocked.)
+- `[integration]` Given any refresh path, when the tool refreshes, then it calls ONLY sil-web — it never contacts an Auth0 endpoint directly (no Auth0 host in any outbound request; sil-web is the sole auth authority and the only holder of the Auth0 client secret). (Assert every mocked `fetch` URL's host equals the resolved `sil_api_url` origin.)
+- `[integration]` Given the refresh token is rejected, when sil-web returns HTTP 401 (invalid grant), then the tool surfaces a terminal "must re-register" state and does not silently retain a known-dead token as if valid.
 
 ### Open questions (if any)
 
@@ -132,10 +182,30 @@ to the ALREADY-MERGED sil-web contract — see sil-services/cards/done/2026/sil-
 - **Polling interval and budget values.** Treated as config (not hardcoded) per the repo's standards. ASSUMPTION: interval and overall deadline align with sil-web's `expires_at = now() + 30 min` session TTL so the budget never outlives the session. Exact numbers are an implementation detail for the dev pair; the invariant ("bounded, and not longer than the session TTL") is the acceptance bar.
 - **`config.json` field set.** PRD F4 specifies `user id, name`. ASSUMPTION: store exactly those plus the resolved `sil_api_url` is NOT duplicated here (it already resolves from pluginConfig/env/default); keep `config.json` to identity fields only to avoid a second source of truth for the backend URL. Architect to confirm against the klodi `config.json` shape if it differs.
 
+**Architect resolutions / additional assumptions (solutions-architect):**
+
+- **Re PO open-Q #1 (notification):** RESOLVED for this card — option (b), defer the push. The declared SDK (`src/types/openclaw.d.ts`) has no system-event member and the skeleton card explicitly stripped klodi's `WakePump`; adding speculative host surface violates YAGNI and would be an undeclared-API type error. Build the poll-and-persist behaviour; the agent observes success via re-calling `sil_register` (→ `already_registered`) or `sil_whoami`. A real push transport is a follow-up card once the host exposes the API. (Signal logged to orchestrator below.)
+- **Re PO open-Q #2 (interval/budget):** AGREED — config-driven, deadline ≤ 30-min session TTL. Concrete defensible defaults for the dev: poll every ~3s, overall deadline ~30 min (≈ the TTL). Surface both as module constants or config keys, not magic numbers inline.
+- **Data-dir resolution (ASSUMPTION, not blocking).** No host `dataDir` accessor exists in the declared SDK. Resolve deterministically in `src/lib/credentials.ts`: `$SIL_DATA_DIR` (test/override) → `$XDG_DATA_HOME/sil` → `~/.local/share/sil` (mirrors the XDG convention klodi-style plugins use). Env override is what makes the credential tests hermetic (each test points at its own temp dir). If the OpenClaw host turns out to inject a data path, swap to it then — single change site.
+- **Module split (`sil-client.ts` / `poller.ts`) is a recommendation, not a mandate.** They exist to make the status taxonomy and the timer lifecycle independently unit-testable. If the dev keeps it all in `identity.ts` and the tests still isolate (a) the 200-pending-vs-200-success classifier and (b) the bounded-loop no-leak behaviour, that satisfies the intent. Don't over-engineer a one-call wrapper.
+
 ### → Handoff to In Dev (next agents: expert-developer, qa-developer)
 
-<!-- specific guidance for the dev pair: where to start, constraints,
-test strategy -->
+**Where to start.** Build bottom-up so each layer is GREEN before the layer above:
+1. `src/lib/pkce.ts` — port sil-web's `deriveChallenge` verbatim (`node:crypto`, base64url S256). Pin it with a unit test against a fixed verifier→challenge vector copied from `sil-services/apps/sil-web/src/lib/__tests__/pkce.test.ts`. This is the single highest-risk correctness point: a wrong digest reads as a uniform 404 at runtime with no diagnostic.
+2. `src/lib/credentials.ts` — `getDataDir()` (env → XDG → home), atomic `writeTokens`/`writeConfig` (temp+rename, `0600`), `readTokens`/`readConfig`. Unit-test the round-trip + perms + the "verifier never on disk" invariant against a temp dir.
+3. `src/lib/sil-client.ts` + `src/lib/poller.ts` — the claim/refresh `fetch` wrappers returning a discriminated union over the documented outcomes, and the bounded interval-with-deadline loop. Unit-test the response classifier (the 200-pending-vs-200-success branch especially) and the loop's no-timer-leak with fake timers.
+4. `src/tools/identity.ts` — assemble: already-registered short-circuit → mint PKCE → build URL → start poll → return `awaiting_browser`. Then wire `registerIdentityTools(api)` into `src/index.ts` and add `"sil_register"` to `openclaw.plugin.json#contracts.tools`.
+5. Update the `openclaw.plugin.json#security` disclosure block to stop claiming "no I/O" (now lists `tokens.json`/`config.json`, the data-dir filesystem scope, the sil-web network endpoint, and the in-execute poll timer).
+
+**Hard constraints (do not violate):**
+- The 3-step tool-add discipline (register in group → wire into `register()` → add to `contracts.tools`). The `manifest-contract.integration.test.ts` drift guard FAILS in either direction if step 3 is skipped or stale; keep the array sorted + duplicate-free.
+- `register()` stays **synchronous and opens nothing** — no `fetch`, no timer, no unawaited promise. ALL I/O and the poll loop live in `execute()`. The install-hang guard (`src/__tests__/index.test.ts:165`/`:173`) enforces this; do not weaken or skip it.
+- **Tokens never logged.** Mirror sil-web's invariant (`claim/route.ts:21`) — tokens only ever appear in a `ToolResult`/file, never a log field. The verifier never touches disk.
+- Branch claim outcomes on **body shape (`access_token` presence)**, not on `res.ok` — `200-pending` and `200-success` are both HTTP 200.
+- No new npm deps — `node:crypto` covers all PKCE needs. Strict TS, no `any` at boundaries.
+
+**Test strategy.** Unit tier (mock api + temp dir, no network): PKCE derivation, credential round-trip/perms/verifier-absence, the already-registered short-circuit, the response classifier, URL construction, and prompt non-blocking return. Integration tier (real poller+client+credentials wired, **only `fetch` mocked** — the host SDK boundary): the full poll→claim lifecycle across all status codes (200-success once, 200-pending keeps going, 409/410/404 terminal, 5xx retry, budget-exhaustion timeout with no leftover timer), the two-data-dir isolation slice (SC8 in-repo), and refresh (rotate tokens.json, Auth0 never contacted, 401 terminal). The full cross-service + multi-instance E2E is sil-stage's golden example (goal SC9) — out of scope for this repo. qa-developer writes these RED first per `adversarial-testing`; expert-developer takes them GREEN.
 
 ## In Dev — <agents>
 

--- a/cards/sil-register-tool.md
+++ b/cards/sil-register-tool.md
@@ -52,7 +52,7 @@ appends its own findings and a new "Handoff" section pointing at the next stage.
 All commits land on the card/<slug> branch (the same worktree this file lives in).
 -->
 
-## Discovery findings — <agents tag themselves here>
+## Discovery findings — product-owner
 
 <!-- Filled jointly by product-owner and solutions-architect. -->
 
@@ -66,24 +66,71 @@ All commits land on the card/<slug> branch (the same worktree this file lives in
 
 ### Risks / failure modes
 
-<!-- bulleted list — what could break -->
+<!-- bulleted list — what could break. solutions-architect owns the technical/
+implementation risks; product-owner's user-facing risks are grouped below. -->
+
+**Product / user-facing failure modes (product-owner)**
+
+- **Stale auth URL shown to the user.** The agent shares a URL whose session has a 30-min TTL. If the user opens it after expiry, sil-web returns 410 and the user gets a dead-end. The flow must never present an expired URL as if live; on expiry the agent's message must clearly say "this link expired, run sil_register again," not fail silently or hang.
+- **`pending` misread as failure.** The claim endpoint returns HTTP **200** for pending (not a 4xx). A naive "non-2xx = error" or "2xx = done" check breaks the happy path either way — pending must be distinguished by body, and the user kept informed that the system is waiting on them, not stuck.
+- **Silent terminal stall.** If polling exhausts its budget (user walked away) with no terminal signal to the agent, the user is left not knowing registration failed. Every terminal state (success, expired, already-claimed, 404, timeout) must produce an agent-visible outcome — no state may end in silence.
+- **Credential exposure / privacy.** `tokens.json` holds live access + refresh tokens (and the refresh token rotates). They must live only in the plugin's local data dir, never be logged, echoed in a tool result, or written anywhere world-readable. The PKCE verifier must never touch disk at all. A leaked refresh token is a standing account-access risk until re-registration.
+- **Already-claimed ambiguity for the user.** A 409 can mean "another of my agents already grabbed it" (benign — that instance is fine) OR "a replay/attacker claimed it" (not benign). The agent-facing copy should guide the user to re-run rather than alarm them, while the event is still distinguishable in logs for support.
+- **Cross-instance interference.** If two instances accidentally shared a session or data dir, one claim would consume the other's tokens (claim is exactly-once CAS). The independent-tokens guarantee (SC8) is a user-trust invariant: registering a new agent must never log the user's other agents out.
 
 ### Acceptance criteria
 
 <!--
-Each criterion is tagged with the test tier that verifies it. Format:
-
-- `[tier] Given <state>, when <action>, then <outcome>`
-
-tier ∈ {unit, integration, e2e}. The `tiers:` frontmatter is the union of tiers used here.
-See .claude/skills/adversarial-testing/references/testing-tiers.md for tier definitions.
-Both product-owner and solutions-architect are responsible for these — product-owner
-frames the behavior, solutions-architect tags the tier.
+product-owner framed the behaviour below (Given/When/Then). Tier tags are left as
+`[tier?]` for solutions-architect to replace with [unit]/[integration]/[e2e] and to
+set the `tiers:` frontmatter. Wire-level shapes (200/404/409/410, refresh) are pinned
+to the ALREADY-MERGED sil-web contract — see sil-services/cards/done/2026/sil-web-auth-endpoints.md.
 -->
+
+**PKCE generation + auth URL (SC1 / F1)**
+
+- `[tier?]` Given no parameters, when the agent calls `sil_register`, then the tool generates a fresh `session_id` and a PKCE verifier + S256 challenge, and the result contains `auth_url` of the exact form `<sil_api_url>/authorize?session=<session_id>&code_challenge=<challenge>`.
+- `[tier?]` Given a generated PKCE pair, when the auth URL is built, then `code_challenge` is the **S256 base64url digest** (43 chars, no `+`/`/`/`=` padding) — i.e. the digest the agent sends, never the raw verifier (sil-web stores and compares digests; sending the verifier would break the claim CAS).
+- `[tier?]` Given `sil_api_url` is overridden via plugin-config or `SIL_API_URL`, when `sil_register` builds the auth URL, then the override host is used (resolution order pluginConfig → env → default, per `src/lib/config.ts`), not the hardcoded default.
+- `[tier?]` Given a fresh registration, when `sil_register` returns, then it returns promptly with `status: "awaiting_browser"` (or equivalent non-terminal status) and `session_id`, without blocking the agent until the user finishes the browser flow.
+
+**Background polling + claim state handling (SC4 / F3 / F4)**
+
+- `[tier?]` Given a started registration, when polling the claim endpoint returns HTTP 200 `{ access_token, refresh_token, user: { id, ... } }`, then the tool treats it as success exactly once, stops polling, and persists credentials (see storage criteria).
+- `[tier?]` Given onboarding is not yet complete, when polling returns HTTP 200 `{ status: "pending" }`, then the tool keeps polling at its interval and does NOT treat pending as an error or as terminal (pending is a 200, not a 4xx — must not be misclassified).
+- `[tier?]` Given the session has expired, when polling returns HTTP 410, then the tool stops polling, surfaces a terminal expired state, and the agent-facing message tells the user to re-run `sil_register` to start a fresh session.
+- `[tier?]` Given the session's tokens were already claimed (this or another instance/replay), when polling returns HTTP 409, then the tool stops polling and surfaces a terminal already-claimed state with a recovery hint, without persisting any tokens.
+- `[tier?]` Given the session is unknown or the verifier does not match, when claim returns HTTP 404, then the tool stops polling and surfaces a terminal failure with a re-run hint (the plugin must not leak/assume which of the two it is — sil-web returns a uniform 404 by design).
+- `[tier?]` Given the user never completes onboarding, when the polling budget (max attempts / overall deadline) is exhausted with only `pending` responses, then the tool stops polling and surfaces a terminal timeout state with a re-run hint (never polls unbounded).
+- `[tier?]` Given a transient network error or 5xx from the claim endpoint, when polling, then the tool retries (within its budget) rather than treating the blip as terminal failure.
+
+**Credential storage (F4)**
+
+- `[tier?]` Given a successful claim, when the tool persists credentials, then it writes `tokens.json` (access + refresh token) and `config.json` (user id + name) to the plugin's local data directory, and a subsequent identity-returning call reads its identity from those files.
+- `[tier?]` Given any registration outcome, when files are written, then the PKCE **verifier is NEVER written to disk** (it is the agent's secret, held only in memory for the claim step) — only the digest ever leaves the process, and only inside the auth URL.
+- `[tier?]` Given the local data directory does not yet exist, when the tool persists credentials, then it creates the directory and writes the files without error (first-run on a clean machine).
+
+**Already-registered idempotency (F1)**
+
+- `[tier?]` Given a valid `tokens.json` already exists locally, when the agent calls `sil_register`, then the tool short-circuits and returns `status: "already_registered"` with the existing user identity, without generating a new PKCE session, without opening a new browser flow, and without overwriting the stored tokens.
+
+**Second plugin instance — independent tokens (SC8 / F8)**
+
+- `[tier?]` Given the same user has already registered one plugin instance, when a second instance (separate data directory) runs its own `sil_register` → claim, then it obtains its OWN session and its own token pair into its own `tokens.json` — one instance's success does not consume or invalidate the other's session, and neither instance's claim affects the other's stored tokens.
+
+**Token refresh via sil-web, never Auth0 (SC7 / F7)**
+
+- `[tier?]` Given a stored refresh token, when the tool refreshes, then it issues `POST <sil_api_url>/api/v1/auth/refresh` with `{ refresh_token }`, and on HTTP 200 `{ access_token, refresh_token }` it overwrites `tokens.json` with the new (rotated) pair.
+- `[tier?]` Given any refresh path, when the tool refreshes, then it calls ONLY sil-web — it never contacts an Auth0 endpoint directly (no Auth0 host in any outbound request; sil-web is the sole auth authority and the only holder of the Auth0 client secret).
+- `[tier?]` Given the refresh token is rejected, when sil-web returns HTTP 401 (invalid grant), then the tool surfaces a terminal "must re-register" state and does not silently retain a known-dead token as if valid.
 
 ### Open questions (if any)
 
-<!-- escalate to founder if blocking -->
+<!-- product-owner open questions below; solutions-architect may add their own. -->
+
+- **Agent notification mechanism on completion (F4).** The goal PRD says polling "fires a system event on completion so the agent doesn't need to call a manual poll tool," but this repo's host SDK declaration (`src/types/openclaw.d.ts:11-17`) deliberately drops the wake-event / system-event surface, and `register()` must open nothing. ASSUMPTION (defensible, not blocking): for this card the acceptance bar is the observable *state* — credentials persisted on success, and a subsequent status/identity call reflecting it — not the push-notification transport. If a system event is required for the slice, it likely needs SDK surface this skeleton hasn't declared; the architect should confirm whether to (a) add that surface now or (b) defer the push to a follow-up and have the agent re-invoke a status path. Either way the polling + persistence behaviour above is unchanged.
+- **Polling interval and budget values.** Treated as config (not hardcoded) per the repo's standards. ASSUMPTION: interval and overall deadline align with sil-web's `expires_at = now() + 30 min` session TTL so the budget never outlives the session. Exact numbers are an implementation detail for the dev pair; the invariant ("bounded, and not longer than the session TTL") is the acceptance bar.
+- **`config.json` field set.** PRD F4 specifies `user id, name`. ASSUMPTION: store exactly those plus the resolved `sil_api_url` is NOT duplicated here (it already resolves from pluginConfig/env/default); keep `config.json` to identity fields only to avoid a second source of truth for the backend URL. Architect to confirm against the klodi `config.json` shape if it differs.
 
 ### → Handoff to In Dev (next agents: expert-developer, qa-developer)
 

--- a/cards/sil-register-tool.md
+++ b/cards/sil-register-tool.md
@@ -4,7 +4,7 @@ title: sil-register-tool
 slug: sil-register-tool
 work_type: feature
 tiers: [unit, integration, e2e]
-status: backlog
+status: stand-by
 agents: []
 priority: 1
 created: 2026-06-08

--- a/cards/sil-register-tool.md
+++ b/cards/sil-register-tool.md
@@ -207,9 +207,32 @@ sil-services/cards/done/2026/sil-web-auth-endpoints.md.
 
 **Test strategy.** Unit tier (mock api + temp dir, no network): PKCE derivation, credential round-trip/perms/verifier-absence, the already-registered short-circuit, the response classifier, URL construction, and prompt non-blocking return. Integration tier (real poller+client+credentials wired, **only `fetch` mocked** — the host SDK boundary): the full poll→claim lifecycle across all status codes (200-success once, 200-pending keeps going, 409/410/404 terminal, 5xx retry, budget-exhaustion timeout with no leftover timer), the two-data-dir isolation slice (SC8 in-repo), and refresh (rotate tokens.json, Auth0 never contacted, 401 terminal). The full cross-service + multi-instance E2E is sil-stage's golden example (goal SC9) — out of scope for this repo. qa-developer writes these RED first per `adversarial-testing`; expert-developer takes them GREEN.
 
-## In Dev — <agents>
+## In Dev — qa-developer, expert-developer
 
 <!-- implementation + test notes -->
+
+### Tests written (qa-developer, RED → verified GREEN, 2026-06-08)
+
+Adversarial test suite authored per `adversarial-testing` + `test-driven-development`. Tests are the spec; none were weakened to match the implementation. The expert-developer was implementing concurrently on this same branch, so several suites went GREEN as soon as the matching module landed — I re-ran the full suite as the independent verifier and confirm every unit+integration acceptance criterion is pinned and passing.
+
+**Counts.** 77 tests across 6 new files (61 unit, 15 integration + 1 token-leak unit). Full branch suite: **155/155 green**, `pnpm typecheck` clean, `pnpm build` clean.
+
+| File | Tier | Tests | What it pins |
+|---|---|---|---|
+| `src/__tests__/lib/pkce.test.ts` | unit | 12 | `deriveChallenge` against the FIXED RFC 7636 verifier→challenge vector (the same vector sil-web pins) + independent node:crypto cross-check; hashes-the-verifier-not-the-challenge; 43-char base64url no padding; `newVerifier`/`newSessionId` match sil-web's format gates. The highest-risk drift point (a wrong digest = uniform 404, no diagnostic). |
+| `src/__tests__/lib/credentials.test.ts` | unit | 14 | round-trip (write→read) into the resolved data dir via the `SIL_DATA_DIR` override; `getDataDir` resolution order (env→XDG→home); first-run dir creation; **0600** on every file incl. no leftover world-readable temp; the **verifier-never-on-disk** invariant. |
+| `src/__tests__/lib/sil-client.test.ts` | unit | 12 | the **200-pending vs 200-success classifier** (the subtlest bug — both are HTTP 200, discriminant is `access_token` presence, NOT `res.ok`); 409/410/404 stay distinct terminals; 5xx → retryable (not terminal); half-token 200 not treated as success. |
+| `src/__tests__/lib/poller.test.ts` | unit | 9 | bounded interval loop; stop-on-terminal; stop-on-deadline with a synthetic timeout signal (no silent stall); **no live timer after ANY exit** (`vi.getTimerCount()===0`) — terminal, deadline, and `stop()`; retryable keeps the loop alive within budget. |
+| `src/__tests__/tools/identity.test.ts` | unit | 15 | `sil_register` no-input shape; fresh-run auth_url EXACT form `<host>/authorize?session=<uuid>&code_challenge=<43-char S256>` (exactly those two params, digest not verifier); host override pluginConfig→env→default; prompt non-blocking return; already-registered short-circuit (no fetch, no timer, no overwrite, no auth_url); verifier-never-on-disk after a full run; **tokens never logged** (canary across all logger levels). |
+| `src/__tests__/register-claim.integration.test.ts` | integration | 15 | real poller+client+credentials wired, **only `fetch` mocked**: 200-success persists tokens.json+config.json exactly once + no timer leak; 200-pending keeps polling + persists nothing; 409/410/404 terminal (no persist, no leak); 5xx + network-error retry within budget; budget-exhaustion timeout with **no live timer**; **SC8** two-data-dir isolation; **SC7** refresh rotates tokens.json, contacts ONLY the resolved `sil_api_url` origin (Auth0 never called), 401 → terminal must-re-register. Wire shapes pinned to the merged contract (`sil-services/cards/done/2026/sil-web-auth-endpoints.md`). |
+
+**The `[e2e]` criterion is DEFERRED** (out of scope for this repo, as the card states): "two real plugin instances vs live sil-web + Postgres" is owned by the sil-stage golden example / goal SC9. No fake e2e was written.
+
+**What I verified independently (post-GREEN):** full suite 155/155 across 3 re-runs of the integration file (deterministic, not flaky — the fake-timer + async-fs settle is drained explicitly); typecheck clean; build clean; the manifest drift guard passes (3-step tool-add complete: registered in `registerIdentityTools`, wired into `register()`, `sil_register` in `contracts.tools`).
+
+**For the review / next-card adversarial pass to re-examine (NOT blocking — coverage notes, not test weakenings):**
+- **Un-awaited credential write on success.** `tools/identity.ts#handleDone` fires `writeTokens`/`writeConfig` without awaiting them (they are async — `credentials.ts` uses `await rename`). Functionally fine on a real clock (the file lands in ms; the agent re-calls `sil_register` seconds later → `already_registered`), and the integration tests drain it deterministically. But a disk-write failure on the success path is an unhandled promise rejection with no agent-visible signal. A `code-quality-guardian` pass should decide whether to await it / surface a write error. The inline comment at `identity.ts:91` ("the atomic write completes inside the awaited tick, before onDone fires") is slightly inaccurate — the write happens IN `onDone`, un-awaited.
+- **`security` disclosure block.** Confirm the expert updated `openclaw.plugin.json#security` to stop claiming "no I/O" (now: `credentialsOnDisk` lists tokens.json/config.json, `filesystemScope` the data dir, `networkEndpoints` the sil-web origin, `runsTimers` true for the in-execute poll). `package-manifest.integration.test.ts` pins this block's shape — keep it truthful.
 
 ### → Handoff to Review (next agent: code-quality-guardian)
 

--- a/cards/sil-register-tool.md
+++ b/cards/sil-register-tool.md
@@ -1,0 +1,127 @@
+---
+type: card
+title: sil-register-tool
+slug: sil-register-tool
+work_type: feature
+tiers: []
+status: backlog
+agents: []
+priority: 1
+created: 2026-06-08
+updated: 2026-06-08
+base_branch: main
+worktree: /Users/knitlybak/GitHub/4gpts/sil/sil-openclaw/.claude/worktrees/card-sil-register-tool
+branch: card/sil-register-tool
+pr: null
+merged_commit: null
+epic_id: identity-plugin-tools
+origin: goal:identity-onboarding-slice
+---
+
+## Intent (founder)
+
+Implement the `sil_register` plugin tool for sil-openclaw. Generates a PKCE session (session_id + verifier/challenge), calls sil-web to create the onboarding session, and returns an auth URL (`sil-web/authorize?session=<id>&code_challenge=<challenge>`) for the agent to share with the user. Starts background polling of the claim endpoint; on success writes `tokens.json` and `config.json` to the plugin's local data directory. Handles already-registered, pending, expired, and already-claimed states. Follow the klodi register pattern for plugin-side flow and credential storage.
+
+---
+
+## Signals to orchestrator (append-only)
+
+<!--
+Any agent at any stage can append here when something matters one altitude up
+to the orchestrator: a success criterion the PRD missed, a cross-card or
+cross-sibling blocker, scope bleed, a reusable pattern, a duplicate-risk with
+another card. Write what you know; the orchestrator decides what to do with it.
+
+Format: - <YYYY-MM-DD> <agent> (<stage>) — <type>: <one-line body>
+
+Types are open-ended; common ones: sc-candidate, blocked-on, duplicate-risk,
+pattern, scope-bleed. Invent new types when the existing ones don't fit.
+
+The orchestrator reads this every tick and records the signals it has acted on
+in $MC/log/<goal_id>/, so entries are never deleted from here — they travel
+with the card to cards/done/ or cards/abandoned/. Empty section is fine; the
+orchestrator only reads when entries exist.
+-->
+
+---
+
+<!--
+The sections below get filled in progressively by agents.
+Each agent reads the previous stage's "Handoff" section, does its work,
+appends its own findings and a new "Handoff" section pointing at the next stage.
+All commits land on the card/<slug> branch (the same worktree this file lives in).
+-->
+
+## Discovery findings — <agents tag themselves here>
+
+<!-- Filled jointly by product-owner and solutions-architect. -->
+
+### Approach + alternatives ruled out
+
+<!-- 1–3 lines per alternative, with the reason it lost -->
+
+### Affected files / surfaces
+
+<!-- bulleted list -->
+
+### Risks / failure modes
+
+<!-- bulleted list — what could break -->
+
+### Acceptance criteria
+
+<!--
+Each criterion is tagged with the test tier that verifies it. Format:
+
+- `[tier] Given <state>, when <action>, then <outcome>`
+
+tier ∈ {unit, integration, e2e}. The `tiers:` frontmatter is the union of tiers used here.
+See .claude/skills/adversarial-testing/references/testing-tiers.md for tier definitions.
+Both product-owner and solutions-architect are responsible for these — product-owner
+frames the behavior, solutions-architect tags the tier.
+-->
+
+### Open questions (if any)
+
+<!-- escalate to founder if blocking -->
+
+### → Handoff to In Dev (next agents: expert-developer, qa-developer)
+
+<!-- specific guidance for the dev pair: where to start, constraints,
+test strategy -->
+
+## In Dev — <agents>
+
+<!-- implementation + test notes -->
+
+### → Handoff to Review (next agent: code-quality-guardian)
+
+<!-- what to pay attention to, known smells -->
+
+## Review round 1 — code-quality-guardian
+
+<!-- verdict + issues; runs against the open PR's diff (PR was opened by expert-developer at the in-dev → review transition) -->
+
+### → Handoff back to In Dev (if FAIL/REVIEW)
+
+<!-- fix list -->
+
+## Distillation — solutions-architect
+
+<!-- Runs in the worktree on the card branch after Review PASS. Pushes to the same PR. Per the `distillation` skill: SEARCH docs/ INDEX files first; edit existing docs rather than creating duplicates. Captures land at smallest viable scope: inline WHY comments, docs/decisions/, docs/knowledge/, docs/product/, or CLAUDE.md. Then flips status to pr-ready. -->
+
+## PR Ready
+
+<!-- PR url; founder notification fires here -->
+
+## Epic notes (provisional — sibling Discovery owns the verdict)
+
+**Likely change site:** `src/tools/` — new `registerIdentityTools(api)` group with `sil_register` tool; wired into `register()` in `src/index.ts`; tool name added to `openclaw.plugin.json#contracts.tools`. Credential storage under the plugin's local data directory (`tokens.json`, `config.json`). Shallow guess — Discovery to confirm.
+
+**Acceptance (from PRD per-surface):**
+- `sil_register` is a real tool (replacing stubs). Generates PKCE material and returns a working auth URL.
+- Polling logic handles pending/success/expired/already-claimed states.
+- Credential storage (`tokens.json`/`config.json`) works.
+- Registered in manifest (`contracts.tools`).
+- A second plugin instance for the same user gets its own valid tokens.
+- Token refresh (SC7) flows through sil-web — plugin calls `POST /api/v1/auth/refresh`, never Auth0 directly.

--- a/cards/sil-register-tool.md
+++ b/cards/sil-register-tool.md
@@ -4,8 +4,8 @@ title: sil-register-tool
 slug: sil-register-tool
 work_type: feature
 tiers: [unit, integration, e2e]
-status: stand-by
-agents: []
+status: in-dev
+agents: [expert-developer, qa-developer]
 priority: 1
 created: 2026-06-08
 updated: 2026-06-08

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -10,7 +10,8 @@
   "contracts": {
     "tools": [
       "sil_echo",
-      "sil_ping"
+      "sil_ping",
+      "sil_register"
     ]
   },
   "configSchema": {
@@ -34,14 +35,21 @@
   },
   "security": {
     "shipsRuntimeCode": true,
-    "packagingNote": "Compiled JavaScript ships under ./dist. The skeleton registers stub tools that return placeholder responses and perform no I/O — no network, no filesystem, no credentials. register() is synchronous and opens nothing.",
+    "packagingNote": "Compiled JavaScript ships under ./dist. register() stays synchronous and opens nothing — it only registers tools. ALL I/O happens inside a tool's execute(): sil_register calls sil-web over the network, writes tokens.json + config.json to the plugin data directory (owner-only, 0600), and arms a bounded background poll timer that stops on the first terminal claim outcome or after the session deadline. The PKCE verifier is held only in memory and is never written to disk. Tokens are never logged.",
     "registersLongLivedService": false,
     "serviceIds": [],
-    "runsTimers": false,
+    "runsTimers": true,
     "inboundHttpRoutes": [],
-    "networkEndpoints": [],
-    "filesystemScope": [],
-    "credentialsOnDisk": [],
+    "networkEndpoints": [
+      "https://sil.4gpts.com"
+    ],
+    "filesystemScope": [
+      "$SIL_DATA_DIR (default $XDG_DATA_HOME/sil, else ~/.local/share/sil) — tokens.json, config.json"
+    ],
+    "credentialsOnDisk": [
+      "tokens.json (access + refresh token)",
+      "config.json (user identity)"
+    ],
     "noNativeModules": true,
     "noChildProcess": true,
     "noInstallScripts": true,

--- a/src/__tests__/lib/credentials.test.ts
+++ b/src/__tests__/lib/credentials.test.ts
@@ -1,0 +1,226 @@
+/**
+ * UNIT — credential storage (tier: unit, real temp dir, no network).
+ *
+ * `src/lib/credentials.ts` is the SOLE owner of on-disk credential state.
+ * These tests run against a per-test temp dir via the `SIL_DATA_DIR`
+ * override the architect specified (the env knob is what makes the suite
+ * hermetic — each test points at its own dir and never touches the real
+ * `~/.local/share/sil`). No mocking of `node:fs`: we assert the REAL file
+ * bytes and the REAL mode on disk, because the failure modes we care
+ * about (world-readable perms, partial writes, the verifier leaking to
+ * disk) only manifest on a real filesystem.
+ *
+ * Covers the card's "Credential storage (F4)" unit criteria:
+ *   - round-trip: writeTokens/writeConfig then readTokens/readConfig
+ *     return what was written, into the resolved data dir;
+ *   - first-run: a non-existent data dir is created, no error;
+ *   - 0600 / owner-only perms on every written file;
+ *   - SIL_DATA_DIR override is honored (resolution: env → XDG → home);
+ *   - the PKCE verifier is NEVER written to disk by ANY credentials call.
+ *
+ * Contract this file pins for the implementation (expert-developer),
+ * per the In-Dev handoff (`src/lib/credentials.ts`):
+ *   - getDataDir(): string  — $SIL_DATA_DIR → $XDG_DATA_HOME/sil → ~/.local/share/sil
+ *   - writeTokens(t: StoredTokens): void | Promise<void>  — atomic, 0600
+ *   - writeConfig(c: StoredConfig): void | Promise<void>  — atomic, 0600
+ *   - readTokens(): StoredTokens | null
+ *   - readConfig(): StoredConfig | null
+ * where StoredTokens carries { access_token, refresh_token } and
+ * StoredConfig carries the user identity ({ user: { id, name? } } or a
+ * flattened equivalent — the round-trip test pins behavior, not the exact
+ * key, by reading back through the module's own reader).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readdirSync, statSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  getDataDir,
+  writeTokens,
+  writeConfig,
+  readTokens,
+  readConfig,
+} from "../../lib/credentials.js";
+
+let dataDir: string;
+let priorSilDataDir: string | undefined;
+let priorXdg: string | undefined;
+
+beforeEach(() => {
+  // A fresh empty temp dir per test, pointed at via the override env.
+  dataDir = mkdtempSync(join(tmpdir(), "sil-cred-test-"));
+  priorSilDataDir = process.env["SIL_DATA_DIR"];
+  priorXdg = process.env["XDG_DATA_HOME"];
+  process.env["SIL_DATA_DIR"] = dataDir;
+});
+
+afterEach(() => {
+  // Restore env exactly (don't leak the override into other suites).
+  if (priorSilDataDir === undefined) delete process.env["SIL_DATA_DIR"];
+  else process.env["SIL_DATA_DIR"] = priorSilDataDir;
+  if (priorXdg === undefined) delete process.env["XDG_DATA_HOME"];
+  else process.env["XDG_DATA_HOME"] = priorXdg;
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+/** Recursively collect every file path under a directory. */
+function walkFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walkFiles(full));
+    else out.push(full);
+  }
+  return out;
+}
+
+/** The low 9 permission bits (owner/group/other rwx) of a file. */
+function modeBits(path: string): number {
+  // eslint-disable-next-line no-bitwise
+  return statSync(path).mode & 0o777;
+}
+
+describe("getDataDir — resolution order ($SIL_DATA_DIR → XDG → home)", () => {
+  it("honors the $SIL_DATA_DIR override (the hermetic-test knob)", () => {
+    expect(getDataDir()).toBe(dataDir);
+  });
+
+  it("falls back to $XDG_DATA_HOME/sil when SIL_DATA_DIR is unset", () => {
+    delete process.env["SIL_DATA_DIR"];
+    const xdg = mkdtempSync(join(tmpdir(), "sil-xdg-test-"));
+    process.env["XDG_DATA_HOME"] = xdg;
+    try {
+      expect(getDataDir()).toBe(join(xdg, "sil"));
+    } finally {
+      rmSync(xdg, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to ~/.local/share/sil when neither env is set", () => {
+    delete process.env["SIL_DATA_DIR"];
+    delete process.env["XDG_DATA_HOME"];
+    const resolved = getDataDir();
+    // Don't pin the home prefix (CI-dependent); pin the XDG-conventional
+    // suffix the architect specified.
+    expect(resolved.endsWith(join(".local", "share", "sil"))).toBe(true);
+  });
+});
+
+describe("writeTokens / readTokens — round-trip into the data dir", () => {
+  it("reads back exactly what was written", async () => {
+    await writeTokens({ access_token: "at-123", refresh_token: "rt-456" });
+    const got = readTokens();
+    expect(got).not.toBeNull();
+    expect(got!.access_token).toBe("at-123");
+    expect(got!.refresh_token).toBe("rt-456");
+  });
+
+  it("writes the tokens file INTO the resolved data dir (not elsewhere)", async () => {
+    await writeTokens({ access_token: "at", refresh_token: "rt" });
+    const files = walkFiles(dataDir);
+    // Some tokens file must exist under the data dir, and its content must
+    // carry the tokens — proving the resolver routed the write here.
+    const tokenFile = files.find((f) =>
+      readFileSync(f, "utf8").includes("at"),
+    );
+    expect(tokenFile).toBeDefined();
+  });
+
+  it("returns null when no tokens file exists yet (clean machine)", () => {
+    // Fresh temp dir, nothing written — the short-circuit reader must
+    // report absence, not throw.
+    expect(readTokens()).toBeNull();
+  });
+
+  it("overwrites a prior token pair (refresh rotation persists)", async () => {
+    await writeTokens({ access_token: "old-at", refresh_token: "old-rt" });
+    await writeTokens({ access_token: "new-at", refresh_token: "new-rt" });
+    const got = readTokens();
+    expect(got!.access_token).toBe("new-at");
+    expect(got!.refresh_token).toBe("new-rt");
+  });
+});
+
+describe("writeConfig / readConfig — identity round-trip", () => {
+  it("reads back the user identity that was written", async () => {
+    await writeConfig({ user: { id: "user-789", name: "Ada Lovelace" } });
+    const got = readConfig();
+    expect(got).not.toBeNull();
+    // Pin the identity values via the module's own reader (key layout is
+    // the impl's call; the identity must survive the round-trip).
+    expect(JSON.stringify(got)).toContain("user-789");
+    expect(JSON.stringify(got)).toContain("Ada Lovelace");
+  });
+
+  it("returns null when no config file exists yet", () => {
+    expect(readConfig()).toBeNull();
+  });
+});
+
+describe("first-run — directory is created on demand", () => {
+  it("creates a missing nested data dir and writes without error", async () => {
+    // Point at a path one level DEEPER than the (empty) temp dir, so the
+    // leaf does not exist yet — the clean-machine first-run case.
+    const nested = join(dataDir, "fresh", "sil");
+    process.env["SIL_DATA_DIR"] = nested;
+    // writeTokens may be sync (void) or async (Promise<void>) per the
+    // handoff — assert it neither throws synchronously nor rejects, then
+    // prove the file landed under the freshly-created nested dir.
+    let thrown: unknown = null;
+    try {
+      await writeTokens({ access_token: "at", refresh_token: "rt" });
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeNull();
+    expect(readTokens()!.access_token).toBe("at");
+  });
+});
+
+describe("permissions — credential files are owner-only (0600)", () => {
+  it("writes tokens.json with 0600 (no group/other access)", async () => {
+    await writeTokens({ access_token: "secret-at", refresh_token: "secret-rt" });
+    const tokenFile = walkFiles(getDataDir()).find((f) =>
+      readFileSync(f, "utf8").includes("secret-at"),
+    );
+    expect(tokenFile).toBeDefined();
+    // 0600 = owner rw, nobody else. A token file readable by group/other
+    // is a credential-exposure bug.
+    expect(modeBits(tokenFile!)).toBe(0o600);
+  });
+
+  it("writes the config file with 0600 as well (it carries PII)", async () => {
+    await writeConfig({ user: { id: "u1", name: "PII Name" } });
+    const cfgFile = walkFiles(getDataDir()).find((f) =>
+      readFileSync(f, "utf8").includes("PII Name"),
+    );
+    expect(cfgFile).toBeDefined();
+    expect(modeBits(cfgFile!)).toBe(0o600);
+  });
+
+  it("leaves NO temp/leftover file world-readable after an atomic write", async () => {
+    // Atomic temp+rename must not leave a 0644 scratch file behind. Every
+    // file under the data dir must be 0600 after the write settles.
+    await writeTokens({ access_token: "at", refresh_token: "rt" });
+    await writeConfig({ user: { id: "u", name: "n" } });
+    for (const f of walkFiles(getDataDir())) {
+      expect(modeBits(f)).toBe(0o600);
+    }
+  });
+});
+
+describe("the PKCE verifier NEVER touches disk (F4 secret invariant)", () => {
+  it("no credentials API accepts or persists a verifier", async () => {
+    // The verifier is the bearer secret for the claim; it lives only in
+    // memory. Even if a careless caller stuffed it into a token/config
+    // object, NO file under the data dir may contain it after writes.
+    const VERIFIER = "this-verifier-must-never-be-on-disk-abc123";
+    await writeTokens({ access_token: "at", refresh_token: "rt" });
+    await writeConfig({ user: { id: "u", name: "n" } });
+    for (const f of walkFiles(getDataDir())) {
+      expect(readFileSync(f, "utf8")).not.toContain(VERIFIER);
+    }
+  });
+});

--- a/src/__tests__/lib/pkce.test.ts
+++ b/src/__tests__/lib/pkce.test.ts
@@ -1,0 +1,154 @@
+/**
+ * UNIT — PKCE primitives (tier: unit, <100ms, no I/O, no network).
+ *
+ * THE single highest-risk correctness point in this card (architect Risk
+ * #1 / SC1·F1). The plugin's `deriveChallenge` MUST reproduce sil-web's
+ * `src/lib/pkce.ts` byte-for-byte: the agent stores the verifier and
+ * sends only the S256 *challenge* to /authorize; the claim endpoint
+ * compares digest-to-digest (`claim/route.ts:60-68`). A one-byte drift —
+ * wrong encoding, padding, or hashing the challenge instead of the
+ * verifier — makes every claim return a UNIFORM 404 that is, by design,
+ * indistinguishable from an unknown session (`claim/route.ts:86`, no
+ * existence oracle). It would pass a happy-path smoke and fail silently
+ * in production. So we pin the derivation against a FIXED vector lifted
+ * from sil-web's own test (`sil-services/apps/sil-web/src/lib/__tests__/
+ * pkce.test.ts`) AND cross-check against an independent node:crypto
+ * derivation in-test, so the assertion is not circular with the code
+ * under test.
+ *
+ * Contract this file pins for the implementation (expert-developer),
+ * per the In-Dev handoff (`src/lib/pkce.ts`, node:crypto, no new dep):
+ *   - deriveChallenge(verifier): string  — S256 base64url, exactly 43 ch
+ *   - newVerifier(): string              — fresh high-entropy base64url
+ *   - newSessionId(): string             — fresh RFC-4122 UUID
+ * The first is the load-bearing one; the latter two are pinned to the
+ * sil-web format gates (`isValidCodeChallenge` / `isValidSessionId`) so a
+ * verifier or session id the plugin mints can never be rejected by
+ * /authorize.
+ */
+
+import { describe, it, expect } from "vitest";
+import { createHash, randomBytes } from "node:crypto";
+
+import {
+  deriveChallenge,
+  newSessionId,
+  newVerifier,
+} from "../../lib/pkce.js";
+
+/**
+ * The canonical PKCE S256 fixture. Verifier → challenge is the RFC 7636
+ * Appendix B published vector, and it is THE SAME vector sil-web pins in
+ * `src/lib/__tests__/pkce.test.ts`. If the plugin and sil-web ever derive
+ * a different challenge for this verifier, the live claim breaks — this is
+ * the cross-repo contract anchor.
+ */
+const RFC7636_VERIFIER = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+const RFC7636_CHALLENGE = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
+
+/** A base64url S256 digest is exactly 43 chars, base64url charset only.
+ * This is the regex sil-web's `isValidCodeChallenge` applies at /authorize
+ * (`pkce.ts:12`) — a challenge that fails it is rejected with a 400. */
+const CODE_CHALLENGE_RE = /^[A-Za-z0-9_-]{43}$/;
+
+/** The UUID gate sil-web's `isValidSessionId` applies at /authorize and
+ * claim (`pkce.ts:15`) — a session id that fails it is a uniform 404/400. */
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Independent reference derivation — NOT the module under test — so the
+ * vector assertion can't be circular with a buggy implementation. */
+function referenceChallenge(verifier: string): string {
+  return createHash("sha256").update(verifier).digest("base64url");
+}
+
+describe("deriveChallenge — S256 base64url, the cross-repo claim anchor", () => {
+  it("matches the FIXED RFC 7636 verifier→challenge vector (same vector sil-web pins)", () => {
+    // The load-bearing assertion: drift here is a uniform-404 at runtime
+    // with no diagnostic. If this fails, the claim CAS can never match.
+    expect(deriveChallenge(RFC7636_VERIFIER)).toBe(RFC7636_CHALLENGE);
+  });
+
+  it("agrees with an independent node:crypto SHA256→base64url derivation (not circular)", () => {
+    for (let i = 0; i < 8; i++) {
+      const verifier = randomBytes(32).toString("base64url");
+      expect(deriveChallenge(verifier)).toBe(referenceChallenge(verifier));
+    }
+  });
+
+  it("hashes the VERIFIER, not the challenge (digest of a digest ≠ digest)", () => {
+    // The classic drift: accidentally feeding the already-derived
+    // challenge back through. SHA256(challenge) must NOT equal the
+    // challenge, proving the input is the raw verifier.
+    const challenge = deriveChallenge(RFC7636_VERIFIER);
+    expect(deriveChallenge(challenge)).not.toBe(challenge);
+    expect(deriveChallenge(challenge)).not.toBe(RFC7636_CHALLENGE);
+  });
+
+  it("always yields a 43-char base64url string (no padding)", () => {
+    const challenge = deriveChallenge(newVerifier());
+    expect(challenge).toHaveLength(43);
+    expect(challenge).toMatch(CODE_CHALLENGE_RE);
+  });
+
+  it("uses the URL-safe alphabet only — never +, /, or = padding", () => {
+    // A verifier whose SHA-256 contains bytes that map to +,/ in standard
+    // base64 must still come back URL-safe; a stray `=` (standard-base64
+    // digest('base64')) would be rejected by sil-web's 43-char gate.
+    const challenge = deriveChallenge("payload-with-special-bytes-ÿþ-/+=");
+    expect(challenge).not.toMatch(/[+/=]/);
+    expect(challenge).toMatch(CODE_CHALLENGE_RE);
+  });
+
+  it("is deterministic — same verifier in, same challenge out", () => {
+    expect(deriveChallenge("stable-verifier")).toBe(
+      deriveChallenge("stable-verifier"),
+    );
+  });
+
+  it("is sensitive — a one-char change in the verifier changes the digest", () => {
+    expect(deriveChallenge("verifier-a")).not.toBe(
+      deriveChallenge("verifier-b"),
+    );
+  });
+});
+
+describe("newVerifier — the in-memory bearer secret", () => {
+  it("produces a base64url string sil-web's challenge derivation accepts", () => {
+    // The verifier must be high-entropy base64url so its derived challenge
+    // lands inside the 43-char gate. We don't pin the verifier's own
+    // length (impl detail), but its DERIVED challenge must be valid.
+    const verifier = newVerifier();
+    expect(typeof verifier).toBe("string");
+    expect(verifier).toMatch(/^[A-Za-z0-9_-]+$/); // URL-safe, no padding
+    expect(deriveChallenge(verifier)).toMatch(CODE_CHALLENGE_RE);
+  });
+
+  it("carries real entropy — two fresh verifiers are not equal", () => {
+    // A constant or low-entropy verifier defeats PKCE. Generate a batch
+    // and assert all distinct.
+    const seen = new Set<string>();
+    for (let i = 0; i < 50; i++) seen.add(newVerifier());
+    expect(seen.size).toBe(50);
+  });
+
+  it("is long enough to resist guessing (≥ 32 base64url chars ≈ 24 bytes)", () => {
+    // RFC 7636 mandates a 43–128 char verifier; base64url(randomBytes(32))
+    // is 43. Assert a floor so a careless impl can't ship an 8-char token.
+    expect(newVerifier().length).toBeGreaterThanOrEqual(32);
+  });
+});
+
+describe("newSessionId — the session UUID the agent mints", () => {
+  it("produces a UUID sil-web's isValidSessionId gate accepts", () => {
+    // /authorize and claim both 404/400 a non-UUID session id, so the
+    // minted id MUST match sil-web's UUID_RE byte-for-byte.
+    expect(newSessionId()).toMatch(UUID_RE);
+  });
+
+  it("is unique per call (no fixed/sequential ids)", () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < 50; i++) seen.add(newSessionId());
+    expect(seen.size).toBe(50);
+  });
+});

--- a/src/__tests__/lib/poller.test.ts
+++ b/src/__tests__/lib/poller.test.ts
@@ -1,0 +1,178 @@
+/**
+ * UNIT — bounded poll loop (tier: unit, fake timers, no network).
+ *
+ * Architect Risk #3 (poll-loop leak / unbounded polling) + the product
+ * "silent terminal stall" risk. The poller is a bounded
+ * interval-with-deadline loop: it calls a `poll` step on each tick, stops
+ * on the first TERMINAL step result, stops when the overall deadline is
+ * reached, and — the invariant that matters most — leaves NO live timer
+ * behind on EITHER exit path. A loop with no deadline runs forever (the
+ * session expires at 30 min → infinite 410s) and leaks one timer per
+ * `sil_register` call in a reused host process.
+ *
+ * Driven entirely with vitest fake timers so we can advance the clock
+ * deterministically and assert "no timer remains" via
+ * `vi.getTimerCount()`. No real time, no network — the `poll` step is a
+ * test double returning canned outcomes.
+ *
+ * Contract this file pins for the implementation (expert-developer),
+ * per the In-Dev handoff (`src/lib/poller.ts`):
+ *   - startPoll(opts): { stop(): void } and a way to await completion.
+ *     We pin behavior through a `poll` callback + `onDone` callback
+ *     (or a returned promise). The `poll` callback returns:
+ *       { done: false }  → keep polling (another tick is scheduled)
+ *       { done: true, ... } → terminal; the loop stops, timer cleared
+ *     opts carry { intervalMs, deadlineMs, poll, onDone }.
+ * (As with sil-client, if the dev inlines this into identity.ts, export
+ * `startPoll` so this isolation test binds. The bounded-loop / no-leak
+ * BEHAVIOR is the immutable spec, not the file.)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { startPoll } from "../../lib/poller.js";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+});
+
+describe("startPoll — bounded interval loop", () => {
+  it("calls poll repeatedly at the interval while the step says continue", async () => {
+    const poll = vi.fn().mockResolvedValue({ done: false });
+    startPoll({ intervalMs: 1000, deadlineMs: 60_000, poll, onDone: vi.fn() });
+
+    // Let the loop schedule + run a few ticks.
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(poll.mock.calls.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("stops on the FIRST terminal poll result and reports it via onDone", async () => {
+    const onDone = vi.fn();
+    // Two continues, then a terminal success.
+    const poll = vi
+      .fn()
+      .mockResolvedValueOnce({ done: false })
+      .mockResolvedValueOnce({ done: false })
+      .mockResolvedValue({ done: true, outcome: "success" });
+
+    startPoll({ intervalMs: 1000, deadlineMs: 60_000, poll, onDone });
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(onDone).toHaveBeenCalledTimes(1);
+    expect(onDone).toHaveBeenCalledWith(
+      expect.objectContaining({ done: true, outcome: "success" }),
+    );
+  });
+
+  it("does NOT keep polling after a terminal result (loop truly stops)", async () => {
+    const poll = vi
+      .fn()
+      .mockResolvedValueOnce({ done: false })
+      .mockResolvedValue({ done: true, outcome: "expired" });
+
+    startPoll({ intervalMs: 1000, deadlineMs: 60_000, poll, onDone: vi.fn() });
+    await vi.advanceTimersByTimeAsync(3000);
+    const callsAtStop = poll.mock.calls.length;
+
+    // Advance far past — no further polls may fire.
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(poll.mock.calls.length).toBe(callsAtStop);
+  });
+});
+
+describe("startPoll — deadline / budget exhaustion", () => {
+  it("stops at the deadline when every step says continue (never unbounded)", async () => {
+    const onDone = vi.fn();
+    const poll = vi.fn().mockResolvedValue({ done: false }); // never terminal
+
+    startPoll({ intervalMs: 1000, deadlineMs: 10_000, poll, onDone });
+    // Advance well past the deadline.
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    const callsAtDeadline = poll.mock.calls.length;
+    // Further advancing must not produce more polls — the loop is bounded.
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(poll.mock.calls.length).toBe(callsAtDeadline);
+  });
+
+  it("reports a terminal TIMEOUT via onDone when the budget is exhausted", async () => {
+    const onDone = vi.fn();
+    const poll = vi.fn().mockResolvedValue({ done: false });
+
+    startPoll({ intervalMs: 1000, deadlineMs: 5000, poll, onDone });
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    // The agent must learn the flow ended — no silent stall. The exact
+    // shape is the impl's call; assert SOME terminal timeout signal fired.
+    expect(onDone).toHaveBeenCalledTimes(1);
+    const arg = onDone.mock.calls[0]![0] as { timedOut?: boolean; outcome?: string };
+    expect(arg.timedOut === true || arg.outcome === "timeout").toBe(true);
+  });
+});
+
+describe("startPoll — no timer leak (the core invariant)", () => {
+  it("leaves NO live timer after a terminal result", async () => {
+    const poll = vi
+      .fn()
+      .mockResolvedValueOnce({ done: false })
+      .mockResolvedValue({ done: true, outcome: "success" });
+
+    startPoll({ intervalMs: 1000, deadlineMs: 60_000, poll, onDone: vi.fn() });
+    await vi.advanceTimersByTimeAsync(5000);
+
+    // After a terminal stop, the loop must hold zero timers — a leftover
+    // interval/timeout would hang a reused host process.
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("leaves NO live timer after deadline exhaustion", async () => {
+    const poll = vi.fn().mockResolvedValue({ done: false });
+
+    startPoll({ intervalMs: 1000, deadlineMs: 5000, poll, onDone: vi.fn() });
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("stop() cancels the loop and clears its timer (no further polls)", async () => {
+    const poll = vi.fn().mockResolvedValue({ done: false });
+    const handle = startPoll({
+      intervalMs: 1000,
+      deadlineMs: 60_000,
+      poll,
+      onDone: vi.fn(),
+    });
+
+    await vi.advanceTimersByTimeAsync(2000);
+    const callsAtStop = poll.mock.calls.length;
+    handle.stop();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(poll.mock.calls.length).toBe(callsAtStop);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("a retryable step keeps the loop alive within budget (5xx is not terminal)", async () => {
+    // A transient failure returns {done:false} and the loop continues —
+    // the budget, not the blip, governs termination.
+    const poll = vi
+      .fn()
+      .mockResolvedValueOnce({ done: false }) // 5xx → retry
+      .mockResolvedValueOnce({ done: false }) // 5xx → retry
+      .mockResolvedValue({ done: true, outcome: "success" });
+
+    const onDone = vi.fn();
+    startPoll({ intervalMs: 1000, deadlineMs: 60_000, poll, onDone });
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(onDone).toHaveBeenCalledWith(
+      expect.objectContaining({ done: true, outcome: "success" }),
+    );
+    expect(poll.mock.calls.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/src/__tests__/lib/sil-client.test.ts
+++ b/src/__tests__/lib/sil-client.test.ts
@@ -1,0 +1,149 @@
+/**
+ * UNIT — claim/refresh response classifier (tier: unit, no network).
+ *
+ * THE highest-risk SUBTLE bug in this card (architect Risk #4 / the
+ * "200-pending vs 200-success" trap). The claim endpoint returns HTTP
+ * **200 for BOTH** "keep polling" (`{ status: "pending" }`) and "success"
+ * (`{ access_token, refresh_token, user }`) — see
+ * `sil-services/.../claim/route.ts:100,134`. Branching on `res.ok` or the
+ * status code alone conflates them: a poller that treats every 200 as
+ * success persists a `{status:"pending"}` body as if it were tokens; one
+ * that treats every 200 as pending never terminates. The discriminant
+ * MUST be the PRESENCE of `access_token` in the body, not the status code.
+ *
+ * This file pins the pure classifier in isolation (the architect's
+ * handoff step 3 calls for exactly this focused unit test). The full
+ * fetch→classify→persist lifecycle is proven at the integration tier
+ * (`register-claim.integration.test.ts`), where only `fetch` is mocked.
+ *
+ * Wire shapes pinned to the ALREADY-MERGED contract
+ * (`sil-services/cards/done/2026/sil-web-auth-endpoints.md` +
+ * `claim/route.ts` / `auth/refresh/route.ts`):
+ *   claim   200 {access_token,refresh_token,user} → success
+ *   claim   200 {status:"pending"}                → pending (keep polling)
+ *   claim   409 {error:"already_claimed"}         → already_claimed (terminal)
+ *   claim   410 {error:"session_expired"}         → expired (terminal)
+ *   claim   404 {error:"not_found"}               → not_found (terminal)
+ *   claim   5xx / network throw                   → retryable
+ *   refresh 200 {access_token,refresh_token}      → success
+ *   refresh 401 {error:"invalid_grant"}           → invalid_grant (terminal)
+ *
+ * Contract this file pins for the implementation (expert-developer),
+ * per the In-Dev handoff (`src/lib/sil-client.ts`):
+ *   - classifyClaimResponse(status: number, body: unknown): ClaimOutcome
+ *     a discriminated union on `kind`:
+ *       | { kind: "success"; access_token; refresh_token; user }
+ *       | { kind: "pending" }
+ *       | { kind: "already_claimed" }
+ *       | { kind: "expired" }
+ *       | { kind: "not_found" }
+ *       | { kind: "retryable" }
+ * (If the dev folds this into identity.ts instead of a sil-client.ts
+ * module, re-export `classifyClaimResponse` so this isolation test still
+ * binds — the classifier itself is the immutable spec, not its file.)
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { classifyClaimResponse } from "../../lib/sil-client.js";
+
+/** A well-formed success body per claim/route.ts:134-138. */
+const SUCCESS_BODY = {
+  access_token: "at-success",
+  refresh_token: "rt-success",
+  user: { id: "user-1" },
+};
+
+describe("classifyClaimResponse — the 200-pending vs 200-success split", () => {
+  it("200 WITH access_token → success (carries the token pair + user)", () => {
+    const out = classifyClaimResponse(200, SUCCESS_BODY);
+    expect(out.kind).toBe("success");
+    if (out.kind === "success") {
+      expect(out.access_token).toBe("at-success");
+      expect(out.refresh_token).toBe("rt-success");
+      expect(out.user).toEqual({ id: "user-1" });
+    }
+  });
+
+  it("200 WITHOUT access_token ({status:'pending'}) → pending, NOT success", () => {
+    // The load-bearing distinction: a 200 pending body must never be read
+    // as success. This is the bug that would persist a non-credential as
+    // tokens.
+    const out = classifyClaimResponse(200, { status: "pending" });
+    expect(out.kind).toBe("pending");
+  });
+
+  it("does NOT branch on res.ok — a 200 pending and a 200 success differ only by body", () => {
+    // Same status code (200), opposite outcomes — proves the discriminant
+    // is the body, not the HTTP status.
+    expect(classifyClaimResponse(200, SUCCESS_BODY).kind).toBe("success");
+    expect(classifyClaimResponse(200, { status: "pending" }).kind).toBe(
+      "pending",
+    );
+  });
+
+  it("200 with an empty/garbage body (no access_token) → pending, never success", () => {
+    // Defensive: a malformed 200 must fall to the safe non-terminal path,
+    // not be mistaken for a token-bearing success.
+    expect(classifyClaimResponse(200, {}).kind).toBe("pending");
+    expect(classifyClaimResponse(200, null).kind).toBe("pending");
+    expect(classifyClaimResponse(200, "not-an-object").kind).toBe("pending");
+  });
+
+  it("200 with access_token but missing refresh_token is NOT a clean success", () => {
+    // A success MUST carry both tokens (the refresh token is what SC7
+    // rotation needs). A half-token 200 must not be persisted as if whole.
+    const out = classifyClaimResponse(200, {
+      access_token: "at-only",
+      user: { id: "u" },
+    });
+    expect(out.kind).not.toBe("success");
+  });
+});
+
+describe("classifyClaimResponse — terminal status codes", () => {
+  it("409 → already_claimed (terminal, no tokens)", () => {
+    const out = classifyClaimResponse(409, { error: "already_claimed" });
+    expect(out.kind).toBe("already_claimed");
+  });
+
+  it("410 → expired (terminal)", () => {
+    const out = classifyClaimResponse(410, { error: "session_expired" });
+    expect(out.kind).toBe("expired");
+  });
+
+  it("404 → not_found (terminal; the uniform wrong-verifier/unknown-session code)", () => {
+    const out = classifyClaimResponse(404, { error: "not_found" });
+    expect(out.kind).toBe("not_found");
+  });
+
+  it("keeps 409/410/404 DISTINCT (each maps to its own terminal kind)", () => {
+    // The agent-facing copy differs per terminal state; collapsing them
+    // loses the recovery hint. Assert no two share a kind.
+    const kinds = new Set([
+      classifyClaimResponse(409, {}).kind,
+      classifyClaimResponse(410, {}).kind,
+      classifyClaimResponse(404, {}).kind,
+    ]);
+    expect(kinds.size).toBe(3);
+  });
+});
+
+describe("classifyClaimResponse — retryable (transient) failures", () => {
+  it("500 → retryable (a 5xx blip is not terminal)", () => {
+    expect(classifyClaimResponse(500, {}).kind).toBe("retryable");
+  });
+
+  it("502/503/504 → retryable", () => {
+    expect(classifyClaimResponse(502, {}).kind).toBe("retryable");
+    expect(classifyClaimResponse(503, {}).kind).toBe("retryable");
+    expect(classifyClaimResponse(504, {}).kind).toBe("retryable");
+  });
+
+  it("a 5xx is NOT misclassified as a terminal failure", () => {
+    // The product risk: a transient 5xx must not end the flow as if the
+    // session were dead. It must stay retryable so the budget governs.
+    const out = classifyClaimResponse(503, {});
+    expect(["expired", "not_found", "already_claimed"]).not.toContain(out.kind);
+  });
+});

--- a/src/__tests__/manifest-contract.integration.test.ts
+++ b/src/__tests__/manifest-contract.integration.test.ts
@@ -35,6 +35,7 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { registerExampleTools } from "../tools/examples.js";
+import { registerIdentityTools } from "../tools/identity.js";
 import {
   createMockPluginApi,
   registeredToolNames,
@@ -68,10 +69,14 @@ function manifestToolNames(): Set<string> {
   return new Set(tools as string[]);
 }
 
-/** The set of names the real register code emits against a mock api. */
+/** The set of names the real register code emits against a mock api. Must call
+ * EVERY tool group that src/index.ts#register() wires, or the drift guard goes
+ * stale (a real tool would be registered + manifest-declared yet read as
+ * "missing from code" here). Mirror register() exactly. */
 function codeRegisteredNames(): Set<string> {
   const api = createMockPluginApi();
   registerExampleTools(api);
+  registerIdentityTools(api);
   return registeredToolNames(api);
 }
 

--- a/src/__tests__/register-claim.integration.test.ts
+++ b/src/__tests__/register-claim.integration.test.ts
@@ -1,0 +1,503 @@
+/**
+ * INTEGRATION — the poll→claim lifecycle + refresh (tier: integration).
+ *
+ * The real poller + sil-client + credentials, wired through the actual
+ * `sil_register` tool's execute(). The ONLY thing mocked is `fetch` —
+ * that is the host/network boundary (there is no live sil-web or Postgres
+ * in this repo; the true cross-service guarantee is sil-stage's e2e, goal
+ * SC9, deferred). Fake timers drive the poll clock deterministically.
+ *
+ * Wire shapes are pinned to the ALREADY-MERGED contract
+ * (`sil-services/cards/done/2026/sil-web-auth-endpoints.md`,
+ * `claim/route.ts`, `auth/refresh/route.ts`):
+ *   claim   200 {access_token,refresh_token,user} → success (once)
+ *   claim   200 {status:"pending"}                → keep polling
+ *   claim   409 / 410 / 404                       → terminal
+ *   claim   5xx / network throw                   → retry within budget
+ *   refresh 200 {access_token,refresh_token}      → rotate tokens.json
+ *   refresh 401 {error:"invalid_grant"}           → terminal "must re-register"
+ *
+ * Covers (integration tier):
+ *   SC4/F3/F4  full claim lifecycle across every status code;
+ *   budget exhaustion → terminal timeout, NO live timer remains;
+ *   SC8 (in-repo) two-data-dir isolation;
+ *   SC7/F7 refresh rotates tokens.json, contacts ONLY sil-web, 401 terminal.
+ *
+ * Contract pinned for the implementation (expert-developer):
+ *   - registerIdentityTools(api) / sil_register execute() starts a real
+ *     bounded poll of POST <host>/api/v1/sessions/<id>/claim with
+ *     { code_verifier } and, on a 200-with-access_token, writes tokens.json
+ *     + config.json (atomic, 0600) into getDataDir();
+ *   - a refresh entry point `refreshStoredTokens()` (sited in sil-client.ts
+ *     / credentials.ts / identity.ts — the dev's call) reads the stored
+ *     refresh token, POSTs <host>/api/v1/auth/refresh { refresh_token },
+ *     rotates tokens.json on 200, and returns a terminal "must re-register"
+ *     signal on 401 — contacting ONLY the resolved sil_api_url origin.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  mkdirSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { registerIdentityTools } from "../tools/identity.js";
+import { refreshStoredTokens } from "../lib/sil-client.js";
+import { setApiUrl, getApiUrl } from "../lib/config.js";
+import { getDataDir, readTokens } from "../lib/credentials.js";
+import {
+  createMockPluginApi,
+  getTool,
+} from "./helpers/mock-plugin-api.js";
+
+const TOOL = "sil_register";
+const HOST = "https://sil-web.test.example.com";
+
+let dataDir: string;
+let priorSilDataDir: string | undefined;
+
+interface StoredTokens {
+  access_token: string;
+  refresh_token: string;
+}
+
+/** Read a JSON file under the (resolved) data dir, or null. */
+function readJsonInDataDir<T>(name: string): T | null {
+  const path = join(getDataDir(), name);
+  if (!existsSync(path)) return null;
+  return JSON.parse(readFileSync(path, "utf8")) as T;
+}
+
+/** Parse a ToolResult payload. */
+function payloadOf(result: { content: { text?: string }[] }): Record<string, unknown> {
+  const text = result.content[0]?.text;
+  if (typeof text !== "string") throw new Error("no tool payload");
+  return JSON.parse(text) as Record<string, unknown>;
+}
+
+/**
+ * Flush the credential write that `onDone` fires un-awaited after a claim
+ * settles. The success path persists via async fs (writeFile→rename→chmod);
+ * those are REAL libuv ops that don't drain under fake timers. After a
+ * terminal the poller has already cleared its interval (no live fake timer),
+ * so we can safely drop to the real clock, yield a few macrotasks for the
+ * write chain to land, and return. Tests that read tokens.json after a
+ * success MUST await this first — otherwise they race the disk write.
+ *
+ * NOTE for the dev pair: this settle dance is necessary BECAUSE the tool's
+ * `handleDone` does not await `writeTokens`/`writeConfig` (identity.ts:165).
+ * Functionally fine on a real clock, but it means a disk-write failure on
+ * the success path is an unhandled rejection with no agent-visible signal —
+ * flagged in the QA handoff for the review pass, not weakened here.
+ */
+async function settleAsyncIo(): Promise<void> {
+  vi.useRealTimers();
+  // A few real macrotask turns: enough for writeFile→rename→chmod to settle.
+  for (let i = 0; i < 5; i++) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+/** Poll the real filesystem until `tokens.json` appears (or time out). Used
+ * after settleAsyncIo for an extra safety margin on slow CI disks. */
+async function waitForTokens(timeoutMs = 1000): Promise<StoredTokens | null> {
+  const deadline = Date.now() + timeoutMs;
+  // Already on real timers via settleAsyncIo by the time this is called.
+  while (Date.now() < deadline) {
+    const t = readTokens();
+    if (t !== null) return t;
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+  }
+  return readTokens();
+}
+
+/**
+ * A programmable fetch double. `respond` is called per request and returns
+ * a queued Response (or throws to simulate a network error). Every request
+ * URL is recorded so we can assert the Auth0-never-contacted invariant.
+ */
+function installFetch(
+  respond: (url: string, init: RequestInit | undefined, callIndex: number) =>
+    | { status: number; body: unknown }
+    | "network-error",
+): { calledUrls: string[]; callCount: () => number } {
+  const calledUrls: string[] = [];
+  let i = 0;
+  vi.spyOn(globalThis, "fetch").mockImplementation(
+    (input: unknown, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : String(input);
+      calledUrls.push(url);
+      const r = respond(url, init, i++);
+      if (r === "network-error") {
+        return Promise.reject(new Error("simulated network failure"));
+      }
+      const res = new Response(JSON.stringify(r.body), {
+        status: r.status,
+        headers: { "content-type": "application/json" },
+      });
+      return Promise.resolve(res);
+    },
+  );
+  return { calledUrls, callCount: () => i };
+}
+
+const SUCCESS_BODY = {
+  access_token: "fresh-at",
+  refresh_token: "fresh-rt",
+  user: { id: "user-42", name: "Polled User" },
+};
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), "sil-claim-int-"));
+  priorSilDataDir = process.env["SIL_DATA_DIR"];
+  process.env["SIL_DATA_DIR"] = dataDir;
+  setApiUrl(HOST); // pin a known origin so host assertions are exact
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  setApiUrl("");
+  if (priorSilDataDir === undefined) delete process.env["SIL_DATA_DIR"];
+  else process.env["SIL_DATA_DIR"] = priorSilDataDir;
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe("claim lifecycle — 200 success persists credentials exactly once", () => {
+  it("on a 200 token body, writes tokens.json + config.json and stops polling", async () => {
+    const fx = installFetch(() => ({ status: 200, body: SUCCESS_BODY }));
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+
+    await getTool(api, TOOL).execute("c1", {});
+    // Drive the poll until the first tick claims.
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    // Exactly-once + no leak are checked on the FAKE clock, immediately after
+    // the claim tick (the poller clears its interval at settle): no further
+    // poll fires and no timer remains.
+    const callsAfterSuccess = fx.callCount();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(fx.callCount()).toBe(callsAfterSuccess);
+    expect(vi.getTimerCount()).toBe(0);
+
+    // The credential write is fired un-awaited in onDone — drain it on the
+    // real clock before asserting the files landed.
+    await settleAsyncIo();
+    const tokens = await waitForTokens();
+    expect(tokens).not.toBeNull();
+    expect(tokens!.access_token).toBe("fresh-at");
+    expect(tokens!.refresh_token).toBe("fresh-rt");
+
+    const config = readJsonInDataDir<Record<string, unknown>>("config.json");
+    expect(JSON.stringify(config)).toContain("user-42");
+  });
+
+  it("posts { code_verifier } to <host>/api/v1/sessions/<id>/claim", async () => {
+    let claimUrl = "";
+    let claimBody: unknown = null;
+    installFetch((url, init) => {
+      claimUrl = url;
+      claimBody = init?.body;
+      return { status: 200, body: SUCCESS_BODY };
+    });
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", {}));
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    const sessionId = payload["session_id"] as string;
+    expect(claimUrl).toBe(`${HOST}/api/v1/sessions/${sessionId}/claim`);
+    const parsed = JSON.parse(claimBody as string) as { code_verifier?: string };
+    expect(typeof parsed.code_verifier).toBe("string");
+    expect(parsed.code_verifier!.length).toBeGreaterThanOrEqual(32);
+
+    // Drain the un-awaited success write so it can't ENOENT against teardown.
+    await settleAsyncIo();
+    await waitForTokens();
+  });
+});
+
+describe("claim lifecycle — 200 pending keeps polling (NOT terminal)", () => {
+  it("polls again after a {status:'pending'} 200, then succeeds", async () => {
+    let n = 0;
+    const fx = installFetch(() => {
+      n += 1;
+      // First two ticks pending, third tick success.
+      if (n < 3) return { status: 200, body: { status: "pending" } };
+      return { status: 200, body: SUCCESS_BODY };
+    });
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+
+    await getTool(api, TOOL).execute("c1", {});
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    // It kept polling through pending (≥3 calls) and ultimately persisted.
+    expect(fx.callCount()).toBeGreaterThanOrEqual(3);
+    await settleAsyncIo();
+    expect((await waitForTokens())!.access_token).toBe("fresh-at");
+  });
+
+  it("does NOT persist anything while only pending is returned", async () => {
+    installFetch(() => ({ status: 200, body: { status: "pending" } }));
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+    await getTool(api, TOOL).execute("c1", {});
+    await vi.advanceTimersByTimeAsync(15_000);
+    // Pending is not success — no tokens file may appear.
+    expect(readTokens()).toBeNull();
+  });
+});
+
+describe("claim lifecycle — terminal status codes stop the loop", () => {
+  for (const { code, body } of [
+    { code: 410, body: { error: "session_expired", message: "Ask your agent to start again." } },
+    { code: 409, body: { error: "already_claimed", message: "This session was already claimed." } },
+    { code: 404, body: { error: "not_found", message: "Session not found." } },
+  ]) {
+    it(`HTTP ${code} → stops polling, persists NO tokens, no timer remains`, async () => {
+      const fx = installFetch(() => ({ status: code, body }));
+      const api = createMockPluginApi();
+      registerIdentityTools(api);
+
+      await getTool(api, TOOL).execute("c1", {});
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      const callsAfterTerminal = fx.callCount();
+      await vi.advanceTimersByTimeAsync(60_000);
+      // No further polling after the terminal code.
+      expect(fx.callCount()).toBe(callsAfterTerminal);
+      // No tokens persisted on any terminal-failure path.
+      expect(readTokens()).toBeNull();
+      // No leaked timer.
+      expect(vi.getTimerCount()).toBe(0);
+    });
+  }
+});
+
+describe("claim lifecycle — transient failures retry within budget", () => {
+  it("retries after a 5xx and then succeeds (5xx is not terminal)", async () => {
+    let n = 0;
+    const fx = installFetch(() => {
+      n += 1;
+      if (n === 1) return { status: 503, body: { error: "unavailable" } };
+      if (n === 2) return { status: 500, body: { error: "boom" } };
+      return { status: 200, body: SUCCESS_BODY };
+    });
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+
+    await getTool(api, TOOL).execute("c1", {});
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(fx.callCount()).toBeGreaterThanOrEqual(3);
+    await settleAsyncIo();
+    expect((await waitForTokens())!.access_token).toBe("fresh-at");
+  });
+
+  it("retries after a network error (thrown fetch) and then succeeds", async () => {
+    let n = 0;
+    installFetch(() => {
+      n += 1;
+      if (n <= 2) return "network-error";
+      return { status: 200, body: SUCCESS_BODY };
+    });
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+
+    await getTool(api, TOOL).execute("c1", {});
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    await settleAsyncIo();
+    expect((await waitForTokens())!.access_token).toBe("fresh-at");
+  });
+});
+
+describe("claim lifecycle — budget exhaustion (never unbounded)", () => {
+  it("stops at the deadline under perpetual pending, leaves NO live timer", async () => {
+    const fx = installFetch(() => ({ status: 200, body: { status: "pending" } }));
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+
+    await getTool(api, TOOL).execute("c1", {});
+    // Advance well past any sane deadline (the session TTL is 30 min;
+    // the budget must be ≤ that).
+    await vi.advanceTimersByTimeAsync(45 * 60 * 1000);
+
+    const callsAtDeadline = fx.callCount();
+    // The clock keeps running; no more polls may fire — the loop is bounded.
+    await vi.advanceTimersByTimeAsync(30 * 60 * 1000);
+    expect(fx.callCount()).toBe(callsAtDeadline);
+
+    // The verdict-critical assertion: no leftover timer after timeout.
+    expect(vi.getTimerCount()).toBe(0);
+    // And nothing was persisted (the user never finished).
+    expect(readTokens()).toBeNull();
+  });
+});
+
+describe("claim lifecycle — only sil-web is contacted (no Auth0 leg)", () => {
+  it("every claim request targets the resolved sil_api_url origin", async () => {
+    const fx = installFetch(() => ({ status: 200, body: SUCCESS_BODY }));
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+    await getTool(api, TOOL).execute("c1", {});
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    const resolvedOrigin = new URL(getApiUrl()).origin;
+    for (const url of fx.calledUrls) {
+      expect(new URL(url).origin).toBe(resolvedOrigin);
+    }
+    // Belt-and-suspenders: no auth0 host anywhere.
+    for (const url of fx.calledUrls) {
+      expect(url).not.toMatch(/auth0\.com/i);
+    }
+    // Drain the un-awaited success write so it can't ENOENT against teardown.
+    await settleAsyncIo();
+    await waitForTokens();
+  });
+});
+
+describe("SC8 (in-repo) — two instances, two data dirs, independent tokens", () => {
+  it("each instance claims into its OWN tokens.json; neither reads/overwrites the other", async () => {
+    // Instance A: its own data dir + its own session/tokens.
+    const dirA = mkdtempSync(join(tmpdir(), "sil-inst-a-"));
+    const dirB = mkdtempSync(join(tmpdir(), "sil-inst-b-"));
+    try {
+      // --- Instance A ---
+      process.env["SIL_DATA_DIR"] = dirA;
+      setApiUrl(HOST);
+      installFetch(() => ({
+        status: 200,
+        body: { access_token: "at-A", refresh_token: "rt-A", user: { id: "user-42" } },
+      }));
+      const apiA = createMockPluginApi();
+      registerIdentityTools(apiA);
+      const payloadA = payloadOf(await getTool(apiA, TOOL).execute("a", {}));
+      await vi.advanceTimersByTimeAsync(10_000);
+      // Drain A's un-awaited success write (switches to real timers).
+      await settleAsyncIo();
+      await waitForTokens();
+      vi.restoreAllMocks();
+
+      // --- Instance B (separate data dir) ---
+      process.env["SIL_DATA_DIR"] = dirB;
+      setApiUrl(HOST);
+      vi.useFakeTimers();
+      installFetch(() => ({
+        status: 200,
+        body: { access_token: "at-B", refresh_token: "rt-B", user: { id: "user-42" } },
+      }));
+      const apiB = createMockPluginApi();
+      registerIdentityTools(apiB);
+      const payloadB = payloadOf(await getTool(apiB, TOOL).execute("b", {}));
+      await vi.advanceTimersByTimeAsync(10_000);
+      // Drain B's un-awaited success write.
+      await settleAsyncIo();
+      await waitForTokens();
+
+      // Distinct sessions.
+      expect(payloadA["session_id"]).not.toBe(payloadB["session_id"]);
+
+      // Each dir holds its OWN token pair — no cross-contamination.
+      const tokA = JSON.parse(readFileSync(join(dirA, "tokens.json"), "utf8")) as StoredTokens;
+      const tokB = JSON.parse(readFileSync(join(dirB, "tokens.json"), "utf8")) as StoredTokens;
+      expect(tokA.access_token).toBe("at-A");
+      expect(tokB.access_token).toBe("at-B");
+      expect(tokA.access_token).not.toBe(tokB.access_token);
+    } finally {
+      rmSync(dirA, { recursive: true, force: true });
+      rmSync(dirB, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("SC7/F7 — token refresh via sil-web, never Auth0", () => {
+  beforeEach(() => {
+    // Seed a stored token pair to refresh.
+    const dir = getDataDir();
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "tokens.json"),
+      JSON.stringify({ access_token: "old-at", refresh_token: "old-rt" }),
+      { mode: 0o600 },
+    );
+  });
+
+  it("POSTs <host>/api/v1/auth/refresh { refresh_token } and rotates tokens.json on 200", async () => {
+    let refreshUrl = "";
+    let refreshBody: unknown = null;
+    installFetch((url, init) => {
+      refreshUrl = url;
+      refreshBody = init?.body;
+      return {
+        status: 200,
+        body: { access_token: "rotated-at", refresh_token: "rotated-rt" },
+      };
+    });
+
+    await refreshStoredTokens();
+
+    expect(refreshUrl).toBe(`${HOST}/api/v1/auth/refresh`);
+    const parsed = JSON.parse(refreshBody as string) as { refresh_token?: string };
+    expect(parsed.refresh_token).toBe("old-rt");
+
+    // tokens.json now carries the ROTATED pair.
+    const tokens = readTokens();
+    expect(tokens!.access_token).toBe("rotated-at");
+    expect(tokens!.refresh_token).toBe("rotated-rt");
+  });
+
+  it("contacts ONLY the resolved sil_api_url origin (Auth0 is never called directly)", async () => {
+    const fx = installFetch(() => ({
+      status: 200,
+      body: { access_token: "rotated-at", refresh_token: "rotated-rt" },
+    }));
+    await refreshStoredTokens();
+
+    const resolvedOrigin = new URL(getApiUrl()).origin;
+    expect(fx.calledUrls.length).toBeGreaterThan(0);
+    for (const url of fx.calledUrls) {
+      expect(new URL(url).origin).toBe(resolvedOrigin);
+      expect(url).not.toMatch(/auth0\.com/i);
+    }
+  });
+
+  it("on a 401 invalid_grant, surfaces a terminal must-re-register and does NOT keep the dead token as valid", async () => {
+    installFetch(() => ({
+      status: 401,
+      body: { error: "invalid_grant", message: "The refresh token was rejected." },
+    }));
+
+    const result = await refreshStoredTokens();
+    // The shape is the impl's call; assert a terminal must-re-register
+    // signal is surfaced (not a silent success).
+    const blob = JSON.stringify(result);
+    expect(blob).toMatch(/re-?register|invalid_grant|must.*register/i);
+
+    // The known-dead token must not be presented as a fresh, valid pair.
+    // Either tokens.json is cleared, or it is NOT silently overwritten with
+    // a "valid" marker — at minimum the access token was not rotated to a
+    // new value (no new pair was minted from a rejected refresh).
+    const tokens = readTokens();
+    if (tokens !== null) {
+      expect(tokens.access_token).not.toBe("rotated-at");
+    }
+  });
+});

--- a/src/__tests__/tools/identity.test.ts
+++ b/src/__tests__/tools/identity.test.ts
@@ -1,0 +1,432 @@
+/**
+ * UNIT — sil_register tool (tier: unit, mock api + temp data dir, fetch
+ * mocked so nothing reaches the network).
+ *
+ * Covers the unit-tier acceptance criteria for `sil_register`
+ * (SC1·F1 PKCE+auth-URL, the pluginConfig→env→default host override, the
+ * prompt non-blocking return, the already-registered short-circuit, and
+ * the verifier-never-on-disk invariant after a full run). The poll→claim
+ * lifecycle across status codes is the integration tier's job
+ * (`register-claim.integration.test.ts`); here we assert the tool's
+ * SYNCHRONOUS-from-the-agent's-view contract and the in-process PKCE/URL
+ * math, with `fetch` stubbed to a never-resolving/pending answer so the
+ * background poll can't escape the test.
+ *
+ * Hermetic via the `SIL_DATA_DIR` override (own temp dir per test) and the
+ * config-reset machinery mirrored from `index.test.ts` (reset the module
+ * singleton + env so each test starts at the default host). Fake timers
+ * are used wherever a fresh registration arms the background poll, so no
+ * live timer leaks across tests.
+ *
+ * Contract this file pins for the implementation (expert-developer):
+ *   - src/tools/identity.ts exports registerIdentityTools(api) which
+ *     registers a `sil_register` tool (Type.Object({}) — no inputs);
+ *   - execute() returns a jsonResult whose payload carries `status`
+ *     ("already_registered" | "awaiting_browser"), and for a fresh run
+ *     `auth_url` + `session_id`;
+ *   - the auth_url is `<resolvedHost>/authorize?session=<uuid>&code_challenge=<43-char S256>`.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { registerIdentityTools } from "../../tools/identity.js";
+import { setApiUrl } from "../../lib/config.js";
+import { getDataDir } from "../../lib/credentials.js";
+import {
+  createMockPluginApi,
+  getTool,
+  type MockPluginAPI,
+} from "../helpers/mock-plugin-api.js";
+
+const TOOL = "sil_register";
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const CHALLENGE_RE = /^[A-Za-z0-9_-]{43}$/;
+
+let dataDir: string;
+let priorSilDataDir: string | undefined;
+
+/** Parse a ToolResult's JSON payload. */
+function payloadOf(result: {
+  content: { text?: string }[];
+}): Record<string, unknown> {
+  const text = result.content[0]?.text;
+  if (typeof text !== "string") {
+    throw new Error(`tool result has no text payload: ${String(text)}`);
+  }
+  return JSON.parse(text) as Record<string, unknown>;
+}
+
+/** Recursively collect file paths under a dir (empty if it doesn't exist). */
+function walkFiles(dir: string): string[] {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const out: string[] = [];
+  for (const e of entries) {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) out.push(...walkFiles(full));
+    else out.push(full);
+  }
+  return out;
+}
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), "sil-register-test-"));
+  priorSilDataDir = process.env["SIL_DATA_DIR"];
+  process.env["SIL_DATA_DIR"] = dataDir;
+  // Reset config singleton + env so each test starts at the default host.
+  setApiUrl("");
+  delete process.env["SIL_API_URL"];
+});
+
+afterEach(() => {
+  if (priorSilDataDir === undefined) delete process.env["SIL_DATA_DIR"];
+  else process.env["SIL_DATA_DIR"] = priorSilDataDir;
+  setApiUrl("");
+  delete process.env["SIL_API_URL"];
+  rmSync(dataDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe("sil_register — tool registration shape", () => {
+  it("registers a sil_register tool with no input parameters", () => {
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+    const tool = getTool(api, TOOL);
+    expect(tool.name).toBe(TOOL);
+    expect(tool.label.length).toBeGreaterThan(0);
+    expect(tool.description.length).toBeGreaterThan(0);
+    // F1: the tool takes no arguments — a TypeBox object with no properties.
+    expect((tool.parameters as { type?: unknown }).type).toBe("object");
+    const props = (tool.parameters as { properties?: Record<string, unknown> })
+      .properties;
+    expect(props === undefined || Object.keys(props).length === 0).toBe(true);
+  });
+});
+
+describe("sil_register — fresh registration: PKCE + auth URL (SC1/F1)", () => {
+  let api: MockPluginAPI;
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Background poll, if armed, hangs on a never-settling fetch — it can
+    // never reach the network nor resolve during the test.
+    fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(() => new Promise<Response>(() => {}));
+    api = createMockPluginApi();
+    registerIdentityTools(api);
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("returns a non-terminal awaiting_browser status with a session_id", async () => {
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", {}));
+    expect(payload["status"]).toBe("awaiting_browser");
+    expect(payload["session_id"]).toMatch(UUID_RE);
+  });
+
+  it("returns an auth_url of the exact form <host>/authorize?session=<id>&code_challenge=<challenge>", async () => {
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", {}));
+    const authUrl = payload["auth_url"] as string;
+    expect(typeof authUrl).toBe("string");
+
+    const url = new URL(authUrl);
+    expect(url.pathname).toBe("/authorize");
+    // session param is the minted UUID and equals the returned session_id.
+    expect(url.searchParams.get("session")).toBe(payload["session_id"]);
+    expect(url.searchParams.get("session")).toMatch(UUID_RE);
+    // code_challenge is the 43-char S256 digest, present and well-formed.
+    const challenge = url.searchParams.get("code_challenge");
+    expect(challenge).toMatch(CHALLENGE_RE);
+    // EXACTLY these two query params (no verifier, no extras leaked).
+    expect([...url.searchParams.keys()].sort()).toEqual([
+      "code_challenge",
+      "session",
+    ]);
+  });
+
+  it("sends the S256 DIGEST in the URL, never the raw verifier", async () => {
+    // sil-web stores/compares digests; a raw verifier in code_challenge
+    // would break the claim CAS. The challenge must NOT be a base64url
+    // of 32 bytes with the wrong length, and must be exactly 43 chars.
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", {}));
+    const challenge = new URL(payload["auth_url"] as string).searchParams.get(
+      "code_challenge",
+    );
+    expect(challenge).toHaveLength(43);
+    // Whatever the verifier is, it is NOT exposed anywhere in the payload.
+    const blob = JSON.stringify(payload);
+    expect(blob).not.toMatch(/verifier/i);
+  });
+
+  it("mints a FRESH session per call (two calls → different session_ids)", async () => {
+    const a = payloadOf(await getTool(api, TOOL).execute("c1", {}));
+    const b = payloadOf(await getTool(api, TOOL).execute("c2", {}));
+    expect(a["session_id"]).not.toBe(b["session_id"]);
+  });
+});
+
+describe("sil_register — host override resolution (pluginConfig → env → default)", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(() => new Promise<Response>(() => {}));
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("builds the auth URL against the SIL_API_URL env override", async () => {
+    process.env["SIL_API_URL"] = "https://api.staging.example.com";
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", {}));
+    const url = new URL(payload["auth_url"] as string);
+    expect(url.origin).toBe("https://api.staging.example.com");
+  });
+
+  it("a pluginConfig override beats the env (config wins)", async () => {
+    process.env["SIL_API_URL"] = "https://env.example.com";
+    // The config singleton is set the way register() would via
+    // applyPluginConfigOverrides; assert config precedence holds.
+    setApiUrl("https://config.example.com");
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", {}));
+    expect(new URL(payload["auth_url"] as string).origin).toBe(
+      "https://config.example.com",
+    );
+  });
+
+  it("falls back to the default host when nothing is overridden", async () => {
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", {}));
+    // Not the staging/config hosts — the configured default origin.
+    const origin = new URL(payload["auth_url"] as string).origin;
+    expect(origin).not.toBe("https://config.example.com");
+    expect(origin).not.toBe("https://env.example.com");
+    expect(origin.startsWith("https://")).toBe(true);
+  });
+});
+
+describe("sil_register — prompt, non-blocking return (F1)", () => {
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("resolves the execute() promise WITHOUT waiting for any poll tick", async () => {
+    vi.useFakeTimers();
+    // fetch would only ever be called by the background poll; make it hang
+    // so that IF execute() awaited the poll, this test would time out.
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      () => new Promise<Response>(() => {}),
+    );
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+
+    // Without advancing fake timers at all, execute() must still resolve —
+    // proving it does not block the agent on the browser flow.
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", {}));
+    expect(payload["status"]).toBe("awaiting_browser");
+  });
+});
+
+describe("sil_register — already-registered short-circuit (F1)", () => {
+  beforeEach(() => {
+    // Seed a valid tokens.json in the data dir so the tool should
+    // short-circuit. Write through the same dir the resolver returns.
+    const dir = getDataDir();
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "tokens.json"),
+      JSON.stringify({ access_token: "existing-at", refresh_token: "existing-rt" }),
+      { mode: 0o600 },
+    );
+    writeFileSync(
+      join(dir, "config.json"),
+      JSON.stringify({ user: { id: "existing-user", name: "Existing User" } }),
+      { mode: 0o600 },
+    );
+  });
+
+  it("returns already_registered with the existing identity", async () => {
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", {}));
+    expect(payload["status"]).toBe("already_registered");
+    // The existing user identity is surfaced (exact key shape is the
+    // impl's call; the identity value must be present).
+    expect(JSON.stringify(payload)).toContain("existing-user");
+  });
+
+  it("makes NO network call and arms NO timer (mints nothing)", async () => {
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const intervalSpy = vi.spyOn(globalThis, "setInterval");
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(new Error("already-registered must not hit the network"));
+
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+    await getTool(api, TOOL).execute("c1", {});
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(intervalSpy).not.toHaveBeenCalled();
+    expect(timeoutSpy).not.toHaveBeenCalled();
+  });
+
+  it("does NOT overwrite the stored tokens", async () => {
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+    await getTool(api, TOOL).execute("c1", {});
+    const tokens = JSON.parse(
+      readFileSync(join(getDataDir(), "tokens.json"), "utf8"),
+    ) as { access_token: string; refresh_token: string };
+    expect(tokens.access_token).toBe("existing-at");
+    expect(tokens.refresh_token).toBe("existing-rt");
+  });
+
+  it("does NOT return an auth_url (no new browser flow)", async () => {
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", {}));
+    expect(payload["auth_url"]).toBeUndefined();
+  });
+});
+
+describe("sil_register — the verifier never reaches disk (F4 invariant)", () => {
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("after a fresh registration, NO file under the data dir contains the verifier", async () => {
+    vi.useFakeTimers();
+    // Capture the verifier by intercepting it the only place it legitimately
+    // leaves the process: the claim POST body. fetch hangs (never resolves)
+    // so no tokens get written, but we can read what the poll WOULD send.
+    let sentVerifier: string | null = null;
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      (_input: unknown, init?: { body?: unknown }) => {
+        if (init && typeof init.body === "string") {
+          try {
+            const parsed = JSON.parse(init.body) as { code_verifier?: string };
+            if (typeof parsed.code_verifier === "string") {
+              sentVerifier = parsed.code_verifier;
+            }
+          } catch {
+            /* non-JSON body — ignore */
+          }
+        }
+        return new Promise<Response>(() => {});
+      },
+    );
+
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+    await getTool(api, TOOL).execute("c1", {});
+
+    // Drive one poll tick so the claim body (carrying the verifier) is built.
+    await vi.advanceTimersByTimeAsync(5000);
+
+    // Whether or not the poll ran, the data dir must never contain the
+    // verifier. If we did capture one, assert it specifically is absent.
+    for (const f of walkFiles(getDataDir())) {
+      const content = readFileSync(f, "utf8");
+      expect(content).not.toMatch(/verifier/i);
+      if (sentVerifier) expect(content).not.toContain(sentVerifier);
+    }
+  });
+});
+
+describe("sil_register — tokens are NEVER logged (hard constraint, F4/secret-hygiene)", () => {
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("no logger call at any level contains a token or verifier value across a full success", async () => {
+    // The card's hard constraint (mirrors sil-web claim/route.ts:21):
+    // tokens appear ONLY in the ToolResult/file, never in a log field. A
+    // careless `logger.info("claimed", { tokens })` would leak credentials
+    // to the host's log sink. Drive a full successful claim and assert NO
+    // logged argument — across info/warn/error/debug — carries a token or
+    // the verifier.
+    vi.useFakeTimers();
+    const ACCESS = "leak-canary-access-token";
+    const REFRESH = "leak-canary-refresh-token";
+    let sentVerifier: string | null = null;
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      (_input: unknown, init?: { body?: unknown }) => {
+        if (init && typeof init.body === "string") {
+          try {
+            const parsed = JSON.parse(init.body) as { code_verifier?: string };
+            if (typeof parsed.code_verifier === "string") {
+              sentVerifier = parsed.code_verifier;
+            }
+          } catch {
+            /* ignore */
+          }
+        }
+        const res = new Response(
+          JSON.stringify({
+            access_token: ACCESS,
+            refresh_token: REFRESH,
+            user: { id: "u-leak", name: "Leak User" },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+        return Promise.resolve(res);
+      },
+    );
+
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+    await getTool(api, TOOL).execute("c1", {});
+    await vi.advanceTimersByTimeAsync(10_000);
+    // Drain the un-awaited credential write on the real clock.
+    vi.useRealTimers();
+    for (let i = 0; i < 5; i++) {
+      await new Promise<void>((resolve) => setTimeout(resolve, 5));
+    }
+
+    // Collect every argument passed to every logger level and serialize.
+    const allLogArgs = [
+      api.logger.info,
+      api.logger.warn,
+      api.logger.error,
+      api.logger.debug,
+    ].flatMap((fn) => vi.mocked(fn).mock.calls.map((c) => JSON.stringify(c)));
+    const logBlob = allLogArgs.join("\n");
+
+    expect(logBlob).not.toContain(ACCESS);
+    expect(logBlob).not.toContain(REFRESH);
+    if (sentVerifier) expect(logBlob).not.toContain(sentVerifier);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ import {
   type SilPluginConfig,
 } from "./lib/config.js";
 import { registerExampleTools } from "./tools/examples.js";
+import { registerIdentityTools } from "./tools/identity.js";
 
 export default definePluginEntry({
   id: "sil",
@@ -40,6 +41,7 @@ export default definePluginEntry({
     );
 
     registerExampleTools(api);
+    registerIdentityTools(api);
 
     api.logger.info("sil_plugin_loaded", {
       message: "sil plugin registered.",

--- a/src/lib/credentials.ts
+++ b/src/lib/credentials.ts
@@ -1,0 +1,161 @@
+/**
+ * Persistent credential + identity storage for the sil plugin — the SOLE owner
+ * of on-disk auth state.
+ *
+ * After a successful claim the plugin writes two files under the resolved data
+ * directory:
+ *   - `tokens.json`  → { access_token, refresh_token }  (the bearer pair)
+ *   - `config.json`  → { user: { id, name? } }          (identity, for whoami)
+ *
+ * The PKCE verifier is NEVER written here — it is the claim bearer secret and
+ * lives only in memory (see `pkce.ts`). Only the post-claim tokens + identity
+ * touch disk.
+ *
+ * Resolution order for the data dir (no host `dataDir` accessor exists in the
+ * declared SDK, so we compute it deterministically; the env override is what
+ * makes the credential tests hermetic — each points at its own temp dir):
+ *   1. `$SIL_DATA_DIR`              (test/override — highest precedence)
+ *   2. `$XDG_DATA_HOME/sil`         (XDG Base Directory spec)
+ *   3. `~/.local/share/sil`         (XDG default)
+ *
+ * Writes are atomic (temp file in the same dir + rename) so a crash mid-write
+ * never leaves a half-written token file, and the files are `0600` (owner-only)
+ * so the bearer pair is never group/world-readable. Reads tolerate a missing
+ * dir/file by returning null (the already-registered short-circuit treats
+ * "no tokens" as "not registered").
+ */
+
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { randomBytes } from "node:crypto";
+
+/** Owner read/write only. The bearer pair must never be group/world-readable. */
+const FILE_MODE = 0o600;
+/** Owner read/write/execute only on the data dir itself. */
+const DIR_MODE = 0o700;
+
+const TOKENS_FILE = "tokens.json";
+const CONFIG_FILE = "config.json";
+
+/** The bearer pair persisted on a successful claim / refresh. */
+export interface StoredTokens {
+  access_token: string;
+  refresh_token: string;
+}
+
+/** The identity persisted alongside the tokens, for `sil_whoami` (next card). */
+export interface StoredConfig {
+  user: StoredUser;
+}
+
+export interface StoredUser {
+  id: string;
+  name?: string;
+}
+
+/**
+ * Resolve the plugin's data directory at call time (never cached — tests flip
+ * `$SIL_DATA_DIR` between cases, and a deployment could relocate `$XDG_DATA_HOME`
+ * between calls). See the module header for the precedence order.
+ */
+export function getDataDir(): string {
+  const override = process.env["SIL_DATA_DIR"];
+  if (override !== undefined && override !== "") return override;
+
+  const xdg = process.env["XDG_DATA_HOME"];
+  if (xdg !== undefined && xdg !== "") return join(xdg, "sil");
+
+  return join(homedir(), ".local", "share", "sil");
+}
+
+export function getTokensPath(): string {
+  return join(getDataDir(), TOKENS_FILE);
+}
+
+export function getConfigPath(): string {
+  return join(getDataDir(), CONFIG_FILE);
+}
+
+/**
+ * True iff a `tokens.json` exists on disk. This is the already-registered
+ * short-circuit's gate — it is PRESENCE-based, not freshness-based: an expired
+ * access token still counts as "registered" for this card (refresh is SC7, the
+ * sil_whoami card). Note carried forward in the card body.
+ */
+export function hasTokens(): boolean {
+  return existsSync(getTokensPath());
+}
+
+/**
+ * Persist the bearer pair atomically with owner-only perms.
+ *
+ * Async signature (returns a Promise) but SYNCHRONOUS fs internals (temp+rename
+ * via the *Sync calls). The async wrapper is the public contract (callers await
+ * it); the sync internals guarantee the file is fully on disk by the time the
+ * returned promise resolves — important under the fake-timer poll loop, where a
+ * threadpool-backed `fs/promises` write would NOT settle within the test's
+ * microtask flush and the persisted file would race the assertion.
+ */
+export async function writeTokens(tokens: StoredTokens): Promise<void> {
+  writeJsonAtomic(getTokensPath(), tokens);
+}
+
+/** Persist the identity atomically with owner-only perms. See `writeTokens`
+ * for why this is an async wrapper over synchronous fs internals. */
+export async function writeConfig(config: StoredConfig): Promise<void> {
+  writeJsonAtomic(getConfigPath(), config);
+}
+
+/** Read the bearer pair, or null if absent/unreadable/malformed. */
+export function readTokens(): StoredTokens | null {
+  return readJson<StoredTokens>(getTokensPath());
+}
+
+/** Read the identity, or null if absent/unreadable/malformed. */
+export function readConfig(): StoredConfig | null {
+  return readJson<StoredConfig>(getConfigPath());
+}
+
+/**
+ * Write `data` as pretty JSON to `path` atomically: serialize to a uniquely
+ * named temp file in the SAME directory (rename is only atomic within a
+ * filesystem), fsync-free `writeFileSync`, then `renameSync` over the target.
+ * The temp file is created `0600` and the final file is re-`chmod`'d to `0600`
+ * in case the rename inherited a different mode on some filesystems.
+ *
+ * Creating the dir first (recursive, `0700`) makes first-run on a clean machine
+ * a non-error. The temp name carries random bytes so two concurrent writers (a
+ * pathological double-register sharing a data dir) don't collide on the temp.
+ */
+function writeJsonAtomic(path: string, data: unknown): void {
+  const dir = dirname(path);
+  mkdirSync(dir, { recursive: true, mode: DIR_MODE });
+
+  const tmp = `${path}.${process.pid}.${randomBytes(6).toString("hex")}.tmp`;
+  writeFileSync(tmp, JSON.stringify(data, null, 2), {
+    encoding: "utf-8",
+    mode: FILE_MODE,
+  });
+  renameSync(tmp, path);
+  // Belt-and-braces: some filesystems drop the temp's mode on rename.
+  chmodSync(path, FILE_MODE);
+}
+
+function readJson<T>(path: string): T | null {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf-8")) as T;
+  } catch {
+    // A corrupt/half-written file reads as "absent" — the caller falls back to
+    // the not-registered path rather than crashing on a SyntaxError.
+    return null;
+  }
+}

--- a/src/lib/pkce.ts
+++ b/src/lib/pkce.ts
@@ -1,0 +1,77 @@
+/**
+ * PKCE primitives for the sil-web auth flow (proof system A — agent ↔ sil-web).
+ *
+ * The plugin mints a session id + a code verifier, holds the verifier as a
+ * secret IN MEMORY, and sends only the S256 CHALLENGE to `/authorize`. This is
+ * load-bearing: sil-web stores what the agent sends (already a digest) and the
+ * claim CAS compares digest-to-digest — so the derivation here MUST match
+ * sil-web's `src/lib/pkce.ts` byte-for-byte, or every claim returns a uniform
+ * 404 (wrong-verifier ≡ unknown-session by construction, no existence oracle).
+ *
+ * `deriveChallenge` / `isValidCodeChallenge` / `isValidSessionId` are ported
+ * verbatim from sil-services/apps/sil-web/src/lib/pkce.ts so the two sides agree.
+ * `newSessionId` / `newVerifier` are the plugin-side minters (sil-web never
+ * mints — it only validates the incoming params).
+ *
+ * node:crypto only; base64url; no dependency.
+ */
+
+import { createHash, randomBytes, randomUUID } from "node:crypto";
+
+/** A base64url S256 digest is exactly 43 chars, no padding ([A-Za-z0-9_-]). */
+const CODE_CHALLENGE_RE = /^[A-Za-z0-9_-]{43}$/;
+
+/** RFC 4122 UUID (any version/variant); the session id is minted by the agent. */
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * The verifier is 32 random bytes, base64url-encoded. 32 bytes → a 43-char
+ * base64url string, comfortably inside RFC 7636's 43–128 char range; the same
+ * width sil-web's own test vectors use.
+ */
+const VERIFIER_BYTES = 32;
+
+/**
+ * Derive the PKCE S256 code challenge from a verifier:
+ *   BASE64URL( SHA256( ASCII(verifier) ) )
+ * Pure; no I/O. The result is a 43-char base64url string.
+ *
+ * Identical to sil-web's `deriveChallenge` — pinned by a shared test vector so
+ * any drift fails in CI rather than silently as a runtime 404.
+ */
+export function deriveChallenge(verifier: string): string {
+  return createHash("sha256").update(verifier).digest("base64url");
+}
+
+/**
+ * True iff `value` is a well-formed S256 code challenge: exactly 43 characters,
+ * base64url charset only ([A-Za-z0-9_-], no padding). This is the format gate
+ * sil-web's `/authorize` applies to the incoming `code_challenge`.
+ */
+export function isValidCodeChallenge(value: string): boolean {
+  return CODE_CHALLENGE_RE.test(value);
+}
+
+/**
+ * True iff `value` is a well-formed session id (UUID). This is the format gate
+ * sil-web's `/authorize` and `/claim` apply to the incoming `session` param.
+ */
+export function isValidSessionId(value: string): boolean {
+  return UUID_RE.test(value);
+}
+
+/** Mint a fresh session id (UUID v4). The agent owns it for the whole flow. */
+export function newSessionId(): string {
+  return randomUUID();
+}
+
+/**
+ * Mint a fresh PKCE code verifier — 32 cryptographically-random bytes as a
+ * base64url string. NEVER written to disk: it is the bearer secret for the
+ * claim CAS; only its digest (the challenge) ever leaves the process, and only
+ * inside the auth URL.
+ */
+export function newVerifier(): string {
+  return randomBytes(VERIFIER_BYTES).toString("base64url");
+}

--- a/src/lib/poller.ts
+++ b/src/lib/poller.ts
@@ -1,0 +1,127 @@
+/**
+ * Generic bounded interval-with-deadline poll loop.
+ *
+ * Lifecycle (the whole reason this is its own module — so the timer behaviour is
+ * unit-testable with fake timers, in isolation from the claim taxonomy):
+ *   - `startPoll` arms a `setInterval` and returns a handle with `stop()`.
+ *   - Each tick calls the injected `poll()` step. It returns `{ done: false }`
+ *     to keep polling or `{ done: true, ... }` to terminate.
+ *   - The FIRST terminal step stops the loop and fires `onDone` EXACTLY once
+ *     with that step result.
+ *   - If the overall deadline passes with no terminal step, the loop stops and
+ *     fires `onDone` with a synthetic timeout result `{ done, timedOut, outcome:
+ *     "timeout" }`, so no run ends in silence.
+ *   - The interval timer is cleared on EVERY exit path (terminal, deadline,
+ *     explicit `stop()`). The architect's "poll loop leak" risk: a missed
+ *     `clearInterval` leaks a timer per `sil_register` call in a reused process.
+ *     `vi.getTimerCount()` must be 0 after any exit — enforced by poller.test.ts.
+ *
+ * The loop is deliberately GENERIC over the step result: it knows only `done`.
+ * The claim-status → done mapping lives in the caller (the tool), keeping the
+ * HTTP taxonomy (sil-client) and the timer lifecycle (here) independently
+ * testable. No system event / wake is fired — the declared OpenClaw SDK has no
+ * such member; success is observed by the credential file landing on disk.
+ */
+
+/** Poll cadence: how often a tick fires a `poll()` step. ~3s (architect default). */
+export const POLL_INTERVAL_MS = 3_000;
+/** Overall budget: must not outlive sil-web's 30-min session TTL. ~30 min. */
+export const POLL_DEADLINE_MS = 30 * 60 * 1_000;
+
+/** Minimal contract a `poll()` step must satisfy. `done:false` → keep polling;
+ * `done:true` (plus any caller-defined fields) → terminate. */
+export interface PollStepResult {
+  done: boolean;
+  [key: string]: unknown;
+}
+
+/** What `onDone` receives: either the terminal step result, or the synthetic
+ * timeout the poller injects on deadline exhaustion. */
+export type PollDoneResult =
+  | PollStepResult
+  | { done: true; timedOut: true; outcome: "timeout" };
+
+/** Handle to a running poll; `stop()` is idempotent and clears the timer. */
+export interface PollHandle {
+  stop(): void;
+}
+
+export interface StartPollOptions {
+  /** Milliseconds between `poll()` ticks. */
+  intervalMs: number;
+  /** Overall budget; the loop stops and reports a timeout once it elapses. */
+  deadlineMs: number;
+  /** One poll step. Injected so tests script results without a network. */
+  poll: () => Promise<PollStepResult>;
+  /** Fired exactly once when the loop reaches any terminal state. */
+  onDone: (result: PollDoneResult) => void;
+  /** Monotonic clock; injectable so deadline tests don't depend on Date.now. */
+  now?: () => number;
+}
+
+/**
+ * Arm the bounded poll. Returns immediately with a handle — the caller (the
+ * tool's `execute`) does NOT await it; that is what keeps the tool non-blocking.
+ */
+export function startPoll(opts: StartPollOptions): PollHandle {
+  const now = opts.now ?? Date.now;
+  const startedAt = now();
+
+  let settled = false;
+  let inFlight = false;
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  const clearTimer = (): void => {
+    if (timer !== null) {
+      clearInterval(timer);
+      timer = null;
+    }
+  };
+
+  // Single exit point: clear the timer once, fire onDone once. Every terminal
+  // branch routes through here so a timer can never be left armed.
+  const settle = (result: PollDoneResult): void => {
+    if (settled) return;
+    settled = true;
+    clearTimer();
+    opts.onDone(result);
+  };
+
+  const tick = async (): Promise<void> => {
+    if (settled) return;
+    // Deadline check FIRST: if the budget is spent, stop before another poll.
+    if (now() - startedAt >= opts.deadlineMs) {
+      settle({ done: true, timedOut: true, outcome: "timeout" });
+      return;
+    }
+    // Skip overlapping ticks — a slow poll step must not stack a second
+    // in-flight call on the next interval.
+    if (inFlight) return;
+
+    inFlight = true;
+    let result: PollStepResult;
+    try {
+      result = await opts.poll();
+    } catch {
+      // A throw from the injected step is treated as non-terminal: the
+      // sil-client wrapper already maps network errors to a retryable result,
+      // so this is belt-and-braces; let the next tick (within budget) retry.
+      result = { done: false };
+    } finally {
+      inFlight = false;
+    }
+
+    if (settled) return; // a concurrent stop() landed during the await.
+    if (result.done) settle(result);
+  };
+
+  timer = setInterval(() => void tick(), opts.intervalMs);
+
+  return {
+    stop(): void {
+      if (settled) return;
+      settled = true;
+      clearTimer();
+    },
+  };
+}

--- a/src/lib/sil-client.ts
+++ b/src/lib/sil-client.ts
@@ -1,0 +1,253 @@
+/**
+ * Typed HTTP wrappers for the two sil-web endpoints the plugin calls, each
+ * returning a DISCRIMINATED UNION over the documented outcomes so the status
+ * taxonomy lives in exactly one place and the caller switches on `kind` rather
+ * than re-deriving meaning from `res.status` at every site.
+ *
+ * Wire contract (pinned to the already-merged sil-web routes —
+ * sil-services/apps/sil-web/src/app/api/v1/...):
+ *
+ *   POST /api/v1/sessions/{id}/claim   body { code_verifier }
+ *     200 { access_token, refresh_token, user:{id} }  → success    (EXACTLY once)
+ *     200 { status: "pending" }                       → pending
+ *     409                                             → already_claimed
+ *     410                                             → expired
+ *     404                                             → not_found (wrong verifier
+ *                                                       ≡ unknown session, uniform)
+ *     5xx / network / abort                           → retryable
+ *
+ *   POST /api/v1/auth/refresh          body { refresh_token }
+ *     200 { access_token, refresh_token, ... }        → refreshed
+ *     401                                             → invalid_grant (terminal)
+ *     5xx / network / abort                           → retryable
+ *
+ * THE subtle correctness point (architect Risk "claim taxonomy mis-mapping"):
+ * 200-pending and 200-success are BOTH HTTP 200. `classifyClaimResponse` branches
+ * on the BODY SHAPE (both tokens present) — never on `res.ok` — so "keep polling"
+ * is never conflated with "success". A malformed/partial 200 falls to the SAFE
+ * non-terminal `pending` path, never to a false success that would persist a
+ * non-credential as tokens. The classifier is exported and pure so it can be
+ * unit-tested in isolation, since misclassifying two 200s is the highest-risk
+ * subtle bug in the whole flow.
+ *
+ * Tokens never appear in a log line here (mirrors sil-web's invariant) — they
+ * only travel inside the returned union variant.
+ *
+ * node:fetch (global) only; no dependency.
+ */
+
+import { getApiUrl } from "./config.js";
+import { readTokens, writeTokens } from "./credentials.js";
+
+/** Per-request timeout: a stalled endpoint (DNS hang, SYN drop) must not wedge
+ * a poll tick forever. Mirrors the 15s ceiling the klodi poller uses. */
+const REQUEST_TIMEOUT_MS = 15_000;
+
+/** The user identity sil-web returns inside a successful claim. */
+export interface ClaimedUser {
+  id: string;
+  name?: string;
+}
+
+/** Outcome of a single claim attempt (classified by status + body). */
+export type ClaimOutcome =
+  | {
+      kind: "success";
+      access_token: string;
+      refresh_token: string;
+      user: ClaimedUser;
+    }
+  | { kind: "pending" }
+  | { kind: "already_claimed" }
+  | { kind: "expired" }
+  | { kind: "not_found" }
+  | { kind: "retryable" };
+
+/** Outcome of a single refresh attempt. */
+export type RefreshOutcome =
+  | { kind: "refreshed"; access_token: string; refresh_token: string }
+  | { kind: "invalid_grant" }
+  | { kind: "retryable" };
+
+/**
+ * Classify a claim response from its HTTP status AND body. The discriminant for
+ * the two-200s split is the PRESENCE OF BOTH TOKENS in the body — never the
+ * status code. A 200 that is not a complete token pair is `pending` (the safe
+ * non-terminal landing); 409/410/404 are distinct terminals; 5xx is retryable.
+ *
+ * Pure and exported — this is the highest-risk subtle branch, unit-tested in
+ * isolation (sil-client.test.ts).
+ */
+export function classifyClaimResponse(status: number, body: unknown): ClaimOutcome {
+  if (status === 409) return { kind: "already_claimed" };
+  if (status === 410) return { kind: "expired" };
+  if (status === 404) return { kind: "not_found" };
+  if (status >= 500) return { kind: "retryable" };
+  if (status !== 200) {
+    // 400 (malformed request) or any other unexpected 4xx: terminal not_found
+    // (re-polling can't fix a bad request); surface a re-run hint, not a spin.
+    return { kind: "not_found" };
+  }
+
+  // 200 — classify by body shape. Both tokens required for a clean success;
+  // anything short of that is the safe non-terminal `pending`.
+  const obj = asRecord(body);
+  if (obj === null) return { kind: "pending" };
+  const accessToken = obj["access_token"];
+  const refreshToken = obj["refresh_token"];
+  if (typeof accessToken === "string" && typeof refreshToken === "string") {
+    return {
+      kind: "success",
+      access_token: accessToken,
+      refresh_token: refreshToken,
+      user: extractUser(obj["user"]),
+    };
+  }
+  return { kind: "pending" };
+}
+
+/**
+ * Classify a refresh response. 200 with both tokens → refreshed; 401 → terminal
+ * invalid_grant ("must re-register"); 5xx / other → retryable.
+ */
+export function classifyRefreshResponse(status: number, body: unknown): RefreshOutcome {
+  if (status === 401) return { kind: "invalid_grant" };
+  if (status >= 500) return { kind: "retryable" };
+  if (status !== 200) return { kind: "invalid_grant" };
+
+  const obj = asRecord(body);
+  const accessToken = obj?.["access_token"];
+  const refreshToken = obj?.["refresh_token"];
+  if (typeof accessToken === "string" && typeof refreshToken === "string") {
+    return { kind: "refreshed", access_token: accessToken, refresh_token: refreshToken };
+  }
+  return { kind: "retryable" };
+}
+
+/**
+ * Attempt to claim the token pair for `sessionId` with `verifier`. The verifier
+ * is sent in the body; sil-web derives the same challenge server-side and the
+ * CAS compares digest-to-digest (the plugin sends the verifier, not the digest).
+ * A network error / timeout maps to `retryable` so the poll budget governs.
+ */
+export async function claimSession(
+  apiUrl: string,
+  sessionId: string,
+  verifier: string,
+): Promise<ClaimOutcome> {
+  const url = `${stripTrailingSlash(apiUrl)}/api/v1/sessions/${sessionId}/claim`;
+  let res: Response;
+  try {
+    res = await postJson(url, { code_verifier: verifier });
+  } catch {
+    return { kind: "retryable" };
+  }
+  const body = await readJsonBody(res);
+  return classifyClaimResponse(res.status, body);
+}
+
+/**
+ * Refresh the bearer pair via sil-web (NEVER Auth0 directly — sil-web is the
+ * sole auth authority and the only holder of the Auth0 client secret).
+ */
+export async function refreshSession(
+  apiUrl: string,
+  refreshToken: string,
+): Promise<RefreshOutcome> {
+  const url = `${stripTrailingSlash(apiUrl)}/api/v1/auth/refresh`;
+  let res: Response;
+  try {
+    res = await postJson(url, { refresh_token: refreshToken });
+  } catch {
+    return { kind: "retryable" };
+  }
+  const body = await readJsonBody(res);
+  return classifyRefreshResponse(res.status, body);
+}
+
+/** Result of the high-level refresh orchestration (read → refresh → rotate). */
+export type RefreshStoredResult =
+  | { status: "refreshed" }
+  | { status: "must_reregister"; reason: "invalid_grant" | "no_stored_tokens" }
+  | { status: "retryable" };
+
+/**
+ * SC7/F7 entry point: read the stored refresh token, exchange it via sil-web,
+ * and rotate `tokens.json` with the new pair on success.
+ *
+ * Contacts ONLY the resolved `sil_api_url` origin — sil-web is the sole auth
+ * authority; the plugin never talks to Auth0 directly (sil-web holds the Auth0
+ * client secret). On a 401 the refresh token is dead: return a terminal
+ * "must re-register" signal and DO NOT rotate (a rejected refresh must never be
+ * presented as a fresh, valid pair). A 5xx / network blip is retryable.
+ */
+export async function refreshStoredTokens(): Promise<RefreshStoredResult> {
+  const stored = readTokens();
+  if (stored === null) {
+    return { status: "must_reregister", reason: "no_stored_tokens" };
+  }
+
+  const outcome = await refreshSession(getApiUrl(), stored.refresh_token);
+  switch (outcome.kind) {
+    case "refreshed":
+      await writeTokens({
+        access_token: outcome.access_token,
+        refresh_token: outcome.refresh_token,
+      });
+      return { status: "refreshed" };
+    case "invalid_grant":
+      return { status: "must_reregister", reason: "invalid_grant" };
+    case "retryable":
+      return { status: "retryable" };
+  }
+}
+
+/** Narrow the `user` field of a claim body to a typed identity. */
+function extractUser(raw: unknown): ClaimedUser {
+  const obj = asRecord(raw);
+  if (obj === null) return { id: "" };
+  const id = obj["id"];
+  const name = obj["name"];
+  return {
+    id: typeof id === "string" ? id : "",
+    ...(typeof name === "string" ? { name } : {}),
+  };
+}
+
+/** A non-null plain object, or null for anything else (incl. arrays/primitives). */
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+/** POST a JSON body with a hard per-request timeout (AbortController). */
+async function postJson(
+  url: string,
+  body: Record<string, unknown>,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    return await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function readJsonBody(res: Response): Promise<unknown> {
+  try {
+    return await res.json();
+  } catch {
+    return null;
+  }
+}
+
+function stripTrailingSlash(url: string): string {
+  return url.endsWith("/") ? url.slice(0, -1) : url;
+}

--- a/src/tools/identity.ts
+++ b/src/tools/identity.ts
@@ -1,0 +1,193 @@
+/**
+ * Identity tools for the sil plugin.
+ *
+ * `sil_register` is the real browser-based registration tool (the first tool to
+ * replace a stub). It follows the klodi register pattern, adapted to sil-web's
+ * PKCE contract and to this skeleton's constraints (no NATS, no system-event
+ * wake — the declared SDK has neither).
+ *
+ * `execute()` flow (ALL I/O lives here — `register()` opens nothing):
+ *   1. Already-registered short-circuit. If `tokens.json` exists, return
+ *      `{ status: "already_registered", user }` — mint nothing, poll nothing,
+ *      overwrite nothing. (Presence-based, not freshness-based: refresh is SC7.)
+ *   2. Mint PKCE in-process. session_id (UUID), verifier (base64url 32 bytes),
+ *      challenge = S256(verifier). The verifier is held ONLY in the poll step
+ *      closure below — it never touches disk.
+ *   3. Build the auth URL `<apiUrl>/authorize?session=<id>&code_challenge=<chal>`.
+ *      The plugin does NOT pre-POST to sil-web: the pending session row is
+ *      INSERTed server-side when the USER's browser opens this URL.
+ *   4. Start a fire-and-forget bounded poll of the claim endpoint, then return
+ *      promptly with `{ status: "awaiting_browser", auth_url, session_id }`.
+ *   5. On the poll's terminal success, persist tokens.json + config.json
+ *      atomically. Other terminals (expired / already_claimed / not_found /
+ *      timeout) persist nothing; the agent learns the outcome by re-calling
+ *      sil_register (→ already_registered) or sil_whoami.
+ *
+ * register() must stay synchronous and side-effect-free beyond registering the
+ * tool — no fetch, no timer, no unawaited promise here. The poll timer is armed
+ * inside execute(), never at register time.
+ */
+
+import type { PluginAPI } from "openclaw/plugin-sdk";
+import { Type } from "@sinclair/typebox";
+
+import { getApiUrl } from "../lib/config.js";
+import {
+  hasTokens,
+  readConfig,
+  writeConfig,
+  writeTokens,
+} from "../lib/credentials.js";
+import { deriveChallenge, newSessionId, newVerifier } from "../lib/pkce.js";
+import {
+  POLL_DEADLINE_MS,
+  POLL_INTERVAL_MS,
+  startPoll,
+  type PollDoneResult,
+} from "../lib/poller.js";
+import { claimSession, type ClaimOutcome } from "../lib/sil-client.js";
+import { jsonResult } from "../lib/tool-result.js";
+
+export function registerIdentityTools(api: PluginAPI): void {
+  registerRegister(api);
+}
+
+function registerRegister(api: PluginAPI): void {
+  api.registerTool({
+    name: "sil_register",
+    label: "Register on sil",
+    description:
+      "Start browser-based registration on sil. Returns an auth URL for the"
+      + " user to open in a browser. The plugin polls the session in the"
+      + " background until registration completes (then it stores credentials"
+      + " locally), the link expires, or the attempt times out. Call this tool"
+      + " again afterwards to confirm registration completed.",
+    parameters: Type.Object({}),
+    async execute() {
+      // 1 — already registered: short-circuit, no mint, no poll, no overwrite.
+      if (hasTokens()) {
+        const config = readConfig();
+        return jsonResult({
+          status: "already_registered",
+          user: config?.user ?? null,
+        });
+      }
+
+      // 2 — mint PKCE. The verifier stays in this closure (never on disk).
+      const sessionId = newSessionId();
+      const verifier = newVerifier();
+      const challenge = deriveChallenge(verifier);
+      const apiUrl = getApiUrl();
+
+      // 3 — build the auth URL. Opening it (by the user's browser) is what
+      // creates the pending session server-side; the plugin does not pre-POST.
+      const authUrl =
+        `${stripTrailingSlash(apiUrl)}/authorize`
+        + `?session=${sessionId}&code_challenge=${challenge}`;
+
+      // 4 — fire-and-forget bounded poll. Not awaited: execute() returns now.
+      // The poll step maps each claim outcome to the loop's done/continue
+      // signal AND performs persistence on success (so the atomic write
+      // completes inside the awaited tick, before onDone fires); the verifier
+      // is captured here and never leaves memory.
+      startPoll({
+        intervalMs: POLL_INTERVAL_MS,
+        deadlineMs: POLL_DEADLINE_MS,
+        poll: () => claimStep(apiUrl, sessionId, verifier),
+        onDone: (result) => handleDone(api, sessionId, result),
+      });
+
+      api.logger.info("sil_register_started", { session_id: sessionId });
+
+      return jsonResult({
+        status: "awaiting_browser",
+        message: `Open this URL in a browser to register: ${authUrl}`,
+        auth_url: authUrl,
+        session_id: sessionId,
+        instructions:
+          "Share the auth URL with the user. The plugin is polling in the"
+          + " background — once the user finishes signing in, call sil_register"
+          + " again to confirm (it will report already_registered).",
+      });
+    },
+  });
+}
+
+/** The terminal step shape carried through the poller to `onDone`. */
+interface ClaimStep extends Record<string, unknown> {
+  done: boolean;
+  outcome?: ClaimOutcome["kind"];
+  user_id?: string;
+}
+
+/**
+ * One poll step: claim, then map the outcome to the loop's done/continue signal.
+ * `pending`/`retryable` keep the loop alive (`done:false`). A successful claim
+ * is persisted HERE — tokens.json + config.json written atomically inside this
+ * awaited tick — so the files are on disk before the loop settles; the step then
+ * carries only the user_id forward (the tokens never travel past this closure).
+ * Other terminals (expired / already_claimed / not_found) persist nothing.
+ */
+async function claimStep(
+  apiUrl: string,
+  sessionId: string,
+  verifier: string,
+): Promise<ClaimStep> {
+  const outcome: ClaimOutcome = await claimSession(apiUrl, sessionId, verifier);
+  switch (outcome.kind) {
+    case "pending":
+    case "retryable":
+      return { done: false };
+    case "success":
+      await writeTokens({
+        access_token: outcome.access_token,
+        refresh_token: outcome.refresh_token,
+      });
+      await writeConfig({ user: outcome.user });
+      return { done: true, outcome: "success", user_id: outcome.user.id };
+    case "expired":
+    case "already_claimed":
+    case "not_found":
+      return { done: true, outcome: outcome.kind };
+  }
+}
+
+/**
+ * Record a structured log on every terminal so no outcome is silent. Tokens are
+ * already persisted (in `claimStep`) and are NEVER logged — the success case
+ * logs only the user id.
+ */
+function handleDone(
+  api: PluginAPI,
+  sessionId: string,
+  result: PollDoneResult,
+): void {
+  const step = result as ClaimStep;
+
+  if (step.outcome === "success") {
+    api.logger.info("sil_register_claimed", {
+      session_id: sessionId,
+      user_id: typeof step.user_id === "string" ? step.user_id : "",
+    });
+    return;
+  }
+
+  if ("timedOut" in step && step.timedOut === true) {
+    api.logger.info("sil_register_timeout", { session_id: sessionId });
+    return;
+  }
+
+  // expired / already_claimed / not_found — log the terminal so the outcome is
+  // never silent; the agent learns it on its next sil_register / sil_whoami.
+  const outcome = typeof step.outcome === "string" ? step.outcome : "unknown";
+  const marker = `sil_register_${outcome}`;
+  if (outcome === "not_found") {
+    api.logger.warn(marker, { session_id: sessionId });
+  } else {
+    api.logger.info(marker, { session_id: sessionId });
+  }
+}
+
+function stripTrailingSlash(url: string): string {
+  return url.endsWith("/") ? url.slice(0, -1) : url;
+}


### PR DESCRIPTION
## Card
`cards/sil-register-tool.md` (lives in the `card/sil-register-tool` branch — see the body for full intent + handoffs). Epic `identity-plugin-tools`, origin `goal:identity-onboarding-slice`.

## Summary
First real OpenClaw tool replacing the stub pattern: `sil_register` runs the browser-based PKCE onboarding flow against sil-web.

- **`execute()` flow:** already-registered short-circuit (`tokens.json` present → `already_registered`, no mint/poll/overwrite) → mint PKCE (`session_id`, in-memory `verifier`, S256 `challenge`) → build `<sil_api_url>/authorize?session=<id>&code_challenge=<challenge>` → start a fire-and-forget bounded poll of `POST /api/v1/sessions/<id>/claim` → return promptly with `{ status: "awaiting_browser", auth_url, session_id }`.
- **Claim taxonomy:** branches on body shape (`access_token` presence), not `res.ok` — 200-pending and 200-success are both HTTP 200. 200-success → persist `tokens.json` + `config.json` (atomic temp+rename, `0600`) once and stop; 200-pending → keep polling; 409/410/404 → distinct terminals; 5xx/network → retry within budget; deadline (≤ 30-min session TTL) → terminal timeout. No timer ever leaks.
- **SC7 refresh:** `refreshStoredTokens()` exchanges the stored refresh token via sil-web **only** (never Auth0), rotates `tokens.json` on 200, returns must-re-register on 401.
- **Invariants:** `register()` stays synchronous and opens nothing (poll timer + I/O confined to `execute()`); the PKCE verifier never touches disk; tokens never logged. No new npm deps (`node:crypto`).
- **3-step tool-add:** registered in `registerIdentityTools` → wired into `register()` → `sil_register` in `contracts.tools`. `security` disclosure block updated to be truthful (network endpoint, credentials on disk, in-execute timer).

New modules: `src/lib/pkce.ts`, `src/lib/credentials.ts`, `src/lib/sil-client.ts`, `src/lib/poller.ts`, `src/tools/identity.ts`.

## Acceptance criteria (from the card)
- [x] **SC1/F1** PKCE + auth URL of the exact form; S256 43-char base64url digest (pinned to sil-web's shared RFC 7636 vector).
- [x] **SC1/F1** host override resolves pluginConfig → env → default.
- [x] **F1** prompt non-blocking return (`awaiting_browser`); fresh session per call.
- [x] **SC4/F3/F4** claim lifecycle: 200-success once + persist, 200-pending keeps polling, 409/410/404 terminal, 5xx/network retry, budget-exhaustion timeout with no leftover timer.
- [x] **F4** credential storage: `tokens.json` + `config.json` in the data dir, `0600`, first-run dir creation; verifier never on disk.
- [x] **F1** already-registered idempotency (no fetch, no timer, no overwrite, no auth_url).
- [x] **SC8 (in-repo)** two data dirs → independent token pairs.
- [x] **SC7/F7** refresh via sil-web only (Auth0 never contacted), rotates tokens, 401 terminal.
- [ ] **[e2e]** two real instances vs live sil-web + Postgres — DEFERRED to the sil-stage golden example (goal SC9), out of scope for this repo.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean (emits `dist/index.js`)
- [x] `pnpm test` — 155/155 green (61 unit incl. token-leak canary, 15 integration; 6 new test files). RED-authored by qa-developer, taken GREEN by expert-developer.
- [x] `plugin-load.integration.test.ts` loads the compiled `dist/index.js` real `register()`; `index.test.ts` install-hang guard confirms no timer/fetch at register time.

## Distillation target
Knowledge capture happens **after Review PASS** in the `distilling` stage — `solutions-architect` runs in this same worktree, commits to this same branch, and pushes here so the PR ends up containing implementation + tests + distillation in one mergeable unit. Likely captures: the PKCE cross-repo derivation contract, the 200-pending-vs-200-success taxonomy, the data-dir resolution convention, and the async-signature-over-sync-fs rationale.