### PR TITLE
bug: sil_whoami reads identity via GET /identity (verb fix)

### DIFF
--- a/docs/knowledge/INDEX.md
+++ b/docs/knowledge/INDEX.md
@@ -6,7 +6,7 @@ Sorted by `updated_at` descending (newest first). One row per doc in this folder
 
 | ID | Title | Tags | Updated |
 |---|---|---|---|
-| [[sil-api-identity-contract]] | sil-api identity read — contract, request gotchas, latent dependency | sil-api, identity, jwt, cross-sibling, blocked-on | 2026-06-08 |
+| [[sil-api-identity-contract]] | sil-api identity read — GET /identity contract, request gotchas, deferred e2e | sil-api, identity, jwt, cross-sibling, e2e | 2026-06-08 |
 | [[sil-response-classification]] | Classify sil responses on body shape, not HTTP status | sil-api, sil-web, http, classification, false-green | 2026-06-08 |
 
 See [`../README.md`](../README.md) for the docs convention.

--- a/docs/knowledge/sil-api-identity-contract.md
+++ b/docs/knowledge/sil-api-identity-contract.md
@@ -1,23 +1,23 @@
 ---
 id: sil-api-identity-contract
-title: sil-api identity read — contract, request gotchas, and the latent cross-sibling dependency
-tags: [sil-api, identity, jwt, contract, cross-sibling, blocked-on, e2e]
+title: sil-api identity read — GET /identity contract, request gotchas, and the deferred cross-service e2e
+tags: [sil-api, identity, jwt, contract, cross-sibling, e2e]
 card: sil-whoami-tool
-commit: a635103
+commit: c6b18f7
 updated_at: 2026-06-08
-updated_by_card: sil-whoami-tool
+updated_by_card: sil-identity-read-verb-fix
 ---
 
-The plugin codes `sil_whoami` against an **agreed but not-yet-live** sil-api identity-read contract: the live happy path (real PII over the wire) is **blocked on a sil-services follow-on**, while the entire plugin-side behavior is built and proven today against a mocked sil-api boundary.
+The plugin reads `sil_whoami` against a **live, merged** sil-api identity-read contract: the real authenticated self-read (`GET /identity`, sil-api PR #7) returns the user's real `{name, addresses}`, and the entire plugin-side behavior is built and proven against a mocked sil-api boundary mirroring it.
 
 ## The contract the plugin consumes
 
-`fetchIdentity` (`src/lib/sil-client.ts:260`) issues:
+`fetchIdentity` (`src/lib/sil-client.ts:270`) issues:
 
 ```
-POST <sil_api_base>/identity          (bare path, NOT /api/v1 — that prefix is sil-web's)
+GET <sil_api_base>/identity           (bare path, NOT /api/v1 — that prefix is sil-web's)
 Authorization: Bearer <stored access_token>
-body: { agent_id: "sil-openclaw" }    (sil-api's SimplifiedAgentRequest)
+(no request body — the GET self-read derives its principal from the JWT `sub`)
 ```
 
 Expected responses (classified by [[sil-response-classification]]):
@@ -27,24 +27,21 @@ Expected responses (classified by [[sil-response-classification]]):
 | `200` UCP envelope `{ result: { name, addresses } }` | authenticated user's identity | unwrap `result`, return identity |
 | `401` | access token expired/invalid | **refresh once via sil-web, retry once** (the only refresh trigger) |
 | `403` `{error: user_not_provisioned}` | the human isn't onboarded | terminal; hint "complete onboarding / run sil_register" — **never refresh** |
-| `403` `{error: principal_mismatch}` | our request bug (should not occur) | terminal distinct error — **never refresh** |
+| `403` `{error: principal_mismatch}` | structurally unreachable now (the bodyless GET sends no `on_behalf_of`); classifier still maps it | terminal distinct error — **never refresh** |
 | `5xx` / network / abort | transient | retryable outcome |
 
 ## Non-obvious request gotchas (these bite if you get them wrong)
 
-- **`agent_id` is required** (`SimplifiedAgentRequest`, 1..200 chars). A constant `AGENT_ID = "sil-openclaw"` (`sil-client.ts:67`) — this plugin *is* the agent. A per-deployment `sil_agent_id` config key is YAGNI until per-deployment identity is actually wanted.
-- **OMIT `on_behalf_of`.** sil-api's JWT middleware returns `403 principal_mismatch` when a request body's `on_behalf_of` ≠ the token `sub`. By omitting it, the JWT `sub` *is* the principal — exactly whoami's contract ("the user this token resolves to"). Sending a mismatching `on_behalf_of` is a **guaranteed 403**.
+- **Send NO body on the GET.** The self-read derives its principal from the JWT `sub` (the Bearer header), not a request body — the route declares only a `response` schema (`handlers/identity.ts`). A GET body is at best ignored and in strict fetch environments throws, so `getJson` (`sil-client.ts:415`) sends no `content-type` and no body. This *eliminates* the `403 principal_mismatch` path entirely: with no body there is no `on_behalf_of` to mismatch the token `sub`, so the principal is unambiguously the token subject — exactly whoami's contract ("the user this token resolves to"). (The earlier POST-stub call sent `{ agent_id }`; that `AGENT_ID` constant is now removed.)
 - **401 is refreshable; 403 is not.** Refreshing a valid-but-unprovisioned token (403) changes nothing — only 401 (expired/invalid token) reaches the refresh path. Conflating "any 4xx → refresh" wastes a rotation and still fails.
 
-## The latent cross-sibling dependency (single source of truth)
+## The cross-sibling read — now live (the POST→GET pivot landed)
 
-> sil-api's `/identity` is currently a **POST stub** (`services/sil-api/src/handlers/identity.ts`) returning `{kind, verified, subject, attributes, note}` — no name, no addresses, ignores `req.user`. The real `{name, addresses}` payload **does not exist yet**.
+> sil-api's real authenticated self-read shipped as **`GET /identity`** (PR #7, `services/sil-api/src/handlers/identity.ts`): it derives the user from `req.user` (the JWT-decorated `UserRow`), loads their addresses, and returns `{ id, name, addresses }` enveloped under `result`. `POST /identity` stays the **agent enrich-stub** (`{kind, verified, subject, attributes, note}`, no name) — it serves the other domains' uniform shape, it was never the identity read.
 
-The sil-services **follow-on** must change **only the `result` payload** of the existing `POST /identity` (stub → real `{name, addresses}` derived from `req.user.name` + an addresses-by-`user.id` query — both already typed in `@sil/db` as `UserRow`/`AddressRow`). The verb/path/auth/envelope stay stable, so the plugin already codes against them. (If the follow-on instead introduces a `GET /me`, it's a one-line pivot in `fetchIdentity` + the mock — a known, cheap change, not a surprise.)
+This is exactly the pivot the `sil_whoami` card anticipated as "a one-line pivot in `fetchIdentity` + the mock if the follow-on introduces a `GET`." It has now happened: `fetchIdentity` (`sil-client.ts:270`) issues the bodyless GET, and the [[sil-response-classification]] gate moved with it (empty `addresses: []` is now a valid identity, gated by `name`). The plugin-side read is **no longer latent** — it codes against a merged contract.
 
-**Two things are blocked on this follow-on:**
-1. The live `sil_whoami` happy path returning real PII (works today only against the mocked boundary).
-2. The full cross-service **e2e** — owned by sil-stage's golden example (**goal SC9**): real PKCE → onboarding → claim → `sil_whoami` returns the user's real `{name, addresses}` against a live sil-api + Postgres. Not provable in this repo (no live sil-api/Postgres here); the strict [[sil-response-classification]] gate is what keeps the in-repo suite honest until then.
+**Still deferred — the cross-service e2e, NOT the plugin read:** the full cross-service **e2e** is owned by sil-stage's golden example (**goal SC9**): real PKCE → onboarding → claim → `sil_whoami` returns the user's real `{name, addresses}` against a live sil-api + Postgres. Not provable in this repo (no live sil-api/Postgres here); the strict [[sil-response-classification]] gate is what keeps the in-repo suite honest until then.
 
 ## Why this is safe to ship now
 

--- a/docs/knowledge/sil-response-classification.md
+++ b/docs/knowledge/sil-response-classification.md
@@ -3,9 +3,9 @@ id: sil-response-classification
 title: Classify sil responses on body shape, not HTTP status (and never on res.ok)
 tags: [sil-api, sil-web, http, classification, gotcha, false-green]
 card: sil-whoami-tool
-commit: a635103
+commit: c6b18f7
 updated_at: 2026-06-08
-updated_by_card: sil-whoami-tool
+updated_by_card: sil-identity-read-verb-fix
 ---
 
 Every sil HTTP response is classified by a **pure, exported, unit-tested classifier** that branches on HTTP status **and, for `200`, the response body shape** — never on `res.ok`. This exists because sil returns semantically-distinct outcomes under the *same* HTTP status, so the status code alone is not enough to decide what happened.
@@ -16,16 +16,18 @@ The classifiers all live in `src/lib/sil-client.ts`: `classifyClaimResponse`, `c
 
 1. **Claim: `200`-pending vs `200`-success.** `POST /api/v1/sessions/{id}/claim` returns HTTP `200` both while the browser leg is still in progress (`{status:"pending"}`) and when the tokens are ready (`{access_token, refresh_token, user}`). The discriminant is **the presence of both tokens in the body** (`classifyClaimResponse`, `sil-client.ts:136`) — *not* the status. A malformed/partial `200` falls to the **safe non-terminal** `pending`, never to a false `success` that would persist a non-credential as tokens.
 
-2. **Identity: anti-false-green `200`.** `POST /identity` returns HTTP `200`, but the real `{name, addresses}` payload is **latent on a sil-services follow-on** — sil-api's `/identity` is still a stub returning `{kind, verified, subject, attributes, note}` (no name, no addresses). `extractIdentity` (`sil-client.ts:325`) requires **both** a non-empty `name` AND a non-empty `addresses` array; any `200` that yields no usable identity (the current stub shape, or a partial/garbage `200`) classifies as `retryable`, **never `ok`**. This is the load-bearing guard: **the test suite cannot go green while `sil_whoami` returns the stub shape** — i.e. it cannot false-green while the product promise (real PII over the wire) is unmet. See [[sil-api-identity-contract]].
+2. **Identity: anti-false-green `200`.** The authenticated self-read is **`GET /identity`** (a bodyless GET — `fetchIdentity`, `sil-client.ts:270`), which returns HTTP `200` with the real `{name, addresses}` payload. The discriminant is the **non-empty `name`**: `extractIdentity` (`sil-client.ts:340`) requires a non-empty `name` string AND that `addresses` is an **array** (which **may be empty** — `addresses: []` is a real, authenticated identity for a user who onboarded a name but no address; see below). Any `200` that yields no usable `name` — sil-api's *enrich-stub* shape `{kind, verified, subject, attributes, note}` that `POST /identity` still returns (no name), or a partial/garbage `200` — classifies as `retryable`, **never `ok`**. This is the load-bearing guard: **the test suite cannot go green while `sil_whoami` reads the stub shape** — i.e. it cannot false-green while the product promise (real PII over the wire) is unmet. The verb is itself load-bearing: POST hits the enrich-stub (no name), GET hits the real self-read. See [[sil-api-identity-contract]].
 
 ## Why `res.ok` is banned
 
-`res.ok` is true for the entire `2xx` range and tells you nothing about *which* `200` you got. Branching on it would conflate "keep polling" with "success" (claim) and "stub placeholder" with "real identity" (identity) — the two highest-risk subtle bugs in the flow. The classifier unit tests are **mutation-verified**: forcing `classifyIdentityResponse` to accept any `200` as `ok` turns exactly 6 tests red (`identity-classify.test.ts`), so the guard demonstrably bites rather than coincidentally passing.
+`res.ok` is true for the entire `2xx` range and tells you nothing about *which* `200` you got. Branching on it would conflate "keep polling" with "success" (claim) and "stub placeholder" with "real identity" (identity) — the two highest-risk subtle bugs in the flow. The classifier unit tests are **mutation-verified**: forcing `extractIdentity` to accept any `200` as `ok` (drop the non-empty-`name` and `Array.isArray` gates) turns **7 tests red** in `identity-classify.test.ts`, so the guard demonstrably bites rather than coincidentally passing.
 
 ## When you add a new sil call
 
 Write a pure `classifyXResponse(status, body)` returning a discriminated union, export it, unit-test it in isolation (especially every `200` sub-case), and have the `fetchX` wrapper delegate to it. Map network errors / timeouts / aborts to the union's `retryable` variant — never let them throw past the wrapper.
 
-## Known open edge (identity)
+## Empty-addresses: a valid identity, gated by `name` (resolved)
 
-`extractIdentity` rejecting `addresses.length === 0` means a real authenticated user with a valid `name` but **zero addresses** currently classifies `retryable` ("temporarily unavailable") — a non-transient state mislabelled transient. This is **accepted for now**: no real user can reach it until the sil-api identity-read ships (the path is latent), and the acceptance criteria ("at least their name and addresses") never pinned the empty case. When the real read lands, the architect/PO decides whether name + empty-addresses is a valid identity; if yes, relax the `addresses.length === 0` reject in `extractIdentity` and add the test. Tracked in [[sil-api-identity-contract]].
+A real authenticated user with a valid `name` but **zero addresses** classifies **`ok`**, not `retryable`. `addresses` is a list that is legitimately empty for someone who has onboarded a name but not yet added an address; sil-api returns `addresses: []` for exactly that user (`handlers/identity.ts` → `buildIdentityReadResult`), and telling them "temporarily unavailable, try again" would strand them on a false transient they could never escape by retrying.
+
+So `extractIdentity` (`sil-client.ts:340`) requires `name` to be a non-empty string and `addresses` to be an **array**, but **does not** require the array to be non-empty. The relax is surgical — it is *only* the empty array that newly passes: an **absent** or **non-array** `addresses` is still rejected (`Array.isArray(undefined) === false`), and a missing/empty `name` is still rejected. The `name` gate is what keeps the anti-false-green guard biting — the enrich-stub shape has no `name`, so it still → `retryable`. (This edge was deferred on [[sil-api-identity-contract]] while the real read was latent; it is now resolved — name + empty-addresses is a valid identity.)

--- a/src/__tests__/lib/identity-classify.test.ts
+++ b/src/__tests__/lib/identity-classify.test.ts
@@ -78,6 +78,18 @@ const STUB_BODY = {
   note: "stub",
 };
 
+/** sil-api returns addresses in its `AddressWire` shape (`street_address`,
+ * `address_locality`, `postal_code`, `address_country`, … — sil-services
+ * `packages/schemas/src/identity.ts`), NOT the `IdentityAddress` hint fields
+ * (`line1`/`city`/…). The classifier must pass addresses through OPAQUE — never
+ * remap fields, which would silently drop real address data. */
+const WIRE_ADDRESS = {
+  street_address: "12 Analytical Engine Way",
+  address_locality: "London",
+  postal_code: "EC1A 1AA",
+  address_country: "GB",
+};
+
 describe("classifyIdentityResponse — status taxonomy (the auth branch)", () => {
   it("200 with a real identity body → ok (carries the identity)", () => {
     const out = classifyIdentityResponse(200, REAL_IDENTITY);
@@ -86,6 +98,26 @@ describe("classifyIdentityResponse — status taxonomy (the auth branch)", () =>
       expect(out.identity.name).toBe("Ada Lovelace");
       expect(Array.isArray(out.identity.addresses)).toBe(true);
       expect(out.identity.addresses.length).toBe(1);
+    }
+  });
+
+  it("200 with a non-empty addresses array → ok, addresses pass through OPAQUE (AddressWire fields preserved, not remapped)", () => {
+    // Acceptance criterion: addresses are passed through opaquely — the sil-api
+    // `AddressWire` field names survive verbatim. A classifier that remapped to
+    // `line1`/`city`/… would drop these and this assertion catches it.
+    const out = classifyIdentityResponse(200, {
+      name: "Ada Lovelace",
+      addresses: [WIRE_ADDRESS],
+    });
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      expect(out.identity.addresses).toHaveLength(1);
+      const addr = out.identity.addresses[0] as Record<string, unknown>;
+      // The wire field names are preserved verbatim (opaque passthrough).
+      expect(addr["street_address"]).toBe("12 Analytical Engine Way");
+      expect(addr["address_locality"]).toBe("London");
+      expect(addr["postal_code"]).toBe("EC1A 1AA");
+      expect(addr["address_country"]).toBe("GB");
     }
   });
 
@@ -169,18 +201,64 @@ describe("classifyIdentityResponse — the anti-false-green body gate on 200", (
     expect(out.kind).not.toBe("ok");
   });
 
-  it("200 with a name but NO addresses is NOT ok (both fields are required)", () => {
-    // The product promise is name AND addresses; a half-identity must not pass
-    // as a clean read.
+  it("200 with a name and an EMPTY addresses array → ok (empty address list is a valid identity)", () => {
+    // THE forced product decision for this card (was deferred on the sil-whoami
+    // card; sil-api PR #7 makes it concrete by returning `addresses: []` for a
+    // provisioned, address-less user). A valid `name` with zero addresses IS a
+    // usable identity — telling that user "temporarily unavailable, try again"
+    // is a false-transient dead-end they can never escape by retrying.
+    //
+    // EXPECT RED against the pre-fix `extractIdentity` (which rejects
+    // `addresses.length === 0`); GREEN only after that reject is removed.
+    const out = classifyIdentityResponse(200, { name: "Ada Lovelace", addresses: [] });
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      expect(out.identity.name).toBe("Ada Lovelace");
+      expect(Array.isArray(out.identity.addresses)).toBe(true);
+      expect(out.identity.addresses).toHaveLength(0);
+    }
+  });
+
+  it("200 with a name and an empty addresses array wrapped in an envelope `result` → ok", () => {
+    // The same relax through the UCP-envelope unwrap path — the real sil-api
+    // `GET /identity` returns `{ result: { id, name, addresses: [] } }`.
+    const out = classifyIdentityResponse(200, {
+      protocol: "ucp",
+      version: "0.1",
+      domain: "identity",
+      result: { id: "u_1", name: "Ada Lovelace", addresses: [] },
+    });
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      expect(out.identity.name).toBe("Ada Lovelace");
+      expect(out.identity.addresses).toHaveLength(0);
+    }
+  });
+
+  it("200 with a name but a MISSING `addresses` field is NOT ok (addresses must be an array)", () => {
+    // The relax is `addresses` may be EMPTY, NOT absent: a body with no
+    // `addresses` key at all is a malformed/partial read (the GET self-read
+    // always populates `addresses`, even to `[]`), so it stays `retryable`. This
+    // keeps the gate from sliding from "empty array OK" to "any name-only body OK".
     const out = classifyIdentityResponse(200, { name: "Ada Lovelace" });
     expect(out.kind).not.toBe("ok");
   });
 
-  it("200 with addresses but NO name is NOT ok", () => {
-    const out = classifyIdentityResponse(200, {
-      addresses: [{ line1: "x" }],
-    });
-    expect(out.kind).not.toBe("ok");
+  it("200 with a name but a NON-ARRAY `addresses` (e.g. null / object / string) is NOT ok", () => {
+    // The `Array.isArray` half of the gate stays: a non-array `addresses` is a
+    // malformed body, not an empty list. Only a genuine empty ARRAY is relaxed.
+    expect(classifyIdentityResponse(200, { name: "Ada", addresses: null }).kind).not.toBe("ok");
+    expect(classifyIdentityResponse(200, { name: "Ada", addresses: {} }).kind).not.toBe("ok");
+    expect(classifyIdentityResponse(200, { name: "Ada", addresses: "nope" }).kind).not.toBe("ok");
+  });
+
+  it("200 with addresses but NO name is NOT ok (the name gate is non-negotiable)", () => {
+    // The `name` requirement is the load-bearing anti-false-green guard and
+    // survives the relax unchanged — a body with addresses but no name (and the
+    // empty-array case below) must still be `retryable`, never `ok`.
+    expect(classifyIdentityResponse(200, { addresses: [{ line1: "x" }] }).kind).not.toBe("ok");
+    expect(classifyIdentityResponse(200, { addresses: [] }).kind).not.toBe("ok");
+    expect(classifyIdentityResponse(200, { name: "", addresses: [] }).kind).not.toBe("ok");
   });
 
   it("200 with an empty / null / non-object body is NOT ok (defensive)", () => {

--- a/src/__tests__/whoami.integration.test.ts
+++ b/src/__tests__/whoami.integration.test.ts
@@ -98,8 +98,17 @@ interface StoredTokens {
 /** One recorded outbound request. */
 interface Recorded {
   url: string;
+  /** The HTTP verb fetch was called with (defaults to "GET" when init omits it,
+   * mirroring the fetch spec). Recorded so the identity-read verb is assertable:
+   * the bug is the read using POST; the fix is GET-with-no-body. */
+  method: string;
   bearer: string | null;
+  /** The parsed request body, or null when none was sent. A correct identity GET
+   * carries NO body; the buggy POST carried `{ agent_id }`. */
   body: unknown;
+  /** Whether a request body was present AT ALL (distinct from a body that parses
+   * to null) — a GET must send no body, asserted independently of its content. */
+  hasBody: boolean;
 }
 
 type Reply = { status: number; body: unknown } | "network-error";
@@ -133,6 +142,10 @@ function installRouter(
         headers["Authorization"] ??
         headers["authorization"] ??
         null;
+      // The fetch spec defaults a method-less request to GET; mirror that so an
+      // implementation that passes no `method` reads as GET, not undefined.
+      const method = (init?.method ?? "GET").toUpperCase();
+      const hasBody = init?.body !== undefined && init?.body !== null;
       let body: unknown = null;
       if (typeof init?.body === "string") {
         try {
@@ -141,7 +154,7 @@ function installRouter(
           body = init.body;
         }
       }
-      const req: Recorded = { url, bearer, body };
+      const req: Recorded = { url, method, bearer, body, hasBody };
       all.push(req);
 
       let kind: "identity" | "refresh" | "other";
@@ -258,6 +271,17 @@ describe("sil_whoami — happy path (valid access token)", () => {
     expect(blob).not.toContain("\"kind\"");
     expect(blob).not.toContain("\"verified\"");
     expect(blob).not.toContain("\"note\"");
+
+    // The founder's reported bug, closed at the TOOL level: the full result
+    // envelope is `{ status: "ok", identity: { name, addresses } }` — NOT the
+    // `retryable` the bug produced. Assert the structured shape, not just markers.
+    expect(payload["status"]).toBe("ok");
+    expect(payload["status"]).not.toBe("retryable");
+    const identity = payload["identity"] as { name?: unknown; addresses?: unknown };
+    expect(identity).toBeDefined();
+    expect(identity.name).toBe("Ada Lovelace");
+    expect(Array.isArray(identity.addresses)).toBe(true);
+    expect((identity.addresses as unknown[]).length).toBe(1);
   });
 
   it("calls sil-api with Authorization: Bearer <stored access token>", async () => {
@@ -274,6 +298,46 @@ describe("sil_whoami — happy path (valid access token)", () => {
 
     expect(rec.identity.length).toBe(1);
     expect(bearerToken(rec.identity[0]!)).toBe("the-stored-access-token");
+  });
+
+  it("reads identity with HTTP GET and sends NO request body (the verb fix)", async () => {
+    // THE LOAD-BEARING RED for this card. The bug: fetchIdentity POSTs to
+    // <sil-api>/identity (the unauthenticated enrich STUB, which carries no
+    // `name`), instead of GET-ing the real authenticated self-read (sil-api PR
+    // #7, which derives the user from the JWT `req.user` and takes NO body).
+    //
+    // The pre-existing router routed on `url.includes("/identity")` and never
+    // inspected `init.method`, so a POST and a GET were indistinguishable to it
+    // — the suite stayed GREEN against the buggy POST AND would stay green if
+    // the dev broke the verb. This assertion is the ONLY in-repo signal for the
+    // bug class (the true cross-service proof is sil-stage's e2e, SC9, deferred).
+    //
+    // EXPECT THIS TEST RED against current code (tool sends POST + `{agent_id}`)
+    // and GREEN only after fetchIdentity switches POST→GET with no body.
+    seedTokens("valid-at", "valid-rt");
+    const rec = installRouter((kind) =>
+      kind === "identity"
+        ? { status: 200, body: identityEnvelope() }
+        : { status: 500, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+
+    await getTool(api, TOOL).execute("c1", {});
+
+    expect(rec.identity.length).toBe(1);
+    const req = rec.identity[0]!;
+    // The verb is GET — the real self-read route, not the POST enrich stub.
+    expect(req.method).toBe("GET");
+    // And no request body at all: the GET derives the principal from the JWT;
+    // a GET-with-a-body is at best ignored, at worst a runtime error in strict
+    // environments. This asserts the absence of the body INDEPENDENTLY of its
+    // content (a parsed-null body and a never-sent body are different things).
+    expect(req.hasBody).toBe(false);
+    expect(req.body).toBeNull();
+    // Specifically: the stale POST payload `{ agent_id }` is gone — a "POST body
+    // adapted to a GET" would still carry agent_id and is also wrong.
+    expect(JSON.stringify(req.body ?? {})).not.toContain("agent_id");
   });
 
   it("targets the resolved sil-api origin (sil_api_base), not sil-web, not a hardcoded host", async () => {
@@ -342,6 +406,15 @@ describe("sil_whoami — transparent refresh (expired access, valid refresh)", (
     expect((rec.refresh[0]!.body as { refresh_token?: string }).refresh_token).toBe("valid-rt");
     // The RETRY carried the NEW access token (proves re-read after rotation).
     expect(bearerToken(rec.identity[1]!)).toBe("rotated-at");
+    // The taxonomy holds against the NEW request shape: BOTH identity reads —
+    // the initial AND the retry-after-refresh — are bodyless GETs (the verb fix
+    // must not regress the refresh-retry path back to a POST). The refresh leg
+    // (sil-web) stays a POST with a body, as its own contract requires.
+    for (const r of rec.identity) {
+      expect(r.method).toBe("GET");
+      expect(r.hasBody).toBe(false);
+    }
+    expect(rec.refresh[0]!.method).toBe("POST");
     // tokens.json now holds the rotated pair (old expired token is gone).
     const tokens = readTokens();
     expect(tokens!.access_token).toBe("rotated-at");
@@ -461,6 +534,11 @@ describe("sil_whoami — 403 forbidden is terminal (NEVER refreshed)", () => {
     // NO refresh on a 403 (the load-bearing assertion), and exactly one read.
     expect(rec.refresh.length).toBe(0);
     expect(rec.identity.length).toBe(1);
+    // The 403-terminal split is exercised against the NEW request shape: the
+    // read that produced the 403 was a bodyless GET (the verb fix must not
+    // perturb the 401-vs-403 taxonomy).
+    expect(rec.identity[0]!.method).toBe("GET");
+    expect(rec.identity[0]!.hasBody).toBe(false);
     // Surfaces a terminal, actionable outcome — not a success, not a transient
     // "try again" (a 403 won't fix itself on retry), not a silent empty.
     expect(payload["name"]).toBeUndefined();
@@ -546,6 +624,11 @@ describe("sil_whoami — transient failure (network / 5xx, distinguished from te
     expect(rec.refresh.length).toBe(0);
     // Tokens are NOT cleared on a transient (the token may be fine).
     expect(readTokens()).not.toBeNull();
+    // The transient path is bound to the NEW request shape: the read that hit
+    // the 5xx was a bodyless GET.
+    expect(rec.identity.length).toBe(1);
+    expect(rec.identity[0]!.method).toBe("GET");
+    expect(rec.identity[0]!.hasBody).toBe(false);
   });
 
   it("a network error (thrown fetch) on the identity read → retryable, not terminal", async () => {
@@ -560,6 +643,11 @@ describe("sil_whoami — transient failure (network / 5xx, distinguished from te
     expect(blob).toMatch(/retry|try.again|temporar|transient|network|later/);
     expect(rec.refresh.length).toBe(0);
     expect(readTokens()).not.toBeNull();
+    // The thrown-fetch path is bound to the NEW request shape: the attempted
+    // read (recorded before the throw) was a bodyless GET.
+    expect(rec.identity.length).toBe(1);
+    expect(rec.identity[0]!.method).toBe("GET");
+    expect(rec.identity[0]!.hasBody).toBe(false);
   });
 });
 
@@ -618,5 +706,20 @@ describe("sil_whoami — rotated tokens never leak to logs or the result", () =>
     const onDisk = JSON.parse(readFileSync(getTokensPath(), "utf8")) as StoredTokens;
     expect(onDisk.access_token).toBe(ROT_AT);
     expect(bearerToken(rec.identity[1]!)).toBe(ROT_AT);
+
+    // Hygiene asserted against the NEW GET request shape: the credential travels
+    // ONLY in the Authorization header, never in a request body. Both identity
+    // reads are bodyless GETs, and no recorded identity request body carries any
+    // token (the bug's POST body would have been a new exfil surface to audit;
+    // a bodyless GET removes it entirely).
+    for (const r of rec.identity) {
+      expect(r.method).toBe("GET");
+      expect(r.hasBody).toBe(false);
+      const reqBodyBlob = JSON.stringify(r.body ?? {});
+      expect(reqBodyBlob).not.toContain(ROT_AT);
+      expect(reqBodyBlob).not.toContain(ROT_RT);
+      expect(reqBodyBlob).not.toContain("valid-rt");
+      expect(reqBodyBlob).not.toContain("expired-at");
+    }
   });
 });

--- a/src/lib/sil-client.ts
+++ b/src/lib/sil-client.ts
@@ -23,21 +23,26 @@
  *
  * Wire contract for the sil-API identity read (a SECOND origin — sil-api, the
  * Fastify domain service — NOT sil-web; bare path, not /api/v1; see the
- * sil-whoami card). The Authorization header carries the stored access token:
+ * sil-whoami card). The authenticated self-read is a BODYLESS GET; the
+ * Authorization header carries the stored access token and IS the principal —
+ * sil-api derives the user from the JWT `sub`, not a request body:
  *
- *   POST <silApiUrl>/identity   Authorization: Bearer <access_token>
- *                               body { agent_id }
+ *   GET <silApiUrl>/identity    Authorization: Bearer <access_token>
+ *                               (no body, no content-type)
  *     200 <UCP envelope>{ result: { name, addresses } }  → ok (carries identity)
  *     401                                                 → unauthorized (→ refresh)
  *     403 { error: user_not_provisioned | principal_mismatch } → forbidden (terminal)
  *     5xx / network / abort                               → retryable
  *
- * The identity lives in the envelope's `result` (the tool unwraps it so the
- * agent sees identity, not transport metadata). The real {name, addresses}
- * payload is LATENT on a sil-services follow-on (sil-api's /identity is still a
- * stub today); `classifyIdentityResponse` therefore narrows DEFENSIVELY — a 200
- * whose result has no usable identity (name) falls to `retryable`, NEVER to a
- * false `ok`, so the suite can't be green while the product promise is unmet.
+ * The VERB is load-bearing: sil-api's `POST /identity` is the agent enrich-STUB
+ * ({kind, verified, subject, ...} — no name/addresses); `GET /identity` is the
+ * real self-read returning {id, name, addresses} (sil-api `handlers/identity.ts`,
+ * PR #7). The identity lives in the envelope's `result` (the tool unwraps it so
+ * the agent sees identity, not transport metadata). `classifyIdentityResponse`
+ * still narrows DEFENSIVELY — a 200 whose result has no usable identity (no
+ * `name`) falls to `retryable`, NEVER to a false `ok`, so a stray stub 200 (or a
+ * malformed body) can't be green while the product promise is unmet. An EMPTY
+ * `addresses: []` IS a valid identity (a provisioned, address-less user).
  *
  * THE subtle correctness point (architect Risk "claim taxonomy mis-mapping"):
  * 200-pending and 200-success are BOTH HTTP 200. `classifyClaimResponse` branches
@@ -60,11 +65,6 @@ import { readTokens, writeTokens } from "./credentials.js";
 /** Per-request timeout: a stalled endpoint (DNS hang, SYN drop) must not wedge
  * a poll tick forever. Mirrors the 15s ceiling the klodi poller uses. */
 const REQUEST_TIMEOUT_MS = 15_000;
-
-/** The agent identity sent to sil-api's `SimplifiedAgentRequest.agent_id`. A
- * stable constant: this plugin is the agent. A per-deployment `sil_agent_id`
- * config key is YAGNI until per-deployment identity is actually wanted. */
-const AGENT_ID = "sil-openclaw";
 
 /** The user identity sil-web returns inside a successful claim. */
 export interface ClaimedUser {
@@ -92,9 +92,14 @@ export type RefreshOutcome =
   | { kind: "invalid_grant" }
   | { kind: "retryable" };
 
-/** A postal address as returned by the sil-api identity read (mirrors
- * `@sil/db`'s AddressRow, narrowed to the fields whoami surfaces; extra
- * fields are tolerated and passed through untyped). */
+/** A postal address as returned by the sil-api identity read. These fields are
+ * only optional HINTS — addresses pass through OPAQUE: `extractIdentity` filters
+ * to plain objects and never reads or remaps individual fields. The ACTUAL wire
+ * shape is sil-api's `AddressWire` (`street_address`, `address_locality`,
+ * `address_region`, `postal_code`, `address_country`, … — sil-services
+ * `packages/schemas/src/identity.ts`), NOT these `line1`/`city`/… names. Do NOT
+ * remap to these fields — that would silently drop real address data. Extra
+ * fields are tolerated and passed through untyped. */
 export interface IdentityAddress extends Record<string, unknown> {
   line1?: string;
   line2?: string;
@@ -248,11 +253,16 @@ export async function refreshSession(
 
 /**
  * Read the authenticated user's identity from sil-api (the SECOND origin — the
- * Fastify domain service, NOT sil-web). The stored access token is sent as
- * `Authorization: Bearer <token>`; the request body carries `agent_id` per
- * sil-api's `SimplifiedAgentRequest`. `on_behalf_of` is deliberately OMITTED so
- * the JWT `sub` is the principal — sending a mismatching `on_behalf_of` is a
- * guaranteed 403 `principal_mismatch`. A network error / timeout → `retryable`.
+ * Fastify domain service, NOT sil-web). This is a bodyless `GET <silApiUrl>/identity`:
+ * sil-api's authenticated self-read derives the principal from the JWT `sub`
+ * (the `Authorization: Bearer <token>` header), loads that user's addresses,
+ * and returns `{ id, name, addresses }` in the UCP envelope's `result`
+ * (sil-api `handlers/identity.ts` GET route — declares only a response schema,
+ * takes no request body). The verb is the whole point: POST hits the agent
+ * enrich-STUB (no name/addresses), GET hits the real self-read. No `agent_id`
+ * or `on_behalf_of` is sent — the GET self-read has no body, so the principal
+ * is unambiguously the token subject and the `principal_mismatch` 403 path is
+ * eliminated entirely. A network error / timeout → `retryable`.
  *
  * The Bearer header is built HERE and never logged; the token travels only in
  * the outbound request, never into the returned union.
@@ -264,7 +274,7 @@ export async function fetchIdentity(
   const url = `${stripTrailingSlash(silApiUrl)}/identity`;
   let res: Response;
   try {
-    res = await postJson(url, { agent_id: AGENT_ID }, { authorization: `Bearer ${token}` });
+    res = await getJson(url, { authorization: `Bearer ${token}` });
   } catch {
     return { kind: "retryable" };
   }
@@ -314,13 +324,18 @@ export async function refreshStoredTokens(): Promise<RefreshStoredResult> {
  * null if it carries no usable identity. Defends against the latent wire shape:
  * the identity may be wrapped in the UCP envelope's `result` OR (if the
  * follow-on returns it bare) at the top level, so we try `result` first and
- * fall back to the body itself. A usable identity REQUIRES BOTH a non-empty
- * `name` string (the authoritative human name) AND a non-empty `addresses`
- * array — the full product promise is name AND addresses, so a half-identity is
- * NOT a clean read. Returning null here is what makes a partial 200 — or the
- * current /identity STUB shape ({kind, verified, subject, ...}, no name/no
- * addresses) — classify as `retryable`, never a false `ok`. Extra fields on
- * each address are preserved.
+ * fall back to the body itself.
+ *
+ * A usable identity REQUIRES a non-empty `name` string (the authoritative human
+ * name) and that `addresses` is an ARRAY — but the array may be EMPTY. sil-api
+ * returns `addresses: []` for a provisioned user who has onboarded a name but
+ * not yet added an address (`handlers/identity.ts` → `buildIdentityReadResult`);
+ * that is a real, authenticated identity, NOT a not-yet-ready read. Rejecting it
+ * would strand such a user on a false `retryable` they could never escape by
+ * retrying. The `name` gate is the load-bearing anti-false-green guard: the
+ * current /identity STUB shape ({kind, verified, subject, ...}) has NO name, so
+ * it still returns null → `retryable`, never a false `ok`. Extra fields on each
+ * address are preserved (addresses pass through opaque — see `IdentityAddress`).
  */
 function extractIdentity(body: unknown): Identity | null {
   const envelope = asRecord(body);
@@ -337,7 +352,6 @@ function extractIdentity(body: unknown): Identity | null {
   const addresses = rawAddresses.filter(
     (a): a is IdentityAddress => asRecord(a) !== null,
   );
-  if (addresses.length === 0) return null;
 
   return { name, addresses };
 }
@@ -385,6 +399,29 @@ async function postJson(
       method: "POST",
       headers: { "content-type": "application/json", ...extraHeaders },
       body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** GET with a hard per-request timeout (AbortController), sharing `postJson`'s
+ * timeout and never-log-the-token invariants. Sends NO `content-type` and NO
+ * body — a GET body is at best ignored and in strict fetch environments throws,
+ * and the sil-api self-read derives its principal from the Bearer JWT, not a
+ * body. Extra headers (e.g. an Authorization bearer) are passed straight to
+ * fetch and never logged. */
+async function getJson(
+  url: string,
+  extraHeaders?: Record<string, string>,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    return await fetch(url, {
+      method: "GET",
+      headers: { ...extraHeaders },
       signal: controller.signal,
     });
   } finally {


### PR DESCRIPTION
## Card
`cards/sil-identity-read-verb-fix.md` (gitignored — local-only working doc; lives in the `card/sil-identity-read-verb-fix` branch worktree, not committed). Full intent + handoffs are in that file.

## Summary
`sil_whoami` returned `retryable` instead of the user's real `{ name, addresses }` because `fetchIdentity` issued `POST <silApiUrl>/identity` with `{ agent_id }` — which hits sil-api's agent **enrich-stub** (`{kind, verified, subject, …}`, no `name`), so `extractIdentity` returned null. The real authenticated self-read is **`GET /identity`** (sil-api PR #7): it derives the user from the JWT `sub`, takes no body, and returns `{ id, name, addresses }`.

Change is confined to `src/lib/sil-client.ts`:
- **`fetchIdentity`** → bodyless **GET** with the same `Authorization: Bearer <token>` header (was already correct — not an auth bug).
- **`getJson`** helper added alongside `postJson`, carrying the `AbortController` timeout, header merge, and never-log-the-token invariant verbatim. GET sends no body / no `content-type`.
- **`extractIdentity`** drops only the empty-`addresses` reject; **keeps** the non-empty `name` gate and `Array.isArray` (the anti-false-green guards). A provisioned, address-less user (`addresses: []`) is now a valid identity instead of a false `retryable`.
- Dead `AGENT_ID` removed; `IdentityAddress` documented as opaque `AddressWire` pass-through.

No change to `src/tools/identity.ts` — the refresh-once / 401-vs-403 / transient-vs-terminal taxonomy is untouched.

## Test plan
- [x] `pnpm test` — **227 passed** (21 files)
- [x] `pnpm typecheck` — clean
- [x] `pnpm build` — clean (`dist/index.js` emitted); plugin-load + manifest-contract gates pass
- [x] TDD integrity: reverting `fetchIdentity` to POST makes the new RED test fail (`expected 'POST' to be 'GET'`); the GET fix turns it green — a true RED→GREEN.

RED-first tests (qa): `whoami.integration.test.ts` now asserts the identity request is **GET + no body** (the old router never inspected `init.method`, so it was falsely green against the POST; refresh request asserted to stay POST). `identity-classify.test.ts` adds `name` + `addresses: []` → `ok` (bare + enveloped) while the stub-shape / no-name cases stay `retryable`.

The cross-service e2e against a live sil-api + Postgres is out of scope (sil-stage SC9, deferred); the mocked-`fetch` integration suite is the in-repo ceiling, per the card.

## Distillation target
Knowledge capture happens **after Review PASS** in the `distilling` stage — `solutions-architect` runs in this same worktree, commits to this same branch, and pushes here so the PR ends up containing implementation + tests + distillation in one mergeable unit. Likely target: `docs/knowledge/sil-api-identity-contract.md` (POST=enrich-stub vs GET=self-read) and the empty-addresses note in `docs/knowledge/sil-response-classification.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)