### PR TITLE
feature: sil_product_get catalog lookup tool

### DIFF
--- a/docs/decisions/sil-shared-catalog-client.md
+++ b/docs/decisions/sil-shared-catalog-client.md
@@ -3,12 +3,12 @@ id: sil-shared-catalog-client
 title: One shared catalog client + locally-redeclared read-subset types (no @sil/schemas / @ucp-js/sdk dep)
 tags: [architecture, contracts, dependencies, catalog, sil-api, reuse]
 card: sil-search-plugin-tool
-commit: c78bc59
+commit: 6df1061
 updated_at: 2026-06-09
-updated_by_card: sil-search-plugin-tool
+updated_by_card: sil-product-get-plugin-tool
 ---
 
-All sil-api **catalog** tools share ONE client layer in `src/lib/sil-client.ts` and ONE error-envelope taxonomy in `src/tools/catalog.ts`, and the plugin **re-declares the catalog wire fields it consumes LOCALLY** — it does **not** depend on `@sil/schemas` (cross-repo) or `@ucp-js/sdk` (no catalog types). `sil_search` (SC1) established this; the sibling lookup tool `sil_product_get` (SC2) reuses it rather than re-deriving a parallel one.
+All sil-api **catalog** tools share ONE client layer in `src/lib/sil-client.ts` and ONE error-envelope taxonomy in `src/tools/catalog.ts`, and the plugin **re-declares the catalog wire fields it consumes LOCALLY** — it does **not** depend on `@sil/schemas` (cross-repo) or `@ucp-js/sdk` (no catalog types). `sil_search` (SC1) established this; the sibling lookup tool `sil_product_get` (SC2) reused it rather than re-deriving a parallel one — and validated the design by exercising exactly the seams it was meant to share (see "What SC2 actually reused vs added" below).
 
 ## What `sil_search` landed (the symbols SC2 reuses)
 
@@ -36,3 +36,20 @@ In `src/tools/catalog.ts`: `registerCatalogTools(api)` (line 58) is the group. S
 > Add the new tool's register fn as a call inside `registerCatalogTools` (don't make a new group). Reuse `searchCatalog`'s shape, the `SearchOutcome`-style union, the `projectProduct`/`projectVariant`/`extractPrice`/`extractAvailability`/`extractCursor`/`extractApiError` normalizers, and the `catalog.ts` error-envelope helpers. Re-declare any *additional* rich fields you consume locally and narrow them — never add a dependency on `@sil/schemas` or `@ucp-js/sdk`. Classify on body shape with a pure exported classifier (see [[sil-response-classification]]).
 
 Origin/path for the catalog endpoint is governed by [[sil-two-origin-model]] (bare `/catalog/search` on `getSilApiUrl()`); the wire contract + the propagated-boilerplate hazard are in [[sil-api-catalog-contract]].
+
+## What SC2 actually reused vs added (the design held)
+
+`sil_product_get` confirmed the split: `src/lib/sil-client.ts` was a **pure addition** (+364/−0 — it modified none of search's primitives). SC2:
+
+- **Reused as-is:** `postJson` / `readJsonBody` / `stripTrailingSlash` / `REQUEST_TIMEOUT_MS` / `asRecord` / `extractPrice` / `extractAvailability` / `extractApiError`, and the `registerCatalogTools` group (added `registerProductGet` as a second call inside it — no new group, no `register()`/`src/index.ts` edit, since adding a tool to an existing group needs none).
+- **Added its OWN** thin `classifyLookupResponse` + `extractLookupResult` + `LookupOutcome` rather than reusing search's — **correctly**, because lookup has no `cursor` and DOES have `not_found` misses + the per-variant `inputs` correlation. A shared classifier would have carried dead cursor logic or dropped miss/correlation data. The shared thing is the low-level primitives + the union SHAPE (same four classes) + the error-envelope taxonomy — NOT the classifier/extractor bodies.
+- **Parameterized the three shared envelope helpers** (`notRegistered` / `mustReregister` / `transient`) to take a `tool` name arg (a genuine 3rd-use: search's 3 sites + product_get's 3 sites). This keeps the no-divergent-error-vocabulary constraint above — the `status`/`recovery` taxonomy stays shared while each message names the right retry tool ("call sil_product_get again"). Per-tool copies would have risked the two sibling tools' error text drifting.
+
+## The narrow-vs-pass-through rule for projection helpers
+
+When a projection helper (`projectProduct` / `projectLookupProduct` / `extractIdentity`) maps an untrusted wire body to the agent-facing shape, **narrow only the fields that gate the contract; pass contextual display data through OPAQUE**.
+
+- **Narrow (read + `typeof`-gate, null-drop when absent/wrong-type):** the purchasability/identity gates — `id`, `title`, `checkout_url` (non-empty), `price`, `source`; identity's non-empty `name`. These are the load-bearing fields; a product/variant missing one is dropped, never surfaced.
+- **Pass through opaque (filter to plain objects, forward verbatim, NEVER read or remap inner fields):** contextual display data — lookup's `categories` and a variant's `options`, identity's `addresses`, lookup's `price_range`/`description`. Use `passThroughObjects` (sil-client.ts) for arrays-of-objects; a bare object via `asRecord`.
+
+**Why this is a rule and not a per-field judgment call:** narrowing on a *guessed inner field name* silently drops real wire data when the guess is wrong. SC2 first narrowed `categories` by requiring an inner `name`; the authoritative `@sil/schemas` `Category` is actually `{ value, taxonomy? }` (no `name`) — so the narrow would have dropped every real category off the wire while passing a test fixture that happened to use `{ name }`. The plugin is a **thin transport client**: the source owns the field shapes of non-gating data, so the plugin must not assert them. Opaque pass-through survives both the real shape and any future drift; it is the same discipline identity `addresses` already used. (The WHY is also inline at each `passThroughObjects` call site.)

--- a/docs/knowledge/INDEX.md
+++ b/docs/knowledge/INDEX.md
@@ -6,7 +6,7 @@ Sorted by `updated_at` descending (newest first). One row per doc in this folder
 
 | ID | Title | Tags | Updated |
 |---|---|---|---|
-| [[sil-api-catalog-contract]] | sil-api catalog search — bare POST /catalog/search, @sil/schemas is wire truth (not @ucp-js/sdk), wrong-boilerplate hazard | sil-api, catalog, search, contract, wire-types, cross-sibling, gotcha | 2026-06-09 |
+| [[sil-api-catalog-contract]] | sil-api catalog reads — bare POST /catalog/{search,lookup}, @sil/schemas is wire truth (not @ucp-js/sdk), wrong-boilerplate hazard | sil-api, catalog, search, lookup, contract, wire-types, cross-sibling, gotcha | 2026-06-09 |
 | [[sil-response-classification]] | Classify sil responses on body shape, not HTTP status (incl. catalog empty-vs-garbage 200) | sil-api, sil-web, http, classification, false-green | 2026-06-09 |
 | [[skeleton-stubs-are-compliant-until-touched]] | The sil_ping/sil_echo skeleton stubs are NOT a stub-free violation — de-stubbing is gated on touch | stub, skeleton, complete-work-is-stub-free, examples, copy-me, gotcha, review | 2026-06-08 |
 | [[typecheck-is-the-only-test-type-gate]] | pnpm typecheck is the only gate that type-checks tests (build excludes them, test strips types) | tooling, typescript, vitest, tsconfig, gotcha, false-green, ci-gate | 2026-06-08 |

--- a/docs/knowledge/sil-api-catalog-contract.md
+++ b/docs/knowledge/sil-api-catalog-contract.md
@@ -1,14 +1,14 @@
 ---
 id: sil-api-catalog-contract
-title: sil-api catalog search — bare POST /catalog/search, @sil/schemas is the wire truth (NOT @ucp-js/sdk), and the wrong-boilerplate hazard
-tags: [sil-api, catalog, search, contract, wire-types, cross-sibling, gotcha]
+title: sil-api catalog reads — bare POST /catalog/{search,lookup}, @sil/schemas is the wire truth (NOT @ucp-js/sdk), and the wrong-boilerplate hazard
+tags: [sil-api, catalog, search, lookup, contract, wire-types, cross-sibling, gotcha]
 card: sil-search-plugin-tool
-commit: c78bc59
+commit: 6df1061
 updated_at: 2026-06-09
-updated_by_card: sil-search-plugin-tool
+updated_by_card: sil-product-get-plugin-tool
 ---
 
-`sil_search` reads catalog against a **live, merged** sil-api contract (PR #18): `POST /catalog/search` returns a UCP envelope whose `result` is `CatalogSearchResult { products: SilCatalogProduct[], pagination?, messages? }`, each product carrying a **required `source`** and variants each carrying a **required, non-empty `checkout_url`**. Two facts about this contract are non-obvious and bit the card on arrival — both were stated WRONG in the card's own Intent (propagated from the goal's card-fanout template).
+sil-api serves **two** catalog read endpoints, both against a **live, merged** contract (PR #18), both on the **bare** path / `getSilApiUrl()` origin, both returning a UCP envelope whose `result.products` is `SilCatalogProduct[]` (each product a **required `source`**, each variant a **required, non-empty `checkout_url`**): `POST /catalog/search` (LEAN, ranked, paginated — `sil_search`/SC1) and `POST /catalog/lookup` (RICH, batch-resolve-by-id — `sil_product_get`/SC2). Two facts about the contract are non-obvious and bit BOTH cards on arrival — both were stated WRONG in each card's Intent (propagated from the goal's card-fanout template).
 
 ## The contract the plugin consumes
 
@@ -33,11 +33,33 @@ Expected responses (classified by [[sil-response-classification]]'s `classifySea
 
 A **genuine empty match** (200 with `result.products: []`) is a SUCCESS (`ok` + empty list), NOT an error — distinct from the no-array guard above. (UCP: "empty search returns an empty array … this is not an error.")
 
+## The lookup endpoint — `POST /catalog/lookup` (the batch-resolve sibling)
+
+`lookupCatalog` (`src/lib/sil-client.ts`, classified by `classifyLookupResponse`) issues:
+
+```
+POST <sil_api_base>/catalog/lookup       (BARE path, same origin as search)
+Authorization: Bearer <stored access_token>
+body: { ids: string[] }                   — ≥1 id; NO filters/context, NO envelope
+```
+
+`result` is `CatalogLookupResult { products: SilCatalogProduct[], messages? }` — **structurally the same product/variant shape as search**, with two deltas that make it its own classifier/extractor rather than a reuse of search's:
+
+1. **No `pagination`.** Lookup is a batch resolve, not a list — there is no `cursor` to hoist. (`@sil/schemas` `catalog.ts`; the doc-line is explicit.)
+2. **Misses come back as `messages`, and a miss is a SUCCESS — never an error.** Each unresolved id is one `{ type:"info", code:"not_found", content:<the-id> }` entry in `result.messages`, in input order, and the `messages` key is **omitted entirely on full success**. The plugin parses those `content` values into `not_found: string[]` on the `ok` outcome. This is the lookup analogue of search's empty-match-is-success, but lookup *names which ids* came back empty. Surfacing a miss as an error (non-200, or `status:"error"`) is wrong — it makes the most common benign case (a saved/`sil_search`-derived id since delisted) fall into the agent's error branch and discards the ids that DID resolve. (UCP §Identifiers Not Found; sil-api `handlers/catalog.ts:88-91,123-128`.)
+
+Two more lookup-only facts the next catalog card needs:
+
+- **Each variant carries an `inputs: [{ id, match }]` correlation** — which request id(s) resolved to it, and whether the match was `exact` (a direct variant/sku/barcode hit) or `featured` (a product-id hit; the server picked a representative variant). It is **load-bearing, not decoration**: UCP does NOT guarantee the response preserves request order, and one id can resolve to a *variant of another id's product* (`lookup.md` §Client Correlation), so `inputs` is the ONLY way to map "the id I asked about" → "the variant I got back". `match` is an OPEN string — pass it through, don't enumerate it.
+- **Empty `ids` is a Fastify SCHEMA 400, NOT search's `empty_search_input` SourceError.** That `SourceError` code (`sourceErrorToHttp`) is search-only and never arises on the lookup route. A missing/empty `ids` is rejected by `CatalogLookupRequest.ids` `minItems:1` → a generic 400; the classifier maps any 400 → `invalid_request` and surfaces the server's `{ error, message }`. Do NOT special-case `empty_search_input` on the lookup path. (A `request_too_large` over-batch is the other 400 on this route — same `invalid_request` mapping.)
+
+The all-missed lookup (200, `result.products: []`, a `not_found` for every id) is a genuine SUCCESS — `ok` with empty `products` + a full `not_found`. The anti-false-green discriminator between it and a garbage/stub 200 is `Array.isArray(result.products)` PRESENCE, **never length** (see [[sil-response-classification]]).
+
 ## Two wrong facts the card/template propagated (these bite the next catalog card)
 
 > The goal's card-fanout template seeded BOTH `sil_search` (SC1) and `sil_product_get` (SC2 — the lookup sibling) — and likely any future agentic-search-slice catalog card — with the same two incorrect facts. They are wrong; do not copy them.
 
-1. **The path is NOT `/api/v1/catalog/search`.** sil-api serves catalog at the **bare** `/catalog/search` — there is no `/api/v1` prefix anywhere in sil-api (that prefix is sil-web's, the auth authority). The catalog read is a sil-api **domain** read, so it goes to `getSilApiUrl()` / `sil_api_base`, the SAME origin as `fetchIdentity` — NOT `getApiUrl()` / sil-web. Using `/api/v1/...` or `getApiUrl()` 404s. Governed by [[sil-two-origin-model]].
+1. **The path is NOT `/api/v1/catalog/{search,lookup}`.** sil-api serves catalog at the **bare** `/catalog/search` and `/catalog/lookup` — there is no `/api/v1` prefix anywhere in sil-api (that prefix is sil-web's, the auth authority). A catalog read is a sil-api **domain** read, so it goes to `getSilApiUrl()` / `sil_api_base`, the SAME origin as `fetchIdentity` — NOT `getApiUrl()` / sil-web. Using `/api/v1/...` or `getApiUrl()` 404s. Governed by [[sil-two-origin-model]]. (SC2/`sil_product_get` inherited the identical wrong `/api/v1` + `@ucp-js/sdk` boilerplate from the template and corrected it the same way — confirming the propagation hazard below.)
 
 2. **The wire-type source is NOT `@ucp-js/sdk`.** That SDK (`vendor/ucp/js-sdk/src/spec_generated.ts`) carries **ZERO** catalog types — it is checkout / payment / fulfillment / order only (verified: no `Product` / `Variant` / `Catalog` / `Search` / `Availability` / `Pagination` export; its sole `availability` hit is a fulfillment comment). The authoritative catalog wire shape is the sil-services sibling `@sil/schemas` `packages/schemas/src/catalog.ts` (TypeBox, hand-mirrored from the UCP spec JSON schemas at `vendor/ucp/spec/source/schemas/shopping/`). The human-readable reference is `vendor/ucp/spec/docs/specification/catalog/`; `@sil/schemas/catalog.ts` is the byte-shape of truth. The plugin still depends on **neither** — see [[sil-shared-catalog-client]] for why (re-declare the read-subset locally, narrow at the boundary).
 
@@ -45,7 +67,7 @@ A **genuine empty match** (200 with `result.products: []`) is a SUCCESS (`ok` + 
 
 ## Enrichment fields are sil-api's, present and required
 
-`checkout_url` (per variant) and `source` (per product) are **NOT raw UCP variant/product fields** — they are sil-api enrichment. PR #18 emits both as REQUIRED: `checkout_url` is `minLength: 1` (non-empty) per variant, `source` is required per product (`@sil/schemas/catalog.ts`). So the tool never synthesizes a checkout_url client-side (it can't — there is no client-side source for it); it trusts the server's. A product whose featured variant lacks a non-empty `checkout_url` is DROPPED by `projectProduct`, never surfaced as a non-purchasable result.
+`checkout_url` (per variant) and `source` (per product) are **NOT raw UCP variant/product fields** — they are sil-api enrichment. PR #18 emits both as REQUIRED: `checkout_url` is `minLength: 1` (non-empty) per variant, `source` is required per product (`@sil/schemas/catalog.ts`). So the tool never synthesizes a checkout_url client-side (it can't — there is no client-side source for it); it trusts the server's. A product whose featured variant lacks a non-empty `checkout_url` is DROPPED — by `projectProduct` (search) and `projectLookupProduct` (lookup) alike — never surfaced as a non-purchasable result. The freshness of `checkout_url`/`price`/`availability` is the entire reason lookup exists: catalog responses are point-in-time, not transactional commitments (UCP), so lookup always re-fetches live and never caches.
 
 ## The cross-service e2e is deferred (as identity's was)
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -11,6 +11,7 @@
     "tools": [
       "sil_echo",
       "sil_ping",
+      "sil_product_get",
       "sil_register",
       "sil_search",
       "sil_whoami"
@@ -48,7 +49,7 @@
   },
   "security": {
     "shipsRuntimeCode": true,
-    "packagingNote": "Compiled JavaScript ships under ./dist. register() stays synchronous and opens nothing — it only registers tools. ALL I/O happens inside a tool's execute(): sil_register calls sil-web over the network, writes tokens.json + config.json to the plugin data directory (owner-only, 0600), and arms a bounded background poll timer that stops on the first terminal claim outcome or after the session deadline. sil_whoami reads the stored access token and calls sil-api for the user's identity, refreshing transparently via sil-web on a 401 (at most one refresh + one retry per call, no timer); a confirmed-dead session clears tokens.json. The PKCE verifier is held only in memory and is never written to disk. Tokens and identity PII are never logged.",
+    "packagingNote": "Compiled JavaScript ships under ./dist. register() stays synchronous and opens nothing — it only registers tools. ALL I/O happens inside a tool's execute(): sil_register calls sil-web over the network, writes tokens.json + config.json to the plugin data directory (owner-only, 0600), and arms a bounded background poll timer that stops on the first terminal claim outcome or after the session deadline. sil_whoami reads the stored access token and calls sil-api for the user's identity, refreshing transparently via sil-web on a 401 (at most one refresh + one retry per call, no timer); a confirmed-dead session clears tokens.json. sil_search and sil_product_get read the stored access token and call sil-api's catalog endpoints (search / lookup) with it — read-only, no token write, no timer, a single round-trip (a 401 is a terminal re-register hint, no refresh). The PKCE verifier is held only in memory and is never written to disk. Tokens and identity PII are never logged.",
     "registersLongLivedService": false,
     "serviceIds": [],
     "runsTimers": true,

--- a/src/__tests__/catalog-lookup.integration.test.ts
+++ b/src/__tests__/catalog-lookup.integration.test.ts
@@ -1,0 +1,715 @@
+/**
+ * INTEGRATION — sil_product_get lookup against sil-api (tier: integration).
+ *
+ * The real `sil_product_get` tool wired through the real sil-client (`lookupCatalog`
+ * + `classifyLookupResponse` + the read-subset normalizer) and the real credentials
+ * module. The ONLY thing mocked is `fetch` — the host/network boundary. There is no
+ * live sil-api or Postgres in this repo; the true cross-service guarantee (a real
+ * catalog over the wire from a live sil-api) is sil-stage's deferred e2e (goal SC9).
+ * Here we prove the whole PLUGIN-SIDE contract — param→request mapping, the
+ * unfound-ids-are-success behavior, the three-distinct-failure taxonomy, the rich
+ * projection + `inputs` correlation, and token privacy — against a mocked boundary,
+ * exactly as sil_search's integration suite proved its read flow.
+ *
+ * ONE ORIGIN: the lookup read targets the resolved **sil-api** origin
+ * (`getSilApiUrl`), at the BARE path `/catalog/lookup` — NOT `/api/v1`, NOT the
+ * sil-web origin (`getApiUrl`). Both origins are pinned to distinct known hosts so
+ * the origin + path assertions are exact, and a misfire onto sil-web is caught.
+ * (Lookup does no refresh choreography in SC2 — a single round-trip; the 401 path is
+ * a terminal re-register hint, parity with sil_search.)
+ *
+ * Wire shapes pinned to the ALREADY-MERGED sil-api `/catalog/lookup` contract
+ * (PR #18; sil-services `@sil/schemas` catalog.ts + envelope.ts) and the UCP
+ * catalog-lookup spec:
+ *   request body (CatalogLookupRequest): { ids: string[] }  (no envelope, no defaults)
+ *   response (200): the UCP envelope buildEnvelope emits, whose `result` is a
+ *     CatalogLookupResult { products: SilCatalogProduct[], messages? } — each
+ *     product with a required `source`, each variant with a non-empty `checkout_url`,
+ *     an `availability` object, and the REQUIRED lookup `inputs` correlation.
+ *     `messages` carries one { type:"info", code:"not_found", content:<id> } per
+ *     unresolved id, and is OMITTED entirely on full success.
+ *   400 (schema reject)  → invalid_request envelope
+ *   401                  → terminal re-register envelope
+ *   500 / network / timeout → retryable envelope
+ *
+ * THE anti-false-green (complete-work-is-stub-free): the happy-path mock returns the
+ * REAL `SilCatalogProduct` lookup envelope shape (each product with a required
+ * `source`, each variant with a non-empty `checkout_url` and the `inputs`
+ * correlation). The suite asserts the tool surfaces the normalized products + the
+ * `not_found` list — so it is UNABLE to go green against the skeleton stub
+ * `{ stub: true, tool, echo }`.
+ *
+ * Contract pinned for the implementation (expert-developer):
+ *   - registerCatalogTools(api) registers `sil_product_get`; execute(callId,{ids})
+ *     reads tokens.json, POSTs <sil-api>/catalog/lookup with body { ids } and
+ *     Authorization: Bearer <at>, then maps the LookupOutcome to a jsonResult.
+ *   - not-registered (no tokens.json) → terminal `not_registered`, ZERO network.
+ *   - unfound ids → status ok + a not_found list, NEVER an error.
+ *   - the access token travels ONLY in the Authorization header — never in a log
+ *     line and never in the result.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { registerCatalogTools } from "../tools/catalog.js";
+import { setApiUrl, setSilApiUrl, getApiUrl, getSilApiUrl } from "../lib/config.js";
+import { getDataDir, getTokensPath } from "../lib/credentials.js";
+import {
+  createMockPluginApi,
+  getTool,
+  type MockPluginAPI,
+} from "./helpers/mock-plugin-api.js";
+
+const TOOL = "sil_product_get";
+const SIL_WEB = "https://sil-web.test.example.com"; // auth origin — must NOT be hit
+const SIL_API = "https://sil-api.test.example.com"; // catalog-read origin
+
+/** A real lookup `variant` resolved by a PRODUCT id (match "featured"): UCP variant
+ * + sil-api's required non-empty `checkout_url` + the REQUIRED `inputs` correlation,
+ * `availability` as the UCP object, `sku`/`options` for the purchase decision. */
+const VARIANT_A1 = {
+  id: "gid://variant/a1",
+  title: "Aeron Chair — Graphite, Size B",
+  description: { plain: "An ergonomic office chair." },
+  sku: "AER-GR-B",
+  options: [
+    { name: "Color", label: "Graphite" },
+    { name: "Size", label: "B" },
+  ],
+  price: { amount: 159900, currency: "USD" },
+  availability: { available: true, status: "in_stock" },
+  checkout_url: "https://buy.example.com/aeron-a1",
+  inputs: [{ id: "gid://product/a", match: "featured" }],
+};
+
+/** A SECOND variant on the SAME product — the tool must surface the FIRST. */
+const VARIANT_A2 = {
+  id: "gid://variant/a2",
+  title: "Aeron Chair — Carbon, Size C",
+  description: { plain: "An ergonomic office chair." },
+  sku: "AER-CB-C",
+  price: { amount: 169900, currency: "USD" },
+  availability: { available: false, status: "out_of_stock" },
+  checkout_url: "https://buy.example.com/aeron-a2",
+  inputs: [{ id: "gid://variant/a2", match: "exact" }],
+};
+
+const PRODUCT_A = {
+  id: "gid://product/a",
+  handle: "aeron-chair",
+  title: "Aeron Chair",
+  description: { plain: "An ergonomic office chair." },
+  categories: [{ name: "Office Furniture" }],
+  price_range: {
+    min: { amount: 159900, currency: "USD" },
+    max: { amount: 169900, currency: "USD" },
+  },
+  variants: [VARIANT_A1, VARIANT_A2],
+  source: "herman-miller",
+};
+
+/** A second product whose featured variant was resolved by a VARIANT id
+ * (match "exact"). */
+const PRODUCT_B = {
+  id: "gid://product/b",
+  handle: "standing-desk",
+  title: "Standing Desk",
+  description: { plain: "A height-adjustable desk." },
+  categories: [{ name: "Office Furniture" }],
+  price_range: {
+    min: { amount: 89900, currency: "USD" },
+    max: { amount: 89900, currency: "USD" },
+  },
+  variants: [
+    {
+      id: "gid://variant/b1",
+      title: "Standing Desk — Oak",
+      description: { plain: "A height-adjustable desk." },
+      sku: "DESK-OAK",
+      options: [{ name: "Finish", label: "Oak" }],
+      price: { amount: 89900, currency: "USD" },
+      availability: { available: true, status: "in_stock" },
+      checkout_url: "https://buy.example.com/desk-b1",
+      inputs: [{ id: "gid://variant/b1", match: "exact" }],
+    },
+  ],
+  source: "uplift",
+};
+
+/** The REAL sil-api lookup envelope (buildEnvelope output). The presence of a
+ * required `source` per product, a non-empty `checkout_url` + an `inputs`
+ * correlation per variant is what makes the suite anti-false-green: a
+ * `{ stub: true }` echo carries none of these, so the assertions below cannot pass
+ * against the skeleton stub. `messages` is included only when there are misses. */
+function lookupEnvelope(products: unknown[], messages?: unknown[]): unknown {
+  const result: Record<string, unknown> = { products };
+  if (messages !== undefined) result["messages"] = messages;
+  return {
+    protocol: "ucp",
+    version: "0.1",
+    domain: "catalog",
+    request_id: "req-int-1",
+    issued_at: "2026-06-09T00:00:00.000Z",
+    enrichment: { agent_id: "auth0|abc", on_behalf_of: "auth0|abc", enriched: true, source: "sil-api" },
+    result,
+  };
+}
+
+/** A single `not_found` info message, exactly as sil-api emits per unresolved id. */
+function notFoundMsg(id: string): Record<string, unknown> {
+  return { type: "info", code: "not_found", content: id };
+}
+
+let dataDir: string;
+let priorSilDataDir: string | undefined;
+
+/** One recorded outbound request. */
+interface Recorded {
+  url: string;
+  method: string;
+  bearer: string | null;
+  body: unknown;
+  hasBody: boolean;
+}
+
+type Reply = { status: number; body: unknown } | "network-error";
+
+/**
+ * A URL-routing fetch double cloned from catalog-search.integration.test.ts.
+ * `reply(kind, nthOfKind, req)` decides each response given whether the request is a
+ * `lookup` (sil-api /catalog/lookup) or `other`. Records every request (url, method,
+ * bearer, body) so origin, path, the Bearer header, the mapped body, and call COUNTS
+ * are all assertable.
+ */
+function installRouter(
+  reply: (kind: "lookup" | "other", nthOfKind: number, req: Recorded) => Reply,
+): { all: Recorded[]; lookup: Recorded[] } {
+  const all: Recorded[] = [];
+  const lookup: Recorded[] = [];
+
+  vi.spyOn(globalThis, "fetch").mockImplementation(
+    (input: unknown, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : String(input);
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      const bearer = headers["Authorization"] ?? headers["authorization"] ?? null;
+      const method = (init?.method ?? "GET").toUpperCase();
+      const hasBody = init?.body !== undefined && init?.body !== null;
+      let body: unknown = null;
+      if (typeof init?.body === "string") {
+        try {
+          body = JSON.parse(init.body);
+        } catch {
+          body = init.body;
+        }
+      }
+      const req: Recorded = { url, method, bearer, body, hasBody };
+      all.push(req);
+
+      const kind: "lookup" | "other" = url.includes("/catalog/lookup") ? "lookup" : "other";
+      let nthOfKind: number;
+      if (kind === "lookup") {
+        lookup.push(req);
+        nthOfKind = lookup.length - 1;
+      } else {
+        nthOfKind = all.length - 1;
+      }
+
+      const r = reply(kind, nthOfKind, req);
+      if (r === "network-error") {
+        return Promise.reject(new Error("simulated network failure"));
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify(r.body), {
+          status: r.status,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    },
+  );
+
+  return { all, lookup };
+}
+
+/** Parse a ToolResult payload. */
+function payloadOf(result: { content: { text?: string }[] }): Record<string, unknown> {
+  const text = result.content[0]?.text;
+  if (typeof text !== "string") throw new Error("no tool payload");
+  return JSON.parse(text) as Record<string, unknown>;
+}
+
+/** Seed a stored token pair so the lookup proceeds to the read. */
+function seedTokens(access: string, refresh: string): void {
+  const dir = getDataDir();
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    getTokensPath(),
+    JSON.stringify({ access_token: access, refresh_token: refresh }),
+    { mode: 0o600 },
+  );
+}
+
+/** The Bearer token value carried on a recorded request (stripped of scheme). */
+function bearerToken(req: Recorded): string | null {
+  if (req.bearer === null) return null;
+  return req.bearer.replace(/^Bearer\s+/i, "");
+}
+
+/** Collect every argument to every logger level, serialized. */
+function logBlob(api: MockPluginAPI): string {
+  return [api.logger.info, api.logger.warn, api.logger.error, api.logger.debug]
+    .flatMap((fn) => vi.mocked(fn).mock.calls.map((c) => JSON.stringify(c)))
+    .join("\n");
+}
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), "sil-lookup-int-"));
+  priorSilDataDir = process.env["SIL_DATA_DIR"];
+  process.env["SIL_DATA_DIR"] = dataDir;
+  // Pin BOTH origins to distinct known hosts so the origin/path assertions are exact
+  // and a misfire onto sil-web is caught.
+  setApiUrl(SIL_WEB);
+  setSilApiUrl(SIL_API);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  setApiUrl("");
+  setSilApiUrl("");
+  delete process.env["SIL_API_URL"];
+  delete process.env["SIL_API_BASE"];
+  if (priorSilDataDir === undefined) delete process.env["SIL_DATA_DIR"];
+  else process.env["SIL_DATA_DIR"] = priorSilDataDir;
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe("sil_product_get — param → request mapping (bare path, sil-api origin, Bearer)", () => {
+  it("POSTs the BARE /catalog/lookup path on the sil-api origin (NOT /api/v1, NOT sil-web)", async () => {
+    seedTokens("the-access-token", "the-refresh-token");
+    const rec = installRouter((kind) =>
+      kind === "lookup"
+        ? { status: 200, body: lookupEnvelope([PRODUCT_A]) }
+        : { status: 500, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] });
+
+    expect(rec.lookup.length).toBe(1);
+    const req = rec.lookup[0]!;
+    // Bare path — no /api/v1 anywhere.
+    const u = new URL(req.url);
+    expect(u.pathname).toBe("/catalog/lookup");
+    expect(req.url).not.toContain("/api/v1");
+    // sil-api origin, NOT sil-web.
+    expect(u.origin).toBe(new URL(getSilApiUrl()).origin);
+    expect(u.origin).not.toBe(new URL(getApiUrl()).origin);
+    // It is a POST carrying a body, with the stored Bearer token.
+    expect(req.method).toBe("POST");
+    expect(req.hasBody).toBe(true);
+    expect(bearerToken(req)).toBe("the-access-token");
+  });
+
+  it("maps { ids } to the body EXACTLY (no envelope, no defaults, ids verbatim)", async () => {
+    seedTokens("at", "rt");
+    const rec = installRouter((kind) =>
+      kind === "lookup"
+        ? { status: 200, body: lookupEnvelope([PRODUCT_A]) }
+        : { status: 500, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a", "gid://variant/b1"] });
+
+    expect(rec.lookup.length).toBe(1);
+    const body = rec.lookup[0]!.body as Record<string, unknown>;
+    // Exact mapped body — the tool builds NO UCP envelope and fills NO defaults.
+    expect(body).toEqual({ ids: ["gid://product/a", "gid://variant/b1"] });
+    // Belt-and-braces: it did NOT smuggle a client-built envelope, context, or filters.
+    expect(body["protocol"]).toBeUndefined();
+    expect(body["domain"]).toBeUndefined();
+    expect(body["context"]).toBeUndefined();
+    expect(body["filters"]).toBeUndefined();
+    expect(body["enrichment"]).toBeUndefined();
+  });
+});
+
+describe("sil_product_get — happy path normalizes the REAL envelope (anti-false-green)", () => {
+  it("returns status ok with the products, each carrying ONE rich projected variant + source + inputs", async () => {
+    seedTokens("at", "rt");
+    installRouter((kind) =>
+      kind === "lookup"
+        ? { status: 200, body: lookupEnvelope([PRODUCT_A, PRODUCT_B]) }
+        : { status: 500, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a", "gid://variant/b1"] }),
+    );
+
+    // The product promise — surfaced from the REAL envelope. A `{ stub: true }` echo
+    // would carry NONE of these markers, so this can't go green on a stub.
+    const blob = JSON.stringify(payload);
+    expect(payload["status"]).toBe("ok");
+    expect(blob).not.toContain('"stub"'); // never the skeleton stub shape
+    const products = payload["products"] as Array<Record<string, unknown>>;
+    expect(Array.isArray(products)).toBe(true);
+    expect(products).toHaveLength(2);
+
+    // Locate product A regardless of response order (lookup does not preserve order).
+    const a = products.find((p) => p["id"] === "gid://product/a")!;
+    expect(a).toBeDefined();
+    // RICH product detail — beyond search's lean six.
+    expect(a["description"]).toEqual({ plain: "An ergonomic office chair." });
+    expect(a["source"]).toBe("herman-miller");
+    expect(a["handle"]).toBe("aeron-chair");
+    // First (featured) variant only, projected with its rich fields + inputs.
+    const v = a["variant"] as Record<string, unknown>;
+    expect(v["id"]).toBe("gid://variant/a1"); // a1, never a2
+    expect(v["checkout_url"]).toBe("https://buy.example.com/aeron-a1");
+    expect(v["price"]).toEqual({ amount: 159900, currency: "USD" });
+    expect(v["sku"]).toBe("AER-GR-B");
+    expect(v["options"]).toEqual([
+      { name: "Color", label: "Graphite" },
+      { name: "Size", label: "B" },
+    ]);
+    // availability passed through as the UCP object, not flattened to a boolean.
+    const avail = v["availability"] as Record<string, unknown>;
+    expect(typeof avail).toBe("object");
+    expect(avail["available"]).toBe(true);
+    expect(avail["status"]).toBe("in_stock");
+    // The inputs correlation — lookup's defining feature — is surfaced.
+    expect(v["inputs"]).toEqual([{ id: "gid://product/a", match: "featured" }]);
+  });
+
+  it("a known id returns its featured variant with a FRESH, non-empty checkout_url", async () => {
+    // The acquisition target — re-fetched live, never a cached/empty value. This is
+    // the entire point of the lookup tool (UCP: catalog responses are not
+    // transactional commitments; re-fetch before buying).
+    seedTokens("at", "rt");
+    installRouter((kind) =>
+      kind === "lookup"
+        ? { status: 200, body: lookupEnvelope([PRODUCT_A]) }
+        : { status: 500, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] }));
+
+    expect(payload["status"]).toBe("ok");
+    const products = payload["products"] as Array<Record<string, unknown>>;
+    const v = products[0]!["variant"] as Record<string, unknown>;
+    const url = v["checkout_url"];
+    expect(typeof url).toBe("string");
+    expect((url as string).length).toBeGreaterThan(0);
+    expect(url).toBe("https://buy.example.com/aeron-a1");
+  });
+
+  it("preserves the `match` distinction across products (featured vs exact)", async () => {
+    seedTokens("at", "rt");
+    installRouter((kind) =>
+      kind === "lookup"
+        ? { status: 200, body: lookupEnvelope([PRODUCT_A, PRODUCT_B]) }
+        : { status: 500, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a", "gid://variant/b1"] }),
+    );
+
+    const products = payload["products"] as Array<Record<string, unknown>>;
+    const matchById = new Map(
+      products.map((p) => {
+        const inputs = (p["variant"] as Record<string, unknown>)["inputs"] as Array<
+          Record<string, unknown>
+        >;
+        return [p["id"], inputs[0]!["match"]];
+      }),
+    );
+    expect(matchById.get("gid://product/a")).toBe("featured");
+    expect(matchById.get("gid://product/b")).toBe("exact");
+  });
+});
+
+describe("sil_product_get — unfound ids are a SUCCESS surfaced as a not_found list (never an error)", () => {
+  it("a mix of known + unknown ids → status ok with the found products AND not_found:[the unfound ids]", async () => {
+    seedTokens("at", "rt");
+    installRouter((kind) =>
+      kind === "lookup"
+        ? {
+            status: 200,
+            body: lookupEnvelope([PRODUCT_A], [notFoundMsg("gid://product/gone")]),
+          }
+        : { status: 500, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a", "gid://product/gone"] }),
+    );
+
+    // A partial hit is a SUCCESS — the found product PLUS a structured not_found list.
+    expect(payload["status"]).toBe("ok");
+    const products = payload["products"] as Array<Record<string, unknown>>;
+    expect(products).toHaveLength(1);
+    expect(products[0]!["id"]).toBe("gid://product/a");
+    expect(payload["not_found"]).toEqual(["gid://product/gone"]);
+    // NOT an error: no recovery hint, no re-register.
+    expect(payload["recovery"]).toBeUndefined();
+    expect(JSON.stringify(payload).toLowerCase()).not.toMatch(/sil_register/);
+  });
+
+  it("NONE of the ids resolve → status ok with products:[] and not_found:[all the ids] (all-missed IS success)", async () => {
+    seedTokens("at", "rt");
+    installRouter((kind) =>
+      kind === "lookup"
+        ? {
+            status: 200,
+            body: lookupEnvelope([], [notFoundMsg("missing-1"), notFoundMsg("missing-2")]),
+          }
+        : { status: 500, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", { ids: ["missing-1", "missing-2"] }),
+    );
+
+    // "None of these exist anymore" is a successful answer, distinct from a
+    // not-registered/transport error and from a happy-path hit.
+    expect(payload["status"]).toBe("ok");
+    expect(payload["products"]).toEqual([]);
+    expect(payload["not_found"]).toEqual(["missing-1", "missing-2"]);
+    expect(payload["recovery"]).toBeUndefined();
+  });
+
+  it("every id resolves → status ok with NO not_found key (messages omitted on full success)", async () => {
+    seedTokens("at", "rt");
+    installRouter((kind) =>
+      kind === "lookup"
+        ? { status: 200, body: lookupEnvelope([PRODUCT_A, PRODUCT_B]) } // no messages key
+        : { status: 500, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a", "gid://variant/b1"] }),
+    );
+
+    expect(payload["status"]).toBe("ok");
+    expect((payload["products"] as unknown[]).length).toBe(2);
+    expect(payload["not_found"]).toBeUndefined();
+  });
+
+  it("the partial-hit success is DISTINCT from both the 401 and the 500 error envelopes", async () => {
+    async function payloadFor(reply: Reply): Promise<Record<string, unknown>> {
+      seedTokens("at", "rt");
+      installRouter((kind) => (kind === "lookup" ? reply : { status: 200, body: {} }));
+      const api = createMockPluginApi();
+      registerCatalogTools(api);
+      const p = payloadOf(await getTool(api, TOOL).execute("c1", { ids: ["x"] }));
+      vi.restoreAllMocks();
+      return p;
+    }
+
+    const partialHit = await payloadFor({
+      status: 200,
+      body: lookupEnvelope([PRODUCT_A], [notFoundMsg("gone")]),
+    });
+    const unauthorized = await payloadFor({ status: 401, body: { error: "unauthorized" } });
+    const sourceFail = await payloadFor({ status: 500, body: { error: "source_unavailable" } });
+
+    // Three distinct agent-facing statuses — a partial hit is ok, the others are not.
+    expect(new Set([partialHit["status"], unauthorized["status"], sourceFail["status"]]).size).toBe(3);
+    expect(partialHit["status"]).toBe("ok");
+  });
+});
+
+describe("sil_product_get — the failure outcomes surface as distinguishable error envelopes", () => {
+  it("401 → terminal re-register envelope (recovery sil_register), single round-trip, NOT a false-green", async () => {
+    seedTokens("dead-at", "dead-rt");
+    const rec = installRouter((kind) =>
+      kind === "lookup" ? { status: 401, body: { error: "unauthorized" } } : { status: 200, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] }));
+
+    // A SINGLE round-trip — lookup does NOT do the transparent refresh-and-retry
+    // choreography whoami performs (parity with sil_search: SC2 is single round-trip).
+    expect(rec.lookup.length).toBe(1);
+    // No refresh call leaked onto sil-web.
+    for (const r of rec.all) {
+      expect(r.url).not.toContain("/auth/refresh");
+    }
+    // Terminal, actionable re-register — not a success, not a silent all-missed.
+    expect(payload["status"]).not.toBe("ok");
+    expect(payload["products"]).toBeUndefined();
+    const blob = JSON.stringify(payload).toLowerCase();
+    expect(blob).toMatch(/re-?register|sil_register|session.*expired/);
+  });
+
+  it("400 (schema reject) → invalid_request envelope, distinct from the all-missed success and the transient", async () => {
+    seedTokens("at", "rt");
+    installRouter((kind) =>
+      kind === "lookup"
+        ? {
+            status: 400,
+            body: { error: "request_too_large", message: "Too many identifiers in one request." },
+          }
+        : { status: 500, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { ids: ["a", "b"] }));
+
+    expect(payload["status"]).toBe("invalid_request");
+    expect(payload["status"]).not.toBe("ok");
+    expect(payload["status"]).not.toBe("retryable");
+    // Not framed as a transient retry, not a re-register — the request is the problem.
+    expect(payload["recovery"]).not.toBe("sil_register");
+  });
+
+  it("source failure: 500 → retryable envelope, NO recovery:sil_register, distinct from the 401 + invalid_request arms", async () => {
+    seedTokens("at", "rt");
+    installRouter((kind) =>
+      kind === "lookup"
+        ? {
+            status: 500,
+            body: { error: "source_unavailable", message: "The catalog source is temporarily unavailable." },
+          }
+        : { status: 200, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] }));
+
+    expect(payload["status"]).toBe("retryable");
+    // Transient — try again, NOT re-register (re-registering can't fix a 5xx).
+    expect(payload["recovery"]).not.toBe("sil_register");
+    const blob = JSON.stringify(payload).toLowerCase();
+    expect(blob).not.toMatch(/sil_register/);
+    expect(blob).toMatch(/retry|try.again|temporar|unavailable|later/);
+  });
+
+  it("network error / timeout (thrown fetch) → retryable, distinct from the all-missed success", async () => {
+    seedTokens("at", "rt");
+    const rec = installRouter((kind) => (kind === "lookup" ? "network-error" : { status: 200, body: {} }));
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] }));
+
+    expect(rec.lookup.length).toBe(1); // one round-trip attempted
+    expect(payload["status"]).toBe("retryable");
+    expect(payload["status"]).not.toBe("ok");
+  });
+
+  it("401 is DISTINCT from the 500 transient outcome (different recovery guidance)", async () => {
+    async function payloadFor(reply: Reply): Promise<Record<string, unknown>> {
+      seedTokens("at", "rt");
+      installRouter((kind) => (kind === "lookup" ? reply : { status: 200, body: {} }));
+      const api = createMockPluginApi();
+      registerCatalogTools(api);
+      const p = payloadOf(await getTool(api, TOOL).execute("c1", { ids: ["x"] }));
+      vi.restoreAllMocks();
+      return p;
+    }
+
+    const unauthorized = await payloadFor({ status: 401, body: { error: "unauthorized" } });
+    const transient = await payloadFor({ status: 500, body: { error: "source_unavailable" } });
+
+    // The 401 carries a re-register hint; the 5xx does NOT (re-registering can't fix
+    // a server fault). The two must be distinguishable envelopes.
+    expect(unauthorized["status"]).not.toBe(transient["status"]);
+    expect(JSON.stringify(unauthorized).toLowerCase()).toMatch(/sil_register|re-?register/);
+    expect(JSON.stringify(transient).toLowerCase()).not.toMatch(/sil_register/);
+  });
+});
+
+describe("sil_product_get — not registered (no tokens.json) makes ZERO network calls", () => {
+  it("returns a terminal not_registered hint (recovery sil_register) and never touches fetch", async () => {
+    // No tokens seeded. A not-registered lookup has nothing to authenticate with, so
+    // it must short-circuit BEFORE any network call (mirrors sil_search / sil_whoami).
+    const rec = installRouter(() => ({ status: 200, body: lookupEnvelope([PRODUCT_A]) }));
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] }));
+
+    expect(rec.all.length).toBe(0); // ZERO network — nothing to authenticate with
+    expect(payload["status"]).not.toBe("ok");
+    expect(payload["products"]).toBeUndefined();
+    expect(JSON.stringify(payload)).toContain("sil_register");
+  });
+});
+
+describe("sil_product_get — the access token is sent on the read but NEVER leaks", () => {
+  it("the Bearer token reaches the request header but NOT the result and NOT any log line", async () => {
+    const AT = "lookup-secret-access-token";
+    const RT = "lookup-secret-refresh-token";
+    seedTokens(AT, RT);
+    const rec = installRouter((kind) =>
+      kind === "lookup" ? { status: 200, body: lookupEnvelope([PRODUCT_A]) } : { status: 500, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] }));
+
+    // The token DID reach the only legitimate place: the Authorization header.
+    expect(rec.lookup.length).toBe(1);
+    expect(bearerToken(rec.lookup[0]!)).toBe(AT);
+    // It is NOT echoed back to the agent in the result.
+    const resultBlob = JSON.stringify(payload);
+    expect(resultBlob).not.toContain(AT);
+    expect(resultBlob).not.toContain(RT);
+    expect(resultBlob).not.toMatch(/Bearer/i);
+    expect(resultBlob).not.toMatch(/authorization/i);
+    // And it never appears in any log line at any level.
+    const logs = logBlob(api);
+    expect(logs).not.toContain(AT);
+    expect(logs).not.toContain(RT);
+    expect(logs).not.toMatch(/Bearer/i);
+    // The token must not ride in the request BODY either — only the header.
+    const bodyBlob = JSON.stringify(rec.lookup[0]!.body ?? {});
+    expect(bodyBlob).not.toContain(AT);
+    expect(bodyBlob).not.toContain(RT);
+  });
+
+  it("on a network error, the access token still never appears in any log line", async () => {
+    const AT = "leak-canary-on-network-error";
+    seedTokens(AT, "rt");
+    installRouter((kind) => (kind === "lookup" ? "network-error" : { status: 200, body: {} }));
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] });
+
+    const logs = logBlob(api);
+    expect(logs).not.toContain(AT);
+    expect(logs).not.toMatch(/Bearer/i);
+  });
+});

--- a/src/__tests__/lib/lookup-classify.test.ts
+++ b/src/__tests__/lib/lookup-classify.test.ts
@@ -1,0 +1,558 @@
+/**
+ * UNIT — sil-api catalog LOOKUP response classifier + the pure lookup outcome
+ * projection (tier: unit, no network).
+ *
+ * The pure, highest-risk core of `sil_product_get`, pinned in isolation exactly
+ * like `classifySearchResponse` / `classifyIdentityResponse`. The whole
+ * agent-facing taxonomy — and the headline lookup invariant that UNFOUND IDS ARE A
+ * SUCCESS (not an error) — hangs off which `LookupOutcome` a (status, body) pair
+ * maps to. So the mapping must be nailed down here, in the cheapest tier, before
+ * any wiring.
+ *
+ * FOUR distinct things this classifier must get right, all load-bearing:
+ *
+ *   1. STATUS taxonomy — four distinct outcomes stay distinct (the catalog routes
+ *      sit behind the same JWT preHandler as search; a 401 is the dead-session
+ *      terminal, a 5xx/source-down is the transient):
+ *        200 (+ a usable `products` array, possibly empty) → ok
+ *        400 (Fastify schema reject — e.g. empty ids,       → invalid_request
+ *             request_too_large)                              (surfaces {error,message})
+ *        401 (auth preHandler rejected)                     → unauthorized  (terminal re-register)
+ *        5xx (source down) / other non-200                  → retryable     (transient try-again)
+ *      400 and 500 must NEVER flatten into the ok path, and 401 (terminal) must be
+ *      DISTINCT from 5xx (transient) — a wrong hint sends the agent down a recovery
+ *      path that can't fix the problem (auth dance on a blip; retry-forever on a
+ *      dead session). NOTE: lookup's empty-`ids` 400 is a SCHEMA-validation reject,
+ *      NOT the search-only `empty_search_input` SourceError — the classifier maps
+ *      ANY 400 → invalid_request and must not special-case that code on this path.
+ *
+ *   2. UNFOUND IDS ARE A SUCCESS surfaced as a `not_found` list — never an error
+ *      (the headline lookup risk; UCP §Identifiers Not Found: "return success with
+ *      the found products … MAY include informational messages indicating which
+ *      identifiers were not found"):
+ *        200 { result: { products:[…found…], messages:[{type:"info",code:"not_found",content:"<id>"}] } }
+ *                          → ok + found products + not_found:[<the unfound ids>]
+ *        200 { result: { products:[], messages:[…not_found for every id…] } }
+ *                          → ok + products:[] + not_found:[<all ids>]   (all-missed IS a success)
+ *        200 { result: { products:[…all resolved…] } } (NO messages key)
+ *                          → ok + NO not_found key                       (every id resolved)
+ *      The `not_found` ids come from `result.messages` entries whose
+ *      `code === "not_found"`; `content` is the id (sil-api emits exactly this,
+ *      `messages` OMITTED on full success). A `not_found` is DATA on the ok result,
+ *      NEVER an error and NEVER a recovery hint.
+ *
+ *   3. The anti-false-green body gate on 200 (mirroring `extractIdentity`'s
+ *      `name`-gate / `extractSearchResult`'s array-gate — complete-work-is-stub-free):
+ *        200 { result: { products: [] } }      → ok + empty list   (a VALID all-missed,
+ *                                                 distinct from the no-array fault)
+ *        200 with NO usable `products` array (partial / garbage / `{stub:true}`)
+ *                                              → retryable, NEVER ok (the false-green guard:
+ *                                                a stub/malformed 200 must not read as ok)
+ *      `ok` is gated on the envelope unwrapping AND `Array.isArray(result.products)` —
+ *      the empty-array case is the all-missed success, the missing/non-array case is
+ *      the fault. SUBTLE: distinguish by PRESENCE of a real products array, NEVER by
+ *      array length.
+ *
+ *   4. The RICH projection + the `inputs` correlation (lookup's defining feature
+ *      over search — the read-subset normalizer): unwrap `result` → products (NOT
+ *      re-ordered; the response does not preserve request order) → per product pick
+ *      the FIRST (featured) variant → project the RICH product subset
+ *      (`id`,`title`,`description`,`categories?`,`price_range`,`source`,`handle?`)
+ *      + the featured variant (`id`,`title`,`price`,`availability` OBJECT,
+ *      `checkout_url`,`sku?`,`options?`, and the **`inputs:[{id,match}]`**
+ *      correlation, `match` ∈ {exact,featured}). `availability` passes through as
+ *      the UCP OBJECT (`{available?,status?}`), NEVER flattened to a bare boolean.
+ *
+ * Contract this file pins for the implementation (expert-developer),
+ * `src/lib/sil-client.ts` — model on `SearchOutcome`:
+ *   classifyLookupResponse(status: number, body: unknown): LookupOutcome
+ *   where LookupOutcome is a discriminated union on `kind`:
+ *     | { kind: "ok"; products: LookupProduct[]; not_found?: string[] }
+ *     | { kind: "unauthorized" }
+ *     | { kind: "invalid_request"; error?: string; message?: string }
+ *     | { kind: "retryable" }
+ *   and LookupProduct surfaces the RICH product subset + a nested featured
+ *   `variant` carrying the `inputs` correlation. The classifier branches on
+ *   `status` (and, for 200, the body shape) — NEVER on `res.ok`. The FIELD NAMES
+ *   below and the unfound-is-success + anti-false-green splits ARE the immutable
+ *   spec. (If the dev sites the classifier elsewhere, re-export it from
+ *   sil-client.ts so this isolation test still binds — the classifier is the spec,
+ *   not its file.)
+ *
+ * Wire shapes pinned to the ALREADY-MERGED sil-api `/catalog/lookup` contract
+ * (PR #18; sil-services `@sil/schemas` catalog.ts + envelope.ts) and the UCP
+ * catalog-lookup spec (`vendor/ucp/spec/.../catalog/lookup.md` +
+ * `source/schemas/shopping/catalog_lookup.json` + `types/input_correlation.json`),
+ * NOT `@ucp-js/sdk` (which carries zero catalog types).
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { classifyLookupResponse } from "../../lib/sil-client.js";
+
+/** A real lookup `variant`: UCP variant + sil-api's required non-empty
+ * `checkout_url` + the REQUIRED lookup `inputs` correlation (UCP
+ * `catalog_lookup.json#/$defs/lookup_variant`: `inputs` required, minItems 1).
+ * `availability` is the UCP OBJECT `{ available?, status? }`. `options` is the
+ * `{ name, label }` selected-option shape. */
+const VARIANT_A1 = {
+  id: "gid://variant/a1",
+  title: "Aeron Chair — Graphite, Size B",
+  description: { plain: "An ergonomic office chair." },
+  sku: "AER-GR-B",
+  options: [
+    { name: "Color", label: "Graphite" },
+    { name: "Size", label: "B" },
+  ],
+  price: { amount: 159900, currency: "USD" },
+  availability: { available: true, status: "in_stock" },
+  checkout_url: "https://buy.example.com/aeron-a1",
+  inputs: [{ id: "gid://product/a", match: "featured" }],
+};
+
+/** A SECOND variant on the SAME product — the projection must pick the FIRST
+ * (featured) one, never this one. */
+const VARIANT_A2 = {
+  id: "gid://variant/a2",
+  title: "Aeron Chair — Carbon, Size C",
+  description: { plain: "An ergonomic office chair." },
+  sku: "AER-CB-C",
+  options: [
+    { name: "Color", label: "Carbon" },
+    { name: "Size", label: "C" },
+  ],
+  price: { amount: 169900, currency: "USD" },
+  availability: { available: false, status: "out_of_stock" },
+  checkout_url: "https://buy.example.com/aeron-a2",
+  inputs: [{ id: "gid://variant/a2", match: "exact" }],
+};
+
+/** A real lookup product (UCP product + sil-api's required `source`), RICH:
+ * description, categories, price_range, handle. Two variants. */
+const PRODUCT_A = {
+  id: "gid://product/a",
+  handle: "aeron-chair",
+  title: "Aeron Chair",
+  description: { plain: "An ergonomic office chair.", html: "<p>An ergonomic office chair.</p>" },
+  categories: [{ name: "Office Furniture" }],
+  price_range: {
+    min: { amount: 159900, currency: "USD" },
+    max: { amount: 169900, currency: "USD" },
+  },
+  variants: [VARIANT_A1, VARIANT_A2],
+  source: "herman-miller",
+};
+
+/** A variant resolved by an EXACT (variant-id) match — to assert the `match`
+ * distinction the agent relies on. */
+const VARIANT_B1 = {
+  id: "gid://variant/b1",
+  title: "Standing Desk — Oak",
+  description: { plain: "A height-adjustable desk." },
+  sku: "DESK-OAK",
+  options: [{ name: "Finish", label: "Oak" }],
+  price: { amount: 89900, currency: "USD" },
+  availability: { available: true, status: "in_stock" },
+  checkout_url: "https://buy.example.com/desk-b1",
+  inputs: [{ id: "gid://variant/b1", match: "exact" }],
+};
+
+const PRODUCT_B = {
+  id: "gid://product/b",
+  handle: "standing-desk",
+  title: "Standing Desk",
+  description: { plain: "A height-adjustable desk." },
+  categories: [{ name: "Office Furniture" }],
+  price_range: {
+    min: { amount: 89900, currency: "USD" },
+    max: { amount: 89900, currency: "USD" },
+  },
+  variants: [VARIANT_B1],
+  source: "uplift",
+};
+
+/** Wrap a `CatalogLookupResult` in the real UCP envelope `buildEnvelope` emits. */
+function envelope(result: unknown): unknown {
+  return {
+    protocol: "ucp",
+    version: "0.1",
+    domain: "catalog",
+    request_id: "req-1",
+    issued_at: "2026-06-09T00:00:00.000Z",
+    enrichment: { agent_id: "auth0|abc", enriched: true, source: "sil-api" },
+    result,
+  };
+}
+
+/** A single `not_found` info message, exactly as sil-api emits per unresolved id
+ * (UCP §Identifiers Not Found; `{ type:"info", code:"not_found", content:<id> }`). */
+function notFoundMsg(id: string): Record<string, unknown> {
+  return { type: "info", code: "not_found", content: id };
+}
+
+/** The current skeleton STUB shape (`stubResult` → `{ stub, tool, echo }`). A 200
+ * carrying this must NEVER read as a clean lookup (complete-work-is-stub-free). */
+const STUB_BODY = { stub: true, tool: "sil_product_get", echo: { ids: ["x"] } };
+
+describe("classifyLookupResponse — the four distinct outcomes stay distinct", () => {
+  it("200 with a populated result → ok (carries the products)", () => {
+    const out = classifyLookupResponse(200, envelope({ products: [PRODUCT_A] }));
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      expect(out.products).toHaveLength(1);
+    }
+  });
+
+  it("400 (schema reject) → invalid_request, surfacing sil-api's {error, message}", () => {
+    // A lookup with an empty/missing `ids` (or an over-limit batch) is rejected by
+    // the Fastify request schema with a generic 400 — NOT the search-only
+    // `empty_search_input` SourceError. The classifier maps ANY 400 →
+    // invalid_request and surfaces whatever {error,message} the body carries.
+    const out = classifyLookupResponse(400, {
+      error: "request_too_large",
+      message: "Too many identifiers in one request.",
+    });
+    expect(out.kind).toBe("invalid_request");
+    if (out.kind === "invalid_request") {
+      expect(out.error).toBe("request_too_large");
+      expect(out.message).toBe("Too many identifiers in one request.");
+    }
+  });
+
+  it("401 → unauthorized (terminal re-register, NOT transient)", () => {
+    // The catalog routes sit behind the JWT preHandler: an unauthenticated/dead-
+    // session request is rejected 401 before the handler.
+    const out = classifyLookupResponse(401, { error: "unauthorized" });
+    expect(out.kind).toBe("unauthorized");
+  });
+
+  it("500 source-down → retryable (transient, NOT invalid_request, NOT unauthorized)", () => {
+    const out = classifyLookupResponse(500, {
+      error: "source_unavailable",
+      message: "The catalog source is temporarily unavailable.",
+    });
+    expect(out.kind).toBe("retryable");
+  });
+
+  it("keeps the four outcome kinds DISTINCT (no two of ok/invalid_request/unauthorized/retryable collapse)", () => {
+    const kinds = new Set([
+      classifyLookupResponse(200, envelope({ products: [PRODUCT_A] })).kind,
+      classifyLookupResponse(400, { error: "request_too_large" }).kind,
+      classifyLookupResponse(401, {}).kind,
+      classifyLookupResponse(500, {}).kind,
+    ]);
+    expect(kinds.size).toBe(4);
+  });
+
+  it("does NOT flatten 400 or 500 into the ok path", () => {
+    expect(classifyLookupResponse(400, { error: "request_too_large" }).kind).not.toBe("ok");
+    expect(classifyLookupResponse(500, { error: "source_unavailable" }).kind).not.toBe("ok");
+  });
+
+  it("4xx other than 400/401 → retryable, never a silent ok (defensive)", () => {
+    for (const code of [403, 404, 409, 429]) {
+      expect(classifyLookupResponse(code, {}).kind).not.toBe("ok");
+    }
+  });
+});
+
+describe("classifyLookupResponse — unfound ids are a SUCCESS surfaced as not_found, never an error", () => {
+  it("a mix of found + unfound → ok with the found products AND not_found:[the unfound ids]", () => {
+    // UCP §Identifiers Not Found: return success with the found products plus info
+    // messages naming the unfound. NOT an error branch.
+    const out = classifyLookupResponse(
+      200,
+      envelope({ products: [PRODUCT_A], messages: [notFoundMsg("gid://product/missing")] }),
+    );
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      expect(out.products).toHaveLength(1);
+      expect(out.not_found).toEqual(["gid://product/missing"]);
+    }
+  });
+
+  it("NONE resolve → ok with products:[] and not_found:[every requested id] (all-missed IS a success)", () => {
+    // The lookup analogue of search's empty-results-as-success — but lookup NAMES
+    // which ids came back empty. Empty products + a full not_found is `ok`, NOT an
+    // error, distinct from a not-registered/transport failure.
+    const out = classifyLookupResponse(
+      200,
+      envelope({
+        products: [],
+        messages: [notFoundMsg("missing-1"), notFoundMsg("missing-2"), notFoundMsg("missing-3")],
+      }),
+    );
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      expect(out.products).toEqual([]);
+      expect(out.not_found).toEqual(["missing-1", "missing-2", "missing-3"]);
+    }
+  });
+
+  it("every id resolves → ok with NO not_found key (messages omitted server-side on full success)", () => {
+    // sil-api omits the `messages` key entirely when every id resolved
+    // (catalog.ts:88-91). The tool surfaces that absence as no `not_found` — never
+    // an empty array the agent must special-case, and never a stray key.
+    const out = classifyLookupResponse(200, envelope({ products: [PRODUCT_A, PRODUCT_B] }));
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      expect(out.products).toHaveLength(2);
+      expect(out.not_found).toBeUndefined();
+    }
+  });
+
+  it("an empty `messages` array → still NO not_found (an empty list is not a miss)", () => {
+    const out = classifyLookupResponse(200, envelope({ products: [PRODUCT_A], messages: [] }));
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      expect(out.not_found).toBeUndefined();
+    }
+  });
+
+  it("not_found ids come from `content` and preserve the server's order", () => {
+    const out = classifyLookupResponse(
+      200,
+      envelope({
+        products: [PRODUCT_A],
+        messages: [notFoundMsg("zeta"), notFoundMsg("alpha"), notFoundMsg("mu")],
+      }),
+    );
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      expect(out.not_found).toEqual(["zeta", "alpha", "mu"]);
+    }
+  });
+
+  it("ignores non-not_found messages (a warning/disclosure does NOT become a not_found id)", () => {
+    // A catalog response may carry warning/disclosure messages too. Only entries
+    // whose `code === "not_found"` are misses; broader passthrough is out of scope.
+    const out = classifyLookupResponse(
+      200,
+      envelope({
+        products: [PRODUCT_A],
+        messages: [
+          { type: "warning", code: "allergens", path: "$.products[0]", content: "Contains nuts." },
+          notFoundMsg("really-missing"),
+        ],
+      }),
+    );
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      expect(out.not_found).toEqual(["really-missing"]);
+      // The warning content must NOT leak into the not_found id list.
+      expect(out.not_found).not.toContain("Contains nuts.");
+      expect(out.not_found).not.toContain("allergens");
+    }
+  });
+
+  it("a partial hit is NOT invalid_request and NOT retryable (it is ok)", () => {
+    const out = classifyLookupResponse(
+      200,
+      envelope({ products: [PRODUCT_A], messages: [notFoundMsg("x")] }),
+    );
+    expect(out.kind).toBe("ok");
+    expect(["invalid_request", "retryable", "unauthorized"]).not.toContain(out.kind);
+  });
+});
+
+describe("classifyLookupResponse — the anti-false-green body gate on 200", () => {
+  it("200 carrying the skeleton STUB body ({stub,tool,echo}) is NOT ok", () => {
+    const out = classifyLookupResponse(200, STUB_BODY);
+    expect(out.kind).not.toBe("ok");
+  });
+
+  it("200 wrapping the STUB body in an envelope `result` is still NOT ok", () => {
+    const out = classifyLookupResponse(200, envelope(STUB_BODY));
+    expect(out.kind).not.toBe("ok");
+  });
+
+  it("200 whose result has NO `products` key → retryable, NEVER ok", () => {
+    // A partial/garbage 200 (no products array at all) is a server fault, not a
+    // valid all-missed lookup. It is `retryable`, DISTINCT from the genuine
+    // all-missed (which has products:[] + not_found).
+    const out = classifyLookupResponse(200, envelope({ messages: [notFoundMsg("x")] }));
+    expect(out.kind).toBe("retryable");
+    expect(out.kind).not.toBe("ok");
+  });
+
+  it("200 whose `products` is a NON-ARRAY (null / object / string) → retryable, never ok", () => {
+    expect(classifyLookupResponse(200, envelope({ products: null })).kind).not.toBe("ok");
+    expect(classifyLookupResponse(200, envelope({ products: {} })).kind).not.toBe("ok");
+    expect(classifyLookupResponse(200, envelope({ products: "nope" })).kind).not.toBe("ok");
+  });
+
+  it("200 with an empty / null / non-object body → retryable, never ok (defensive)", () => {
+    expect(classifyLookupResponse(200, {}).kind).not.toBe("ok");
+    expect(classifyLookupResponse(200, null).kind).not.toBe("ok");
+    expect(classifyLookupResponse(200, "not-an-object").kind).not.toBe("ok");
+  });
+
+  it("the all-missed success (products:[]) is DISTINCT from the no-array fault — by PRESENCE, not length", () => {
+    // THE subtle correctness point: a 200 with a real empty `products` array is the
+    // all-missed SUCCESS; a 200 with NO products array is the fault. The
+    // discriminant is the array's presence, NEVER its length.
+    const allMissed = classifyLookupResponse(
+      200,
+      envelope({ products: [], messages: [notFoundMsg("x")] }),
+    );
+    const noArray = classifyLookupResponse(200, envelope({ messages: [notFoundMsg("x")] }));
+    expect(allMissed.kind).toBe("ok");
+    expect(noArray.kind).toBe("retryable");
+  });
+
+  it("does NOT branch on res.ok — a 200 stub and a 200 real result differ only by body", () => {
+    expect(classifyLookupResponse(200, envelope({ products: [PRODUCT_A] })).kind).toBe("ok");
+    expect(classifyLookupResponse(200, STUB_BODY).kind).not.toBe("ok");
+  });
+});
+
+describe("classifyLookupResponse — rich projection (first/featured variant, rich subset, source)", () => {
+  it("does NOT rely on response order — surfaces each product with its own id (order not guaranteed)", () => {
+    // UCP §Client Correlation: the response does NOT guarantee request order. The
+    // tool surfaces products as the server returns them and the agent correlates
+    // via `inputs`, never by array position.
+    const out = classifyLookupResponse(200, envelope({ products: [PRODUCT_B, PRODUCT_A] }));
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      expect(out.products).toHaveLength(2);
+      const ids = out.products.map((p) => p.id);
+      expect(ids).toContain("gid://product/a");
+      expect(ids).toContain("gid://product/b");
+    }
+  });
+
+  it("picks the FIRST (featured) variant per product, never a later one", () => {
+    const out = classifyLookupResponse(200, envelope({ products: [PRODUCT_A] }));
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      const v = out.products[0]!.variant;
+      expect(v.id).toBe("gid://variant/a1");
+      expect(v.id).not.toBe("gid://variant/a2");
+    }
+  });
+
+  it("projects the RICH product subset: id, title, description, categories, price_range, source, handle", () => {
+    const out = classifyLookupResponse(200, envelope({ products: [PRODUCT_A] }));
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      const p = out.products[0]! as unknown as Record<string, unknown>;
+      expect(p["id"]).toBe("gid://product/a");
+      expect(p["title"]).toBe("Aeron Chair");
+      // description is the full object (not just a title — lookup is for a purchase
+      // decision), passed through.
+      expect(p["description"]).toEqual({
+        plain: "An ergonomic office chair.",
+        html: "<p>An ergonomic office chair.</p>",
+      });
+      expect(p["categories"]).toEqual([{ name: "Office Furniture" }]);
+      expect(p["price_range"]).toEqual({
+        min: { amount: 159900, currency: "USD" },
+        max: { amount: 169900, currency: "USD" },
+      });
+      expect(p["source"]).toBe("herman-miller");
+      expect(p["handle"]).toBe("aeron-chair");
+    }
+  });
+
+  it("projects the featured variant: id, title, price, availability OBJECT, checkout_url, sku, options", () => {
+    const out = classifyLookupResponse(200, envelope({ products: [PRODUCT_A] }));
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      const v = out.products[0]!.variant as unknown as Record<string, unknown>;
+      expect(v["id"]).toBe("gid://variant/a1");
+      expect(v["title"]).toBe("Aeron Chair — Graphite, Size B");
+      expect(v["price"]).toEqual({ amount: 159900, currency: "USD" });
+      expect(v["checkout_url"]).toBe("https://buy.example.com/aeron-a1");
+      expect(v["sku"]).toBe("AER-GR-B");
+      // options tell the agent WHICH variant this is (e.g. "Graphite / B").
+      expect(v["options"]).toEqual([
+        { name: "Color", label: "Graphite" },
+        { name: "Size", label: "B" },
+      ]);
+    }
+  });
+
+  it("passes `availability` through as the UCP OBJECT, never flattened to a bare boolean", () => {
+    const out = classifyLookupResponse(200, envelope({ products: [PRODUCT_A] }));
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      const avail = (out.products[0]!.variant as unknown as Record<string, unknown>)[
+        "availability"
+      ] as Record<string, unknown>;
+      expect(typeof avail).toBe("object");
+      expect(avail).not.toBe(true);
+      expect(avail["available"]).toBe(true);
+      expect(avail["status"]).toBe("in_stock");
+    }
+  });
+
+  it("carries the product-level `source` per product (a sil enrichment field)", () => {
+    const out = classifyLookupResponse(200, envelope({ products: [PRODUCT_A, PRODUCT_B] }));
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      const bySource = new Map(out.products.map((p) => [p.id, p.source]));
+      expect(bySource.get("gid://product/a")).toBe("herman-miller");
+      expect(bySource.get("gid://product/b")).toBe("uplift");
+    }
+  });
+});
+
+describe("classifyLookupResponse — the `inputs` correlation (lookup's defining feature)", () => {
+  it("surfaces the featured variant's `inputs:[{id,match}]` so the agent maps id → result", () => {
+    // UCP §Client Correlation: each variant carries `inputs` — which request id(s)
+    // resolved to it and how. Dropping `inputs` makes a multi-id lookup
+    // uncorrelatable; the tool MUST surface it.
+    const out = classifyLookupResponse(200, envelope({ products: [PRODUCT_A] }));
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      const inputs = (out.products[0]!.variant as unknown as Record<string, unknown>)[
+        "inputs"
+      ] as Array<Record<string, unknown>>;
+      expect(Array.isArray(inputs)).toBe(true);
+      expect(inputs).toEqual([{ id: "gid://product/a", match: "featured" }]);
+    }
+  });
+
+  it("preserves the `match` distinction — `featured` (product id) vs `exact` (variant id)", () => {
+    // PRODUCT_A's featured variant was resolved by a PRODUCT id → match "featured";
+    // PRODUCT_B's by a VARIANT id → match "exact". The agent tells the user whether
+    // they're looking at the exact thing they referenced or a featured stand-in.
+    const out = classifyLookupResponse(200, envelope({ products: [PRODUCT_A, PRODUCT_B] }));
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      const byId = new Map(
+        out.products.map((p) => [
+          p.id,
+          (p.variant as unknown as Record<string, unknown>)["inputs"] as Array<
+            Record<string, unknown>
+          >,
+        ]),
+      );
+      expect(byId.get("gid://product/a")![0]!["match"]).toBe("featured");
+      expect(byId.get("gid://product/b")![0]!["match"]).toBe("exact");
+    }
+  });
+
+  it("surfaces MULTIPLE inputs on one variant (a product id AND a variant id resolving to it)", () => {
+    // UCP: multiple request ids may resolve to the same variant — its `inputs`
+    // carries one entry per resolved id. The tool must surface ALL of them, not
+    // just the first, so the agent can mark both ids as resolved.
+    const multiInputVariant = {
+      ...VARIANT_A1,
+      inputs: [
+        { id: "gid://product/a", match: "featured" },
+        { id: "gid://variant/a1", match: "exact" },
+      ],
+    };
+    const productMulti = { ...PRODUCT_A, variants: [multiInputVariant] };
+    const out = classifyLookupResponse(200, envelope({ products: [productMulti] }));
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      const inputs = (out.products[0]!.variant as unknown as Record<string, unknown>)[
+        "inputs"
+      ] as Array<Record<string, unknown>>;
+      expect(inputs).toHaveLength(2);
+      expect(inputs.map((i) => i["id"])).toEqual(["gid://product/a", "gid://variant/a1"]);
+    }
+  });
+});

--- a/src/__tests__/lib/lookup-client.test.ts
+++ b/src/__tests__/lib/lookup-client.test.ts
@@ -1,0 +1,229 @@
+/**
+ * UNIT — `lookupCatalog` HTTP wrapper request construction (tier: unit, `fetch`
+ * spied so nothing reaches the network).
+ *
+ * The lookup sibling of `search-client.test.ts`. Pins the request-construction
+ * half of the catalog LOOKUP client in isolation (the classifier — the response
+ * half — is `lookup-classify.test.ts`). `lookupCatalog(silApiUrl, token, ids)` is
+ * the seam where the agent's `{ ids: string[] }` becomes the sil-api
+ * `CatalogLookupRequest` body and the stored Bearer token becomes the
+ * `Authorization` header — both load-bearing and both cheaply assertable with a
+ * single `fetch` spy, exactly as `search-client.test.ts` pins `searchCatalog`.
+ *
+ * What this file locks down (the request side — card AC "[unit] … calls
+ * POST <silApiUrl>/catalog/lookup with body { ids } (no envelope) … carrying the
+ * stored user's Authorization: Bearer <token>"):
+ *   - the URL is the BARE `${silApiUrl}/catalog/lookup` — NO `/api/v1` anywhere
+ *     (the card's own Intent is WRONG; the route is bare — see
+ *     docs/knowledge/sil-api-catalog-contract.md), trailing slash on the base
+ *     tolerated, sil-api origin (NOT sil-web);
+ *   - the method is POST with a JSON content-type and an `Authorization: Bearer
+ *     <token>` header;
+ *   - the body is EXACTLY `{ ids }` — the SIMPLIFIED shape: the tool builds NO UCP
+ *     envelope and injects NO defaults (no `filters`, no `context`, no `signals`),
+ *     forwarding the ids verbatim (sil-api owns dedup + any batch cap);
+ *   - on a thrown fetch (network/timeout) the wrapper returns `retryable` and the
+ *     token never appears in the returned union (the never-leak invariant at the
+ *     wrapper boundary; the tool-level log canary is in `tools/product-get.test.ts`).
+ *
+ * Contract this file pins for the implementation (expert-developer),
+ * `src/lib/sil-client.ts`:
+ *   lookupCatalog(
+ *     silApiUrl: string,
+ *     token: string,
+ *     ids: string[],
+ *   ): Promise<LookupOutcome>
+ *   It POSTs `{ ids }` to the bare `/catalog/lookup` with the Bearer header, then
+ *   returns `classifyLookupResponse(status, body)`. A thrown fetch →
+ *   `{ kind: "retryable" }`. The exact request shape below IS the immutable spec.
+ *
+ * Wire shapes pinned to the ALREADY-MERGED sil-api `/catalog/lookup` contract
+ * (PR #18; sil-services `@sil/schemas` catalog.ts) + the UCP catalog-lookup spec
+ * (`vendor/ucp/spec/source/schemas/shopping/catalog_lookup.json#/$defs/lookup_request`
+ * — `ids` required, `minItems: 1`).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { lookupCatalog } from "../../lib/sil-client.js";
+
+const SIL_API = "https://sil-api.test.example.com";
+
+interface Captured {
+  url: string;
+  method: string;
+  bearer: string | null;
+  contentType: string | null;
+  body: unknown;
+}
+
+/** The REAL sil-api lookup envelope (buildEnvelope output), one product whose
+ * featured variant carries the required `inputs` correlation — so a forwarded
+ * request resolves cleanly through the classifier and the wrapper returns `ok`. */
+function lookupEnvelope(): unknown {
+  return {
+    protocol: "ucp",
+    version: "0.1",
+    domain: "catalog",
+    result: {
+      products: [
+        {
+          id: "gid://product/a",
+          title: "Aeron Chair",
+          description: { plain: "An ergonomic office chair." },
+          price_range: {
+            min: { amount: 159900, currency: "USD" },
+            max: { amount: 159900, currency: "USD" },
+          },
+          source: "herman-miller",
+          variants: [
+            {
+              id: "gid://variant/a1",
+              title: "Aeron Chair — Graphite, Size B",
+              price: { amount: 159900, currency: "USD" },
+              availability: { available: true, status: "in_stock" },
+              checkout_url: "https://buy.example.com/aeron-a1",
+              inputs: [{ id: "gid://product/a", match: "featured" }],
+            },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+/** Spy `fetch` and capture the single outbound request, replying 200 with the
+ * real lookup envelope so the wrapper resolves cleanly. */
+function spyFetch(captured: Captured[]): void {
+  vi.spyOn(globalThis, "fetch").mockImplementation(
+    (input: unknown, init?: RequestInit) => {
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      let body: unknown = null;
+      if (typeof init?.body === "string") {
+        try {
+          body = JSON.parse(init.body);
+        } catch {
+          body = init.body;
+        }
+      }
+      captured.push({
+        url: typeof input === "string" ? input : String(input),
+        method: (init?.method ?? "GET").toUpperCase(),
+        bearer: headers["Authorization"] ?? headers["authorization"] ?? null,
+        contentType: headers["content-type"] ?? headers["Content-Type"] ?? null,
+        body,
+      });
+      return Promise.resolve(
+        new Response(JSON.stringify(lookupEnvelope()), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    },
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("lookupCatalog — endpoint, method, and auth header", () => {
+  let cap: Captured[];
+  beforeEach(() => {
+    cap = [];
+    spyFetch(cap);
+  });
+
+  it("POSTs the BARE /catalog/lookup path (no /api/v1 anywhere)", async () => {
+    await lookupCatalog(SIL_API, "tok", ["gid://product/a"]);
+    expect(cap).toHaveLength(1);
+    expect(new URL(cap[0]!.url).pathname).toBe("/catalog/lookup");
+    expect(cap[0]!.url).not.toContain("/api/v1");
+    expect(cap[0]!.url).toBe(`${SIL_API}/catalog/lookup`);
+  });
+
+  it("tolerates a trailing slash on the base URL (no double slash)", async () => {
+    await lookupCatalog(`${SIL_API}/`, "tok", ["gid://product/a"]);
+    expect(cap[0]!.url).toBe(`${SIL_API}/catalog/lookup`);
+    expect(cap[0]!.url).not.toContain("//catalog");
+  });
+
+  it("uses POST with a JSON content-type and the stored Bearer token", async () => {
+    await lookupCatalog(SIL_API, "the-access-token", ["gid://product/a"]);
+    expect(cap[0]!.method).toBe("POST");
+    expect(cap[0]!.contentType).toMatch(/application\/json/);
+    expect(cap[0]!.bearer).toBe("Bearer the-access-token");
+  });
+});
+
+describe("lookupCatalog — body is EXACTLY { ids } (no envelope, no defaults, ids verbatim)", () => {
+  let cap: Captured[];
+  beforeEach(() => {
+    cap = [];
+    spyFetch(cap);
+  });
+
+  it("sends the body { ids } with the ids verbatim and in the given order", async () => {
+    await lookupCatalog(SIL_API, "tok", ["id-1", "id-2", "id-3"]);
+    expect(cap[0]!.body).toEqual({ ids: ["id-1", "id-2", "id-3"] });
+  });
+
+  it("a single-id lookup carries that one id in the array", async () => {
+    await lookupCatalog(SIL_API, "tok", ["gid://variant/solo"]);
+    expect(cap[0]!.body).toEqual({ ids: ["gid://variant/solo"] });
+  });
+
+  it("builds NO UCP envelope and injects NO context/filters/signals (the agent sends { ids } only)", async () => {
+    await lookupCatalog(SIL_API, "tok", ["gid://product/a"]);
+    const body = cap[0]!.body as Record<string, unknown>;
+    expect(Object.keys(body)).toEqual(["ids"]);
+    expect(body["protocol"]).toBeUndefined();
+    expect(body["version"]).toBeUndefined();
+    expect(body["domain"]).toBeUndefined();
+    expect(body["enrichment"]).toBeUndefined();
+    expect(body["context"]).toBeUndefined();
+    expect(body["filters"]).toBeUndefined();
+    expect(body["signals"]).toBeUndefined();
+  });
+
+  it("forwards duplicate ids VERBATIM — does NOT dedup client-side (sil-api owns dedup)", async () => {
+    // UCP mandates dedup, but sil-api owns it (it already dedups at the seam). The
+    // tool must NOT dedup-then-mask, which would hide a seam regression. It
+    // forwards the ids as given; the server returns each matched product once.
+    await lookupCatalog(SIL_API, "tok", ["dup", "dup", "other"]);
+    expect(cap[0]!.body).toEqual({ ids: ["dup", "dup", "other"] });
+  });
+
+  it("does NOT cap or truncate the batch — forwards a large id list verbatim (sil-api owns the cap)", async () => {
+    // UCP allows an optional batch cap with a request_too_large 400; that is
+    // sil-api's to enforce. The tool forwards the full list and trusts the server.
+    const many = Array.from({ length: 50 }, (_, i) => `id-${i}`);
+    await lookupCatalog(SIL_API, "tok", many);
+    expect(cap[0]!.body).toEqual({ ids: many });
+  });
+});
+
+describe("lookupCatalog — transport failure maps to retryable without leaking the token", () => {
+  it("a thrown fetch (network/timeout) → retryable", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("simulated network failure"));
+    const out = await lookupCatalog(SIL_API, "tok", ["gid://product/a"]);
+    expect(out.kind).toBe("retryable");
+  });
+
+  it("the returned union NEVER carries the access token (privacy at the wrapper boundary)", async () => {
+    // On every path — success AND thrown — the token travels only in the outbound
+    // request header, never into the returned LookupOutcome.
+    const SECRET = "wrapper-secret-token";
+
+    // Success path.
+    spyFetch([]);
+    const ok = await lookupCatalog(SIL_API, SECRET, ["gid://product/a"]);
+    expect(JSON.stringify(ok)).not.toContain(SECRET);
+    vi.restoreAllMocks();
+
+    // Thrown path.
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("boom"));
+    const thrown = await lookupCatalog(SIL_API, SECRET, ["gid://product/a"]);
+    expect(JSON.stringify(thrown)).not.toContain(SECRET);
+  });
+});

--- a/src/__tests__/manifest-contract.integration.test.ts
+++ b/src/__tests__/manifest-contract.integration.test.ts
@@ -129,6 +129,17 @@ describe("manifest ↔ code drift guard (set-equality, BOTH directions)", () => 
     expect(codeRegisteredNames().has("sil_search")).toBe(true);
     expect(manifestToolNames().has("sil_search")).toBe(true);
   });
+
+  it("sil_product_get is BOTH registered by register() and declared in contracts.tools", () => {
+    // The sibling lookup tool's self-enforcing-registration criterion, pinned by
+    // name. registerCatalogTools is ALREADY wired into codeRegisteredNames (search
+    // added the call), so adding sil_product_get as a second tool in that group is
+    // picked up automatically — it must appear on BOTH sides of the equal set:
+    // registered by registerCatalogTools AND listed in
+    // openclaw.plugin.json#contracts.tools.
+    expect(codeRegisteredNames().has("sil_product_get")).toBe(true);
+    expect(manifestToolNames().has("sil_product_get")).toBe(true);
+  });
 });
 
 describe("the drift guard actually bites (failure-direction proof)", () => {

--- a/src/__tests__/tools/product-get.test.ts
+++ b/src/__tests__/tools/product-get.test.ts
@@ -1,0 +1,305 @@
+/**
+ * UNIT — sil_product_get tool: registration shape + the client-side non-empty-ids
+ * guard + the not-registered short-circuit + the token-log canary (tier: unit,
+ * mock api + temp data dir, `fetch` spied so nothing reaches the network).
+ *
+ * Covers the unit-tier acceptance criteria that live at the TOOL boundary (the
+ * request-mapping + classifier pure pieces are pinned in `lib/lookup-client.test.ts`
+ * and `lib/lookup-classify.test.ts`; the full wired pipeline + the unfound-is-success
+ * + three-distinct-failures taxonomy are the integration tier's job in
+ * `catalog-lookup.integration.test.ts`). Here we assert:
+ *
+ *   - the tool-registration shape (a `sil_product_get` tool whose parameters are a
+ *     TypeBox object with an `ids` array of strings);
+ *   - the CLIENT-SIDE non-empty-ids guard the tool owns: a request with an empty
+ *     `ids` array (or no `ids`) returns a structured validation error naming the
+ *     missing input and makes ZERO network calls (sil-api's `minItems:1` schema 400
+ *     is the authoritative backstop, but the cheap client guard saves the
+ *     round-trip);
+ *   - the not-registered short-circuit: no tokens.json → terminal `not_registered`
+ *     (recovery `sil_register`), ZERO network (mirrors sil_search / sil_whoami);
+ *   - the token-log canary: on every path the stored token never appears in any
+ *     logger call at any level.
+ *
+ * Hermetic via the `SIL_DATA_DIR` temp-dir override and the config-reset machinery
+ * mirrored from the sil_search unit test.
+ *
+ * Contract this file pins for the implementation (expert-developer):
+ *   - src/tools/catalog.ts#registerCatalogTools(api) ALSO registers a
+ *     `sil_product_get` tool whose parameters are a Type.Object with an `ids`
+ *     Type.Array(Type.String());
+ *   - execute() returns a jsonResult; with an empty (or missing) `ids` it returns a
+ *     structured validation error and calls no fetch; with no tokens.json it returns
+ *     a terminal not_registered hint and calls no fetch.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { registerCatalogTools } from "../../tools/catalog.js";
+import { setApiUrl, setSilApiUrl } from "../../lib/config.js";
+import { getDataDir, getTokensPath } from "../../lib/credentials.js";
+import {
+  createMockPluginApi,
+  getTool,
+  type MockPluginAPI,
+} from "../helpers/mock-plugin-api.js";
+
+const TOOL = "sil_product_get";
+
+let dataDir: string;
+let priorSilDataDir: string | undefined;
+
+/** Parse a ToolResult's JSON payload. */
+function payloadOf(result: { content: { text?: string }[] }): Record<string, unknown> {
+  const text = result.content[0]?.text;
+  if (typeof text !== "string") {
+    throw new Error(`tool result has no text payload: ${String(text)}`);
+  }
+  return JSON.parse(text) as Record<string, unknown>;
+}
+
+/** Seed a valid token pair so the lookup proceeds past the not-registered guard. */
+function seedTokens(access = "stored-at", refresh = "stored-rt"): void {
+  const dir = getDataDir();
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    getTokensPath(),
+    JSON.stringify({ access_token: access, refresh_token: refresh }),
+    { mode: 0o600 },
+  );
+}
+
+/** A 200 real lookup envelope (one product whose featured variant carries the
+ * required `inputs`), so a forwarded request resolves cleanly to `ok`. */
+function okEnvelopeFetch(): ReturnType<typeof vi.spyOn> {
+  return vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response(
+      JSON.stringify({
+        protocol: "ucp",
+        version: "0.1",
+        domain: "catalog",
+        result: {
+          products: [
+            {
+              id: "gid://product/a",
+              title: "Aeron Chair",
+              description: { plain: "An ergonomic office chair." },
+              price_range: { min: { amount: 159900, currency: "USD" }, max: { amount: 159900, currency: "USD" } },
+              source: "herman-miller",
+              variants: [
+                {
+                  id: "gid://variant/a1",
+                  title: "Aeron Chair — Graphite, Size B",
+                  price: { amount: 159900, currency: "USD" },
+                  availability: { available: true, status: "in_stock" },
+                  checkout_url: "https://buy.example.com/aeron-a1",
+                  inputs: [{ id: "gid://product/a", match: "featured" }],
+                },
+              ],
+            },
+          ],
+        },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    ),
+  );
+}
+
+/** Collect every argument to every logger level, serialized. */
+function logBlob(api: MockPluginAPI): string {
+  return [api.logger.info, api.logger.warn, api.logger.error, api.logger.debug]
+    .flatMap((fn) => vi.mocked(fn).mock.calls.map((c) => JSON.stringify(c)))
+    .join("\n");
+}
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), "sil-product-get-unit-"));
+  priorSilDataDir = process.env["SIL_DATA_DIR"];
+  process.env["SIL_DATA_DIR"] = dataDir;
+  setApiUrl("");
+  setSilApiUrl("");
+  delete process.env["SIL_API_URL"];
+  delete process.env["SIL_API_BASE"];
+});
+
+afterEach(() => {
+  if (priorSilDataDir === undefined) delete process.env["SIL_DATA_DIR"];
+  else process.env["SIL_DATA_DIR"] = priorSilDataDir;
+  setApiUrl("");
+  setSilApiUrl("");
+  delete process.env["SIL_API_URL"];
+  delete process.env["SIL_API_BASE"];
+  rmSync(dataDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe("sil_product_get — tool registration shape", () => {
+  it("registers a sil_product_get tool with a typed `ids` array-of-strings param", () => {
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+    const tool = getTool(api, TOOL);
+    expect(tool.name).toBe(TOOL);
+    expect(tool.label.length).toBeGreaterThan(0);
+    expect(tool.description.length).toBeGreaterThan(0);
+    // A TypeBox object whose `ids` property is an array of strings.
+    expect((tool.parameters as { type?: unknown }).type).toBe("object");
+    const props = (tool.parameters as { properties?: Record<string, unknown> }).properties ?? {};
+    expect(Object.keys(props)).toContain("ids");
+    const ids = props["ids"] as { type?: unknown; items?: { type?: unknown } };
+    expect(ids.type).toBe("array");
+    expect(ids.items?.type).toBe("string");
+  });
+
+  it("is registered ALONGSIDE sil_search in the same catalog group (both present)", () => {
+    // The card's reuse constraint: sil_product_get is a SECOND call inside
+    // registerCatalogTools — registering it must not displace sil_search.
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+    expect(() => getTool(api, "sil_search")).not.toThrow();
+    expect(() => getTool(api, TOOL)).not.toThrow();
+  });
+});
+
+describe("sil_product_get — client-side non-empty-ids guard (reject empty BEFORE any network)", () => {
+  let api: MockPluginAPI;
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // A token IS present (so the guard, not the not-registered path, is what
+    // rejects); fetch fails loudly if the guard lets an empty request through.
+    seedTokens();
+    fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(new Error("empty ids must not hit the network"));
+    api = createMockPluginApi();
+    registerCatalogTools(api);
+  });
+
+  it("an empty ids array → structured validation error naming the missing input, ZERO network calls", async () => {
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { ids: [] }));
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(payload["status"]).not.toBe("ok");
+    const blob = JSON.stringify(payload).toLowerCase();
+    expect(blob).toMatch(/id/);
+    expect(blob).toMatch(/status|error|invalid/);
+  });
+
+  it("a missing ids key → validation error, ZERO network calls", async () => {
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", {}));
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(payload["status"]).not.toBe("ok");
+    expect(JSON.stringify(payload).toLowerCase()).toMatch(/id/);
+  });
+
+  it("the validation error is NOT a re-register hint (auth is fine; the input is the problem)", async () => {
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { ids: [] }));
+    expect(payload["recovery"]).not.toBe("sil_register");
+  });
+});
+
+describe("sil_product_get — a non-empty ids request PROCEEDS to the network", () => {
+  it("a request with one id reaches the network (the guard does not over-reject)", async () => {
+    seedTokens();
+    const fetchSpy = okEnvelopeFetch();
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] }),
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(payload["status"]).toBe("ok");
+  });
+});
+
+describe("sil_product_get — not registered (no tokens.json) short-circuit", () => {
+  let api: MockPluginAPI;
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // No tokens seeded. fetch fails loudly if the tool calls it.
+    fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(new Error("not-registered must not hit the network"));
+    api = createMockPluginApi();
+    registerCatalogTools(api);
+  });
+
+  it("makes NO sil-api call and names sil_register as the recovery", async () => {
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] }),
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(payload["status"]).not.toBe("ok");
+    // No products field so the agent can't mistake it for an all-missed success.
+    expect(payload["products"]).toBeUndefined();
+    expect(JSON.stringify(payload)).toContain("sil_register");
+  });
+
+  it("does NOT crash and resolves promptly when not registered", async () => {
+    const result = await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] });
+    expect(result).toBeTypeOf("object");
+    expect(result.content[0]?.text).toBeTypeOf("string");
+  });
+});
+
+describe("sil_product_get — token never logged (leak-canary)", () => {
+  it("on the SUCCESS path, no logger call carries the access token", async () => {
+    seedTokens("leak-canary-access", "leak-canary-refresh");
+    okEnvelopeFetch();
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] });
+
+    const blob = logBlob(api);
+    expect(blob).not.toContain("leak-canary-access");
+    expect(blob).not.toContain("leak-canary-refresh");
+    expect(blob).not.toMatch(/Bearer/i);
+  });
+
+  it("on a 401 (non-success) path, no logger call carries the access token", async () => {
+    seedTokens("leak-canary-access-2", "leak-canary-refresh-2");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "unauthorized" }), {
+        status: 401,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] });
+
+    const blob = logBlob(api);
+    expect(blob).not.toContain("leak-canary-access-2");
+    expect(blob).not.toContain("leak-canary-refresh-2");
+    expect(blob).not.toMatch(/Bearer/i);
+  });
+
+  it("the success result does NOT echo the access token or Authorization header", async () => {
+    seedTokens("secret-access-token", "secret-refresh-token");
+    okEnvelopeFetch();
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const blob = JSON.stringify(
+      payloadOf(await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] })),
+    );
+    expect(blob).not.toContain("secret-access-token");
+    expect(blob).not.toContain("secret-refresh-token");
+    expect(blob).not.toMatch(/Bearer/i);
+    expect(blob).not.toMatch(/authorization/i);
+  });
+});

--- a/src/lib/sil-client.ts
+++ b/src/lib/sil-client.ts
@@ -48,6 +48,34 @@
  *     401                                            → unauthorized (terminal here)
  *     5xx / network / abort                          → retryable
  *
+ * Wire contract for the sil-API catalog LOOKUP (SAME origin/path style as search —
+ * sil-api, bare `/catalog/lookup`, NOT /api/v1; see the sil-product-get card). The
+ * lookup COMPANION to search: an agent passes ids it already holds and gets fresh
+ * RICH detail back (search is LEAN). sil-api owns enrichment + the `not_found`
+ * messaging + the envelope; the plugin sends just `{ ids }` (NO filters/context,
+ * NO envelope). The two structural deltas from search's response: NO `pagination`
+ * (a batch resolve, not a list) and a `messages[]` carrying the misses:
+ *
+ *   POST <silApiUrl>/catalog/lookup   Authorization: Bearer <access_token>
+ *     body { ids: string[] }                         (≥1; no filters/context)
+ *     200 <UCP envelope>{ result: { products: SilCatalogProduct[],
+ *            messages?:[{ type:"info", code:"not_found", content:<id> }] } } → ok
+ *     400 (schema: empty `ids` / request_too_large)  → invalid_request
+ *     401                                            → unauthorized (terminal here)
+ *     5xx / network / abort                          → retryable
+ *
+ * A lookup MISS is partial-SUCCESS data, NEVER an error: an unresolved id is a
+ * `not_found` info `message` (the server omits `messages` entirely on full
+ * success), surfaced on the `ok` outcome as a `not_found: string[]`. Each looked-up
+ * variant carries an `inputs:[{ id, match }]` correlation (lookup's defining
+ * feature over search — the response does NOT preserve request order and one id
+ * may resolve to a variant of another id's product, so `inputs` is the only way to
+ * map a request id to its result). `classifyLookupResponse` gates `ok` on a real
+ * `Array.isArray(result.products)` — a 200 with no usable products array is
+ * `retryable`, NEVER a false-green; a genuine ALL-MISSED lookup is a 200 whose
+ * `result.products` IS `[]` WITH a populated `not_found` → `ok` (success: "none of
+ * these exist anymore"), the discriminator being array PRESENCE, never length.
+ *
  * `SilCatalogProduct` = a UCP product PLUS a required `source`; each variant PLUS
  * a required non-empty `checkout_url` (sil-services `@sil/schemas` catalog.ts —
  * the byte-shape of truth; `@ucp-js/sdk` carries ZERO catalog types). The plugin
@@ -238,6 +266,92 @@ export type SearchOutcome =
   | { kind: "invalid_request"; error: string; message: string }
   | { kind: "retryable" };
 
+/** Which request id resolved to a looked-up variant, and how. Lookup's defining
+ * feature over search: the response does NOT preserve request order and one id
+ * may resolve to a VARIANT of another id's product, so `inputs` is the only way
+ * to correlate "the id I asked about" → "the variant I got back". `match` is an
+ * OPEN string (UCP well-known values `exact` — a direct variant/sku/barcode hit —
+ * and `featured` — a product-id hit where the server picked a representative
+ * variant), passed through as-is. `id` is required; a missing/non-string `match`
+ * is dropped (not coerced). */
+export interface LookupInput {
+  id: string;
+  match?: string;
+}
+
+/** The featured variant of a looked-up product, projected to the purchase-decision
+ * fields a lookup caller needs. Richer than {@link SearchVariant}: adds `sku` and
+ * `options` (which specific configuration this is — e.g. "Blue / Large") and the
+ * lookup-only `inputs` correlation. `price`/`availability` pass through opaque;
+ * `checkout_url` is the non-empty acquisition target (re-fetched live — freshness
+ * is the reason this tool exists). Optional fields are omitted when absent rather
+ * than emitted as `undefined`. */
+export interface LookupVariant {
+  id: string;
+  title: string;
+  price: SearchPrice;
+  availability: SearchAvailability;
+  checkout_url: string;
+  sku?: string;
+  options?: SelectedOption[];
+  inputs?: LookupInput[];
+}
+
+/** One option selection on a variant, passed through OPAQUE from the UCP
+ * `SelectedOption` (well-known fields `{ name, label }`, e.g. "Size: Large") —
+ * the tool does NOT read or remap individual fields; it filters to plain objects
+ * and passes them through verbatim, exactly as identity `addresses` pass through.
+ * Surfaced so a lookup caller knows WHICH variant of a product they are buying. */
+export type SelectedOption = Record<string, unknown>;
+
+/** One looked-up product, projected to its RICH agent-facing detail (the deliberate
+ * split vs search's LEAN six: a lookup caller is making a purchase decision, so it
+ * gets `description`, `categories`, `handle`). Carries the product-level identity
+ * AND the single featured `variant` (what to buy) — mirroring search's structural
+ * shape; the split is rich-vs-lean FIELDS, not a different envelope. `categories`/
+ * `handle` are omitted when absent. `description`/`categories` pass through opaque
+ * (the tool surfaces them, it does not interpret them). */
+export interface LookupProduct {
+  id: string;
+  title: string;
+  description: Record<string, unknown>;
+  price_range: unknown;
+  source: string;
+  categories?: Record<string, unknown>[];
+  handle?: string;
+  variant: LookupVariant;
+}
+
+/** The normalized lookup payload: the resolved products (in server order — lookup
+ * does NOT guarantee request order, and the tool does not re-sort; the agent
+ * correlates via each variant's `inputs`) plus `not_found`, the request ids that
+ * resolved to nothing. `not_found` is OMITTED when every id resolved (the
+ * server-side `messages`-absent-on-full-success contract surfaced as no key) and
+ * is the partial-success DATA, never an error. */
+export interface LookupResult {
+  products: LookupProduct[];
+  not_found?: string[];
+}
+
+/**
+ * Outcome of a single sil-api catalog lookup (classified by status + body).
+ * Models {@link SearchOutcome} — the SAME four error/success classes so the two
+ * catalog tools present ONE agent-facing error vocabulary, NOT a divergent one.
+ * The `ok` variant carries the projected `products` + optional `not_found`
+ * DIRECTLY (no nested `result`). `unauthorized` (401) is terminal — a single
+ * round-trip, no transparent refresh (parity with `sil_search`; the refresh
+ * choreography is `sil_whoami`'s, an additive follow-on across both tools).
+ *
+ * Structural deltas from `SearchOutcome`, both handled here: NO `cursor` (lookup
+ * is a batch resolve, not a list) and a `not_found` id list parsed from the
+ * server's `not_found` info `messages`.
+ */
+export type LookupOutcome =
+  | { kind: "ok"; products: LookupProduct[]; not_found?: string[] }
+  | { kind: "unauthorized" }
+  | { kind: "invalid_request"; error: string; message: string }
+  | { kind: "retryable" };
+
 /**
  * Classify a claim response from its HTTP status AND body. The discriminant for
  * the two-200s split is the PRESENCE OF BOTH TOKENS in the body — never the
@@ -353,6 +467,48 @@ export function classifySearchResponse(status: number, body: unknown): SearchOut
 }
 
 /**
+ * Classify a sil-api catalog-LOOKUP response from its HTTP status AND body.
+ * Branches on STATUS (and, for 200, the body shape) — never on `res.ok`. The
+ * SAME class structure as `classifySearchResponse` (so the two catalog tools
+ * share one error vocabulary), minus search's `empty_search_input` subtlety:
+ *   400 → invalid_request (a SCHEMA-validation 400 — an empty/missing `ids`
+ *         rejected by `CatalogLookupRequest.ids` `minItems:1`, or a
+ *         `request_too_large` over-batch — surface the server's `{ error,
+ *         message }`. NOTE: this is NOT search's `empty_search_input` SourceError,
+ *         which never arises on the lookup route; do not special-case it.)
+ *   401 → unauthorized (terminal here — single round-trip, no refresh; parity
+ *         with search)
+ *   5xx / other non-200 → retryable
+ *   200 → unwrap the envelope `result`, normalize, and require `result.products`
+ *         to be a real ARRAY. A 200 that yields no usable products array (a
+ *         partial / garbage / stub-shaped body) is `retryable`, NEVER `ok` — the
+ *         anti-false-green guard, the analogue of the identity `name`-gate and
+ *         search's products-array gate.
+ *
+ * THE subtle correctness point: an all-MISSED lookup is a genuine SUCCESS — a 200
+ * whose `result.products` IS an empty array WITH a populated `not_found` list
+ * ("none of these ids exist anymore"). It is `ok` with empty `products` + full
+ * `not_found`, distinct from the no-array guard above. The discriminator between
+ * "valid all-missed" and "garbage 200" is envelope/`products`-array PRESENCE,
+ * NEVER array length — exactly as search distinguishes empty-match from a
+ * partial-200 false-green.
+ *
+ * Pure and exported — unit-tested in isolation like `classifySearchResponse`.
+ */
+export function classifyLookupResponse(status: number, body: unknown): LookupOutcome {
+  if (status === 400) {
+    const { error, message } = extractApiError(body);
+    return { kind: "invalid_request", error, message };
+  }
+  if (status === 401) return { kind: "unauthorized" };
+  if (status !== 200) return { kind: "retryable" };
+
+  const result = extractLookupResult(body);
+  if (result === null) return { kind: "retryable" };
+  return { kind: "ok", ...result };
+}
+
+/**
  * Attempt to claim the token pair for `sessionId` with `verifier`. The verifier
  * is sent in the body; sil-web derives the same challenge server-side and the
  * CAS compares digest-to-digest (the plugin sends the verifier, not the digest).
@@ -454,6 +610,36 @@ export async function searchCatalog(
   }
   const body = await readJsonBody(res);
   return classifySearchResponse(res.status, body);
+}
+
+/**
+ * Resolve catalog ids against sil-api (the SAME origin as the identity read and
+ * `searchCatalog` — NOT sil-web; bare `/catalog/lookup`, no `/api/v1`). The agent
+ * already holds the ids (from a prior `sil_search`, a saved list, or cart
+ * validation); this re-fetches CURRENT detail for them — building NO UCP envelope
+ * and filling NO defaults. The body is just `{ ids }` (the simplified contract;
+ * `filters`/`context` are sil-api options this tool does not expose). The ids are
+ * forwarded AS GIVEN — sil-api owns dedup (its seam already dedups) and any batch
+ * cap; the tool does not pre-dedup (which would mask a seam regression).
+ *
+ * The Bearer header is built HERE and never logged; the token travels only in the
+ * outbound request, never into the returned union. A network error / timeout maps
+ * to `retryable`.
+ */
+export async function lookupCatalog(
+  silApiUrl: string,
+  token: string,
+  ids: string[],
+): Promise<LookupOutcome> {
+  const url = `${stripTrailingSlash(silApiUrl)}/catalog/lookup`;
+  let res: Response;
+  try {
+    res = await postJson(url, { ids }, { authorization: `Bearer ${token}` });
+  } catch {
+    return { kind: "retryable" };
+  }
+  const body = await readJsonBody(res);
+  return classifyLookupResponse(res.status, body);
 }
 
 /** Result of the high-level refresh orchestration (read → refresh → rotate). */
@@ -663,6 +849,184 @@ function projectVariant(raw: unknown): SearchVariant | null {
     availability: extractAvailability(variant["availability"]),
     checkout_url: checkoutUrl,
   };
+}
+
+/**
+ * Unwrap + narrow a sil-api catalog-LOOKUP response body to a typed
+ * {@link LookupResult}, or null if it carries no usable products array. Mirrors
+ * `extractSearchResult`'s structure and shares its load-bearing anti-false-green
+ * guard — `result.products` MUST be a real ARRAY; a 200 lacking it (partial /
+ * garbage / stub `{ stub: true }`) returns null → `retryable`. An EMPTY array is a
+ * VALID all-missed lookup (the products gate passes; `not_found` carries the ids)
+ * — distinct from the no-array guard. The two structural deltas from search:
+ *   - NO cursor hoist — lookup is a batch resolve, not a list (no `pagination`).
+ *   - `not_found` is parsed from `result.messages`: each `{ code: 'not_found',
+ *     content: <id> }` entry's `content` IS a missed request id (server emits one
+ *     per unresolved id, in input order, and OMITS `messages` on full success).
+ *     The `not_found` key is omitted here when there are no misses.
+ *
+ * Products unusable in lookup terms (no projectable featured variant, missing
+ * `checkout_url`) are dropped via `projectLookupProduct` returning null, never
+ * fabricated — same null-drop discipline as search.
+ */
+function extractLookupResult(body: unknown): LookupResult | null {
+  const envelope = asRecord(body);
+  if (envelope === null) return null;
+
+  const result = asRecord(envelope["result"]);
+  if (result === null) return null;
+
+  const rawProducts = result["products"];
+  if (!Array.isArray(rawProducts)) return null;
+
+  const products = rawProducts
+    .map(projectLookupProduct)
+    .filter((p): p is LookupProduct => p !== null);
+
+  const notFound = extractNotFound(result["messages"]);
+  return notFound.length === 0 ? { products } : { products, not_found: notFound };
+}
+
+/**
+ * Project one `SilCatalogProduct` to the agent-facing {@link LookupProduct}, or
+ * null if it is unusable. RICHER than search's `projectProduct`: carries the
+ * product-level `description`, `price_range`, `categories?` and `handle?` (a lookup
+ * caller is making a purchase decision) plus the featured variant nested under
+ * `variant`. Picks the FIRST (featured) variant — `lookup_catalog` returns one
+ * featured variant per product; UCP: "Platforms SHOULD treat the first element as
+ * featured". A product whose featured variant has no non-empty `checkout_url`, or
+ * that is missing any required field, is dropped rather than surfaced as a
+ * non-purchasable result.
+ */
+function projectLookupProduct(raw: unknown): LookupProduct | null {
+  const product = asRecord(raw);
+  if (product === null) return null;
+
+  const id = product["id"];
+  const title = product["title"];
+  const source = product["source"];
+  if (typeof id !== "string" || id.length === 0) return null;
+  if (typeof title !== "string") return null;
+  if (typeof source !== "string" || source.length === 0) return null;
+
+  const description = asRecord(product["description"]);
+  if (description === null) return null;
+  const priceRange = product["price_range"];
+  if (asRecord(priceRange) === null) return null;
+
+  const variants = product["variants"];
+  if (!Array.isArray(variants) || variants.length === 0) return null;
+  const variant = projectLookupVariant(variants[0]);
+  if (variant === null) return null;
+
+  const result: LookupProduct = {
+    id,
+    title,
+    description,
+    price_range: priceRange,
+    source,
+    variant,
+  };
+  const categories = passThroughObjects(product["categories"]);
+  if (categories !== null) result.categories = categories;
+  const handle = product["handle"];
+  if (typeof handle === "string" && handle.length > 0) result.handle = handle;
+  return result;
+}
+
+/**
+ * Project a `SilCatalogVariant` to the agent-facing {@link LookupVariant}, or null
+ * if it is not a usable purchasable variant. RICHER than search's `projectVariant`:
+ * adds `sku`, `options` (which configuration this variant is), and the lookup-only
+ * `inputs` correlation. Requires `id`, `title`, a price object, and a non-empty
+ * `checkout_url`; `price`/`availability` pass through opaque. Optional rich fields
+ * are omitted when absent rather than emitted as `undefined`.
+ */
+function projectLookupVariant(raw: unknown): LookupVariant | null {
+  const variant = asRecord(raw);
+  if (variant === null) return null;
+
+  const id = variant["id"];
+  const title = variant["title"];
+  const checkoutUrl = variant["checkout_url"];
+  if (typeof id !== "string" || id.length === 0) return null;
+  if (typeof title !== "string") return null;
+  if (typeof checkoutUrl !== "string" || checkoutUrl.length === 0) return null;
+
+  const price = extractPrice(variant["price"]);
+  if (price === null) return null;
+
+  const result: LookupVariant = {
+    id,
+    title,
+    price,
+    availability: extractAvailability(variant["availability"]),
+    checkout_url: checkoutUrl,
+  };
+  const sku = variant["sku"];
+  if (typeof sku === "string" && sku.length > 0) result.sku = sku;
+  const options = passThroughObjects(variant["options"]);
+  if (options !== null) result.options = options;
+  const inputs = extractInputs(variant["inputs"]);
+  if (inputs !== null) result.inputs = inputs;
+  return result;
+}
+
+/** Pass a wire array of objects through OPAQUE — filter to plain objects, preserve
+ * each verbatim, never read or remap individual fields. Used for `categories` and
+ * the variant's `options`: contextual display data the tool SURFACES but does not
+ * interpret (it is not a purchasability gate — that is `checkout_url`/`price`).
+ * Mirrors how identity `addresses` pass through (the wire field names — `value` vs
+ * `name` on a category — are the source's to define, not the tool's to assert).
+ * Returns null when the field is absent/non-array or yields no usable object, so
+ * the caller omits the key rather than emitting an empty array. */
+function passThroughObjects(raw: unknown): Record<string, unknown>[] | null {
+  if (!Array.isArray(raw)) return null;
+  const objects = raw.filter(
+    (o): o is Record<string, unknown> => asRecord(o) !== null,
+  );
+  return objects.length === 0 ? null : objects;
+}
+
+/** Narrow a wire `inputs` correlation array to {@link LookupInput}[] — each entry
+ * needs a non-empty `id` (the request id that resolved to this variant); a missing
+ * or non-string `match` is dropped (not coerced). Returns null when the field is
+ * absent or yields no usable entry, so the caller omits the key. Surfacing this is
+ * what makes a multi-id lookup correlatable — without it the agent cannot map "the
+ * id I asked about" to "the variant I got back". */
+function extractInputs(raw: unknown): LookupInput[] | null {
+  if (!Array.isArray(raw)) return null;
+  const inputs = raw
+    .map((i): LookupInput | null => {
+      const obj = asRecord(i);
+      if (obj === null) return null;
+      const id = obj["id"];
+      if (typeof id !== "string" || id.length === 0) return null;
+      const match = obj["match"];
+      return typeof match === "string" ? { id, match } : { id };
+    })
+    .filter((i): i is LookupInput => i !== null);
+  return inputs.length === 0 ? null : inputs;
+}
+
+/** Parse the missed request ids out of a wire `messages` array. Each
+ * `{ code: 'not_found', content: <id> }` info entry's `content` IS an unresolved
+ * id (sil-api emits one per miss, in input order; `messages` is OMITTED on full
+ * success). Returns the ids in order — an empty array when there are no misses
+ * (the caller then omits the `not_found` key). Only `not_found` codes are
+ * surfaced; any other message code (a future UCP `warning`/`delayed_fulfillment`)
+ * is ignored here — broader message passthrough is out of scope. */
+function extractNotFound(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  const ids: string[] = [];
+  for (const entry of raw) {
+    const obj = asRecord(entry);
+    if (obj === null) continue;
+    if (obj["code"] !== "not_found") continue;
+    const content = obj["content"];
+    if (typeof content === "string" && content.length > 0) ids.push(content);
+  }
+  return ids;
 }
 
 /** Narrow a wire price (`{ amount: number, currency: string }`) — passed through

--- a/src/tools/catalog.ts
+++ b/src/tools/catalog.ts
@@ -49,7 +49,9 @@ import { Type } from "typebox";
 import { getSilApiUrl } from "../lib/config.js";
 import { readTokens } from "../lib/credentials.js";
 import {
+  lookupCatalog,
   searchCatalog,
+  type LookupOutcome,
   type SearchOutcome,
   type SearchParams,
 } from "../lib/sil-client.js";
@@ -57,9 +59,7 @@ import { jsonResult } from "../lib/tool-result.js";
 
 export function registerCatalogTools(api: PluginAPI): void {
   registerSearch(api);
-  // The sibling card `sil-product-get-plugin-tool` (SC2) adds registerProductGet(api)
-  // here as a second call in this same group — no structural change, reusing the
-  // shared sil-client catalog layer and this error-envelope taxonomy.
+  registerProductGet(api);
 }
 
 function registerSearch(api: PluginAPI): void {
@@ -117,7 +117,7 @@ function registerSearch(api: PluginAPI): void {
       // 1 — not registered: terminal, zero network calls.
       const stored = readTokens();
       if (stored === null) {
-        return notRegistered();
+        return notRegistered("sil_search");
       }
 
       // Narrow the untrusted params (the SDK types `params` as
@@ -141,12 +141,144 @@ function registerSearch(api: PluginAPI): void {
           return invalidRequest(outcome.error, outcome.message);
         case "unauthorized":
           api.logger.info("sil_search_unauthorized", {});
-          return mustReregister();
+          return mustReregister("sil_search");
         case "retryable":
           api.logger.info("sil_search_retryable", {});
-          return transient();
+          return transient("sil_search");
       }
     },
+  });
+}
+
+/**
+ * `sil_product_get` — the lookup COMPANION to `sil_search`. The agent passes ids
+ * it already holds (from a prior `sil_search`, a saved list, deep links, or cart
+ * validation) and gets back the matching products in UCP shape, each with its
+ * FRESH featured variant `{ id, title, price, availability, checkout_url, ... }`.
+ * RICH where search is LEAN: lookup adds the description, the variant's options,
+ * and — its defining feature — the per-variant `inputs` correlation, because the
+ * response does NOT preserve request order and one id can resolve to a variant of
+ * another id's product. The agent builds no envelope and fills no defaults; the
+ * tool sends just `{ ids }`, sil-api owns enrichment + the `not_found` messaging.
+ *
+ * `execute()` flow (ALL I/O here; `register()` opens nothing — a synchronous
+ * request/response, NOT a poll). MIRRORS `sil_search` and shares its taxonomy:
+ *   1. Not registered (no stored tokens) → terminal `not_registered` + a
+ *      `recovery: sil_register` hint, ZERO network calls. Mirrors `sil_whoami`.
+ *   2. Client-side guard: an empty `ids` (after dropping non-strings) is rejected
+ *      with a structured validation error and NO network call (sil-api's
+ *      `minItems:1` schema 400 is the authoritative backstop).
+ *   3. lookupCatalog(getSilApiUrl(), token, ids) → map the `LookupOutcome`:
+ *        ok            → the resolved products + the `not_found` id list (a PARTIAL
+ *                        or ALL-MISSED hit is `status:"ok"` — a SUCCESS, never an
+ *                        error, with NO recovery hint: re-running won't conjure a
+ *                        delisted product);
+ *        invalid_request (400) → surface sil-api's `{ error, message }`;
+ *        unauthorized  (401)   → terminal re-register (single round-trip — parity
+ *                                with `sil_search`, no transparent refresh);
+ *        retryable (5xx/net)   → transient "try again", NO re-register hint.
+ *
+ * The unfound-ids outcome is the headline: a lookup that resolves SOME (or NONE)
+ * of its ids is a success the agent relays ("3 of your 4 items are still
+ * available; 1 is no longer listed"), distinguished from the two true-error
+ * classes (not-registered/401 and source/transport failure) by DISTINCT recovery
+ * hints. One wrong hint = one misdirected user.
+ *
+ * Privacy + freshness: the access token and Bearer header never reach a log line
+ * or the result; the products are always live-fetched (never cached — freshness is
+ * the reason this tool exists; a cached `checkout_url`/price is a broken purchase).
+ */
+function registerProductGet(api: PluginAPI): void {
+  api.registerTool({
+    name: "sil_product_get",
+    label: "Look up sil products by id",
+    description:
+      "Look up sil products or variants by id — the companion to sil_search."
+      + " Pass `ids` (one or more product/variant ids you already hold, e.g. from"
+      + " a prior sil_search result) and get the matching products back with FRESH"
+      + " detail: each product's description plus its featured purchasable variant"
+      + " (id, title, price, availability, checkout_url, options). Re-fetch right"
+      + " before the user buys — prices, availability, and checkout_url are"
+      + " point-in-time, not guarantees. Each variant carries an `inputs` list"
+      + " correlating it back to the id(s) you asked about (the response is NOT in"
+      + " request order). Ids that no longer resolve come back in a `not_found`"
+      + " list — that is a normal outcome, not an error (the other products are"
+      + " still valid). Requires registration (run sil_register first).",
+    parameters: Type.Object({
+      ids: Type.Array(Type.String(), {
+        minItems: 1,
+        description:
+          "Product or variant ids to resolve (at least one). Typically ids from a"
+          + " prior sil_search result, a saved list, or a deep link.",
+      }),
+    }),
+    async execute(_callId, params) {
+      // 1 — not registered: terminal, zero network calls.
+      const stored = readTokens();
+      if (stored === null) {
+        return notRegistered("sil_product_get");
+      }
+
+      // Narrow the untrusted params (the SDK types `params` as
+      // Record<string, unknown>; the host validates against the schema, but the
+      // read site still guards — non-string entries are dropped, not coerced).
+      const ids = readIds(params);
+
+      // 2 — client-side input guard: reject an empty `ids` before any network
+      // call (sil-api's `minItems:1` schema 400 is the authoritative backstop).
+      if (ids.length === 0) {
+        return invalidIds();
+      }
+
+      // 3 — look up and map the outcome to the agent-facing envelope (the SAME
+      // taxonomy as sil_search). A partial/all-missed hit is `ok` + `not_found`.
+      const outcome = await lookupCatalog(getSilApiUrl(), stored.access_token, ids);
+      switch (outcome.kind) {
+        case "ok":
+          return lookupResult(outcome);
+        case "invalid_request":
+          api.logger.info("sil_product_get_invalid_request", { error: outcome.error });
+          return invalidRequest(outcome.error, outcome.message);
+        case "unauthorized":
+          api.logger.info("sil_product_get_unauthorized", {});
+          return mustReregister("sil_product_get");
+        case "retryable":
+          api.logger.info("sil_product_get_retryable", {});
+          return transient("sil_product_get");
+      }
+    },
+  });
+}
+
+/** Narrow the untrusted `params` to a string[] of ids. A non-string entry is
+ * DROPPED (treated as absent), not coerced — the host has already validated
+ * against the schema, but a drifted on-disk call must not slip a non-string into
+ * the id list. No `any`, no unchecked `as`. */
+function readIds(params: Record<string, unknown>): string[] {
+  const raw = params["ids"];
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((id): id is string => typeof id === "string");
+}
+
+/** Success: the resolved products + optional `not_found` id list — no token, no
+ * Bearer header. An empty `products` list WITH a `not_found` list is a valid,
+ * successful all-missed lookup. The `ok` outcome already carries `products` (+
+ * optional `not_found`); spread its payload (minus the `kind` discriminant) onto
+ * the agent-facing `{ status: "ok", ... }` envelope. A `not_found` list is
+ * partial-success DATA, NOT an error and NOT a recovery hint. */
+function lookupResult(outcome: Extract<LookupOutcome, { kind: "ok" }>) {
+  const { kind: _kind, ...payload } = outcome;
+  return jsonResult({ status: "ok", ...payload });
+}
+
+/** Client-side validation: the request named no usable id. Distinct from a sil-api
+ * 400 (which carries the server's structured error) — this never hit the network.
+ * No `recovery: sil_register` (auth is fine; the input is the problem). */
+function invalidIds() {
+  return jsonResult({
+    status: "invalid_request",
+    error: "empty_ids",
+    message: "Provide at least one product or variant id to look up.",
   });
 }
 
@@ -195,13 +327,14 @@ function searchResult(outcome: Extract<SearchOutcome, { kind: "ok" }>) {
 }
 
 /** Not registered: a distinct, actionable outcome naming the recovery tool. No
- * products field so the agent can't mistake it for an empty match. */
-function notRegistered() {
+ * products field so the agent can't mistake it for an empty match. The `tool`
+ * name keeps the message actionable per-tool (re-run THIS tool) while the
+ * status/recovery taxonomy stays shared across the catalog tools. */
+function notRegistered(tool: string) {
   return jsonResult({
     status: "not_registered",
     message:
-      "Not registered on sil. Run sil_register to authenticate, then call"
-      + " sil_search again.",
+      `Not registered on sil. Run sil_register to authenticate, then call ${tool} again.`,
     recovery: "sil_register",
   });
 }
@@ -227,23 +360,24 @@ function invalidRequest(error: string, message: string) {
   return jsonResult({ status: "invalid_request", error, message });
 }
 
-/** Terminal: the session is dead (401). Re-register. Single round-trip — this
- * card does no transparent refresh (that is `sil_whoami`'s, an additive follow-on). */
-function mustReregister() {
+/** Terminal: the session is dead (401). Re-register. Single round-trip — these
+ * tools do no transparent refresh (that is `sil_whoami`'s, an additive follow-on).
+ * The `tool` name keeps the message actionable while the taxonomy stays shared. */
+function mustReregister(tool: string) {
   return jsonResult({
     status: "must_reregister",
     message:
-      "Your sil session has expired. Run sil_register to sign in again, then"
-      + " call sil_search again.",
+      `Your sil session has expired. Run sil_register to sign in again, then call ${tool} again.`,
     recovery: "sil_register",
   });
 }
 
 /** Transient: a network/5xx blip — try again, NOT a re-register (a false terminal
- * on a transient would send the agent down a recovery path that can't fix it). */
-function transient() {
+ * on a transient would send the agent down a recovery path that can't fix it).
+ * The `tool` name keeps the retry guidance actionable; the taxonomy is shared. */
+function transient(tool: string) {
   return jsonResult({
     status: "retryable",
-    message: "sil is temporarily unavailable. Please try sil_search again.",
+    message: `sil is temporarily unavailable. Please try ${tool} again.`,
   });
 }


### PR DESCRIPTION
## Card
`cards/sil-product-get-plugin-tool.md` (lives in the `card/sil-product-get-plugin-tool` branch — gitignored-mode, so the card body stays a local working doc; see it for the full intent + handoffs). Epic `catalog-plugin-tools`, goal `agentic-search-slice` SC2.

## Summary
Adds **`sil_product_get`**, the lookup companion to the merged `sil_search` (#8). An agent passes `{ ids: string[] }` (product/variant ids it already holds — e.g. from a prior `sil_search`) and gets the matching products back in UCP shape with **fresh** RICH detail: each product's description + categories + its featured purchasable variant `{ id, title, price, availability, checkout_url, sku, options }` plus the lookup-only **`inputs`** correlation. This is the RICH side of the deliberate lean(search)/rich(lookup) split.

- **`src/lib/sil-client.ts`** — `lookupCatalog(silApiUrl, token, ids)` (POST bare `/catalog/lookup`, body `{ ids }`, Bearer header), the exported pure `classifyLookupResponse` → `LookupOutcome`, and the `extractLookupResult` read-subset normalizer. Reuses search's low-level primitives (`postJson`, `extractPrice`, `extractAvailability`, `extractApiError`, `asRecord`) and re-declares the lookup read-subset locally — no `@sil/schemas` / `@ucp-js/sdk` dependency (per `docs/decisions/sil-shared-catalog-client.md`).
- **`src/tools/catalog.ts`** — `registerProductGet` added as a second call inside the existing `registerCatalogTools` group (no new group, no `src/index.ts` change). Mirrors `sil_search`'s `execute` flow and shares the error-envelope taxonomy; the three message helpers now take a tool-name param so each tool's message is actionable while the `status`/`recovery` taxonomy stays shared.
- **`openclaw.plugin.json`** — `sil_product_get` added to `contracts.tools` (the load-bearing step 3); `packagingNote` extended.

**Key invariants:** unfound ids are a **SUCCESS** (`status:"ok"` + `not_found:[…]`), never an error and never a recovery hint; `401` is a terminal re-register (single round-trip — parity with search); `500`/network is a **distinct** transient. Anti-false-green: `ok` is gated on `Array.isArray(result.products)`, so a stub/garbage 200 falls to `retryable`. Stub-free on the exercised path. Tokens never logged, never in the result.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean
- [x] `pnpm test` — **366 tests / 28 files, all green**, incl. QA's four new suites (`lib/lookup-classify`, `lib/lookup-client`, `tools/product-get`, `catalog-lookup.integration`) and the manifest-contract drift guard (now exercises `sil_product_get`)
- [x] No regression in the pre-existing search/whoami/identity suites (the shared-helper parameterization)

## Distillation target
Knowledge capture happens **after Review PASS** in the `distilling` stage — `solutions-architect` runs in this same worktree, commits to this same branch, and pushes here so the PR ends up containing implementation + tests + distillation in one mergeable unit. Likely targets: extend `docs/knowledge/sil-api-catalog-contract.md` with the lookup wire shape (`messages`/`not_found`, `inputs`, no pagination) and `docs/decisions/sil-shared-catalog-client.md` with the `sil_product_get` reuse + the tool-name-parameterized envelope helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)