### PR TITLE
refactor: uniform 401 refresh-and-retry-once across catalog tools (one shared helper)

### DIFF
--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -6,7 +6,8 @@ Sorted by `updated_at` descending (newest first). One row per doc in this folder
 
 | ID | Title | Tags | Updated |
 |---|---|---|---|
-| [[sil-shared-catalog-client]] | One shared catalog client + locally-redeclared read-subset types (no @sil/schemas / @ucp-js/sdk dep) | architecture, contracts, dependencies, catalog, reuse | 2026-06-09 |
-| [[sil-two-origin-model]] | Two sil origins: sil-web auth authority + sil-api domain reads (now incl. catalog) | architecture, config, auth, contracts | 2026-06-09 |
+| [[sil-uniform-401-refresh-retry]] | One shared 401 refresh-and-retry-once helper — every sil-api tool routes its 401 through it, never a per-tool handler | architecture, auth, contracts, reuse, refresh, anti-divergence | 2026-06-10 |
+| [[sil-shared-catalog-client]] | One shared catalog client + locally-redeclared read-subset types (no @sil/schemas / @ucp-js/sdk dep) | architecture, contracts, dependencies, catalog, reuse | 2026-06-10 |
+| [[sil-two-origin-model]] | Two sil origins: sil-web auth authority + sil-api domain reads (now incl. catalog) | architecture, config, auth, contracts | 2026-06-10 |
 
 See [`../README.md`](../README.md) for the docs convention.

--- a/docs/decisions/sil-shared-catalog-client.md
+++ b/docs/decisions/sil-shared-catalog-client.md
@@ -4,8 +4,8 @@ title: One shared catalog client + locally-redeclared read-subset types (no @sil
 tags: [architecture, contracts, dependencies, catalog, sil-api, reuse]
 card: sil-search-plugin-tool
 commit: 6df1061
-updated_at: 2026-06-09
-updated_by_card: sil-product-get-plugin-tool
+updated_at: 2026-06-10
+updated_by_card: uniform-401-refresh-across-catalog-tools
 ---
 
 All sil-api **catalog** tools share ONE client layer in `src/lib/sil-client.ts` and ONE error-envelope taxonomy in `src/tools/catalog.ts`, and the plugin **re-declares the catalog wire fields it consumes LOCALLY** — it does **not** depend on `@sil/schemas` (cross-repo) or `@ucp-js/sdk` (no catalog types). `sil_search` (SC1) established this; the sibling lookup tool `sil_product_get` (SC2) reused it rather than re-deriving a parallel one — and validated the design by exercising exactly the seams it was meant to share (see "What SC2 actually reused vs added" below).
@@ -34,6 +34,8 @@ In `src/tools/catalog.ts`: `registerCatalogTools(api)` (line 58) is the group. S
 ## The constraint on SC2 (and any future catalog tool)
 
 > Add the new tool's register fn as a call inside `registerCatalogTools` (don't make a new group). Reuse `searchCatalog`'s shape, the `SearchOutcome`-style union, the `projectProduct`/`projectVariant`/`extractPrice`/`extractAvailability`/`extractCursor`/`extractApiError` normalizers, and the `catalog.ts` error-envelope helpers. Re-declare any *additional* rich fields you consume locally and narrow them — never add a dependency on `@sil/schemas` or `@ucp-js/sdk`. Classify on body shape with a pure exported classifier (see [[sil-response-classification]]).
+
+A 401 from the catalog read is **not** terminal: route it through the shared `refreshAndRetryOnce` choreography (refresh-once → retry-once), never a per-tool 401 handler — see [[sil-uniform-401-refresh-retry]] for that constraint and the call-site mapping.
 
 Origin/path for the catalog endpoint is governed by [[sil-two-origin-model]] (bare `/catalog/search` on `getSilApiUrl()`); the wire contract + the propagated-boilerplate hazard are in [[sil-api-catalog-contract]].
 

--- a/docs/decisions/sil-two-origin-model.md
+++ b/docs/decisions/sil-two-origin-model.md
@@ -4,8 +4,8 @@ title: The plugin talks to two sil origins (sil-web auth authority + sil-api dom
 tags: [architecture, config, auth, contracts, sil-api, sil-web]
 card: sil-whoami-tool
 commit: a635103
-updated_at: 2026-06-09
-updated_by_card: sil-search-plugin-tool
+updated_at: 2026-06-10
+updated_by_card: uniform-401-refresh-across-catalog-tools
 ---
 
 This plugin addresses **two distinct sil services at two distinct origins**, resolved from two distinct config keys — never one. Any future tool must pick the right origin for what it is doing.
@@ -32,4 +32,4 @@ When you add a sil-api origin to anything, also add it to `openclaw.plugin.json#
 
 `DEFAULT_SIL_API_BASE` (`config.ts:34`) is a **documented placeholder** (`https://api.sil.4gpts.com`) — the sil-api production URL is unpinned anywhere in the workspace. The override chain means tests and staging always set it explicitly via `sil_api_base` / `SIL_API_BASE`; only the fallback is a guess. Founder/devops must pin it at deploy (or set it to the same origin if a single gateway fronts both services).
 
-See [[sil-api-identity-contract]] for the sil-api request/response shape, and [[sil-response-classification]] for how outcomes from both origins are classified.
+See [[sil-api-identity-contract]] for the sil-api request/response shape, and [[sil-response-classification]] for how outcomes from both origins are classified. The cross-origin handshake — a 401 on a sil-api domain read triggers a refresh against **sil-web** (never sil-api, never Auth0), then one retry of the sil-api read — is the shared `refreshAndRetryOnce` choreography in [[sil-uniform-401-refresh-retry]].

--- a/docs/decisions/sil-uniform-401-refresh-retry.md
+++ b/docs/decisions/sil-uniform-401-refresh-retry.md
@@ -1,0 +1,48 @@
+---
+id: sil-uniform-401-refresh-retry
+title: One shared 401 refresh-and-retry-once helper — every sil-api tool routes its 401 through it, never a per-tool handler
+tags: [architecture, auth, contracts, reuse, refresh, anti-divergence]
+card: uniform-401-refresh-across-catalog-tools
+commit: c8f9ed4
+updated_at: 2026-06-10
+updated_by_card: uniform-401-refresh-across-catalog-tools
+---
+
+**Every sil-api-calling tool MUST route a 401 through the single generic `refreshAndRetryOnce<O>` helper (`src/lib/sil-client.ts:747`) — never fork a per-tool 401 handler.** 401 auth-recovery is a property of sil's auth boundary, not of any one tool: the same expired access token must self-heal identically (transparent refresh-once → retry-once) whether the agent called `sil_search`, `sil_product_get`, or `sil_whoami`. A per-tool difference is the exact divergence this decision exists to forbid.
+
+## The rule for the next sil-api tool
+
+> When you add a tool that calls a sil-api domain (cart, checkout, order, fulfillment, payments, loyalty, …) and its read can return 401: do NOT write a terminal `case "unauthorized":` arm, and do NOT inline a copy of the refresh loop. Call `refreshAndRetryOnce(first, isUnauthorized, retryWithToken)` and map its `RefreshRetryResult<O>` to your envelope, exactly as the three existing call sites do (`identity.ts:178`, `catalog.ts:144`, `catalog.ts:284`). Then add your tool to `cross-tool-401-parity.integration.test.ts` so the parity guard covers it too.
+
+The helper is **the** single 401 path: `refreshStoredTokens()` is invoked at exactly one non-test call site (`sil-client.ts:759`, inside the helper). A second invocation anywhere is the regression signal.
+
+## Why a shared helper, not inline parity (FLAG-10)
+
+The `sil_search` / `sil_product_get` Discovery deliberately deferred transparent refresh, landing 401 as a *terminal re-register* while `sil_whoami` already refreshed-and-retried. That per-tool divergence (FLAG-10) is precisely the goal's forbidden state: an agent that can `sil_whoami` through an expired token but is dead-ended by `sil_search` on the *same* token. Three hand-maintained copies of a subtle bounded-refresh loop drift silently — the invariants (one refresh max, second-401 terminal, TOCTOU re-read, clear-only-on-`invalid_grant`) are exactly the kind that diverge when copied. So the choreography is factored into one control-flow helper and **all three** sites — `sil_whoami` included, re-pointed off its old inline block — call it. Inline parity was rejected: it is the status quo the card killed.
+
+**Alternatives rejected:** (a) leave `sil_whoami` inline, extract a helper only for catalog — leaves whoami as a fourth un-deduplicated copy, the same drift; (b) push the loop down into `searchCatalog`/`lookupCatalog`/`fetchIdentity` — forces the pure single-round-trip client functions to own `clearTokens()` + tool-facing terminal/transient UX and to re-enter themselves (impure). The helper sits at the right seam: above the single-round-trip client calls, below the envelope mapping.
+
+## What the helper owns vs. what the caller owns (the seam)
+
+The helper owns the **control flow and its invariants**, and is `O`-parametric so the three different outcome unions share it with no `any`/cast (it only ever returns an `O` produced by `first` or `retryWithToken`, never fabricates one; it inspects `O` only via the caller's `isUnauthorized` predicate):
+
+- **At most one refresh + at most one retry, structural — no loop.** Straight-line `first → refresh → re-read → retry`. A freshly-rotated token that is *still* 401 is structurally dead → `second_unauthorized` terminal, **never a second refresh** (the refresh-storm guard).
+- **TOCTOU re-read.** After `refreshStoredTokens()` rotates `tokens.json`, the helper re-reads the rotated pair through the module's `readTokens()`; a `null` read ⇒ `must_reregister/no_stored_tokens`, no retry with a stale/absent token.
+- **The `RefreshRetryResult<O>` discriminant** that tells the caller which terminal/transient/success path was taken — including the `refreshed: boolean` bit on the `result` variant (see "observability" below).
+
+The caller owns ONLY: the `isUnauthorized` predicate, the token-bearing `retryWithToken` thunk (closing over its params + the rotated token), envelope mapping, `clearTokens()` on the clearing terminals, and logging. **Token-clearing stays at the call site, not in the helper** — *when* to clear is uniform but credential side-effects beyond the rotation `refreshStoredTokens` already does stay at the edges (mirrors `identity.ts`). `clearTokens()` fires on exactly two terminals — `must_reregister`+`invalid_grant` and `second_unauthorized` — and **never** on `no_stored_tokens` / `retryable` / a `result`-mapped 403/5xx.
+
+## Two-axis observability: silent in the payload, visible in the logs
+
+A silent refresh is **invisible in the agent-facing payload** (outcome 1 returns a normal `ok` result with no `refreshed`/`retried` marker — by product design; the agent must never reason about token mechanics) **but observable in operator logs** via a uniform `<tool>_refreshed` info marker (`sil_search_refreshed` / `sil_product_get_refreshed` / `sil_whoami_refreshed`). These are two deliberately-separate axes. The marker is **logs-only, carries no token material, and adds no payload field**; it fires on (and only on) the silent-recovery path, gated by the helper's `refreshed: true` discriminant. This restores the seam the card's risk-mitigation named (a session that refreshes on nearly every call — wrong TTL/cadence upstream — is otherwise invisible) and makes it uniform across all three tools, where it was whoami-only before. The full WHY is inline at `sil-client.ts:690-784` (helper) and each call site's `case "result":` arm (`catalog.ts:154`, `:294`; `identity.ts:190`).
+
+## How drift is prevented (test, not reviewer vigilance)
+
+`cross-tool-401-parity.integration.test.ts` drives the identical expired-token + 401 scenario through all three tools and collapses each dimension (`status` / `refreshCount` / `readCount` / `tokensCleared` / `<tool>_refreshed` count) to a `Set`, asserting size 1 — with an explicit FLAG-10 canary that fails if any one tool's `refreshCount` (or success-marker count) diverges. A new tool with a forked terminal-401 branch shows a different `refreshCount` → set size 2 → fail. **A new sil-api tool is only covered once it is added to this test** — adding the tool to the parity suite is part of the rule above, not optional.
+
+## See also
+
+- [[sil-two-origin-model]] — refresh goes **only** to sil-web (`POST /api/v1/auth/refresh`), the sole auth authority; the helper's `refreshStoredTokens()` hard-codes that origin. 401 on a sil-api domain read triggers the refresh; the refresh itself never hits sil-api or Auth0.
+- [[sil-api-identity-contract]] — the original spec of the read→401→refresh-once→retry-once choreography and the 401-vs-403-vs-5xx taxonomy (401 refreshable; 403 never; 5xx transient). This decision generalizes that single-tool choreography into the shared cross-tool helper.
+- [[sil-shared-catalog-client]] — the shared catalog client + the `mustReregister`/`transient`/`notRegistered` envelope taxonomy the `RefreshRetryResult` variants map onto. That doc owns the catalog *client* reuse; this doc owns the *401-recovery control flow* reuse — distinct concerns, both binding the next tool.
+- [[sil-response-classification]] — classifiers keep mapping 401 → `{ kind: "unauthorized" }` (unchanged); what this card changed is that `unauthorized` stopped being *terminal* for the catalog callers — it became the helper's trigger.

--- a/src/__tests__/catalog-lookup.integration.test.ts
+++ b/src/__tests__/catalog-lookup.integration.test.ts
@@ -294,6 +294,19 @@ function logBlob(api: MockPluginAPI): string {
     .join("\n");
 }
 
+/**
+ * Count how many `api.logger.info(marker, …)` calls used `marker` as their first
+ * argument. The marker name is the FIRST positional arg of the info call (the
+ * convention every `sil_*` log marker in this plugin follows). Used to assert the
+ * `sil_product_get_refreshed` operator marker fires exactly once on the
+ * silent-recovery path and ZERO times on a first-try (no-refresh) success.
+ */
+function infoMarkerCount(api: MockPluginAPI, marker: string): number {
+  return vi
+    .mocked(api.logger.info)
+    .mock.calls.filter((c) => c[0] === marker).length;
+}
+
 beforeEach(() => {
   dataDir = mkdtempSync(join(tmpdir(), "sil-lookup-int-"));
   priorSilDataDir = process.env["SIL_DATA_DIR"];
@@ -416,6 +429,13 @@ describe("sil_product_get — happy path normalizes the REAL envelope (anti-fals
     expect(avail["status"]).toBe("in_stock");
     // The inputs correlation — lookup's defining feature — is surfaced.
     expect(v["inputs"]).toEqual([{ id: "gid://product/a", match: "featured" }]);
+
+    // NEGATIVE half of the observability seam (review-round-1 fix): this is a
+    // FIRST-TRY success (no 401, no refresh), so the `sil_product_get_refreshed`
+    // marker must NOT fire. The marker means "this success was a silent recovery";
+    // on a plain success it would be a false signal that the session is thrashing.
+    // The marker keys off the helper's `refreshed:false` passthrough discriminant.
+    expect(infoMarkerCount(api, "sil_product_get_refreshed")).toBe(0);
   });
 
   it("a known id returns its featured variant with a FRESH, non-empty checkout_url", async () => {
@@ -631,7 +651,8 @@ describe("sil_product_get — 401 → transparent refresh-and-retry-once (outcom
     expect(Array.isArray(products)).toBe(true);
     expect(products).toHaveLength(1);
     expect(products[0]!["id"]).toBe("gid://product/a");
-    // The refresh is INVISIBLE: no refreshed/retried marker, no recovery hint.
+    // The refresh is INVISIBLE TO THE AGENT: no refreshed/retried marker, no
+    // recovery hint IN THE PAYLOAD. (This payload contract is correct and stays.)
     expect(payload["refreshed"]).toBeUndefined();
     expect(payload["retried"]).toBeUndefined();
     expect(payload["recovery"]).toBeUndefined();
@@ -641,6 +662,30 @@ describe("sil_product_get — 401 → transparent refresh-and-retry-once (outcom
     // The refresh used the STORED refresh token.
     expect(rec.refresh.length).toBe(1);
     expect((rec.refresh[0]!.body as { refresh_token?: string }).refresh_token).toBe("valid-rt");
+
+    // OPERATOR-OBSERVABILITY SEAM (review-round-1 fix; card line 161): the silent
+    // recovery is invisible in the PAYLOAD but MUST be observable in operator logs
+    // — a session that refreshes on (nearly) every call is the degrading-session
+    // signal on-call needs, and the card's own risk-mitigation names the
+    // `sil_*_refreshed` marker by hand. Assert the `sil_product_get_refreshed` INFO
+    // marker fired EXACTLY ONCE on this recovered-401 path. RED until the tool
+    // emits it (logs-only — NOT a payload field) when the helper reports
+    // `refreshed: true`.
+    expect(infoMarkerCount(api, "sil_product_get_refreshed")).toBe(1);
+    // The marker is logs-only — it does NOT add any field to the agent payload
+    // (outcome 1's invisible-to-the-agent contract stays inviolate).
+    expect(payload["sil_product_get_refreshed"]).toBeUndefined();
+    // The marker carries NO token material (the privacy invariant holds on the
+    // marker too — its meta must never carry a token value).
+    const refreshedMarkerArgs = vi
+      .mocked(api.logger.info)
+      .mock.calls.filter((c) => c[0] === "sil_product_get_refreshed");
+    const refreshedMarkerBlob = JSON.stringify(refreshedMarkerArgs);
+    expect(refreshedMarkerBlob).not.toContain("rotated-at");
+    expect(refreshedMarkerBlob).not.toContain("rotated-rt");
+    expect(refreshedMarkerBlob).not.toContain("valid-rt");
+    expect(refreshedMarkerBlob).not.toContain("expired-at");
+    expect(refreshedMarkerBlob).not.toMatch(/Bearer/i);
   });
 
   it("makes EXACTLY one refresh (sil-web) + EXACTLY two catalog reads (the failed read + one retry) — no loop, no storm", async () => {

--- a/src/__tests__/catalog-lookup.integration.test.ts
+++ b/src/__tests__/catalog-lookup.integration.test.ts
@@ -11,12 +11,14 @@
  * projection + `inputs` correlation, and token privacy — against a mocked boundary,
  * exactly as sil_search's integration suite proved its read flow.
  *
- * ONE ORIGIN: the lookup read targets the resolved **sil-api** origin
- * (`getSilApiUrl`), at the BARE path `/catalog/lookup` — NOT `/api/v1`, NOT the
- * sil-web origin (`getApiUrl`). Both origins are pinned to distinct known hosts so
- * the origin + path assertions are exact, and a misfire onto sil-web is caught.
- * (Lookup does no refresh choreography in SC2 — a single round-trip; the 401 path is
- * a terminal re-register hint, parity with sil_search.)
+ * TWO ORIGINS: the lookup read targets the resolved **sil-api** origin
+ * (`getSilApiUrl`), at the BARE path `/catalog/lookup` — NOT `/api/v1`. On a 401
+ * the tool now refreshes transparently against the **sil-web** origin
+ * (`getApiUrl`, via the real `refreshStoredTokens`) and retries the lookup ONCE —
+ * the SAME refresh-and-retry-once choreography sil_whoami / sil_search perform
+ * (this card makes 401 recovery uniform across every sil-api-calling tool;
+ * FLAG-10). Both origins are pinned to distinct known hosts so the origin + path
+ * assertions are exact, and a misfire is caught.
  *
  * Wire shapes pinned to the ALREADY-MERGED sil-api `/catalog/lookup` contract
  * (PR #18; sil-services `@sil/schemas` catalog.ts + envelope.ts) and the UCP
@@ -29,8 +31,13 @@
  *     `messages` carries one { type:"info", code:"not_found", content:<id> } per
  *     unresolved id, and is OMITTED entirely on full success.
  *   400 (schema reject)  → invalid_request envelope
- *   401                  → terminal re-register envelope
+ *   401                  → refresh-and-retry-once (see below)
  *   500 / network / timeout → retryable envelope
+ *
+ *   refresh (sil-web):  POST <sil-web>/api/v1/auth/refresh { refresh_token }
+ *     200 { access_token, refresh_token }  → rotate tokens.json, retry lookup once
+ *     401 { error: "invalid_grant" }       → terminal re-register, tokens cleared
+ *     5xx / network                        → transient retryable, NO retry
  *
  * THE anti-false-green (complete-work-is-stub-free): the happy-path mock returns the
  * REAL `SilCatalogProduct` lookup envelope shape (each product with a required
@@ -57,13 +64,13 @@ import {
   beforeEach,
   afterEach,
 } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { registerCatalogTools } from "../tools/catalog.js";
 import { setApiUrl, setSilApiUrl, getApiUrl, getSilApiUrl } from "../lib/config.js";
-import { getDataDir, getTokensPath } from "../lib/credentials.js";
+import { getDataDir, getTokensPath, readTokens } from "../lib/credentials.js";
 import {
   createMockPluginApi,
   getTool,
@@ -187,15 +194,22 @@ type Reply = { status: number; body: unknown } | "network-error";
 /**
  * A URL-routing fetch double cloned from catalog-search.integration.test.ts.
  * `reply(kind, nthOfKind, req)` decides each response given whether the request is a
- * `lookup` (sil-api /catalog/lookup) or `other`. Records every request (url, method,
- * bearer, body) so origin, path, the Bearer header, the mapped body, and call COUNTS
- * are all assertable.
+ * `lookup` (sil-api /catalog/lookup), a `refresh` (sil-web /auth/refresh — the
+ * transparent 401 recovery leg, reached via the real `refreshStoredTokens`), or
+ * `other`. Records every request (url, method, bearer, body) so origin, path, the
+ * Bearer header, the mapped body, and call COUNTS (including "exactly one refresh")
+ * are all assertable. The `refresh` bucket is what makes the no-storm bound testable.
  */
 function installRouter(
-  reply: (kind: "lookup" | "other", nthOfKind: number, req: Recorded) => Reply,
-): { all: Recorded[]; lookup: Recorded[] } {
+  reply: (
+    kind: "lookup" | "refresh" | "other",
+    nthOfKind: number,
+    req: Recorded,
+  ) => Reply,
+): { all: Recorded[]; lookup: Recorded[]; refresh: Recorded[] } {
   const all: Recorded[] = [];
   const lookup: Recorded[] = [];
+  const refresh: Recorded[] = [];
 
   vi.spyOn(globalThis, "fetch").mockImplementation(
     (input: unknown, init?: RequestInit) => {
@@ -215,11 +229,20 @@ function installRouter(
       const req: Recorded = { url, method, bearer, body, hasBody };
       all.push(req);
 
-      const kind: "lookup" | "other" = url.includes("/catalog/lookup") ? "lookup" : "other";
+      // Check refresh first (sil-web /auth/refresh) so it is never misrouted to
+      // the lookup bucket.
+      let kind: "lookup" | "refresh" | "other";
+      if (url.includes("/auth/refresh")) kind = "refresh";
+      else if (url.includes("/catalog/lookup")) kind = "lookup";
+      else kind = "other";
+
       let nthOfKind: number;
       if (kind === "lookup") {
         lookup.push(req);
         nthOfKind = lookup.length - 1;
+      } else if (kind === "refresh") {
+        refresh.push(req);
+        nthOfKind = refresh.length - 1;
       } else {
         nthOfKind = all.length - 1;
       }
@@ -237,7 +260,7 @@ function installRouter(
     },
   );
 
-  return { all, lookup };
+  return { all, lookup, refresh };
 }
 
 /** Parse a ToolResult payload. */
@@ -520,55 +543,340 @@ describe("sil_product_get — unfound ids are a SUCCESS surfaced as a not_found 
     expect(payload["not_found"]).toBeUndefined();
   });
 
-  it("the partial-hit success is DISTINCT from both the 401 and the 500 error envelopes", async () => {
-    async function payloadFor(reply: Reply): Promise<Record<string, unknown>> {
+  it("the partial-hit success is DISTINCT from both the dead-401 (re-register) and the 500 (transient) envelopes", async () => {
+    // The partial hit is `ok`; a 401 whose refresh is also dead terminates at
+    // `must_reregister`; a first-call 500 is `retryable`. Three distinct statuses.
+    // (The 401 case now drives the refresh leg via the `refresh` route — a dead
+    // refresh keeps it terminal, so the three-way distinction is preserved under
+    // the refresh-and-retry-once path this card introduces.)
+    const partialHit = await (async () => {
       seedTokens("at", "rt");
-      installRouter((kind) => (kind === "lookup" ? reply : { status: 200, body: {} }));
+      installRouter((kind) =>
+        kind === "lookup"
+          ? { status: 200, body: lookupEnvelope([PRODUCT_A], [notFoundMsg("gone")]) }
+          : { status: 200, body: {} },
+      );
       const api = createMockPluginApi();
       registerCatalogTools(api);
       const p = payloadOf(await getTool(api, TOOL).execute("c1", { ids: ["x"] }));
       vi.restoreAllMocks();
       return p;
-    }
+    })();
 
-    const partialHit = await payloadFor({
-      status: 200,
-      body: lookupEnvelope([PRODUCT_A], [notFoundMsg("gone")]),
-    });
-    const unauthorized = await payloadFor({ status: 401, body: { error: "unauthorized" } });
-    const sourceFail = await payloadFor({ status: 500, body: { error: "source_unavailable" } });
+    const unauthorized = await (async () => {
+      seedTokens("expired-at", "dead-rt");
+      installRouter((kind) => {
+        if (kind === "lookup") return { status: 401, body: { error: "unauthorized" } };
+        if (kind === "refresh") return { status: 401, body: { error: "invalid_grant" } };
+        return { status: 500, body: {} };
+      });
+      const api = createMockPluginApi();
+      registerCatalogTools(api);
+      const p = payloadOf(await getTool(api, TOOL).execute("c1", { ids: ["x"] }));
+      vi.restoreAllMocks();
+      return p;
+    })();
+
+    const sourceFail = await (async () => {
+      seedTokens("at", "rt");
+      installRouter((kind) =>
+        kind === "lookup" ? { status: 500, body: { error: "source_unavailable" } } : { status: 200, body: {} },
+      );
+      const api = createMockPluginApi();
+      registerCatalogTools(api);
+      const p = payloadOf(await getTool(api, TOOL).execute("c1", { ids: ["x"] }));
+      vi.restoreAllMocks();
+      return p;
+    })();
 
     // Three distinct agent-facing statuses — a partial hit is ok, the others are not.
     expect(new Set([partialHit["status"], unauthorized["status"], sourceFail["status"]]).size).toBe(3);
     expect(partialHit["status"]).toBe("ok");
+    expect(unauthorized["status"]).toBe("must_reregister");
+    expect(sourceFail["status"]).toBe("retryable");
   });
 });
 
-describe("sil_product_get — the failure outcomes surface as distinguishable error envelopes", () => {
-  it("401 → terminal re-register envelope (recovery sil_register), single round-trip, NOT a false-green", async () => {
-    seedTokens("dead-at", "dead-rt");
-    const rec = installRouter((kind) =>
-      kind === "lookup" ? { status: 401, body: { error: "unauthorized" } } : { status: 200, body: {} },
-    );
+describe("sil_product_get — 401 → transparent refresh-and-retry-once (outcome 1: the agent never sees the 401)", () => {
+  it("401 → refresh once via sil-web → rotate tokens.json → retry the lookup once with the NEW token → normal lookup result", async () => {
+    // AC[integration]: outcome 1 — a registered agent whose access token is
+    // expired gets the normal `{ status: ok, products, not_found? }`,
+    // indistinguishable from a call that never 401'd. The card brings
+    // sil_product_get onto sil_whoami's refresh-and-retry-once choreography.
+    // EXPECT RED against current code (catalog.ts 401 is terminal mustReregister,
+    // no refresh) and GREEN once it routes through the shared helper.
+    seedTokens("expired-at", "valid-rt");
+    const rec = installRouter((kind, nth) => {
+      if (kind === "lookup") {
+        // First lookup 401 (expired); second (after refresh) returns products.
+        return nth === 0
+          ? { status: 401, body: { error: "unauthorized" } }
+          : { status: 200, body: lookupEnvelope([PRODUCT_A]) };
+      }
+      if (kind === "refresh") {
+        return { status: 200, body: { access_token: "rotated-at", refresh_token: "rotated-rt" } };
+      }
+      return { status: 500, body: {} };
+    });
     const api = createMockPluginApi();
     registerCatalogTools(api);
 
-    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] }));
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] }),
+    );
 
-    // A SINGLE round-trip — lookup does NOT do the transparent refresh-and-retry
-    // choreography whoami performs (parity with sil_search: SC2 is single round-trip).
-    expect(rec.lookup.length).toBe(1);
-    // No refresh call leaked onto sil-web.
-    for (const r of rec.all) {
-      expect(r.url).not.toContain("/auth/refresh");
+    // The agent sees a normal success — NOT a re-register, NOT a silent all-missed.
+    expect(payload["status"]).toBe("ok");
+    const products = payload["products"] as Array<Record<string, unknown>>;
+    expect(Array.isArray(products)).toBe(true);
+    expect(products).toHaveLength(1);
+    expect(products[0]!["id"]).toBe("gid://product/a");
+    // The refresh is INVISIBLE: no refreshed/retried marker, no recovery hint.
+    expect(payload["refreshed"]).toBeUndefined();
+    expect(payload["retried"]).toBeUndefined();
+    expect(payload["recovery"]).toBeUndefined();
+    // The retry carried the ROTATED access token (proves the re-read after rotation).
+    expect(rec.lookup.length).toBe(2);
+    expect(bearerToken(rec.lookup[1]!)).toBe("rotated-at");
+    // The refresh used the STORED refresh token.
+    expect(rec.refresh.length).toBe(1);
+    expect((rec.refresh[0]!.body as { refresh_token?: string }).refresh_token).toBe("valid-rt");
+  });
+
+  it("makes EXACTLY one refresh (sil-web) + EXACTLY two catalog reads (the failed read + one retry) — no loop, no storm", async () => {
+    // AC[integration]: the silent path does not loop or storm. Exactly 1 refresh
+    // + 2 catalog calls on a recovered 401.
+    seedTokens("expired-at", "valid-rt");
+    const rec = installRouter((kind, nth) => {
+      if (kind === "lookup") {
+        return nth === 0
+          ? { status: 401, body: { error: "unauthorized" } }
+          : { status: 200, body: lookupEnvelope([PRODUCT_A]) };
+      }
+      if (kind === "refresh") {
+        return { status: 200, body: { access_token: "rotated-at", refresh_token: "rotated-rt" } };
+      }
+      return { status: 500, body: {} };
+    });
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] });
+
+    expect(rec.lookup.length).toBe(2); // failed read + exactly one retry
+    expect(rec.refresh.length).toBe(1); // exactly one refresh, never more
+    // The refresh hit sil-web; the lookups hit sil-api — origins asserted apart.
+    const silApiOrigin = new URL(getSilApiUrl()).origin;
+    const silWebOrigin = new URL(getApiUrl()).origin;
+    for (const r of rec.lookup) expect(new URL(r.url).origin).toBe(silApiOrigin);
+    for (const r of rec.refresh) expect(new URL(r.url).origin).toBe(silWebOrigin);
+    // No Auth0 contacted on any path (sil-web is the sole auth authority).
+    for (const r of rec.all) expect(r.url).not.toMatch(/auth0\.com/i);
+  });
+
+  it("persists the rotated pair to tokens.json and leaks NO token to the result or any log line", async () => {
+    // AC[integration]: tokens.json holds the rotated pair, and neither old nor new
+    // token value appears in any logger call or the returned payload.
+    const ROT_AT = "rotated-secret-access";
+    const ROT_RT = "rotated-secret-refresh";
+    seedTokens("expired-at", "valid-rt");
+    const rec = installRouter((kind, nth) => {
+      if (kind === "lookup") {
+        return nth === 0
+          ? { status: 401, body: { error: "unauthorized" } }
+          : { status: 200, body: lookupEnvelope([PRODUCT_A]) };
+      }
+      if (kind === "refresh") return { status: 200, body: { access_token: ROT_AT, refresh_token: ROT_RT } };
+      return { status: 500, body: {} };
+    });
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] }),
+    );
+
+    // tokens.json now holds the rotated pair (the refresh persisted).
+    const tokens = readTokens();
+    expect(tokens!.access_token).toBe(ROT_AT);
+    expect(tokens!.refresh_token).toBe(ROT_RT);
+    // The rotated token reached the retry's Authorization header, and ONLY there.
+    expect(bearerToken(rec.lookup[1]!)).toBe(ROT_AT);
+    // No token (old or rotated) in the result.
+    const resultBlob = JSON.stringify(payload);
+    expect(resultBlob).not.toContain(ROT_AT);
+    expect(resultBlob).not.toContain(ROT_RT);
+    expect(resultBlob).not.toContain("valid-rt");
+    expect(resultBlob).not.toContain("expired-at");
+    // No token in any log line, and never a Bearer string.
+    const logs = logBlob(api);
+    expect(logs).not.toContain(ROT_AT);
+    expect(logs).not.toContain(ROT_RT);
+    expect(logs).not.toContain("valid-rt");
+    expect(logs).not.toContain("expired-at");
+    expect(logs).not.toMatch(/Bearer/i);
+    // Nor in any request BODY (the credential rides only the header).
+    for (const r of [...rec.lookup, ...rec.refresh]) {
+      const b = JSON.stringify(r.body ?? {});
+      expect(b).not.toContain(ROT_AT);
+      expect(b).not.toContain("expired-at");
     }
-    // Terminal, actionable re-register — not a success, not a silent all-missed.
-    expect(payload["status"]).not.toBe("ok");
+  });
+});
+
+describe("sil_product_get — 401 → second 401 / dead refresh is terminal (outcome 2: re-register, refreshed at most once)", () => {
+  it("refresh OK but the retried read is ALSO 401 → terminal re-register, exactly ONE refresh (a freshly-rotated-still-401 is structurally dead)", async () => {
+    // AC[integration]: the no-storm bound. A retry that is still 401 must be
+    // terminal, never a second refresh.
+    seedTokens("expired-at", "valid-rt");
+    const rec = installRouter((kind) => {
+      // Lookup ALWAYS 401 (even after a good refresh — structurally dead).
+      if (kind === "lookup") return { status: 401, body: { error: "unauthorized" } };
+      if (kind === "refresh") {
+        return { status: 200, body: { access_token: "rotated-at", refresh_token: "rotated-rt" } };
+      }
+      return { status: 500, body: {} };
+    });
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] }),
+    );
+
+    // Exactly: lookup(401) → refresh(200) → retry-lookup(401) → STOP.
+    expect(rec.lookup.length).toBe(2); // initial + exactly one retry
+    expect(rec.refresh.length).toBe(1); // exactly one refresh, NEVER a second
+    expect(payload["status"]).toBe("must_reregister");
     expect(payload["products"]).toBeUndefined();
+    expect(payload["recovery"]).toBe("sil_register");
     const blob = JSON.stringify(payload).toLowerCase();
     expect(blob).toMatch(/re-?register|sil_register|session.*expired/);
   });
 
+  it("refresh returns invalid_grant (sil-web 401) → terminal re-register, tokens.json cleared, NO catalog retry", async () => {
+    // AC[integration]: a dead refresh token. Terminal re-register, the dead pair
+    // cleared, and NO retry of the lookup (there is no rotated token to retry).
+    seedTokens("expired-at", "dead-rt");
+    const rec = installRouter((kind) => {
+      if (kind === "lookup") return { status: 401, body: { error: "unauthorized" } };
+      if (kind === "refresh") return { status: 401, body: { error: "invalid_grant" } };
+      return { status: 500, body: {} };
+    });
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] }),
+    );
+
+    expect(payload["status"]).toBe("must_reregister");
+    expect(payload["recovery"]).toBe("sil_register");
+    // No retry after a failed refresh — exactly ONE lookup (the original 401) +
+    // ONE refresh.
+    expect(rec.lookup.length).toBe(1);
+    expect(rec.refresh.length).toBe(1);
+    // The confirmed-dead pair is cleared so sil_register does not short-circuit.
+    expect(existsSync(getTokensPath())).toBe(false);
+    expect(readTokens()).toBeNull();
+  });
+
+  it("the second-401 / dead-refresh terminal leaks NO token to any log line or the payload", async () => {
+    // AC[integration]: privacy holds on the terminal path too.
+    seedTokens("expired-at", "dead-rt");
+    installRouter((kind) => {
+      if (kind === "lookup") return { status: 401, body: { error: "unauthorized" } };
+      if (kind === "refresh") return { status: 401, body: { error: "invalid_grant" } };
+      return { status: 500, body: {} };
+    });
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] }),
+    );
+
+    const resultBlob = JSON.stringify(payload);
+    expect(resultBlob).not.toContain("expired-at");
+    expect(resultBlob).not.toContain("dead-rt");
+    const logs = logBlob(api);
+    expect(logs).not.toContain("expired-at");
+    expect(logs).not.toContain("dead-rt");
+    expect(logs).not.toMatch(/Bearer/i);
+  });
+});
+
+describe("sil_product_get — 401 → transient refresh failure is 'try again', NOT a re-register (outcome 3)", () => {
+  it("the refresh leg returns 5xx → transient retryable, NO recovery:sil_register, NO catalog retry", async () => {
+    // AC[integration]: a refresh-leg 5xx is a blip, not a dead session.
+    seedTokens("expired-at", "valid-rt");
+    const rec = installRouter((kind) => {
+      if (kind === "lookup") return { status: 401, body: { error: "unauthorized" } };
+      if (kind === "refresh") return { status: 503, body: { error: "unavailable" } };
+      return { status: 500, body: {} };
+    });
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] }),
+    );
+
+    expect(payload["status"]).toBe("retryable");
+    expect(payload["recovery"]).not.toBe("sil_register");
+    const blob = JSON.stringify(payload).toLowerCase();
+    expect(blob).not.toMatch(/sil_register/);
+    expect(blob).toMatch(/retry|try.again|temporar|unavailable|later/);
+    // The refresh was attempted once; the lookup was NOT retried (no rotated token).
+    expect(rec.refresh.length).toBe(1);
+    expect(rec.lookup.length).toBe(1);
+    // Tokens are NOT cleared on a transient (the pair may be fine).
+    expect(readTokens()).not.toBeNull();
+  });
+
+  it("the refresh leg throws (network error) → transient retryable, NO re-register, NO catalog retry", async () => {
+    seedTokens("expired-at", "valid-rt");
+    const rec = installRouter((kind) => {
+      if (kind === "lookup") return { status: 401, body: { error: "unauthorized" } };
+      if (kind === "refresh") return "network-error";
+      return { status: 500, body: {} };
+    });
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] }),
+    );
+
+    expect(payload["status"]).toBe("retryable");
+    expect(JSON.stringify(payload).toLowerCase()).not.toMatch(/sil_register/);
+    expect(rec.refresh.length).toBe(1);
+    expect(rec.lookup.length).toBe(1);
+    expect(readTokens()).not.toBeNull();
+  });
+
+  it("a first-call 5xx (before any 401) keeps its existing transient outcome and attempts NO refresh (the refresh path is reachable only via a 401)", async () => {
+    // AC[integration]: this card does NOT alter the non-401 branches. A 5xx on the
+    // ORIGINAL lookup must NOT trigger the refresh path.
+    seedTokens("at", "rt");
+    const rec = installRouter((kind) => {
+      if (kind === "lookup") return { status: 500, body: { error: "source_unavailable" } };
+      return { status: 200, body: { access_token: "x", refresh_token: "y" } };
+    });
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] }),
+    );
+
+    expect(payload["status"]).toBe("retryable");
+    expect(rec.lookup.length).toBe(1); // single round-trip
+    expect(rec.refresh.length).toBe(0); // NO refresh — a first-call 5xx is not a 401
+  });
+});
+
+describe("sil_product_get — the failure outcomes surface as distinguishable error envelopes", () => {
   it("400 (schema reject) → invalid_request envelope, distinct from the all-missed success and the transient", async () => {
     seedTokens("at", "rt");
     installRouter((kind) =>
@@ -627,24 +935,39 @@ describe("sil_product_get — the failure outcomes surface as distinguishable er
     expect(payload["status"]).not.toBe("ok");
   });
 
-  it("401 is DISTINCT from the 500 transient outcome (different recovery guidance)", async () => {
-    async function payloadFor(reply: Reply): Promise<Record<string, unknown>> {
-      seedTokens("at", "rt");
-      installRouter((kind) => (kind === "lookup" ? reply : { status: 200, body: {} }));
+  it("a 401 with a DEAD refresh (re-register) is DISTINCT from a first-call 500 (transient) — different recovery guidance", async () => {
+    // AC[integration]: the recovery-hint discriminator. A 401 whose refresh token
+    // is also dead (invalid_grant) terminates at re-register with the sil_register
+    // hint; a first-call 5xx is transient with NO hint. The two must stay
+    // distinguishable envelopes (one wrong hint = one misdirected user).
+    const deadRefresh = await (async () => {
+      seedTokens("expired-at", "dead-rt");
+      installRouter((kind) => {
+        if (kind === "lookup") return { status: 401, body: { error: "unauthorized" } };
+        if (kind === "refresh") return { status: 401, body: { error: "invalid_grant" } };
+        return { status: 500, body: {} };
+      });
       const api = createMockPluginApi();
       registerCatalogTools(api);
       const p = payloadOf(await getTool(api, TOOL).execute("c1", { ids: ["x"] }));
       vi.restoreAllMocks();
       return p;
-    }
+    })();
 
-    const unauthorized = await payloadFor({ status: 401, body: { error: "unauthorized" } });
-    const transient = await payloadFor({ status: 500, body: { error: "source_unavailable" } });
+    const transient = await (async () => {
+      seedTokens("at", "rt");
+      installRouter((kind) =>
+        kind === "lookup" ? { status: 500, body: { error: "source_unavailable" } } : { status: 200, body: {} },
+      );
+      const api = createMockPluginApi();
+      registerCatalogTools(api);
+      const p = payloadOf(await getTool(api, TOOL).execute("c1", { ids: ["x"] }));
+      vi.restoreAllMocks();
+      return p;
+    })();
 
-    // The 401 carries a re-register hint; the 5xx does NOT (re-registering can't fix
-    // a server fault). The two must be distinguishable envelopes.
-    expect(unauthorized["status"]).not.toBe(transient["status"]);
-    expect(JSON.stringify(unauthorized).toLowerCase()).toMatch(/sil_register|re-?register/);
+    expect(deadRefresh["status"]).not.toBe(transient["status"]);
+    expect(JSON.stringify(deadRefresh).toLowerCase()).toMatch(/sil_register|re-?register/);
     expect(JSON.stringify(transient).toLowerCase()).not.toMatch(/sil_register/);
   });
 });

--- a/src/__tests__/catalog-search.integration.test.ts
+++ b/src/__tests__/catalog-search.integration.test.ts
@@ -11,13 +11,14 @@
  * empty-match-is-success, cursor hoist, and token privacy — against a mocked
  * boundary, exactly as whoami's integration suite proved its read flow.
  *
- * ONE ORIGIN: the search read targets the resolved **sil-api** origin
- * (`getSilApiUrl`), at the BARE path `/catalog/search` — NOT `/api/v1`, NOT the
- * sil-web origin (`getApiUrl`). Both origins are pinned to distinct known hosts
- * so the origin + path assertions are exact, and a misfire onto sil-web is
- * caught. (Search does no refresh choreography in SC1 — a single round-trip; the
- * 401 path is a terminal re-register hint, not a transparent refresh. See the
- * card's open question.)
+ * TWO ORIGINS: the search read targets the resolved **sil-api** origin
+ * (`getSilApiUrl`), at the BARE path `/catalog/search` — NOT `/api/v1`. On a 401
+ * the tool now refreshes transparently against the **sil-web** origin
+ * (`getApiUrl`, via the real `refreshStoredTokens`) and retries the search ONCE —
+ * the SAME refresh-and-retry-once choreography `sil_whoami` performs (this card
+ * makes 401 recovery uniform across every sil-api-calling tool; FLAG-10). Both
+ * origins are pinned to distinct known hosts so the origin + path assertions are
+ * exact, and a misfire is caught.
  *
  * Wire shapes pinned to the ALREADY-MERGED sil-api contract (sil-services
  * `@sil/schemas` `packages/schemas/src/catalog.ts` + `envelope.ts` +
@@ -28,8 +29,13 @@
  *   response (200): the UCP envelope buildEnvelope emits, whose `result` is a
  *     CatalogSearchResult { products: SilCatalogProduct[], pagination?, messages? }.
  *   400 { error: "empty_search_input", message }  → invalid_request envelope
- *   401                                           → terminal re-register envelope
+ *   401                                           → refresh-and-retry-once (see below)
  *   500 / network / timeout                       → retryable envelope
+ *
+ *   refresh (sil-web):  POST <sil-web>/api/v1/auth/refresh { refresh_token }
+ *     200 { access_token, refresh_token }         → rotate tokens.json, retry once
+ *     401 { error: "invalid_grant" }              → terminal re-register, tokens cleared
+ *     5xx / network                               → transient retryable, NO retry
  *
  * THE anti-false-green (complete-work-is-stub-free): the happy-path mock returns
  * the REAL `SilCatalogProduct` envelope shape (each product with a required
@@ -54,13 +60,13 @@ import {
   beforeEach,
   afterEach,
 } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { registerCatalogTools } from "../tools/catalog.js";
 import { setApiUrl, setSilApiUrl, getApiUrl, getSilApiUrl } from "../lib/config.js";
-import { getDataDir, getTokensPath } from "../lib/credentials.js";
+import { getDataDir, getTokensPath, readTokens } from "../lib/credentials.js";
 import {
   createMockPluginApi,
   getTool,
@@ -163,15 +169,22 @@ type Reply = { status: number; body: unknown } | "network-error";
 /**
  * A URL-routing fetch double cloned from whoami.integration.test.ts. `reply(kind,
  * nthOfKind, req)` decides each response given whether the request is a `search`
- * (sil-api /catalog/search) or `other`. Records every request (url, method,
- * bearer, body) so origin, path, the Bearer header, the mapped body, and call
- * COUNTS are all assertable.
+ * (sil-api /catalog/search), a `refresh` (sil-web /auth/refresh — the transparent
+ * 401 recovery leg, reached via the real `refreshStoredTokens`), or `other`.
+ * Records every request (url, method, bearer, body) so origin, path, the Bearer
+ * header, the mapped body, and call COUNTS (including "exactly one refresh") are
+ * all assertable. The `refresh` bucket is what makes the no-storm bound testable.
  */
 function installRouter(
-  reply: (kind: "search" | "other", nthOfKind: number, req: Recorded) => Reply,
-): { all: Recorded[]; search: Recorded[] } {
+  reply: (
+    kind: "search" | "refresh" | "other",
+    nthOfKind: number,
+    req: Recorded,
+  ) => Reply,
+): { all: Recorded[]; search: Recorded[]; refresh: Recorded[] } {
   const all: Recorded[] = [];
   const search: Recorded[] = [];
+  const refresh: Recorded[] = [];
 
   vi.spyOn(globalThis, "fetch").mockImplementation(
     (input: unknown, init?: RequestInit) => {
@@ -191,13 +204,21 @@ function installRouter(
       const req: Recorded = { url, method, bearer, body, hasBody };
       all.push(req);
 
-      const kind: "search" | "other" = url.includes("/catalog/search")
-        ? "search"
-        : "other";
+      // Order matters: /auth/refresh is the sil-web leg; /catalog/search the
+      // sil-api leg. Check refresh first so a future shared path can't be
+      // misrouted to `search`.
+      let kind: "search" | "refresh" | "other";
+      if (url.includes("/auth/refresh")) kind = "refresh";
+      else if (url.includes("/catalog/search")) kind = "search";
+      else kind = "other";
+
       let nthOfKind: number;
       if (kind === "search") {
         search.push(req);
         nthOfKind = search.length - 1;
+      } else if (kind === "refresh") {
+        refresh.push(req);
+        nthOfKind = refresh.length - 1;
       } else {
         nthOfKind = all.length - 1;
       }
@@ -215,7 +236,7 @@ function installRouter(
     },
   );
 
-  return { all, search };
+  return { all, search, refresh };
 }
 
 /** Parse a ToolResult payload. */
@@ -564,35 +585,283 @@ describe("sil_search — the three distinct sil-api outcomes surface as three di
   });
 });
 
-describe("sil_search — 401 is a terminal re-register hint (single round-trip, no refresh in SC1)", () => {
-  it("401 → structured re-register envelope (recovery sil_register), NOT a crash, NOT a false-green", async () => {
-    seedTokens("dead-at", "dead-rt");
-    const rec = installRouter((kind) =>
-      kind === "search" ? { status: 401, body: { error: "unauthorized" } } : { status: 200, body: {} },
-    );
+describe("sil_search — 401 → transparent refresh-and-retry-once (outcome 1: the agent never sees the 401)", () => {
+  it("401 → refresh once via sil-web → rotate tokens.json → retry the search once with the NEW token → normal ranked result", async () => {
+    // AC[integration]: outcome 1 — a registered agent whose access token is
+    // expired gets a NORMAL ranked result, indistinguishable from a call that
+    // never 401'd. This is the choreography sil_whoami already performs; the card
+    // brings sil_search onto it. EXPECT RED against current code (catalog.ts 401 is
+    // terminal mustReregister, no refresh) and GREEN once it routes through the
+    // shared refreshAndRetryOnce helper.
+    seedTokens("expired-at", "valid-rt");
+    const rec = installRouter((kind, nth) => {
+      if (kind === "search") {
+        // First search 401 (expired); second (after refresh) returns products.
+        return nth === 0
+          ? { status: 401, body: { error: "unauthorized" } }
+          : { status: 200, body: searchEnvelope([PRODUCT_A]) };
+      }
+      if (kind === "refresh") {
+        return { status: 200, body: { access_token: "rotated-at", refresh_token: "rotated-rt" } };
+      }
+      return { status: 500, body: {} };
+    });
     const api = createMockPluginApi();
     registerCatalogTools(api);
 
     const payload = payloadOf(await getTool(api, TOOL).execute("c1", { query: "chair" }));
 
-    // A SINGLE round-trip — search does NOT do the transparent refresh-and-retry
-    // choreography whoami performs (card open question: SC1 is single round-trip).
-    expect(rec.search.length).toBe(1);
-    // No refresh call leaked onto sil-web.
-    for (const r of rec.all) {
-      expect(r.url).not.toContain("/auth/refresh");
+    // The agent sees a normal success — NOT a re-register, NOT an empty.
+    expect(payload["status"]).toBe("ok");
+    const products = payload["products"] as Array<Record<string, unknown>>;
+    expect(Array.isArray(products)).toBe(true);
+    expect(products).toHaveLength(1);
+    expect(products[0]!["id"]).toBe("gid://product/a");
+    // The refresh is INVISIBLE: no refreshed/retried marker, no recovery hint.
+    expect(payload["refreshed"]).toBeUndefined();
+    expect(payload["retried"]).toBeUndefined();
+    expect(payload["recovery"]).toBeUndefined();
+    // The retry carried the ROTATED access token (proves the re-read after rotation).
+    expect(rec.search.length).toBe(2);
+    expect(bearerToken(rec.search[1]!)).toBe("rotated-at");
+    // The refresh used the STORED refresh token.
+    expect(rec.refresh.length).toBe(1);
+    expect((rec.refresh[0]!.body as { refresh_token?: string }).refresh_token).toBe("valid-rt");
+  });
+
+  it("makes EXACTLY one refresh (sil-web) + EXACTLY two catalog reads (the failed read + one retry) — no loop, no storm", async () => {
+    // AC[integration]: the silent path does not loop or storm. Exactly 1 refresh
+    // + 2 catalog calls on a recovered 401.
+    seedTokens("expired-at", "valid-rt");
+    const rec = installRouter((kind, nth) => {
+      if (kind === "search") {
+        return nth === 0
+          ? { status: 401, body: { error: "unauthorized" } }
+          : { status: 200, body: searchEnvelope([PRODUCT_A]) };
+      }
+      if (kind === "refresh") {
+        return { status: 200, body: { access_token: "rotated-at", refresh_token: "rotated-rt" } };
+      }
+      return { status: 500, body: {} };
+    });
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    await getTool(api, TOOL).execute("c1", { query: "chair" });
+
+    expect(rec.search.length).toBe(2); // failed read + exactly one retry
+    expect(rec.refresh.length).toBe(1); // exactly one refresh, never more
+    // The refresh hit sil-web; the searches hit sil-api — origins asserted apart.
+    const silApiOrigin = new URL(getSilApiUrl()).origin;
+    const silWebOrigin = new URL(getApiUrl()).origin;
+    for (const r of rec.search) expect(new URL(r.url).origin).toBe(silApiOrigin);
+    for (const r of rec.refresh) expect(new URL(r.url).origin).toBe(silWebOrigin);
+    // No Auth0 contacted on any path (sil-web is the sole auth authority).
+    for (const r of rec.all) expect(r.url).not.toMatch(/auth0\.com/i);
+  });
+
+  it("persists the rotated pair to tokens.json and leaks NO token to the result or any log line", async () => {
+    // AC[integration]: tokens.json holds the rotated pair, and neither old nor new
+    // token value appears in any logger call or the returned payload.
+    const ROT_AT = "rotated-secret-access";
+    const ROT_RT = "rotated-secret-refresh";
+    seedTokens("expired-at", "valid-rt");
+    const rec = installRouter((kind, nth) => {
+      if (kind === "search") {
+        return nth === 0
+          ? { status: 401, body: { error: "unauthorized" } }
+          : { status: 200, body: searchEnvelope([PRODUCT_A]) };
+      }
+      if (kind === "refresh") return { status: 200, body: { access_token: ROT_AT, refresh_token: ROT_RT } };
+      return { status: 500, body: {} };
+    });
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { query: "chair" }));
+
+    // tokens.json now holds the rotated pair (the refresh persisted).
+    const tokens = readTokens();
+    expect(tokens!.access_token).toBe(ROT_AT);
+    expect(tokens!.refresh_token).toBe(ROT_RT);
+    // The rotated token reached the retry's Authorization header, and ONLY there.
+    expect(bearerToken(rec.search[1]!)).toBe(ROT_AT);
+    // No token (old or rotated) in the result.
+    const resultBlob = JSON.stringify(payload);
+    expect(resultBlob).not.toContain(ROT_AT);
+    expect(resultBlob).not.toContain(ROT_RT);
+    expect(resultBlob).not.toContain("valid-rt");
+    expect(resultBlob).not.toContain("expired-at");
+    // No token in any log line, and never a Bearer string.
+    const logs = logBlob(api);
+    expect(logs).not.toContain(ROT_AT);
+    expect(logs).not.toContain(ROT_RT);
+    expect(logs).not.toContain("valid-rt");
+    expect(logs).not.toContain("expired-at");
+    expect(logs).not.toMatch(/Bearer/i);
+    // Nor in any request BODY (the credential rides only the header).
+    for (const r of [...rec.search, ...rec.refresh]) {
+      const b = JSON.stringify(r.body ?? {});
+      expect(b).not.toContain(ROT_AT);
+      expect(b).not.toContain("expired-at");
     }
+  });
+});
+
+describe("sil_search — 401 → second 401 / dead refresh is terminal (outcome 2: re-register, refreshed at most once)", () => {
+  it("refresh OK but the retried read is ALSO 401 → terminal re-register, exactly ONE refresh (a freshly-rotated-still-401 is structurally dead)", async () => {
+    // AC[integration]: the no-storm bound. A retry that is still 401 must be
+    // terminal, never a second refresh.
+    seedTokens("expired-at", "valid-rt");
+    const rec = installRouter((kind) => {
+      // Search ALWAYS 401 (even after a good refresh — structurally dead).
+      if (kind === "search") return { status: 401, body: { error: "unauthorized" } };
+      // Refresh succeeds (rotates), so the tool DOES retry once.
+      if (kind === "refresh") {
+        return { status: 200, body: { access_token: "rotated-at", refresh_token: "rotated-rt" } };
+      }
+      return { status: 500, body: {} };
+    });
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { query: "chair" }));
+
+    // Exactly: search(401) → refresh(200) → retry-search(401) → STOP.
+    expect(rec.search.length).toBe(2); // initial + exactly one retry
+    expect(rec.refresh.length).toBe(1); // exactly one refresh, NEVER a second
     // Terminal, actionable re-register — not a success, not a silent empty.
-    expect(payload["status"]).not.toBe("ok");
+    expect(payload["status"]).toBe("must_reregister");
     expect(payload["products"]).toBeUndefined();
+    expect(payload["recovery"]).toBe("sil_register");
     const blob = JSON.stringify(payload).toLowerCase();
     expect(blob).toMatch(/re-?register|sil_register|session.*expired/);
   });
 
-  it("401 is DISTINCT from the 500 transient outcome (different recovery guidance)", async () => {
-    async function payloadFor(reply: Reply): Promise<Record<string, unknown>> {
-      seedTokens("at", "rt");
-      installRouter((kind) => (kind === "search" ? reply : { status: 200, body: {} }));
+  it("refresh returns invalid_grant (sil-web 401) → terminal re-register, tokens.json cleared, NO catalog retry", async () => {
+    // AC[integration]: a dead refresh token. Terminal re-register, the dead pair
+    // cleared (so the agent's sil_register recovery is not blocked by stale
+    // presence), and NO retry of the search (there is no rotated token to retry).
+    seedTokens("expired-at", "dead-rt");
+    const rec = installRouter((kind) => {
+      if (kind === "search") return { status: 401, body: { error: "unauthorized" } };
+      if (kind === "refresh") return { status: 401, body: { error: "invalid_grant" } };
+      return { status: 500, body: {} };
+    });
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { query: "chair" }));
+
+    expect(payload["status"]).toBe("must_reregister");
+    expect(payload["recovery"]).toBe("sil_register");
+    // No retry after a failed refresh — exactly ONE search (the original 401) +
+    // ONE refresh. (A retry with no rotated token is a bug.)
+    expect(rec.search.length).toBe(1);
+    expect(rec.refresh.length).toBe(1);
+    // The confirmed-dead pair is cleared so sil_register does not short-circuit.
+    expect(existsSync(getTokensPath())).toBe(false);
+    expect(readTokens()).toBeNull();
+  });
+
+  it("the second-401 / dead-refresh terminal leaks NO token to any log line or the payload", async () => {
+    // AC[integration]: privacy holds on the terminal path too.
+    seedTokens("expired-at", "dead-rt");
+    installRouter((kind) => {
+      if (kind === "search") return { status: 401, body: { error: "unauthorized" } };
+      if (kind === "refresh") return { status: 401, body: { error: "invalid_grant" } };
+      return { status: 500, body: {} };
+    });
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { query: "chair" }));
+
+    const resultBlob = JSON.stringify(payload);
+    expect(resultBlob).not.toContain("expired-at");
+    expect(resultBlob).not.toContain("dead-rt");
+    const logs = logBlob(api);
+    expect(logs).not.toContain("expired-at");
+    expect(logs).not.toContain("dead-rt");
+    expect(logs).not.toMatch(/Bearer/i);
+  });
+});
+
+describe("sil_search — 401 → transient refresh failure is 'try again', NOT a re-register (outcome 3)", () => {
+  it("the refresh leg returns 5xx → transient retryable, NO recovery:sil_register, NO catalog retry", async () => {
+    // AC[integration]: a refresh-leg 5xx is a blip, not a dead session. The agent
+    // is told to try again — re-registering would eject a still-valid session.
+    seedTokens("expired-at", "valid-rt");
+    const rec = installRouter((kind) => {
+      if (kind === "search") return { status: 401, body: { error: "unauthorized" } };
+      if (kind === "refresh") return { status: 503, body: { error: "unavailable" } };
+      return { status: 500, body: {} };
+    });
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { query: "chair" }));
+
+    expect(payload["status"]).toBe("retryable");
+    expect(payload["recovery"]).not.toBe("sil_register");
+    const blob = JSON.stringify(payload).toLowerCase();
+    expect(blob).not.toMatch(/sil_register/);
+    expect(blob).toMatch(/retry|try.again|temporar|unavailable|later/);
+    // The refresh was attempted once; the search was NOT retried (no rotated token).
+    expect(rec.refresh.length).toBe(1);
+    expect(rec.search.length).toBe(1);
+    // Tokens are NOT cleared on a transient (the pair may be fine).
+    expect(readTokens()).not.toBeNull();
+  });
+
+  it("the refresh leg throws (network error) → transient retryable, NO re-register, NO catalog retry", async () => {
+    seedTokens("expired-at", "valid-rt");
+    const rec = installRouter((kind) => {
+      if (kind === "search") return { status: 401, body: { error: "unauthorized" } };
+      if (kind === "refresh") return "network-error";
+      return { status: 500, body: {} };
+    });
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { query: "chair" }));
+
+    expect(payload["status"]).toBe("retryable");
+    expect(JSON.stringify(payload).toLowerCase()).not.toMatch(/sil_register/);
+    expect(rec.refresh.length).toBe(1);
+    expect(rec.search.length).toBe(1);
+    expect(readTokens()).not.toBeNull();
+  });
+
+  it("a first-call 5xx (before any 401) keeps its existing transient outcome and attempts NO refresh (the refresh path is reachable only via a 401)", async () => {
+    // AC[integration]: this card does NOT alter the non-401 branches. A 5xx on the
+    // ORIGINAL search must NOT trigger the refresh path.
+    seedTokens("at", "rt");
+    const rec = installRouter((kind) => {
+      if (kind === "search") return { status: 500, body: { error: "source_unavailable" } };
+      return { status: 200, body: { access_token: "x", refresh_token: "y" } };
+    });
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { query: "chair" }));
+
+    expect(payload["status"]).toBe("retryable");
+    expect(rec.search.length).toBe(1); // single round-trip
+    expect(rec.refresh.length).toBe(0); // NO refresh — a first-call 5xx is not a 401
+  });
+
+  it("401 (terminal re-register) is DISTINCT from a refresh-leg 5xx (transient) — different recovery guidance", async () => {
+    // The recovery-hint discriminator: a dead session (invalid_grant) carries the
+    // sil_register hint; a transient refresh blip does NOT. The two must be
+    // distinguishable envelopes for the same originating 401.
+    async function payloadFor(refreshReply: Reply): Promise<Record<string, unknown>> {
+      seedTokens("expired-at", "valid-rt");
+      installRouter((kind) => {
+        if (kind === "search") return { status: 401, body: { error: "unauthorized" } };
+        if (kind === "refresh") return refreshReply;
+        return { status: 500, body: {} };
+      });
       const api = createMockPluginApi();
       registerCatalogTools(api);
       const p = payloadOf(await getTool(api, TOOL).execute("c1", { query: "x" }));
@@ -600,14 +869,12 @@ describe("sil_search — 401 is a terminal re-register hint (single round-trip, 
       return p;
     }
 
-    const unauthorized = await payloadFor({ status: 401, body: { error: "unauthorized" } });
-    const transient = await payloadFor({ status: 500, body: { error: "source_unavailable" } });
+    const deadRefresh = await payloadFor({ status: 401, body: { error: "invalid_grant" } });
+    const transientRefresh = await payloadFor({ status: 503, body: { error: "unavailable" } });
 
-    // The 401 carries a re-register hint; the 5xx does NOT (re-registering can't
-    // fix a server fault). The two must be distinguishable envelopes.
-    expect(unauthorized["status"]).not.toBe(transient["status"]);
-    expect(JSON.stringify(unauthorized).toLowerCase()).toMatch(/sil_register|re-?register/);
-    expect(JSON.stringify(transient).toLowerCase()).not.toMatch(/sil_register/);
+    expect(deadRefresh["status"]).not.toBe(transientRefresh["status"]);
+    expect(JSON.stringify(deadRefresh).toLowerCase()).toMatch(/sil_register|re-?register/);
+    expect(JSON.stringify(transientRefresh).toLowerCase()).not.toMatch(/sil_register/);
   });
 });
 

--- a/src/__tests__/catalog-search.integration.test.ts
+++ b/src/__tests__/catalog-search.integration.test.ts
@@ -270,6 +270,19 @@ function logBlob(api: MockPluginAPI): string {
     .join("\n");
 }
 
+/**
+ * Count how many `api.logger.info(marker, …)` calls used `marker` as their first
+ * argument. The marker name is the FIRST positional arg of the info call (the
+ * convention every `sil_*` log marker in this plugin follows). Used to assert the
+ * `sil_search_refreshed` operator marker fires exactly once on the silent-recovery
+ * path and ZERO times on a first-try (no-refresh) success.
+ */
+function infoMarkerCount(api: MockPluginAPI, marker: string): number {
+  return vi
+    .mocked(api.logger.info)
+    .mock.calls.filter((c) => c[0] === marker).length;
+}
+
 beforeEach(() => {
   dataDir = mkdtempSync(join(tmpdir(), "sil-search-int-"));
   priorSilDataDir = process.env["SIL_DATA_DIR"];
@@ -433,6 +446,13 @@ describe("sil_search — happy path normalizes the REAL envelope (anti-false-gre
     expect(typeof avail).toBe("object");
     expect(avail["available"]).toBe(true);
     expect(avail["status"]).toBe("in_stock");
+
+    // NEGATIVE half of the observability seam (review-round-1 fix): this is a
+    // FIRST-TRY success (no 401, no refresh), so the `sil_search_refreshed` marker
+    // must NOT fire. The marker means "this success was a silent recovery"; on a
+    // plain success it would be a false signal that the session is thrashing. The
+    // marker keys off the helper's `refreshed:false` passthrough discriminant.
+    expect(infoMarkerCount(api, "sil_search_refreshed")).toBe(0);
   });
 
   it("hoists result.pagination.cursor to a top-level cursor when has_next_page is true", async () => {
@@ -617,7 +637,8 @@ describe("sil_search — 401 → transparent refresh-and-retry-once (outcome 1: 
     expect(Array.isArray(products)).toBe(true);
     expect(products).toHaveLength(1);
     expect(products[0]!["id"]).toBe("gid://product/a");
-    // The refresh is INVISIBLE: no refreshed/retried marker, no recovery hint.
+    // The refresh is INVISIBLE TO THE AGENT: no refreshed/retried marker, no
+    // recovery hint IN THE PAYLOAD. (This payload contract is correct and stays.)
     expect(payload["refreshed"]).toBeUndefined();
     expect(payload["retried"]).toBeUndefined();
     expect(payload["recovery"]).toBeUndefined();
@@ -627,6 +648,30 @@ describe("sil_search — 401 → transparent refresh-and-retry-once (outcome 1: 
     // The refresh used the STORED refresh token.
     expect(rec.refresh.length).toBe(1);
     expect((rec.refresh[0]!.body as { refresh_token?: string }).refresh_token).toBe("valid-rt");
+
+    // OPERATOR-OBSERVABILITY SEAM (review-round-1 fix; card line 161): the silent
+    // recovery is invisible in the PAYLOAD but MUST be observable in operator logs
+    // — a session that refreshes on (nearly) every call is the degrading-session
+    // signal on-call needs, and the card's own risk-mitigation names the
+    // `sil_*_refreshed` marker by hand. Assert the `sil_search_refreshed` INFO
+    // marker fired EXACTLY ONCE on this recovered-401 path. RED until the tool
+    // emits it (logs-only — NOT a payload field) when the helper reports
+    // `refreshed: true`.
+    expect(infoMarkerCount(api, "sil_search_refreshed")).toBe(1);
+    // The marker is logs-only — it does NOT add any field to the agent payload
+    // (outcome 1's invisible-to-the-agent contract stays inviolate).
+    expect(payload["sil_search_refreshed"]).toBeUndefined();
+    // The marker carries NO token material (the privacy invariant holds on the
+    // marker too — its meta must never carry a token value).
+    const refreshedMarkerArgs = vi
+      .mocked(api.logger.info)
+      .mock.calls.filter((c) => c[0] === "sil_search_refreshed");
+    const refreshedMarkerBlob = JSON.stringify(refreshedMarkerArgs);
+    expect(refreshedMarkerBlob).not.toContain("rotated-at");
+    expect(refreshedMarkerBlob).not.toContain("rotated-rt");
+    expect(refreshedMarkerBlob).not.toContain("valid-rt");
+    expect(refreshedMarkerBlob).not.toContain("expired-at");
+    expect(refreshedMarkerBlob).not.toMatch(/Bearer/i);
   });
 
   it("makes EXACTLY one refresh (sil-web) + EXACTLY two catalog reads (the failed read + one retry) — no loop, no storm", async () => {

--- a/src/__tests__/cross-tool-401-parity.integration.test.ts
+++ b/src/__tests__/cross-tool-401-parity.integration.test.ts
@@ -1,0 +1,442 @@
+/**
+ * INTEGRATION — cross-tool 401 parity (tier: integration).
+ *
+ * THE structural guard against FLAG-10 re-entry. The card's deliverable is that
+ * `sil_search`, `sil_product_get`, and `sil_whoami` present the IDENTICAL 401
+ * choreography — one transparent refresh via `refreshStoredTokens()`, one retry of
+ * the original read, and the same terminal/transient/ok envelope CLASS for each of
+ * the four refresh sub-outcomes (retry-ok, second-401, invalid_grant, refresh-5xx).
+ * The divergence the goal forbids re-enters the moment a fourth tool copies
+ * catalog's OLD terminal branch instead of the shared path — so parity is enforced
+ * here by a real shared-behaviour assertion that FAILS if any one tool drifts, not
+ * left to reviewer vigilance.
+ *
+ * This is deliberately NOT three independent per-tool suites (those live in
+ * whoami / catalog-search / catalog-lookup integration). Here we drive the SAME
+ * scenario through all three tools in one test and assert their observable 401
+ * behaviour is the same — the equality IS the assertion. A tool whose 401 stayed
+ * terminal (no refresh) shows refresh.length 0 where the others show 1, or maps a
+ * recovered 401 to a re-register where the others map to ok — and the parity check
+ * fails.
+ *
+ * The ONLY thing mocked is `fetch`. Real `sil-client` + `credentials` +
+ * `refreshStoredTokens`, real `SIL_DATA_DIR` token seeding — stub-free, exactly as
+ * the per-tool suites. The fetch double routes the THREE sil-api read endpoints
+ * (`/identity` GET, `/catalog/search`, `/catalog/lookup`) plus the sil-web
+ * `/auth/refresh` leg, and exposes per-tool read + refresh call counts.
+ *
+ * EXPECT RED until all three tools route 401 through the shared
+ * `refreshAndRetryOnce` helper: against current code `sil_whoami` already
+ * refreshes (refresh.length 1, recovered-ok) but the two catalog tools are
+ * terminal (refresh.length 0, re-register) — so the per-sub-outcome parity sets
+ * have size > 1 and these tests fail. GREEN only once catalog 401 matches whoami.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { registerCatalogTools } from "../tools/catalog.js";
+import { registerIdentityTools } from "../tools/identity.js";
+import { setApiUrl, setSilApiUrl } from "../lib/config.js";
+import { getDataDir, getTokensPath, readTokens } from "../lib/credentials.js";
+import {
+  createMockPluginApi,
+  getTool,
+  type MockPluginAPI,
+} from "./helpers/mock-plugin-api.js";
+
+const SIL_WEB = "https://sil-web.test.example.com"; // refresh origin
+const SIL_API = "https://sil-api.test.example.com"; // read origin (all three reads)
+
+/** A real identity envelope (sil_whoami's ok shape). */
+function identityEnvelope(): unknown {
+  return {
+    protocol: "ucp",
+    version: "0.1",
+    domain: "identity",
+    result: {
+      name: "Ada Lovelace",
+      addresses: [{ line1: "12 Analytical Engine Way", city: "London", country: "GB" }],
+    },
+  };
+}
+
+/** A real search envelope with one product (sil_search's ok shape). */
+function searchEnvelope(): unknown {
+  return {
+    protocol: "ucp",
+    version: "0.1",
+    domain: "catalog",
+    result: {
+      products: [
+        {
+          id: "gid://product/a",
+          title: "Aeron Chair",
+          source: "herman-miller",
+          variants: [
+            {
+              id: "gid://variant/a1",
+              title: "Aeron Chair — Graphite",
+              price: { amount: 159900, currency: "USD" },
+              availability: { available: true, status: "in_stock" },
+              checkout_url: "https://buy.example.com/aeron-a1",
+            },
+          ],
+        },
+      ],
+      pagination: { has_next_page: false },
+    },
+  };
+}
+
+/** A real lookup envelope with one product (sil_product_get's ok shape). */
+function lookupEnvelope(): unknown {
+  return {
+    protocol: "ucp",
+    version: "0.1",
+    domain: "catalog",
+    result: {
+      products: [
+        {
+          id: "gid://product/a",
+          title: "Aeron Chair",
+          description: { plain: "An ergonomic office chair." },
+          price_range: { min: { amount: 159900, currency: "USD" }, max: { amount: 159900, currency: "USD" } },
+          source: "herman-miller",
+          variants: [
+            {
+              id: "gid://variant/a1",
+              title: "Aeron Chair — Graphite",
+              price: { amount: 159900, currency: "USD" },
+              availability: { available: true, status: "in_stock" },
+              checkout_url: "https://buy.example.com/aeron-a1",
+              inputs: [{ id: "gid://product/a", match: "featured" }],
+            },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+let dataDir: string;
+let priorSilDataDir: string | undefined;
+
+/** One recorded outbound request. */
+interface Recorded {
+  url: string;
+  method: string;
+  bearer: string | null;
+  body: unknown;
+}
+
+type Reply = { status: number; body: unknown } | "network-error";
+type ReadKind = "identity" | "search" | "lookup";
+type Kind = ReadKind | "refresh" | "other";
+
+/** What a recording double returns to the caller. */
+interface Buckets {
+  all: Recorded[];
+  read: Recorded[]; // the tool's sil-api read endpoint (identity|search|lookup)
+  refresh: Recorded[]; // the sil-web /auth/refresh leg
+}
+
+/**
+ * A URL-routing fetch double covering all three sil-api read endpoints + the
+ * sil-web refresh leg. `readKind` selects which read endpoint THIS tool uses, so
+ * the `read` bucket counts only that tool's reads (the parity assertion compares
+ * read + refresh counts across tools). `replyRead(nthRead)` and
+ * `replyRefresh(nthRefresh)` drive the two legs independently.
+ */
+function installRouter(
+  readKind: ReadKind,
+  replyRead: (nthRead: number) => Reply,
+  replyRefresh: (nthRefresh: number) => Reply,
+): Buckets {
+  const all: Recorded[] = [];
+  const read: Recorded[] = [];
+  const refresh: Recorded[] = [];
+
+  vi.spyOn(globalThis, "fetch").mockImplementation(
+    (input: unknown, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : String(input);
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      const bearer = headers["Authorization"] ?? headers["authorization"] ?? null;
+      const method = (init?.method ?? "GET").toUpperCase();
+      let body: unknown = null;
+      if (typeof init?.body === "string") {
+        try {
+          body = JSON.parse(init.body);
+        } catch {
+          body = init.body;
+        }
+      }
+      const req: Recorded = { url, method, bearer, body };
+      all.push(req);
+
+      let kind: Kind;
+      if (url.includes("/auth/refresh")) kind = "refresh";
+      else if (url.includes("/catalog/search")) kind = "search";
+      else if (url.includes("/catalog/lookup")) kind = "lookup";
+      else if (url.includes("/identity")) kind = "identity";
+      else kind = "other";
+
+      let r: Reply;
+      if (kind === "refresh") {
+        refresh.push(req);
+        r = replyRefresh(refresh.length - 1);
+      } else if (kind === readKind) {
+        read.push(req);
+        r = replyRead(read.length - 1);
+      } else {
+        // A read endpoint that is NOT this tool's, or an unexpected URL — a tool
+        // must hit ONLY its own read endpoint + refresh. Fail loudly.
+        return Promise.reject(
+          new Error(`unexpected fetch to ${url} (kind=${kind}) for readKind=${readKind}`),
+        );
+      }
+
+      if (r === "network-error") {
+        return Promise.reject(new Error("simulated network failure"));
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify(r.body), {
+          status: r.status,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    },
+  );
+
+  return { all, read, refresh };
+}
+
+/** Parse a ToolResult payload. */
+function payloadOf(result: { content: { text?: string }[] }): Record<string, unknown> {
+  const text = result.content[0]?.text;
+  if (typeof text !== "string") throw new Error("no tool payload");
+  return JSON.parse(text) as Record<string, unknown>;
+}
+
+/** Seed a stored token pair so each tool proceeds to its read. */
+function seedTokens(access: string, refresh: string): void {
+  const dir = getDataDir();
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    getTokensPath(),
+    JSON.stringify({ access_token: access, refresh_token: refresh }),
+    { mode: 0o600 },
+  );
+}
+
+/** The ok-shape envelope a given tool's read endpoint returns on success. */
+function okEnvelopeFor(readKind: ReadKind): unknown {
+  if (readKind === "identity") return identityEnvelope();
+  if (readKind === "search") return searchEnvelope();
+  return lookupEnvelope();
+}
+
+/** Register the right tool group and return the tool name for a given read kind. */
+function setupTool(readKind: ReadKind): { api: MockPluginAPI; tool: string } {
+  const api = createMockPluginApi();
+  if (readKind === "identity") {
+    registerIdentityTools(api);
+    return { api, tool: "sil_whoami" };
+  }
+  registerCatalogTools(api);
+  return { api, tool: readKind === "search" ? "sil_search" : "sil_product_get" };
+}
+
+/** Invoke a tool with the call args its schema requires. */
+function callArgs(readKind: ReadKind): Record<string, unknown> {
+  if (readKind === "search") return { query: "chair" };
+  if (readKind === "lookup") return { ids: ["gid://product/a"] };
+  return {}; // whoami takes no params
+}
+
+/** One observation of a tool's 401 behaviour under a given refresh-leg scenario. */
+interface Observation {
+  readKind: ReadKind;
+  status: unknown;
+  hasRecoveryHint: boolean;
+  readCount: number;
+  refreshCount: number;
+  tokensCleared: boolean;
+}
+
+/**
+ * Drive a SINGLE refresh-leg scenario through ALL THREE tools and return one
+ * Observation per tool. `replyRead(readKind, nthRead)` makes the first read 401
+ * and lets the caller return each tool's OWN ok envelope on the retry; `replyRefresh`
+ * decides the refresh-leg outcome. Each tool runs in its own fresh token seed +
+ * fetch double so the runs are independent.
+ */
+async function observeAllTools(
+  replyRead: (readKind: ReadKind, nthRead: number) => Reply,
+  replyRefresh: (nthRefresh: number) => Reply,
+): Promise<Observation[]> {
+  const kinds: ReadKind[] = ["identity", "search", "lookup"];
+  const out: Observation[] = [];
+  for (const readKind of kinds) {
+    // Fresh seed per tool (the prior tool's run may have cleared tokens).
+    rmSync(getTokensPath(), { force: true });
+    seedTokens("expired-at", "valid-rt");
+    const rec = installRouter(readKind, (nthRead) => replyRead(readKind, nthRead), replyRefresh);
+    const { api, tool } = setupTool(readKind);
+    const payload = payloadOf(await getTool(api, tool).execute("c1", callArgs(readKind)));
+    out.push({
+      readKind,
+      status: payload["status"],
+      hasRecoveryHint: payload["recovery"] === "sil_register",
+      readCount: rec.read.length,
+      refreshCount: rec.refresh.length,
+      tokensCleared: !existsSync(getTokensPath()),
+    });
+    vi.restoreAllMocks();
+  }
+  return out;
+}
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), "sil-parity-int-"));
+  priorSilDataDir = process.env["SIL_DATA_DIR"];
+  process.env["SIL_DATA_DIR"] = dataDir;
+  setApiUrl(SIL_WEB);
+  setSilApiUrl(SIL_API);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  setApiUrl("");
+  setSilApiUrl("");
+  delete process.env["SIL_API_URL"];
+  delete process.env["SIL_API_BASE"];
+  if (priorSilDataDir === undefined) delete process.env["SIL_DATA_DIR"];
+  else process.env["SIL_DATA_DIR"] = priorSilDataDir;
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe("cross-tool 401 parity — all three tools share ONE refresh-and-retry-once choreography", () => {
+  it("sub-outcome retry-ok: every tool refreshes once, retries once, and returns a NORMAL ok result (no tool dead-ends)", async () => {
+    // AC[integration]: identical scenario (expired token → 401 → good refresh →
+    // retry ok) through search / product_get / whoami. All three must look the
+    // same: exactly 1 refresh, exactly 2 reads, status ok, NO recovery hint. The
+    // retry returns each tool's OWN ok envelope (via okEnvelopeFor).
+    const observed = await observeAllTools(
+      (readKind, nthRead) =>
+        nthRead === 0
+          ? { status: 401, body: { error: "unauthorized" } }
+          : { status: 200, body: okEnvelopeFor(readKind) },
+      () => ({ status: 200, body: { access_token: "rotated-at", refresh_token: "rotated-rt" } }),
+    );
+
+    // PARITY: every tool maps the recovered 401 to ok, with identical call counts.
+    for (const o of observed) {
+      expect(o.status).toBe("ok");
+      expect(o.hasRecoveryHint).toBe(false);
+      expect(o.refreshCount).toBe(1); // exactly one refresh
+      expect(o.readCount).toBe(2); // failed read + one retry
+    }
+    // The equality across tools IS the guard: collapse each dimension to a set.
+    expect(new Set(observed.map((o) => o.status)).size).toBe(1);
+    expect(new Set(observed.map((o) => o.refreshCount)).size).toBe(1);
+    expect(new Set(observed.map((o) => o.readCount)).size).toBe(1);
+  });
+
+  it("sub-outcome second-401: every tool refreshes EXACTLY once, retries once, then terminates re-register (no tool storms)", async () => {
+    // AC[integration]: a freshly-rotated token still 401 is terminal for ALL three
+    // — exactly 1 refresh, exactly 2 reads, status must_reregister with the hint.
+    const observed = await observeAllTools(
+      () => ({ status: 401, body: { error: "unauthorized" } }), // read ALWAYS 401
+      () => ({ status: 200, body: { access_token: "rotated-at", refresh_token: "rotated-rt" } }),
+    );
+
+    for (const o of observed) {
+      expect(o.status).toBe("must_reregister");
+      expect(o.hasRecoveryHint).toBe(true);
+      expect(o.refreshCount).toBe(1); // exactly one refresh, NEVER a second
+      expect(o.readCount).toBe(2); // initial + exactly one retry
+    }
+    expect(new Set(observed.map((o) => o.status)).size).toBe(1);
+    expect(new Set(observed.map((o) => o.refreshCount)).size).toBe(1);
+    expect(new Set(observed.map((o) => o.readCount)).size).toBe(1);
+  });
+
+  it("sub-outcome invalid_grant: every tool refreshes once, does NOT retry, terminates re-register, and clears tokens", async () => {
+    // AC[integration]: a dead refresh token. ALL three: 1 refresh, NO retry (1
+    // read), status must_reregister + hint, tokens.json cleared.
+    const observed = await observeAllTools(
+      () => ({ status: 401, body: { error: "unauthorized" } }),
+      () => ({ status: 401, body: { error: "invalid_grant" } }),
+    );
+
+    for (const o of observed) {
+      expect(o.status).toBe("must_reregister");
+      expect(o.hasRecoveryHint).toBe(true);
+      expect(o.refreshCount).toBe(1);
+      expect(o.readCount).toBe(1); // the original 401 only — NO retry without a rotated token
+      expect(o.tokensCleared).toBe(true);
+    }
+    expect(new Set(observed.map((o) => o.status)).size).toBe(1);
+    expect(new Set(observed.map((o) => o.readCount)).size).toBe(1);
+    expect(new Set(observed.map((o) => o.tokensCleared)).size).toBe(1);
+  });
+
+  it("sub-outcome refresh-5xx: every tool surfaces TRANSIENT retryable with NO re-register hint, does NOT retry, keeps tokens", async () => {
+    // AC[integration]: a refresh-leg 5xx is a blip, not a dead session, for ALL
+    // three — status retryable, NO hint, 1 refresh, NO retry (1 read), tokens kept.
+    const observed = await observeAllTools(
+      () => ({ status: 401, body: { error: "unauthorized" } }),
+      () => ({ status: 503, body: { error: "unavailable" } }),
+    );
+
+    for (const o of observed) {
+      expect(o.status).toBe("retryable");
+      expect(o.hasRecoveryHint).toBe(false); // a refresh blip is NOT a dead session
+      expect(o.refreshCount).toBe(1);
+      expect(o.readCount).toBe(1); // NO retry — no rotated token
+      expect(o.tokensCleared).toBe(false); // the pair may be fine
+    }
+    expect(new Set(observed.map((o) => o.status)).size).toBe(1);
+    expect(new Set(observed.map((o) => o.hasRecoveryHint)).size).toBe(1);
+    expect(new Set(observed.map((o) => o.tokensCleared)).size).toBe(1);
+  });
+
+  it("the FLAG-10 regression canary: a tool whose 401 stayed terminal (no refresh) breaks parity (refreshCount diverges from the others)", async () => {
+    // This is the explicit anti-divergence assertion the card requires: if any one
+    // tool does NOT refresh on a 401 (the old terminal catalog branch), its
+    // refreshCount is 0 while the refreshing tools' is 1 — so the cross-tool set
+    // has size 2 and this fails. With all three on the shared helper, the set
+    // collapses to {1}. (Against current code, the two catalog tools are terminal
+    // and whoami refreshes — so this is RED until catalog adopts the shared path.)
+    const observed = await observeAllTools(
+      (readKind, nthRead) =>
+        nthRead === 0
+          ? { status: 401, body: { error: "unauthorized" } }
+          : { status: 200, body: okEnvelopeFor(readKind) },
+      () => ({ status: 200, body: { access_token: "rotated-at", refresh_token: "rotated-rt" } }),
+    );
+
+    // Every tool must have attempted the refresh — the FLAG-10 divergence is
+    // precisely "one tool refreshes, another doesn't". One shared refresh count.
+    for (const o of observed) {
+      expect(o.refreshCount).toBe(1);
+    }
+    expect(new Set(observed.map((o) => o.refreshCount)).size).toBe(1);
+    // And every tool retried exactly once after the refresh (2 reads) — the second
+    // structural half of the shared choreography.
+    for (const o of observed) {
+      expect(o.readCount).toBe(2);
+    }
+    expect(new Set(observed.map((o) => o.readCount)).size).toBe(1);
+  });
+});

--- a/src/__tests__/cross-tool-401-parity.integration.test.ts
+++ b/src/__tests__/cross-tool-401-parity.integration.test.ts
@@ -263,6 +263,23 @@ function callArgs(readKind: ReadKind): Record<string, unknown> {
   return {}; // whoami takes no params
 }
 
+/** The per-tool silent-success operator marker each tool MUST emit on a recovered
+ * 401 (review-round-1 fix; card line 161). The marker name is tool-specific but
+ * the BEHAVIOUR (emit exactly once on silent recovery) must be uniform — that
+ * uniformity is what this parity guard pins so the seam cannot drift per-tool. */
+function refreshedMarkerFor(readKind: ReadKind): string {
+  if (readKind === "search") return "sil_search_refreshed";
+  if (readKind === "lookup") return "sil_product_get_refreshed";
+  return "sil_whoami_refreshed";
+}
+
+/** Count `api.logger.info(marker, …)` calls whose first positional arg is `marker`. */
+function infoMarkerCount(api: MockPluginAPI, marker: string): number {
+  return vi
+    .mocked(api.logger.info)
+    .mock.calls.filter((c) => c[0] === marker).length;
+}
+
 /** One observation of a tool's 401 behaviour under a given refresh-leg scenario. */
 interface Observation {
   readKind: ReadKind;
@@ -271,6 +288,10 @@ interface Observation {
   readCount: number;
   refreshCount: number;
   tokensCleared: boolean;
+  /** How many times THIS tool emitted its own `<tool>_refreshed` operator marker
+   * (review-round-1 fix). 1 on a recovered 401, 0 otherwise — folded into the
+   * anti-divergence guard so the restored seam cannot disappear per-tool again. */
+  refreshedMarkerCount: number;
 }
 
 /**
@@ -300,6 +321,7 @@ async function observeAllTools(
       readCount: rec.read.length,
       refreshCount: rec.refresh.length,
       tokensCleared: !existsSync(getTokensPath()),
+      refreshedMarkerCount: infoMarkerCount(api, refreshedMarkerFor(readKind)),
     });
     vi.restoreAllMocks();
   }
@@ -345,11 +367,22 @@ describe("cross-tool 401 parity — all three tools share ONE refresh-and-retry-
       expect(o.hasRecoveryHint).toBe(false);
       expect(o.refreshCount).toBe(1); // exactly one refresh
       expect(o.readCount).toBe(2); // failed read + one retry
+      // OBSERVABILITY-SEAM PARITY (review-round-1 fix; card line 161): every tool
+      // emits its own `<tool>_refreshed` operator marker EXACTLY ONCE on this
+      // silent-recovery path — the seam restored uniformly across all three. Folded
+      // into THIS anti-divergence guard so the marker cannot drift/disappear
+      // per-tool again (the same FLAG-10 failure mode, applied to logging). RED
+      // until all three tools emit the marker via the helper's `refreshed:true`.
+      expect(o.refreshedMarkerCount).toBe(1);
     }
     // The equality across tools IS the guard: collapse each dimension to a set.
     expect(new Set(observed.map((o) => o.status)).size).toBe(1);
     expect(new Set(observed.map((o) => o.refreshCount)).size).toBe(1);
     expect(new Set(observed.map((o) => o.readCount)).size).toBe(1);
+    // The marker-emission behaviour is uniform across tools (all 1). A tool that
+    // silently recovered WITHOUT emitting its marker would show 0 here while the
+    // others show 1 — set size 2, and the seam has drifted. Pin it to size 1.
+    expect(new Set(observed.map((o) => o.refreshedMarkerCount)).size).toBe(1);
   });
 
   it("sub-outcome second-401: every tool refreshes EXACTLY once, retries once, then terminates re-register (no tool storms)", async () => {

--- a/src/__tests__/lib/refresh-retry.test.ts
+++ b/src/__tests__/lib/refresh-retry.test.ts
@@ -28,7 +28,7 @@
  * `src/lib/sil-client.ts` (or a colocated `src/lib/refresh-retry.ts`):
  *
  *   export type RefreshRetryResult<O> =
- *     | { kind: "result"; outcome: O }
+ *     | { kind: "result"; outcome: O; refreshed: boolean }
  *     | { kind: "must_reregister"; reason: "invalid_grant" | "no_stored_tokens" }
  *     | { kind: "retryable" }
  *     | { kind: "second_unauthorized" };
@@ -39,14 +39,27 @@
  *     retryWithToken: (accessToken: string) => Promise<O>,
  *   ): Promise<RefreshRetryResult<O>>;
  *
+ * The `result` variant carries a `refreshed: boolean` DISCRIMINANT (added by the
+ * review-round-1 fix, card §"→ Handoff back to In Dev"): `false` when the result
+ * is the first-try passthrough (no refresh happened), `true` when it was produced
+ * via the refresh+retry recovery path. The helper already knows this bit from its
+ * own straight-line control flow; surfacing it lets each caller emit its
+ * `<tool>_refreshed` operator log marker on (and ONLY on) the silent-recovery
+ * success — restoring the `sil_*_refreshed` observability seam the card's
+ * risk-mitigation (line 161) names, uniformly across all three tools, WITHOUT
+ * leaking any field into the agent-facing payload (outcome 1 stays invisible).
+ *
  * Behaviour (the immutable spec):
- *   - first NOT unauthorized            → { kind: "result", outcome: first }, and
- *                                          NEITHER refreshStoredTokens NOR the thunk
- *                                          is called (refresh is reachable only via
- *                                          a first-call 401).
+ *   - first NOT unauthorized            → { kind: "result", outcome: first,
+ *                                            refreshed: false }, and NEITHER
+ *                                          refreshStoredTokens NOR the thunk is
+ *                                          called (refresh is reachable only via a
+ *                                          first-call 401).
  *   - first unauthorized, refresh OK,
- *     re-read OK, retry NOT unauthorized → { kind: "result", outcome: <retry> };
- *                                          exactly ONE refresh + exactly ONE retry.
+ *     re-read OK, retry NOT unauthorized → { kind: "result", outcome: <retry>,
+ *                                            refreshed: true }; exactly ONE refresh
+ *                                          + exactly ONE retry (the silent-recovery
+ *                                          path — `refreshed` MUST be true here).
  *   - first unauthorized, refresh OK,
  *     re-read OK, retry STILL 401        → { kind: "second_unauthorized" }; exactly
  *                                          ONE refresh (NEVER a second), exactly ONE
@@ -210,6 +223,13 @@ describe("refreshAndRetryOnce — one-refresh-max success (the bound is structur
     expect(result.kind).toBe("result");
     if (result.kind === "result") {
       expect(result.outcome).toEqual({ kind: "ok", marker: "retried-ok" });
+      // The `refreshed` discriminant MUST be true on the silent-recovery path:
+      // this success was produced via refresh+retry, so the caller emits its
+      // `<tool>_refreshed` operator log marker. (review-round-1 fix; card line
+      // 161 + §"→ Handoff back to In Dev".) RED until the helper widens the
+      // `result` variant with `refreshed: boolean` and sets it true at the
+      // post-retry return.
+      expect(result.refreshed).toBe(true);
     }
     // EXACTLY one refresh and EXACTLY one retry — the bound is structural.
     expect(rec.refresh.length).toBe(1);
@@ -412,6 +432,12 @@ describe("refreshAndRetryOnce — a non-401 first outcome passes through untouch
       // The SAME first outcome, passed straight through.
       expect(result.outcome).toBe(first);
       expect(result.outcome).toEqual({ kind: "ok", marker: "first-call-ok" });
+      // The `refreshed` discriminant MUST be false on the passthrough path: no
+      // refresh happened, so the caller must NOT emit its `<tool>_refreshed`
+      // marker. This is the negative half of the discriminant the marker keys off
+      // (review-round-1 fix). RED until the helper sets `refreshed: false` at the
+      // first-try passthrough return.
+      expect(result.refreshed).toBe(false);
     }
     // No refresh, no retry — the helper did not touch the network at all.
     expect(rec.refresh.length).toBe(0);
@@ -441,6 +467,8 @@ describe("refreshAndRetryOnce — a non-401 first outcome passes through untouch
     expect(result.kind).toBe("result");
     if (result.kind === "result") {
       expect(result.outcome).toBe(first);
+      // A second non-401 passthrough — `refreshed` is false here too (no refresh).
+      expect(result.refreshed).toBe(false);
     }
     expect(rec.refresh.length).toBe(0);
     expect(retryCalls).toBe(0);

--- a/src/__tests__/lib/refresh-retry.test.ts
+++ b/src/__tests__/lib/refresh-retry.test.ts
@@ -1,0 +1,448 @@
+/**
+ * UNIT — the pure `refreshAndRetryOnce<O>` bounded refresh-and-retry helper
+ * (tier: unit, real `refreshStoredTokens` against a mocked `fetch` boundary +
+ * real `SIL_DATA_DIR` token seeding — NOT a stubbed refresh).
+ *
+ * This is the single 401-recovery choreography the card extracts so `sil_search`,
+ * `sil_product_get`, and `sil_whoami` cannot drift apart again (FLAG-10). The
+ * helper is the control-flow core mirrored out of `identity.ts:170-208`: given a
+ * first outcome, an `isUnauthorized` predicate, and a token-bearing retry thunk,
+ * it does AT MOST ONE refresh (via the real `refreshStoredTokens`) and AT MOST ONE
+ * retry, then returns a small typed discriminant the caller maps to its own
+ * envelope. The bound is STRUCTURAL (straight-line first → refresh → retry, no
+ * loop), and these tests assert the refresh/retry COUNTS so "at most once" is
+ * enforced structurally, not merely by the happy path.
+ *
+ * STUB-FREE (`.claude/rules/complete-work-is-stub-free.md`): the helper's only I/O
+ * is `refreshStoredTokens()` + `readTokens()`, and BOTH run for real here. The
+ * refresh-leg outcomes (refreshed / invalid_grant / retryable) are driven through
+ * the REAL `refreshStoredTokens` by mocking ONLY `fetch` (the sil-web /auth/refresh
+ * boundary) and seeding a real `tokens.json` under a temp `SIL_DATA_DIR` — exactly
+ * as `whoami.integration.test.ts` exercises the same primitive. The `first`
+ * outcome, the `isUnauthorized` predicate, and the `retryWithToken` thunk are the
+ * helper's PARAMETRIC inputs (a generic `O`), supplied by the test as the caller
+ * would supply them — they are inputs to the function under test, not stubs of
+ * production code. No `AUTH_DEV_BYPASS`, no stubbed refresh.
+ *
+ * Contract this file pins for the implementation (expert-developer),
+ * `src/lib/sil-client.ts` (or a colocated `src/lib/refresh-retry.ts`):
+ *
+ *   export type RefreshRetryResult<O> =
+ *     | { kind: "result"; outcome: O }
+ *     | { kind: "must_reregister"; reason: "invalid_grant" | "no_stored_tokens" }
+ *     | { kind: "retryable" }
+ *     | { kind: "second_unauthorized" };
+ *
+ *   export function refreshAndRetryOnce<O>(
+ *     first: O,
+ *     isUnauthorized: (o: O) => boolean,
+ *     retryWithToken: (accessToken: string) => Promise<O>,
+ *   ): Promise<RefreshRetryResult<O>>;
+ *
+ * Behaviour (the immutable spec):
+ *   - first NOT unauthorized            → { kind: "result", outcome: first }, and
+ *                                          NEITHER refreshStoredTokens NOR the thunk
+ *                                          is called (refresh is reachable only via
+ *                                          a first-call 401).
+ *   - first unauthorized, refresh OK,
+ *     re-read OK, retry NOT unauthorized → { kind: "result", outcome: <retry> };
+ *                                          exactly ONE refresh + exactly ONE retry.
+ *   - first unauthorized, refresh OK,
+ *     re-read OK, retry STILL 401        → { kind: "second_unauthorized" }; exactly
+ *                                          ONE refresh (NEVER a second), exactly ONE
+ *                                          retry (a freshly-rotated-still-401 token
+ *                                          is structurally dead).
+ *   - first unauthorized, refresh
+ *     invalid_grant                      → { kind: "must_reregister",
+ *                                            reason: "invalid_grant" }; the thunk is
+ *                                          NEVER called (no rotated token to retry).
+ *   - first unauthorized, refresh
+ *     retryable (5xx/network)            → { kind: "retryable" }; the thunk is NEVER
+ *                                          called (a blip is transient, not dead).
+ *   - first unauthorized, refresh OK,
+ *     but the rotated pair re-read is
+ *     gone (TOCTOU)                      → { kind: "must_reregister",
+ *                                            reason: "no_stored_tokens" }; the thunk
+ *                                          is NEVER called with a stale/absent token.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { refreshAndRetryOnce } from "../../lib/sil-client.js";
+import { setApiUrl } from "../../lib/config.js";
+import * as credentials from "../../lib/credentials.js";
+import { getDataDir, getTokensPath, readTokens } from "../../lib/credentials.js";
+
+const SIL_WEB = "https://sil-web.test.example.com"; // refresh origin (the ONLY leg)
+
+/**
+ * A minimal generic outcome union standing in for the three real outcome unions
+ * (`SearchOutcome` / `LookupOutcome` / `IdentityOutcome`). The helper is generic
+ * over `O` and inspects it ONLY through the caller-supplied `isUnauthorized`
+ * predicate — so a tiny local union is a faithful `O`, proving the helper never
+ * fabricates or inspects a concrete outcome shape.
+ */
+type Outcome =
+  | { kind: "ok"; marker: string }
+  | { kind: "unauthorized" }
+  | { kind: "forbidden" }
+  | { kind: "retryable" };
+
+const isUnauthorized = (o: Outcome): boolean => o.kind === "unauthorized";
+
+const UNAUTHORIZED: Outcome = { kind: "unauthorized" };
+
+let dataDir: string;
+let priorSilDataDir: string | undefined;
+
+/** Seed a stored token pair so the real `refreshStoredTokens` has a refresh token
+ * to exchange (it reads `tokens.json` for `refresh_token` before contacting
+ * sil-web). */
+function seedTokens(access: string, refresh: string): void {
+  const dir = getDataDir();
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    getTokensPath(),
+    JSON.stringify({ access_token: access, refresh_token: refresh }),
+    { mode: 0o600 },
+  );
+}
+
+type Reply = { status: number; body: unknown } | "network-error";
+
+/** One recorded outbound refresh request. */
+interface RecordedRefresh {
+  url: string;
+  body: unknown;
+}
+
+/**
+ * Route the sil-web `/auth/refresh` POST (the helper's only network leg, via the
+ * real `refreshStoredTokens`). `reply(nthRefresh)` decides each refresh response;
+ * any non-refresh URL is a hard failure (the helper must contact ONLY the refresh
+ * endpoint — never the original read; that is the caller's `retryWithToken`).
+ */
+function installRefreshRouter(reply: (nthRefresh: number) => Reply): {
+  refresh: RecordedRefresh[];
+} {
+  const refresh: RecordedRefresh[] = [];
+  vi.spyOn(globalThis, "fetch").mockImplementation(
+    (input: unknown, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : String(input);
+      if (!url.includes("/auth/refresh")) {
+        return Promise.reject(
+          new Error(`unexpected fetch to ${url} — helper must contact ONLY /auth/refresh`),
+        );
+      }
+      let body: unknown = null;
+      if (typeof init?.body === "string") {
+        try {
+          body = JSON.parse(init.body);
+        } catch {
+          body = init.body;
+        }
+      }
+      refresh.push({ url, body });
+      const r = reply(refresh.length - 1);
+      if (r === "network-error") {
+        return Promise.reject(new Error("simulated network failure"));
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify(r.body), {
+          status: r.status,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    },
+  );
+  return { refresh };
+}
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), "sil-refresh-retry-"));
+  priorSilDataDir = process.env["SIL_DATA_DIR"];
+  process.env["SIL_DATA_DIR"] = dataDir;
+  // refreshStoredTokens posts to getApiUrl() (sil-web). Pin it to a known host.
+  setApiUrl(SIL_WEB);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  setApiUrl("");
+  delete process.env["SIL_API_URL"];
+  if (priorSilDataDir === undefined) delete process.env["SIL_DATA_DIR"];
+  else process.env["SIL_DATA_DIR"] = priorSilDataDir;
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe("refreshAndRetryOnce — one-refresh-max success (the bound is structural)", () => {
+  it("first 401 → refresh once → retry once with the rotated token → result (counts: 1 refresh, 1 retry)", async () => {
+    // AC[unit]: first unauthorized, refresh succeeds, retry returns a non-401 ok.
+    seedTokens("expired-at", "valid-rt");
+    const rec = installRefreshRouter(() => ({
+      status: 200,
+      body: { access_token: "rotated-at", refresh_token: "rotated-rt" },
+    }));
+
+    const retryTokens: string[] = [];
+    const retryWithToken = (accessToken: string): Promise<Outcome> => {
+      retryTokens.push(accessToken);
+      return Promise.resolve({ kind: "ok", marker: "retried-ok" });
+    };
+
+    const result = await refreshAndRetryOnce<Outcome>(
+      UNAUTHORIZED,
+      isUnauthorized,
+      retryWithToken,
+    );
+
+    // The discriminant the caller maps: the retry's outcome, passed through.
+    expect(result.kind).toBe("result");
+    if (result.kind === "result") {
+      expect(result.outcome).toEqual({ kind: "ok", marker: "retried-ok" });
+    }
+    // EXACTLY one refresh and EXACTLY one retry — the bound is structural.
+    expect(rec.refresh.length).toBe(1);
+    expect(retryTokens.length).toBe(1);
+    // The refresh exchanged the STORED refresh token.
+    expect((rec.refresh[0]!.body as { refresh_token?: string }).refresh_token).toBe("valid-rt");
+    // The retry carried the ROTATED access token (proves re-read after rotation,
+    // not a reuse of the stale `first`-call token).
+    expect(retryTokens[0]).toBe("rotated-at");
+    // tokens.json now holds the rotated pair (the real refresh persisted).
+    const tokens = readTokens();
+    expect(tokens!.access_token).toBe("rotated-at");
+    expect(tokens!.refresh_token).toBe("rotated-rt");
+  });
+});
+
+describe("refreshAndRetryOnce — a second 401 after a good refresh is terminal (the storm guard)", () => {
+  it("first 401 → refresh OK → retry STILL 401 → second_unauthorized, NEVER a second refresh", async () => {
+    // AC[unit]: the cardinal risk. A freshly-rotated token still rejected is
+    // structurally dead — terminal, never another refresh cycle.
+    seedTokens("expired-at", "valid-rt");
+    const rec = installRefreshRouter(() => ({
+      status: 200,
+      body: { access_token: "rotated-at", refresh_token: "rotated-rt" },
+    }));
+
+    let retryCalls = 0;
+    const retryWithToken = (): Promise<Outcome> => {
+      retryCalls += 1;
+      return Promise.resolve(UNAUTHORIZED); // the rotated token is ALSO rejected
+    };
+
+    const result = await refreshAndRetryOnce<Outcome>(
+      UNAUTHORIZED,
+      isUnauthorized,
+      retryWithToken,
+    );
+
+    expect(result.kind).toBe("second_unauthorized");
+    // EXACTLY one refresh (never a second on a freshly-rotated-still-401) and
+    // EXACTLY one retry. This is the no-storm bound at the unit boundary.
+    expect(rec.refresh.length).toBe(1);
+    expect(retryCalls).toBe(1);
+  });
+});
+
+describe("refreshAndRetryOnce — a dead refresh (invalid_grant) is terminal, with NO retry", () => {
+  it("first 401 → refresh invalid_grant → must_reregister(invalid_grant), thunk NEVER called", async () => {
+    // AC[unit]: a failed refresh leaves NO rotated token to retry with, so the
+    // retry must not fire (retrying with the stale `first` token would be wrong).
+    seedTokens("expired-at", "dead-rt");
+    const rec = installRefreshRouter(() => ({ status: 401, body: { error: "invalid_grant" } }));
+
+    let retryCalls = 0;
+    const retryWithToken = (): Promise<Outcome> => {
+      retryCalls += 1;
+      return Promise.resolve({ kind: "ok", marker: "must-not-happen" });
+    };
+
+    const result = await refreshAndRetryOnce<Outcome>(
+      UNAUTHORIZED,
+      isUnauthorized,
+      retryWithToken,
+    );
+
+    expect(result.kind).toBe("must_reregister");
+    if (result.kind === "must_reregister") {
+      expect(result.reason).toBe("invalid_grant");
+    }
+    // One refresh attempt, and the retry thunk was NEVER invoked.
+    expect(rec.refresh.length).toBe(1);
+    expect(retryCalls).toBe(0);
+  });
+});
+
+describe("refreshAndRetryOnce — a transient refresh (5xx/network) surfaces retryable, NOT a re-register", () => {
+  it("first 401 → refresh 5xx → retryable, thunk NEVER called", async () => {
+    // AC[unit]: a refresh-leg 5xx is a blip, not a dead session. It must NOT be
+    // mapped to a terminal re-register (the false-terminal trap), and the retry
+    // must not fire (there is no rotated token).
+    seedTokens("expired-at", "valid-rt");
+    const rec = installRefreshRouter(() => ({ status: 503, body: { error: "unavailable" } }));
+
+    let retryCalls = 0;
+    const retryWithToken = (): Promise<Outcome> => {
+      retryCalls += 1;
+      return Promise.resolve({ kind: "ok", marker: "must-not-happen" });
+    };
+
+    const result = await refreshAndRetryOnce<Outcome>(
+      UNAUTHORIZED,
+      isUnauthorized,
+      retryWithToken,
+    );
+
+    expect(result.kind).toBe("retryable");
+    expect(rec.refresh.length).toBe(1);
+    expect(retryCalls).toBe(0);
+  });
+
+  it("first 401 → refresh network-error (thrown fetch) → retryable, thunk NEVER called", async () => {
+    // The network-throw arm of the same transient invariant: a thrown fetch on
+    // the refresh leg (timeout / DNS hang) is `retryable`, never a re-register.
+    seedTokens("expired-at", "valid-rt");
+    const rec = installRefreshRouter(() => "network-error");
+
+    let retryCalls = 0;
+    const retryWithToken = (): Promise<Outcome> => {
+      retryCalls += 1;
+      return Promise.resolve({ kind: "ok", marker: "must-not-happen" });
+    };
+
+    const result = await refreshAndRetryOnce<Outcome>(
+      UNAUTHORIZED,
+      isUnauthorized,
+      retryWithToken,
+    );
+
+    expect(result.kind).toBe("retryable");
+    expect(rec.refresh.length).toBe(1);
+    expect(retryCalls).toBe(0);
+  });
+});
+
+describe("refreshAndRetryOnce — TOCTOU: rotated pair gone before re-read is terminal, with NO retry", () => {
+  it("first 401 → refresh OK → tokens.json gone on the post-rotate re-read → must_reregister(no_stored_tokens), thunk NEVER called", async () => {
+    // AC[unit]: if tokens.json disappears between the rotate (inside
+    // refreshStoredTokens, which writes the new pair) and the HELPER's own
+    // re-read of that pair, the helper must NOT retry with a stale/absent token —
+    // it goes terminal `no_stored_tokens`.
+    //
+    // The race lives INSIDE the helper (between refreshStoredTokens returning and
+    // the helper's readTokens()), so a fetch mock alone cannot reach it — a real
+    // refresh re-writes tokens.json on success. We isolate the helper's OWN
+    // re-read by spying readTokens: the FIRST read (refreshStoredTokens' internal
+    // read of the refresh token) sees the seeded pair so the real refresh still
+    // fires + rotates; every read AFTER it (the helper's post-rotate re-read)
+    // yields null — the file "vanished" at exactly the guarded seam. The refresh
+    // (real fetch + real classifyRefresh → `refreshed`) is NOT stubbed.
+    seedTokens("expired-at", "valid-rt");
+    const rec = installRefreshRouter(() => ({
+      status: 200,
+      body: { access_token: "rotated-at", refresh_token: "rotated-rt" },
+    }));
+
+    const seeded = { access_token: "expired-at", refresh_token: "valid-rt" };
+    let readCalls = 0;
+    vi.spyOn(credentials, "readTokens").mockImplementation(() => {
+      readCalls += 1;
+      // Call 1 = refreshStoredTokens' internal read (needs the refresh token);
+      // call 2+ = the helper's post-rotate re-read (the TOCTOU — now empty).
+      return readCalls === 1 ? seeded : null;
+    });
+
+    let retryCalls = 0;
+    const retryWithToken = (): Promise<Outcome> => {
+      retryCalls += 1;
+      return Promise.resolve({ kind: "ok", marker: "must-not-happen" });
+    };
+
+    const result = await refreshAndRetryOnce<Outcome>(
+      UNAUTHORIZED,
+      isUnauthorized,
+      retryWithToken,
+    );
+
+    expect(result.kind).toBe("must_reregister");
+    if (result.kind === "must_reregister") {
+      expect(result.reason).toBe("no_stored_tokens");
+    }
+    // The refresh leg DID fire (the seeded refresh token reached sil-web), and the
+    // helper re-read AFTER it — but the retry was NOT made (no usable rotated token).
+    expect(rec.refresh.length).toBe(1);
+    expect(readCalls).toBeGreaterThanOrEqual(2); // internal read + the helper's re-read
+    expect(retryCalls).toBe(0);
+  });
+});
+
+describe("refreshAndRetryOnce — a non-401 first outcome passes through untouched", () => {
+  it("first is ok → result(first), refresh NEVER attempted, thunk NEVER called", async () => {
+    // AC[unit]: the refresh path is reachable ONLY via a first-call 401. Any
+    // non-unauthorized first outcome short-circuits to passthrough.
+    seedTokens("valid-at", "valid-rt");
+    const rec = installRefreshRouter(() => ({
+      status: 200,
+      body: { access_token: "x", refresh_token: "y" },
+    }));
+
+    let retryCalls = 0;
+    const retryWithToken = (): Promise<Outcome> => {
+      retryCalls += 1;
+      return Promise.resolve({ kind: "ok", marker: "must-not-happen" });
+    };
+
+    const first: Outcome = { kind: "ok", marker: "first-call-ok" };
+    const result = await refreshAndRetryOnce<Outcome>(first, isUnauthorized, retryWithToken);
+
+    expect(result.kind).toBe("result");
+    if (result.kind === "result") {
+      // The SAME first outcome, passed straight through.
+      expect(result.outcome).toBe(first);
+      expect(result.outcome).toEqual({ kind: "ok", marker: "first-call-ok" });
+    }
+    // No refresh, no retry — the helper did not touch the network at all.
+    expect(rec.refresh.length).toBe(0);
+    expect(retryCalls).toBe(0);
+  });
+
+  it("first is forbidden (403) → result(first), refresh NEVER attempted (403 is not a refresh trigger)", async () => {
+    // Belt-and-braces over a SECOND non-401 kind: a 403/forbidden first outcome
+    // must also pass through (only 401 triggers the refresh — a 403 token is valid
+    // but unprovisioned, refreshing it changes nothing). Guards the predicate's
+    // contract — `isUnauthorized` is the ONLY gate into the refresh path.
+    seedTokens("valid-at", "valid-rt");
+    const rec = installRefreshRouter(() => ({
+      status: 200,
+      body: { access_token: "x", refresh_token: "y" },
+    }));
+
+    let retryCalls = 0;
+    const retryWithToken = (): Promise<Outcome> => {
+      retryCalls += 1;
+      return Promise.resolve({ kind: "ok", marker: "must-not-happen" });
+    };
+
+    const first: Outcome = { kind: "forbidden" };
+    const result = await refreshAndRetryOnce<Outcome>(first, isUnauthorized, retryWithToken);
+
+    expect(result.kind).toBe("result");
+    if (result.kind === "result") {
+      expect(result.outcome).toBe(first);
+    }
+    expect(rec.refresh.length).toBe(0);
+    expect(retryCalls).toBe(0);
+  });
+});

--- a/src/__tests__/whoami.integration.test.ts
+++ b/src/__tests__/whoami.integration.test.ts
@@ -228,6 +228,20 @@ function logBlob(api: MockPluginAPI): string {
     .join("\n");
 }
 
+/**
+ * Count how many `api.logger.info(marker, …)` calls used `marker` as their first
+ * argument. The marker name is the FIRST positional arg of the info call (the
+ * convention every `sil_*` log marker in this plugin follows). Used to assert the
+ * `sil_whoami_refreshed` operator marker fires exactly once on the silent-recovery
+ * path and ZERO times on a first-try (no-refresh) success — restoring the seam
+ * `origin/main:identity.ts` emitted but the refactor dropped (review round 1).
+ */
+function infoMarkerCount(api: MockPluginAPI, marker: string): number {
+  return vi
+    .mocked(api.logger.info)
+    .mock.calls.filter((c) => c[0] === marker).length;
+}
+
 beforeEach(() => {
   dataDir = mkdtempSync(join(tmpdir(), "sil-whoami-int-"));
   priorSilDataDir = process.env["SIL_DATA_DIR"];
@@ -373,6 +387,10 @@ describe("sil_whoami — happy path (valid access token)", () => {
 
     expect(rec.identity.length).toBe(1);
     expect(rec.refresh.length).toBe(0); // refresh is taken ONLY on a real 401
+    // NEGATIVE half of the observability seam (review-round-1 fix): a first-try
+    // success took no refresh, so the `sil_whoami_refreshed` marker must NOT fire.
+    // The marker keys off the helper's `refreshed:false` passthrough discriminant.
+    expect(infoMarkerCount(api, "sil_whoami_refreshed")).toBe(0);
   });
 });
 
@@ -421,6 +439,26 @@ describe("sil_whoami — transparent refresh (expired access, valid refresh)", (
     expect(tokens!.refresh_token).toBe("rotated-rt");
     // The agent sees identity — never an expiry/refresh state.
     expect(JSON.stringify(payload)).toContain("Ada Lovelace");
+
+    // OPERATOR-OBSERVABILITY SEAM (review-round-1 fix; card line 161): the silent
+    // recovery is invisible in the PAYLOAD but MUST be observable in operator logs.
+    // `origin/main:identity.ts` emitted `sil_whoami_refreshed` here; the consolidation
+    // dropped it (the regression this fix restores). Assert the marker fired EXACTLY
+    // ONCE on the recovered-401 path. RED until whoami re-emits it via the helper's
+    // `refreshed: true` signal — logs-only, NOT a payload field.
+    expect(infoMarkerCount(api, "sil_whoami_refreshed")).toBe(1);
+    // Logs-only — the marker does NOT add a field to the agent-facing payload.
+    expect(payload["sil_whoami_refreshed"]).toBeUndefined();
+    // The marker carries NO token material (privacy invariant holds on the marker).
+    const refreshedMarkerArgs = vi
+      .mocked(api.logger.info)
+      .mock.calls.filter((c) => c[0] === "sil_whoami_refreshed");
+    const refreshedMarkerBlob = JSON.stringify(refreshedMarkerArgs);
+    expect(refreshedMarkerBlob).not.toContain("rotated-at");
+    expect(refreshedMarkerBlob).not.toContain("rotated-rt");
+    expect(refreshedMarkerBlob).not.toContain("valid-rt");
+    expect(refreshedMarkerBlob).not.toContain("expired-at");
+    expect(refreshedMarkerBlob).not.toMatch(/Bearer/i);
   });
 
   it("the refresh contacts ONLY sil-web (never Auth0); identity ONLY sil-api", async () => {

--- a/src/lib/sil-client.ts
+++ b/src/lib/sil-client.ts
@@ -45,7 +45,7 @@
  *     200 <UCP envelope>{ result: { products: SilCatalogProduct[],
  *                                   pagination?:{ has_next_page, cursor? } } } → ok
  *     400 { error:"empty_search_input", message }    → invalid_request
- *     401                                            → unauthorized (terminal here)
+ *     401                                            → unauthorized (→ refresh)
  *     5xx / network / abort                          → retryable
  *
  * Wire contract for the sil-API catalog LOOKUP (SAME origin/path style as search —
@@ -61,7 +61,7 @@
  *     200 <UCP envelope>{ result: { products: SilCatalogProduct[],
  *            messages?:[{ type:"info", code:"not_found", content:<id> }] } } → ok
  *     400 (schema: empty `ids` / request_too_large)  → invalid_request
- *     401                                            → unauthorized (terminal here)
+ *     401                                            → unauthorized (→ refresh)
  *     5xx / network / abort                          → retryable
  *
  * A lookup MISS is partial-SUCCESS data, NEVER an error: an unresolved id is a
@@ -256,9 +256,10 @@ export interface SearchResult {
  * Models `IdentityOutcome`, with `invalid_request` for sil-api's structured 400
  * (`empty_search_input`) carried through to the agent. The `ok` variant carries
  * the projected `products` + optional hoisted `cursor` DIRECTLY (no nested
- * `result` — the normalized payload IS the outcome). `unauthorized` (401) is
- * terminal in this card — a single round-trip, no transparent refresh (the
- * refresh choreography is `sil_whoami`'s; adding it here is additive follow-on).
+ * `result` — the normalized payload IS the outcome). `unauthorized` (401) is the
+ * refresh trigger — the caller routes it through {@link refreshAndRetryOnce}
+ * (transparent refresh-and-retry-once), the SAME choreography `sil_whoami` uses;
+ * it is no longer terminal for the catalog tools.
  */
 export type SearchOutcome =
   | { kind: "ok"; products: SearchProduct[]; cursor?: string }
@@ -338,9 +339,10 @@ export interface LookupResult {
  * Models {@link SearchOutcome} — the SAME four error/success classes so the two
  * catalog tools present ONE agent-facing error vocabulary, NOT a divergent one.
  * The `ok` variant carries the projected `products` + optional `not_found`
- * DIRECTLY (no nested `result`). `unauthorized` (401) is terminal — a single
- * round-trip, no transparent refresh (parity with `sil_search`; the refresh
- * choreography is `sil_whoami`'s, an additive follow-on across both tools).
+ * DIRECTLY (no nested `result`). `unauthorized` (401) is the refresh trigger —
+ * the caller routes it through {@link refreshAndRetryOnce} (transparent
+ * refresh-and-retry-once, parity with `sil_search` and `sil_whoami`); it is no
+ * longer terminal for the catalog tools.
  *
  * Structural deltas from `SearchOutcome`, both handled here: NO `cursor` (lookup
  * is a batch resolve, not a list) and a `not_found` id list parsed from the
@@ -440,7 +442,8 @@ export function classifyIdentityResponse(status: number, body: unknown): Identit
  *         e.g. `empty_search_input` — distinct from both the empty-match success
  *         and a transient failure; the agent must learn to fix its query, not
  *         retry or re-register)
- *   401 → unauthorized (terminal here — single round-trip, no refresh in SC1)
+ *   401 → unauthorized (the refresh trigger — the caller drives transparent
+ *         refresh-and-retry-once via `refreshAndRetryOnce`, not terminal)
  *   5xx / other non-200 → retryable
  *   200 → unwrap the envelope `result`, normalize, and require `result.products`
  *         to be a real ARRAY. A 200 that yields no usable products array (a
@@ -476,8 +479,8 @@ export function classifySearchResponse(status: number, body: unknown): SearchOut
  *         `request_too_large` over-batch — surface the server's `{ error,
  *         message }`. NOTE: this is NOT search's `empty_search_input` SourceError,
  *         which never arises on the lookup route; do not special-case it.)
- *   401 → unauthorized (terminal here — single round-trip, no refresh; parity
- *         with search)
+ *   401 → unauthorized (the refresh trigger — the caller drives transparent
+ *         refresh-and-retry-once via `refreshAndRetryOnce`, parity with search)
  *   5xx / other non-200 → retryable
  *   200 → unwrap the envelope `result`, normalize, and require `result.products`
  *         to be a real ARRAY. A 200 that yields no usable products array (a
@@ -677,6 +680,94 @@ export async function refreshStoredTokens(): Promise<RefreshStoredResult> {
     case "retryable":
       return { status: "retryable" };
   }
+}
+
+/**
+ * The discriminant {@link refreshAndRetryOnce} returns for the caller to map to
+ * its own agent-facing envelope. Generic over the caller's outcome union `O`
+ * (`SearchOutcome` / `LookupOutcome` / `IdentityOutcome`) — the helper only ever
+ * surfaces an `O` produced by the first call or the retry, never one it
+ * fabricates, so `O` stays parametric (no `any`, no cast).
+ *
+ *   result             — pass `outcome` through the caller's normal mapping (the
+ *                        first non-401 outcome, OR the retry's non-401 outcome).
+ *   must_reregister     — terminal: refresh failed. `invalid_grant` is a dead
+ *                        refresh token (the caller clears tokens); `no_stored_tokens`
+ *                        is the pre-refresh or post-rotate TOCTOU empty read (nothing
+ *                        to clear). NO retry was made.
+ *   retryable           — transient: the refresh leg blipped (5xx/network). NO retry;
+ *                        the caller surfaces "try again", NEVER a re-register.
+ *   second_unauthorized — the retry with the freshly-rotated token was ALSO 401, so
+ *                        the rotated pair is structurally dead (the caller clears
+ *                        tokens + goes terminal). NEVER a second refresh.
+ */
+export type RefreshRetryResult<O> =
+  | { kind: "result"; outcome: O }
+  | { kind: "must_reregister"; reason: "invalid_grant" | "no_stored_tokens" }
+  | { kind: "retryable" }
+  | { kind: "second_unauthorized" };
+
+/**
+ * THE single 401 refresh-and-retry-once choreography, shared by every
+ * sil-api-calling tool (`sil_search`, `sil_product_get`, `sil_whoami`) so the 401
+ * behaviour cannot drift apart between them (FLAG-10). The control flow IS the
+ * contract — straight-line, AT MOST one refresh + AT MOST one retry, no loop:
+ *
+ *   1. `first` not unauthorized           → passthrough `{ result, first }`. The
+ *                                            refresh path is reachable ONLY via a 401.
+ *   2. `first` unauthorized → refresh ONCE via {@link refreshStoredTokens} (sil-web;
+ *      rotates tokens.json):
+ *        must_reregister (invalid_grant /  → terminal, NO retry (a failed refresh
+ *          no_stored_tokens)                 leaves no rotated token to retry with).
+ *        retryable (5xx/network)           → transient, NO retry.
+ *        refreshed                         → re-read the rotated pair THROUGH the
+ *                                            module's `readTokens` (so a TOCTOU on
+ *                                            the on-disk pair is observed):
+ *          re-read empty (TOCTOU)          → must_reregister(no_stored_tokens), NO retry.
+ *          re-read ok → retry ONCE with the rotated access token:
+ *            retry still unauthorized      → second_unauthorized (the rotated token is
+ *                                            structurally dead — NEVER refresh again).
+ *            retry otherwise               → `{ result, retry }`.
+ *
+ * The helper owns the bound, the rotation re-read, and the TOCTOU + second-401
+ * guards. The caller owns ONLY: the `isUnauthorized` predicate, the token-bearing
+ * `retryWithToken` thunk (closing over its params + the rotated token), the
+ * envelope mapping, `clearTokens()` on the clearing terminals, and logging.
+ * Credential side-effects beyond the rotation `refreshStoredTokens` already does
+ * stay at the call site (mirrors `identity.ts`).
+ */
+export async function refreshAndRetryOnce<O>(
+  first: O,
+  isUnauthorized: (outcome: O) => boolean,
+  retryWithToken: (accessToken: string) => Promise<O>,
+): Promise<RefreshRetryResult<O>> {
+  if (!isUnauthorized(first)) {
+    return { kind: "result", outcome: first };
+  }
+
+  const refresh = await refreshStoredTokens();
+  if (refresh.status === "must_reregister") {
+    return { kind: "must_reregister", reason: refresh.reason };
+  }
+  if (refresh.status === "retryable") {
+    return { kind: "retryable" };
+  }
+
+  // refresh.status === "refreshed" — re-read the rotated pair through the module
+  // binding (the TOCTOU seam: tokens.json may have vanished between the rotate
+  // inside refreshStoredTokens and this read).
+  const rotated = readTokens();
+  if (rotated === null) {
+    return { kind: "must_reregister", reason: "no_stored_tokens" };
+  }
+
+  const retry = await retryWithToken(rotated.access_token);
+  if (isUnauthorized(retry)) {
+    // A freshly-rotated token STILL rejected is structurally dead — terminal,
+    // never another refresh cycle.
+    return { kind: "second_unauthorized" };
+  }
+  return { kind: "result", outcome: retry };
 }
 
 /**

--- a/src/lib/sil-client.ts
+++ b/src/lib/sil-client.ts
@@ -691,6 +691,14 @@ export async function refreshStoredTokens(): Promise<RefreshStoredResult> {
  *
  *   result             — pass `outcome` through the caller's normal mapping (the
  *                        first non-401 outcome, OR the retry's non-401 outcome).
+ *                        `refreshed` discriminates the two: `false` when `outcome`
+ *                        is the first-try passthrough (no refresh happened),
+ *                        `true` when it was produced via the refresh+retry recovery
+ *                        path. The caller emits its `<tool>_refreshed` operator log
+ *                        marker on (and ONLY on) `refreshed: true` — a logs-only
+ *                        seam for the otherwise-invisible silent recovery; it adds
+ *                        NO field to the agent-facing payload (outcome 1 stays
+ *                        invisible to the agent).
  *   must_reregister     — terminal: refresh failed. `invalid_grant` is a dead
  *                        refresh token (the caller clears tokens); `no_stored_tokens`
  *                        is the pre-refresh or post-rotate TOCTOU empty read (nothing
@@ -702,7 +710,7 @@ export async function refreshStoredTokens(): Promise<RefreshStoredResult> {
  *                        tokens + goes terminal). NEVER a second refresh.
  */
 export type RefreshRetryResult<O> =
-  | { kind: "result"; outcome: O }
+  | { kind: "result"; outcome: O; refreshed: boolean }
   | { kind: "must_reregister"; reason: "invalid_grant" | "no_stored_tokens" }
   | { kind: "retryable" }
   | { kind: "second_unauthorized" };
@@ -742,7 +750,10 @@ export async function refreshAndRetryOnce<O>(
   retryWithToken: (accessToken: string) => Promise<O>,
 ): Promise<RefreshRetryResult<O>> {
   if (!isUnauthorized(first)) {
-    return { kind: "result", outcome: first };
+    // First-try passthrough: no refresh happened, so the caller must NOT emit its
+    // `<tool>_refreshed` marker. `refreshed: false` is the negative half of the
+    // observability discriminant.
+    return { kind: "result", outcome: first, refreshed: false };
   }
 
   const refresh = await refreshStoredTokens();
@@ -767,7 +778,10 @@ export async function refreshAndRetryOnce<O>(
     // never another refresh cycle.
     return { kind: "second_unauthorized" };
   }
-  return { kind: "result", outcome: retry };
+  // Silent-recovery success: this outcome was produced via refresh+retry, so the
+  // caller emits its `<tool>_refreshed` operator marker. `refreshed: true` is the
+  // positive half of the observability discriminant — logs-only, never a payload field.
+  return { kind: "result", outcome: retry, refreshed: true };
 }
 
 /**

--- a/src/tools/catalog.ts
+++ b/src/tools/catalog.ts
@@ -23,9 +23,14 @@
  *   3. searchCatalog(getSilApiUrl(), token, params) → map the `SearchOutcome`:
  *        ok            → the ranked products + cursor;
  *        invalid_request (400) → surface sil-api's `{ error, message }`;
- *        unauthorized  (401)   → terminal re-register (single round-trip — no
- *                                transparent refresh in this card; that is the
- *                                additive follow-on `sil_whoami` already does);
+ *        unauthorized  (401)   → refresh-and-retry ONCE via the shared
+ *                                `refreshAndRetryOnce` choreography (sil-web refresh,
+ *                                re-read rotated pair, retry once). The agent never
+ *                                sees a recovered 401; a second 401 or a dead refresh
+ *                                is terminal re-register (tokens cleared); a refresh
+ *                                5xx/network blip is transient "try again". 401
+ *                                recovery is UNIFORM across sil_search /
+ *                                sil_product_get / sil_whoami — never per-tool;
  *        retryable (5xx/net)   → transient "try again", NO re-register hint.
  *
  * The three distinct sil-api outcomes (empty match 200 / invalid 400 / source
@@ -47,9 +52,10 @@ import type { PluginAPI } from "openclaw/plugin-sdk";
 import { Type } from "typebox";
 
 import { getSilApiUrl } from "../lib/config.js";
-import { readTokens } from "../lib/credentials.js";
+import { clearTokens, readTokens } from "../lib/credentials.js";
 import {
   lookupCatalog,
+  refreshAndRetryOnce,
   searchCatalog,
   type LookupOutcome,
   type SearchOutcome,
@@ -131,23 +137,56 @@ function registerSearch(api: PluginAPI): void {
         return invalidInput();
       }
 
-      // 3 — search and map the outcome to the agent-facing envelope.
-      const outcome = await searchCatalog(getSilApiUrl(), stored.access_token, search);
-      switch (outcome.kind) {
-        case "ok":
-          return searchResult(outcome);
-        case "invalid_request":
-          api.logger.info("sil_search_invalid_request", { error: outcome.error });
-          return invalidRequest(outcome.error, outcome.message);
-        case "unauthorized":
-          api.logger.info("sil_search_unauthorized", {});
+      // 3 — search; on a 401 refresh-and-retry ONCE via the shared choreography
+      // (the SAME path sil_whoami / sil_product_get use — 401 recovery is uniform
+      // across every sil-api-calling tool, never per-tool).
+      const first = await searchCatalog(getSilApiUrl(), stored.access_token, search);
+      const recovered = await refreshAndRetryOnce(
+        first,
+        (o): boolean => o.kind === "unauthorized",
+        (accessToken) => searchCatalog(getSilApiUrl(), accessToken, search),
+      );
+      switch (recovered.kind) {
+        case "result":
+          return mapSearchOutcome(api, recovered.outcome);
+        case "must_reregister":
+          // A dead refresh token (invalid_grant) is cleared so the agent's
+          // sil_register recovery is not blocked by stale presence; a TOCTOU
+          // empty re-read (no_stored_tokens) has nothing to clear.
+          if (recovered.reason === "invalid_grant") clearTokens();
+          api.logger.info("sil_search_must_reregister", { cause: recovered.reason });
+          return mustReregister("sil_search");
+        case "second_unauthorized":
+          // A freshly-rotated token STILL rejected is structurally dead — clear it.
+          clearTokens();
+          api.logger.info("sil_search_must_reregister", { cause: "retry_unauthorized" });
           return mustReregister("sil_search");
         case "retryable":
-          api.logger.info("sil_search_retryable", {});
+          api.logger.info("sil_search_refresh_retryable", {});
           return transient("sil_search");
       }
     },
   });
+}
+
+/** Map a search outcome that has ALREADY cleared the 401-recovery path (so it is
+ * never `unauthorized` — that is the refresh trigger, handled by the caller via
+ * {@link refreshAndRetryOnce}) to the agent-facing envelope. The `unauthorized`
+ * arm is structurally unreachable but kept exhaustive so a future refactor can't
+ * silently drop a variant — it falls to the same terminal re-register. */
+function mapSearchOutcome(api: PluginAPI, outcome: SearchOutcome) {
+  switch (outcome.kind) {
+    case "ok":
+      return searchResult(outcome);
+    case "invalid_request":
+      api.logger.info("sil_search_invalid_request", { error: outcome.error });
+      return invalidRequest(outcome.error, outcome.message);
+    case "retryable":
+      api.logger.info("sil_search_retryable", {});
+      return transient("sil_search");
+    case "unauthorized":
+      return mustReregister("sil_search");
+  }
 }
 
 /**
@@ -174,8 +213,12 @@ function registerSearch(api: PluginAPI): void {
  *                        error, with NO recovery hint: re-running won't conjure a
  *                        delisted product);
  *        invalid_request (400) → surface sil-api's `{ error, message }`;
- *        unauthorized  (401)   → terminal re-register (single round-trip — parity
- *                                with `sil_search`, no transparent refresh);
+ *        unauthorized  (401)   → refresh-and-retry ONCE via the shared
+ *                                `refreshAndRetryOnce` choreography (parity with
+ *                                `sil_search` and `sil_whoami` — 401 recovery is
+ *                                uniform). Recovered 401 is invisible; second 401 /
+ *                                dead refresh is terminal re-register (tokens
+ *                                cleared); a refresh 5xx/network blip is transient;
  *        retryable (5xx/net)   → transient "try again", NO re-register hint.
  *
  * The unfound-ids outcome is the headline: a lookup that resolves SOME (or NONE)
@@ -230,24 +273,52 @@ function registerProductGet(api: PluginAPI): void {
         return invalidIds();
       }
 
-      // 3 — look up and map the outcome to the agent-facing envelope (the SAME
-      // taxonomy as sil_search). A partial/all-missed hit is `ok` + `not_found`.
-      const outcome = await lookupCatalog(getSilApiUrl(), stored.access_token, ids);
-      switch (outcome.kind) {
-        case "ok":
-          return lookupResult(outcome);
-        case "invalid_request":
-          api.logger.info("sil_product_get_invalid_request", { error: outcome.error });
-          return invalidRequest(outcome.error, outcome.message);
-        case "unauthorized":
-          api.logger.info("sil_product_get_unauthorized", {});
+      // 3 — look up; on a 401 refresh-and-retry ONCE via the shared choreography
+      // (the SAME path sil_whoami / sil_search use). A partial/all-missed hit is
+      // `ok` + `not_found`.
+      const first = await lookupCatalog(getSilApiUrl(), stored.access_token, ids);
+      const recovered = await refreshAndRetryOnce(
+        first,
+        (o): boolean => o.kind === "unauthorized",
+        (accessToken) => lookupCatalog(getSilApiUrl(), accessToken, ids),
+      );
+      switch (recovered.kind) {
+        case "result":
+          return mapLookupOutcome(api, recovered.outcome);
+        case "must_reregister":
+          if (recovered.reason === "invalid_grant") clearTokens();
+          api.logger.info("sil_product_get_must_reregister", { cause: recovered.reason });
+          return mustReregister("sil_product_get");
+        case "second_unauthorized":
+          clearTokens();
+          api.logger.info("sil_product_get_must_reregister", { cause: "retry_unauthorized" });
           return mustReregister("sil_product_get");
         case "retryable":
-          api.logger.info("sil_product_get_retryable", {});
+          api.logger.info("sil_product_get_refresh_retryable", {});
           return transient("sil_product_get");
       }
     },
   });
+}
+
+/** Map a lookup outcome that has ALREADY cleared the 401-recovery path (never
+ * `unauthorized` — the refresh trigger handled by {@link refreshAndRetryOnce}) to
+ * the agent-facing envelope. The `unauthorized` arm is structurally unreachable
+ * but kept exhaustive (falls to the same terminal re-register) so a future
+ * refactor can't silently drop a variant. */
+function mapLookupOutcome(api: PluginAPI, outcome: LookupOutcome) {
+  switch (outcome.kind) {
+    case "ok":
+      return lookupResult(outcome);
+    case "invalid_request":
+      api.logger.info("sil_product_get_invalid_request", { error: outcome.error });
+      return invalidRequest(outcome.error, outcome.message);
+    case "retryable":
+      api.logger.info("sil_product_get_retryable", {});
+      return transient("sil_product_get");
+    case "unauthorized":
+      return mustReregister("sil_product_get");
+  }
 }
 
 /** Narrow the untrusted `params` to a string[] of ids. A non-string entry is
@@ -360,9 +431,10 @@ function invalidRequest(error: string, message: string) {
   return jsonResult({ status: "invalid_request", error, message });
 }
 
-/** Terminal: the session is dead (401). Re-register. Single round-trip — these
- * tools do no transparent refresh (that is `sil_whoami`'s, an additive follow-on).
- * The `tool` name keeps the message actionable while the taxonomy stays shared. */
+/** Terminal: the session is dead — reached only after the shared refresh-and-retry
+ * choreography ({@link refreshAndRetryOnce}) has exhausted its one refresh + one
+ * retry (a second 401, or a dead `invalid_grant` refresh token). Re-register. The
+ * `tool` name keeps the message actionable while the taxonomy stays shared. */
 function mustReregister(tool: string) {
   return jsonResult({
     status: "must_reregister",

--- a/src/tools/catalog.ts
+++ b/src/tools/catalog.ts
@@ -148,6 +148,10 @@ function registerSearch(api: PluginAPI): void {
       );
       switch (recovered.kind) {
         case "result":
+          // On a silent recovery (`refreshed`: a 401 was healed by the refresh+retry)
+          // emit the operator marker so a thrashing session is visible in logs —
+          // logs-only, no token material, NOT a payload field (the agent never sees it).
+          if (recovered.refreshed) api.logger.info("sil_search_refreshed", {});
           return mapSearchOutcome(api, recovered.outcome);
         case "must_reregister":
           // A dead refresh token (invalid_grant) is cleared so the agent's
@@ -284,6 +288,10 @@ function registerProductGet(api: PluginAPI): void {
       );
       switch (recovered.kind) {
         case "result":
+          // On a silent recovery (`refreshed`: a 401 was healed by the refresh+retry)
+          // emit the operator marker so a thrashing session is visible in logs —
+          // logs-only, no token material, NOT a payload field (the agent never sees it).
+          if (recovered.refreshed) api.logger.info("sil_product_get_refreshed", {});
           return mapLookupOutcome(api, recovered.outcome);
         case "must_reregister":
           if (recovered.reason === "invalid_grant") clearTokens();

--- a/src/tools/identity.ts
+++ b/src/tools/identity.ts
@@ -50,7 +50,7 @@ import {
 import {
   claimSession,
   fetchIdentity,
-  refreshStoredTokens,
+  refreshAndRetryOnce,
   type ClaimOutcome,
   type Identity,
   type IdentityOutcome,
@@ -132,17 +132,21 @@ function registerRegister(api: PluginAPI): void {
  * whoami is a synchronous request/response, NOT a poll):
  *   1. Read tokens.json. Absent → terminal `not_registered` (run sil_register),
  *      ZERO network calls (nothing to authenticate with).
- *   2. fetchIdentity(sil-api, access_token). On `ok` → return the identity.
- *      `forbidden` → terminal (distinct hint per reason). `retryable` → terminal
- *      transient ("try again"). `unauthorized` (401) → the refresh path (3).
- *   3. Refresh ONCE via refreshStoredTokens() (sil-web only, never Auth0; rotates
- *      tokens.json). `refreshed` → re-read tokens, retry the identity read ONCE;
- *      `must_reregister` → terminal (clear tokens on invalid_grant);
- *      `retryable` → terminal transient.
- *   4. The single retry: `ok` → return; anything non-ok (incl. a SECOND 401) →
- *      terminal `must_reregister` + clear tokens. A freshly-rotated token still
- *      rejected is structurally dead — NEVER refresh again. At most one refresh
- *      + one retry per call.
+ *   2. fetchIdentity(sil-api, access_token), then route the outcome through the
+ *      SHARED `refreshAndRetryOnce` choreography — the SAME path sil_search and
+ *      sil_product_get use, so 401 recovery is uniform across every
+ *      sil-api-calling tool (factored so the three cannot drift apart; FLAG-10).
+ *      The helper owns the bounded refresh-and-retry-once: on a 401 it refreshes
+ *      ONCE via sil-web (rotates tokens.json), re-reads the rotated pair, and
+ *      retries the read ONCE; a non-401 first outcome passes straight through.
+ *   3. Map the helper's discriminant to the agent-facing result:
+ *        result            → ok / forbidden / retryable mapped as usual (the first
+ *                            non-401, OR the retry's non-401 outcome);
+ *        must_reregister    → terminal (clear tokens on invalid_grant);
+ *        second_unauthorized→ terminal + clear tokens (a freshly-rotated token still
+ *                            rejected is structurally dead — NEVER a second refresh);
+ *        retryable          → terminal transient ("try again").
+ *      At most one refresh + one retry per call (structural in the helper).
  *
  * Privacy: the access/refresh tokens and the Bearer header never reach a log
  * line or the result; identity PII (name, addresses) is in the result (the
@@ -166,46 +170,38 @@ function registerWhoami(api: PluginAPI): void {
         return notRegistered();
       }
 
-      // 2 — read identity with the stored access token.
+      // 2 — read identity; on a 401 refresh-and-retry ONCE via the shared
+      // choreography (the SAME `refreshAndRetryOnce` path sil_search /
+      // sil_product_get use — 401 recovery is uniform across every
+      // sil-api-calling tool, factored so the three cannot drift apart).
       const first = await fetchIdentity(getSilApiUrl(), stored.access_token);
-      if (first.kind !== "unauthorized") {
-        return identityOutcomeToResult(api, first);
+      const recovered = await refreshAndRetryOnce(
+        first,
+        (o): boolean => o.kind === "unauthorized",
+        (accessToken) => fetchIdentity(getSilApiUrl(), accessToken),
+      );
+      switch (recovered.kind) {
+        case "result":
+          // The first non-401 outcome, OR the retry's non-401 outcome (ok /
+          // forbidden / retryable) — mapped to its terminal/transient/success result.
+          return identityOutcomeToResult(api, recovered.outcome);
+        case "must_reregister":
+          // The refresh token is dead (invalid_grant) → clear the now-known-dead
+          // pair so the user's sil_register recovery is not blocked by stale
+          // presence; a TOCTOU empty re-read (no_stored_tokens) has nothing to clear.
+          if (recovered.reason === "invalid_grant") clearTokens();
+          api.logger.info("sil_whoami_must_reregister", { cause: recovered.reason });
+          return mustReregister();
+        case "second_unauthorized":
+          // A freshly-rotated token STILL rejected is structurally dead — terminal,
+          // never another refresh. Clear the dead pair.
+          clearTokens();
+          api.logger.info("sil_whoami_must_reregister", { cause: "retry_unauthorized" });
+          return mustReregister();
+        case "retryable":
+          api.logger.info("sil_whoami_refresh_retryable", {});
+          return transient();
       }
-
-      // 3 — 401: refresh transparently, exactly once (sil-web; rotates tokens).
-      const refresh = await refreshStoredTokens();
-      if (refresh.status === "must_reregister") {
-        // The refresh token is dead. Clear the now-known-dead pair so the user's
-        // sil_register recovery is not blocked by stale presence.
-        if (refresh.reason === "invalid_grant") clearTokens();
-        api.logger.info("sil_whoami_must_reregister", { cause: refresh.reason });
-        return mustReregister();
-      }
-      if (refresh.status === "retryable") {
-        api.logger.info("sil_whoami_refresh_retryable", {});
-        return transient();
-      }
-
-      // refresh.status === "refreshed" — re-read the rotated pair and retry ONCE.
-      api.logger.info("sil_whoami_refreshed", {});
-      const rotated = readTokens();
-      if (rotated === null) {
-        // TOCTOU: tokens vanished between rotate and re-read — treat as terminal.
-        return mustReregister();
-      }
-      const retry = await fetchIdentity(getSilApiUrl(), rotated.access_token);
-      if (retry.kind === "ok") {
-        return identityResult(retry.identity);
-      }
-      if (retry.kind === "unauthorized") {
-        // A freshly-rotated token STILL rejected is structurally dead — terminal,
-        // never another refresh. Clear the dead pair.
-        clearTokens();
-        api.logger.info("sil_whoami_must_reregister", { cause: "retry_unauthorized" });
-        return mustReregister();
-      }
-      // 403 / 5xx on the retry — surface its own terminal/transient outcome.
-      return identityOutcomeToResult(api, retry);
     },
   });
 }

--- a/src/tools/identity.ts
+++ b/src/tools/identity.ts
@@ -184,6 +184,10 @@ function registerWhoami(api: PluginAPI): void {
         case "result":
           // The first non-401 outcome, OR the retry's non-401 outcome (ok /
           // forbidden / retryable) — mapped to its terminal/transient/success result.
+          // On a silent recovery (`refreshed`: a 401 was healed by the refresh+retry)
+          // emit the operator marker so a thrashing session is visible in logs —
+          // logs-only, no token material, NOT a payload field (the agent never sees it).
+          if (recovered.refreshed) api.logger.info("sil_whoami_refreshed", {});
           return identityOutcomeToResult(api, recovered.outcome);
         case "must_reregister":
           // The refresh token is dead (invalid_grant) → clear the now-known-dead


### PR DESCRIPTION
## Card
`cards/uniform-401-refresh-across-catalog-tools.md` (gitignored — lives only in the `card/uniform-401-refresh-across-catalog-tools` worktree; this PR carries the implementation + tests, never the card body).

Closes the FLAG-10 divergence: `sil_search` / `sil_product_get` treated a 401 from sil-api as a **terminal** re-register while `sil_whoami` recovered transparently (refresh once, retry once). The goal's sil-openclaw acceptance requires 401 recovery to be **uniform across every sil-api-calling tool** — never per-tool.

## Summary
- **One shared choreography.** New generic `refreshAndRetryOnce<O>(first, isUnauthorized, retryWithToken): Promise<RefreshRetryResult<O>>` in `src/lib/sil-client.ts` (colocated with its sole collaborator `refreshStoredTokens`). The control flow IS the contract — straight-line `first → refresh once → re-read rotated pair → retry once`, **no loop**: a non-401 first outcome passes through; a 401 refreshes ONCE via the existing `refreshStoredTokens()`; `invalid_grant`/`no_stored_tokens` → terminal (no retry); `retryable` (5xx/network) → transient (no retry); `refreshed` → re-read the rotated pair **through the module's `readTokens`** (TOCTOU-safe; empty ⇒ terminal `no_stored_tokens`), then retry once; a second 401 ⇒ `second_unauthorized` (NEVER a second refresh).
- **Three unified call sites.** `sil_search` + `sil_product_get` (`catalog.ts`) and `sil_whoami` (`identity.ts`) all route their 401 through the one helper. `sil_whoami` is **re-pointed off its inline copy** so there is exactly one choreography — the Intent's "do not fork a second 401 handler". The only per-site variance is call arity / outcome union / result envelope; the helper is generic over `O` (no `any`, no cast — `O` stays parametric via the predicate + thunk).
- **No new refresh machinery.** Reuses `refreshStoredTokens` / `refreshSession` / `classifyRefreshResponse` / `readTokens` / `writeTokens` as-is. Classifiers keep returning `{ kind: "unauthorized" }`; it simply stops being *terminal* for the catalog callers (it becomes the helper's trigger).
- **No backwards-compat.** The terminal-only `case "unauthorized":` branches and every "single round-trip / no transparent refresh / additive follow-on" comment in `catalog.ts` + `sil-client.ts` are **deleted**, not kept alongside.
- **Token-clearing stays at the call site** (mirrors `identity.ts`): `clearTokens()` fires on exactly the two clearing terminals — `invalid_grant` and `second_unauthorized` — never on `no_stored_tokens` / `retryable` / 403 / 5xx.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — **372 passed / 0 failed** (full suite; the 28 RED tests qa wrote at `963865d` now pass with zero regressions)
- [x] `pnpm build` — clean (`tsc -p tsconfig.build.json` → `dist/`)
- [x] `whoami.integration.test.ts` green unchanged (16/16) — the regression net proving the re-pointing preserved whoami's observable behaviour
- [x] `refresh-retry.test.ts` unit — the bounded-loop invariants in isolation (one-refresh-max, second-401, dead-refresh-no-retry, refresh-5xx/network, TOCTOU via `vi.spyOn(credentials, "readTokens")`, non-401 passthrough)
- [x] `cross-tool-401-parity.integration.test.ts` — the FLAG-10 divergence-killer: drives the identical expired-token + 401 scenario through all three tools and set-compares each dimension, failing if any one tool's `refreshCount` / envelope class diverges

Tiers: `[unit, integration]`. No e2e gate in this repo (the cross-service proof is sil-stage's deferred e2e); the integration tier exercises the real `sil-client` + `credentials` + `refreshStoredTokens` wiring against a mocked `fetch` boundary — stub-free, no `AUTH_DEV_BYPASS`.

## Distillation target
Knowledge capture happens **after Review PASS** in the `distilling` stage — `solutions-architect` runs in this same worktree, commits to this same branch, and pushes here so the PR ends up containing implementation + tests + distillation in one mergeable unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)