### PR TITLE
refactor: migrate OpenClaw tool schemas to TypeBox 1.x

### DIFF
--- a/docs/knowledge/INDEX.md
+++ b/docs/knowledge/INDEX.md
@@ -6,6 +6,7 @@ Sorted by `updated_at` descending (newest first). One row per doc in this folder
 
 | ID | Title | Tags | Updated |
 |---|---|---|---|
+| [[typecheck-is-the-only-test-type-gate]] | pnpm typecheck is the only gate that type-checks tests (build excludes them, test strips types) | tooling, typescript, vitest, tsconfig, gotcha, false-green, ci-gate | 2026-06-08 |
 | [[sil-api-identity-contract]] | sil-api identity read — GET /identity contract, request gotchas, deferred e2e | sil-api, identity, jwt, cross-sibling, e2e | 2026-06-08 |
 | [[sil-response-classification]] | Classify sil responses on body shape, not HTTP status | sil-api, sil-web, http, classification, false-green | 2026-06-08 |
 

--- a/docs/knowledge/typecheck-is-the-only-test-type-gate.md
+++ b/docs/knowledge/typecheck-is-the-only-test-type-gate.md
@@ -1,0 +1,31 @@
+---
+id: typecheck-is-the-only-test-type-gate
+title: pnpm typecheck is the only gate that type-checks tests (build excludes them, test strips types)
+tags: [tooling, typescript, vitest, tsconfig, gotcha, false-green, ci-gate]
+card: migrate-openclaw-tool-schemas-to-typebox-1-x
+commit: 7e9d951
+updated_at: 2026-06-08
+updated_by_card: migrate-openclaw-tool-schemas-to-typebox-1-x
+---
+
+A **type error that lives only in a test file passes `pnpm build` AND `pnpm test`, and is caught solely by `pnpm typecheck`.** Any green gate for a change that touches `src/__tests__/**` must therefore run `pnpm typecheck` — `build && test` alone is a false-green for test type-correctness.
+
+This is not visible from any single file; it emerges from how the three scripts are wired (`package.json`):
+
+| Script | Command | Type-checks `src/__tests__`? | Why |
+|---|---|---|---|
+| `pnpm build` | `tsc -p tsconfig.build.json` | **No** | `tsconfig.build.json` sets `"exclude": [..., "src/__tests__"]` — the build deliberately compiles only shippable sources into `dist/`. |
+| `pnpm test` | `vitest run` | **No** | vitest (esbuild under the hood) **strips** types without checking them — it runs the JS, it does not `tsc` the tests. |
+| `pnpm typecheck` | `tsc --noEmit` | **Yes** | Uses `tsconfig.json` (`"include": ["src"]`, which covers `src/__tests__`) — the only one of the three that reads the tests through the type-checker. |
+
+## Why it matters (the failure it prevents)
+
+A change can be functionally correct and fully green on `build` + `test` while carrying a test that does not type-check. If a gate omits `typecheck`, that error ships and only surfaces the next time someone runs `typecheck` locally — detached from the change that introduced it.
+
+The migrate-openclaw-tool-schemas-to-typebox-1-x card hit this exactly: TypeBox 1.x tightened a type such that three casts in `tool-schema-contract.unit.test.ts` stopped compiling (TS2352), yet `pnpm build` and `pnpm test` both stayed green — only `pnpm typecheck` went red. The migration's own acceptance criteria listed all three gates for this reason. (The specific cast fix is captured inline at the cast sites; the point *here* is the gate topology, which recurs for any test-only type error regardless of cause.)
+
+## The rule for future cards
+
+- The green gate for any card touching test files is **`pnpm typecheck && pnpm build && pnpm test`**, all three — in any order, but `typecheck` is non-negotiable.
+- Do **not** assume `pnpm test` covers type-correctness. It runs behavior; it is blind to types.
+- Do **not** assume `pnpm build` covers the tests. It excludes them by design (tests are not shipped).

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@sinclair/typebox": "0.34.14"
+    "typebox": "^1.2.2"
   },
   "devDependencies": {
     "@types/node": "22.15.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,9 @@ importers:
 
   .:
     dependencies:
-      '@sinclair/typebox':
-        specifier: 0.34.14
-        version: 0.34.14
+      typebox:
+        specifier: ^1.2.2
+        version: 1.2.2
     devDependencies:
       '@types/node':
         specifier: 22.15.3
@@ -136,9 +136,6 @@ packages:
 
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
-
-  '@sinclair/typebox@0.34.14':
-    resolution: {integrity: sha512-TJ7Al17j3+by5y2QkTLcF/oBVMbgXBhILVgi9PuwpxQVZZvGh5BFRzWbJPmZVNKpbRLjuMzFuRwR+tdFPqCkvA==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -358,6 +355,9 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  typebox@1.2.2:
+    resolution: {integrity: sha512-0nqIJFL+baWoAEtwa0l/vfbfXg0+3gEhiWGnHuoIiivXjlk/TpxDddG0WER34CojKNpHi4ZXku8XGEz9H55b5Q==}
+
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
@@ -528,8 +528,6 @@ snapshots:
     optional: true
 
   '@rolldown/pluginutils@1.0.1': {}
-
-  '@sinclair/typebox@0.34.14': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -726,6 +724,8 @@ snapshots:
 
   tslib@2.8.1:
     optional: true
+
+  typebox@1.2.2: {}
 
   typescript@5.8.3: {}
 

--- a/src/__tests__/tools/tool-schema-contract.unit.test.ts
+++ b/src/__tests__/tools/tool-schema-contract.unit.test.ts
@@ -1,0 +1,217 @@
+/**
+ * UNIT — agent-facing tool-schema contract is invariant across the
+ * TypeBox 0.34 → 1.x migration (tier: unit, <100ms, no I/O, mock api).
+ *
+ * Card: migrate-openclaw-tool-schemas-to-typebox-1-x. The migration is a
+ * dependency-major swap ONLY — the JSON-schema object each tool publishes
+ * in `parameters` (the value the OpenClaw host serializes and presents to
+ * agents) must be equivalent before and after. This file pins that
+ * equivalence OBSERVATIONALLY against the known-good literals captured in
+ * the card's Risks section, so an unexpected emission drift fails the
+ * build rather than silently reaching an agent.
+ *
+ * Why this exists alongside examples.test.ts: that file asserts only
+ * `parameters.type === "object"` — which passes even if `required` or a
+ * nested `description` silently drifted. This file deep-equals the WHOLE
+ * schema, so structure cannot be lost.
+ *
+ * CONTRACT NOTE (architect Risk — load-bearing for these assertions):
+ * TypeBox 1.x reorders JSON-schema keys vs 0.34 (e.g. `required` before
+ * `properties`, nested `type` before `description`). JSON-Schema objects
+ * are UNORDERED key sets; the host serializes and validates by key, not
+ * byte order. So every schema assertion below uses `toEqual` (deep,
+ * order-insensitive) — NEVER `expect(JSON.stringify(a)).toBe(<0.34
+ * byte-literal>)`, which would flip RED on a pure dependency bump even
+ * though the contract is intact.
+ *
+ * Runs entirely against createMockPluginApi() — no host, no network, no
+ * filesystem.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { registerExampleTools } from "../../tools/examples.js";
+import { registerIdentityTools } from "../../tools/identity.js";
+import {
+  createMockPluginApi,
+  getTool,
+  registeredToolNames,
+  type MockPluginAPI,
+} from "../helpers/mock-plugin-api.js";
+
+/**
+ * The complete agent-facing tool contract, captured from the live 0.34.14
+ * emission (transcribed verbatim from the card's Risks section). The
+ * migration must keep every tool's `parameters` JSON-schema deep-equal to
+ * the value here. `name` / `label` / `description` are plain string
+ * literals (TypeBox-independent) and must not be incidentally edited
+ * during the import swap.
+ *
+ * The four schemas are: `Type.Object({})` (×3 — the no-argument tools) and
+ * `Type.Object({ message: Type.String({ description }) })` (sil_echo, the
+ * one tool with structure to lose).
+ */
+const EMPTY_OBJECT_SCHEMA = { type: "object", properties: {} } as const;
+
+const ECHO_PARAMETERS_SCHEMA = {
+  type: "object",
+  properties: {
+    message: {
+      type: "string",
+      description: "Text echoed back verbatim in the stub payload.",
+    },
+  },
+  required: ["message"],
+} as const;
+
+/** Every tool the plugin registers, with the agent-visible contract each
+ * must honour after the migration. The set is itself part of the contract:
+ * exactly these four, no additions / removals / renames. */
+const TOOL_CONTRACT = {
+  sil_ping: {
+    label: "Ping",
+    description:
+      "Liveness check. Takes no arguments and returns a stub payload"
+      + " confirming the plugin's tools are registered and invocable.",
+    parameters: EMPTY_OBJECT_SCHEMA,
+  },
+  sil_echo: {
+    label: "Echo",
+    description:
+      "Echo the supplied message back inside a stub payload. Demonstrates"
+      + " that a typed parameter round-trips from request to response.",
+    parameters: ECHO_PARAMETERS_SCHEMA,
+  },
+  sil_register: {
+    label: "Register on sil",
+    description:
+      "Start browser-based registration on sil. Returns an auth URL for the"
+      + " user to open in a browser. The plugin polls the session in the"
+      + " background until registration completes (then it stores credentials"
+      + " locally), the link expires, or the attempt times out. Call this tool"
+      + " again afterwards to confirm registration completed.",
+    parameters: EMPTY_OBJECT_SCHEMA,
+  },
+  sil_whoami: {
+    label: "Who am I on sil",
+    description:
+      "Return the registered user's identity (name and addresses) from sil,"
+      + " using the credentials stored by sil_register. If the access token has"
+      + " expired it is refreshed transparently and the read is retried. If you"
+      + " are not registered, or the session has fully expired, the result names"
+      + " the recovery action (run sil_register).",
+    parameters: EMPTY_OBJECT_SCHEMA,
+  },
+} as const;
+
+/** Register the entire plugin tool surface exactly as src/index.ts#register()
+ * does (both groups), so the assertions run against the real registration
+ * code — not a re-stated schema literal. Mirror register() exactly. */
+function registerAllTools(): MockPluginAPI {
+  const api = createMockPluginApi();
+  registerExampleTools(api);
+  registerIdentityTools(api);
+  return api;
+}
+
+describe("tool-set invariant — exactly the four contracted tools", () => {
+  it("registers exactly { sil_echo, sil_ping, sil_register, sil_whoami } — no additions, removals, or renames", () => {
+    const names = registeredToolNames(registerAllTools());
+    expect([...names].sort()).toEqual([
+      "sil_echo",
+      "sil_ping",
+      "sil_register",
+      "sil_whoami",
+    ]);
+  });
+});
+
+describe("tool string fields are invariant across the migration (TypeBox-independent literals)", () => {
+  let api: MockPluginAPI;
+
+  beforeEach(() => {
+    api = registerAllTools();
+  });
+
+  for (const [name, contract] of Object.entries(TOOL_CONTRACT)) {
+    it(`${name}: name, label, and description equal their pre-migration values verbatim`, () => {
+      const tool = getTool(api, name);
+      expect(tool.name).toBe(name);
+      expect(tool.label).toBe(contract.label);
+      expect(tool.description).toBe(contract.description);
+    });
+  }
+});
+
+describe("parameters JSON-schema is the same shape agents see today (deep-equal, order-insensitive)", () => {
+  let api: MockPluginAPI;
+
+  beforeEach(() => {
+    api = registerAllTools();
+  });
+
+  for (const name of ["sil_ping", "sil_register", "sil_whoami"] as const) {
+    it(`${name} (no-argument tool): parameters deep-equals { type: "object", properties: {} } with no \`required\``, () => {
+      // The empty-object schema carries `properties: {}` present-and-empty
+      // on BOTH 0.34 and 1.x (architect-verified) — and no `required` key.
+      // Deep-equal pins both: the empty properties map AND the absence of
+      // a spurious `required`.
+      const params = getTool(api, name).parameters as unknown as Record<
+        string,
+        unknown
+      >;
+      expect(params).toEqual(EMPTY_OBJECT_SCHEMA);
+      expect(params).not.toHaveProperty("required");
+    });
+  }
+
+  it("sil_echo (the only non-empty schema — the boundary case): parameters deep-equals today's full structure", () => {
+    // The one schema with structure to lose: nested properties.message of
+    // { type: "string", description: <exact text> } AND required: ["message"].
+    // 1.x reorders keys (required before properties; nested type before
+    // description) — toEqual is order-insensitive, so a pure dependency bump
+    // stays GREEN while any real drift (lost description, lost/extra required,
+    // changed type) flips RED.
+    const params = getTool(api, "sil_echo").parameters as unknown as Record<
+      string,
+      unknown
+    >;
+    expect(params).toEqual(ECHO_PARAMETERS_SCHEMA);
+  });
+
+  it("sil_echo: preserves the nested description verbatim and the exact required array (drift-resistant sub-assertions)", () => {
+    // Belt-and-braces: even if a future refactor of the literal above were
+    // wrong, these pin the two pieces most likely to be silently dropped.
+    const params = getTool(api, "sil_echo").parameters as unknown as {
+      properties: { message: { type: unknown; description: unknown } };
+      required: unknown;
+    };
+    expect(params.properties.message.type).toBe("string");
+    expect(params.properties.message.description).toBe(
+      "Text echoed back verbatim in the stub payload.",
+    );
+    expect(params.required).toEqual(["message"]);
+  });
+});
+
+describe("TypeBox introspection metadata never leaks into the agent-visible schema", () => {
+  // TypeBox 1.x's headline breaking change moves Kind/Optional/Readonly off
+  // enumerable symbols onto NON-enumerable `~kind` / `~optional` / `~readonly`
+  // properties. The host serializes `parameters` with JSON.stringify before
+  // exposing it to an agent; that output must carry none of those keys. This
+  // is the ONE place JSON.stringify is the right tool — it asserts key
+  // ABSENCE, not byte-order equality (so it is migration-safe).
+  let api: MockPluginAPI;
+
+  beforeEach(() => {
+    api = registerAllTools();
+  });
+
+  for (const name of ["sil_ping", "sil_echo", "sil_register", "sil_whoami"] as const) {
+    it(`${name}: JSON.stringify(parameters) leaks no ~kind / ~optional / ~readonly key`, () => {
+      const serialized = JSON.stringify(getTool(api, name).parameters);
+      expect(serialized).not.toContain("~kind");
+      expect(serialized).not.toContain("~optional");
+      expect(serialized).not.toContain("~readonly");
+    });
+  }
+});

--- a/src/__tests__/typebox-no-trace.integration.test.ts
+++ b/src/__tests__/typebox-no-trace.integration.test.ts
@@ -1,0 +1,132 @@
+/**
+ * INTEGRATION — no `@sinclair/typebox` left in the dependency tree after
+ * the migration (tier: integration — reads the two real dependency-manifest
+ * files on disk: package.json and pnpm-lock.yaml).
+ *
+ * Card: migrate-openclaw-tool-schemas-to-typebox-1-x, Pillar B. The whole
+ * point of the migration is to stop straddling two TypeBox majors: the
+ * plugin must depend on the standalone `typebox@1.x` and carry NO trace of
+ * `@sinclair/typebox@0.34` anywhere. The lockfile is the load-bearing one —
+ * 3 `@sinclair/typebox@0.34.14` references live there pre-migration and are
+ * the easiest to leave behind if `package.json` is edited but the lock isn't
+ * regenerated (a stale-lockfile straddle).
+ *
+ * THIS TEST IS GENUINELY RED ON THE PRE-MIGRATION TREE — package.json's
+ * dependency block and pnpm-lock.yaml both name `@sinclair/typebox` today.
+ * That failure is the Red signal the expert-developer turns Green by
+ * swapping the dependency and regenerating the lockfile. Do NOT weaken or
+ * skip it to make the suite pass before the migration lands.
+ *
+ * (Source-tree `@sinclair/typebox` references — the import specifiers in
+ * src/tools/*.ts and src/types/openclaw.d.ts — are caught by `pnpm
+ * typecheck` failing once the package is gone, and by the contract test
+ * running against the new package. This file pins the DEPENDENCY-manifest
+ * half of the no-trace criterion, which typecheck alone does not see.)
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+// src/__tests__ → repo root is two levels up.
+const REPO_ROOT = join(HERE, "..", "..");
+
+const OLD_TYPEBOX = "@sinclair/typebox";
+/** The standalone successor the migration adopts. Used ONLY as an exact
+ * dependency KEY in package.json (where it is unambiguous — `typebox` is a
+ * distinct key from `@sinclair/typebox`). It is deliberately NOT used as a
+ * raw-text `toContain` probe, because `@sinclair/typebox` contains the
+ * substring `typebox`: a raw-text "does it mention typebox" check is
+ * satisfied by the OLD package and proves nothing. New-package PRESENCE is
+ * pinned by the package.json key + 1.x-range assertions below and by the
+ * contract test, which only resolves if `typebox` is installed. */
+const NEW_TYPEBOX = "typebox";
+
+function readText(rel: string): string {
+  return readFileSync(join(REPO_ROOT, rel), "utf8");
+}
+
+interface PackageJson {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+}
+
+function readPackageJson(): PackageJson {
+  return JSON.parse(readText("package.json")) as PackageJson;
+}
+
+/** Every dependency bucket flattened to one name→range map, so a stray
+ * `@sinclair/typebox` cannot hide in devDependencies / optional / peer. */
+function allDependencies(pkg: PackageJson): Record<string, string> {
+  return {
+    ...pkg.dependencies,
+    ...pkg.devDependencies,
+    ...pkg.optionalDependencies,
+    ...pkg.peerDependencies,
+  };
+}
+
+describe("package.json — no @sinclair/typebox, depends on standalone typebox@1.x", () => {
+  const pkg = readPackageJson();
+  const deps = allDependencies(pkg);
+
+  it("declares NO @sinclair/typebox in any dependency bucket", () => {
+    // RED pre-migration: dependencies['@sinclair/typebox'] === "0.34.14".
+    expect(Object.keys(deps)).not.toContain(OLD_TYPEBOX);
+  });
+
+  it("declares the standalone `typebox` dependency", () => {
+    // RED pre-migration: the standalone package is not yet a dependency.
+    expect(Object.keys(deps)).toContain(NEW_TYPEBOX);
+  });
+
+  it("resolves `typebox` to a 1.x range (the migration target major)", () => {
+    // Accepts exact-pin (`1.2.2`) or caret (`^1.2.2`) — both are defensible
+    // per the architect; pin the MAJOR (1), not the discovery-time patch.
+    const range = deps[NEW_TYPEBOX];
+    expect(range).toBeTypeOf("string");
+    // Leading `1` optionally prefixed by ^ ~ >= etc. — never a 0.x straddle.
+    expect(range).toMatch(/^[\^~>=v\s]*1[.0-9xX]*/);
+    expect(range).not.toMatch(/^[\^~>=v\s]*0\./);
+  });
+
+  it("contains the substring `@sinclair/typebox` NOWHERE in the raw file", () => {
+    // Adversarial: catches the package surfacing outside the parsed
+    // dependency buckets — a comment, a resolutions/overrides block, a
+    // pnpm.overrides pin, anywhere in the raw text.
+    expect(readText("package.json")).not.toContain(OLD_TYPEBOX);
+  });
+});
+
+describe("pnpm-lock.yaml — no @sinclair/typebox node survives the regen (the load-bearing grep)", () => {
+  // 3 `@sinclair/typebox@0.34.14` references live in the lockfile today
+  // (importer spec, resolution block, dependency entry). A `package.json`
+  // edit WITHOUT a lockfile regen — or `--frozen-lockfile` against the old
+  // lock — leaves them behind and the plugin still straddles two majors.
+  const lockfile = readText("pnpm-lock.yaml");
+
+  it("contains NO `@sinclair/typebox` reference (zero, not 'fewer')", () => {
+    // RED pre-migration: 3 references present. The byte-for-byte string is
+    // what `grep -r "@sinclair/typebox" pnpm-lock.yaml` keys on. This is
+    // the unambiguous load-bearing assertion — absence of the OLD scoped
+    // package. (A positive "lockfile mentions typebox" probe is NOT done
+    // here: the old name `@sinclair/typebox` contains the substring
+    // `typebox`, so such a probe is green even on the unmigrated tree and
+    // proves nothing. New-package presence is pinned in package.json above
+    // and by the contract test resolving against the installed `typebox`.)
+    expect(lockfile).not.toContain(OLD_TYPEBOX);
+  });
+
+  it("resolves the standalone `typebox` package at a 1.x version in the lock", () => {
+    // Pins new-package PRESENCE unambiguously: the lockfile keys packages
+    // as `typebox@<version>:` and `'typebox': specifier|version`. Match a
+    // `typebox@1` token — produced ONLY by the standalone package at major
+    // 1, never by `@sinclair/typebox@0.34.14` (different name AND major).
+    // RED pre-migration: no `typebox@1` token exists in the lock yet.
+    expect(lockfile).toMatch(/(^|[^@\w/])typebox@1\./m);
+  });
+});

--- a/src/tools/examples.ts
+++ b/src/tools/examples.ts
@@ -24,7 +24,7 @@
  */
 
 import type { PluginAPI } from "openclaw/plugin-sdk";
-import { Type } from "@sinclair/typebox";
+import { Type } from "typebox";
 
 import { stubResult } from "../lib/tool-result.js";
 

--- a/src/tools/identity.ts
+++ b/src/tools/identity.ts
@@ -29,7 +29,7 @@
  */
 
 import type { PluginAPI } from "openclaw/plugin-sdk";
-import { Type } from "@sinclair/typebox";
+import { Type } from "typebox";
 
 import { getApiUrl, getSilApiUrl } from "../lib/config.js";
 import {

--- a/src/types/openclaw.d.ts
+++ b/src/types/openclaw.d.ts
@@ -18,7 +18,7 @@
  */
 
 declare module "openclaw/plugin-sdk" {
-  import type { TObject } from "@sinclair/typebox";
+  import type { TObject } from "typebox";
 
   export interface PluginAPI {
     registerTool(tool: ToolDefinition): void;


### PR DESCRIPTION
## Card
`cards/migrate-openclaw-tool-schemas-to-typebox-1-x.md` (gitignored-mode repo — the card body lives only in the worktree, not in this PR; it holds the full intent + Discovery + in-dev handoffs). Epic: `typebox-1x-migration-2026-06`.

## Summary
Dependency-major migration only — **no contract change**. Moves the plugin's MCP tool-parameter schemas off `@sinclair/typebox@0.34.14` onto the standalone `typebox@1.2.2`, so the plugin no longer straddles a different TypeBox major than `sil-services`.

- `package.json`: `@sinclair/typebox@0.34.14` → `typebox@^1.2.2`.
- `pnpm-lock.yaml`: regenerated — 3 `@sinclair/typebox@0.34.14` nodes removed, `typebox@1.2.2` added.
- `src/tools/examples.ts`, `src/tools/identity.ts`: import specifier `"@sinclair/typebox"` → `"typebox"` (the `{ Type }` named import is unchanged — resolves from the `typebox` root).
- `src/types/openclaw.d.ts`: `import type { TObject }` specifier → `"typebox"`.

No `Type.Object(...)`/`Type.String(...)` call site changed; `src/index.ts`, `openclaw.plugin.json`, `tsconfig*`, `vitest.config.ts` untouched. `typebox@1.x` is ESM-only — already matches the repo's ESM/`bundler` setup, so no tsconfig change was needed.

The agent-facing JSON-schema contract is invariant: verified against the installed `typebox@1.2.2` that every tool's `parameters` deep-equals the known-good 0.34 emission. 1.x reorders schema keys (`required` before `properties`, nested `type` before `description`) but the key *set* is identical and JSON-Schema is unordered — so the host/agent see the same contract. No `~kind`/`~optional`/`~readonly` leakage.

## Test plan
- [x] `pnpm typecheck` — exit 0
- [x] `pnpm build` — emits `dist/index.js`
- [x] `pnpm test` — 250/250 across 23 files
- [x] No `@sinclair/typebox` in `package.json`, `pnpm-lock.yaml`, or production `src/`
- New tests (RED commit `6683832`): `tool-schema-contract.unit.test.ts` (Pillar A — contract equivalence via `toEqual`, tool-set invariant, no-metadata-leak) and `typebox-no-trace.integration.test.ts` (Pillar B — no `@sinclair/typebox` in the dependency manifests). Pre-existing `examples.test.ts` + `manifest-contract.integration.test.ts` stay green untouched.

## Distillation target
Knowledge capture happens **after Review PASS** in the `distilling` stage — `solutions-architect` runs in this same worktree, commits to this same branch, and pushes here so the PR ends up containing implementation + tests + distillation in one mergeable unit. Likely target: a `docs/decisions/` note that the plugin is on `typebox@1.x` (standalone, ESM-only) and why schema equivalence is asserted by unordered `toEqual`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)