### PR TITLE
feat: sil_web_public_url — browser-facing origin for the register auth_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ release (`clawhub package publish --changelog`). See [README](./README.md#releas
 
 ## [Unreleased]
 
+### Added
+
+- `sil_web_public_url` plugin config (env `SIL_WEB_PUBLIC_URL`) — the
+  browser-facing sil-web origin for the `sil_register` `auth_url`, distinct from
+  the internal `sil_web_url` the plugin calls server-side. Defaults to
+  `sil_web_url`, so single-origin deployments are unchanged; set it only in
+  split-network topologies (e.g. local docker staging, where the plugin reaches
+  sil-web by an internal name but the user's browser needs the host-published
+  origin). The claim poll continues to use `sil_web_url`.
+
 ## [0.2.1] - 2026-06-11
 
 ### Changed

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -28,6 +28,11 @@
         "type": "string",
         "format": "uri",
         "description": "Override for the sil-api origin (the domain service — sil_whoami's identity read). Distinct from sil_web_url (sil-web). Falls back to the SIL_API_URL env var, then https://sil-api.4gpts.com. Set this at deploy to pin the sil-api host (or to the same origin as sil_web_url if a single gateway fronts both)."
+      },
+      "sil_web_public_url": {
+        "type": "string",
+        "format": "uri",
+        "description": "Browser-facing sil-web origin for the registration auth URL. Defaults to sil_web_url. Set ONLY when the user's browser reaches sil-web at a different origin than the plugin does — e.g. local docker staging, where the plugin uses an internal service name (sil-web:3000) but the browser must use the host-published origin (localhost:13000). sil_register builds its auth_url from this; the claim poll still uses sil_web_url."
       }
     }
   },
@@ -42,6 +47,12 @@
       "label": "sil-api URL (identity)",
       "help": "The sil-api origin — sil_whoami reads the user's identity here. Distinct from the sil-web URL. Override for staging or self-hosted deployments.",
       "placeholder": "https://sil-api.4gpts.com",
+      "advanced": true
+    },
+    "sil_web_public_url": {
+      "label": "sil-web public URL (browser)",
+      "help": "The browser-facing sil-web origin used to build the registration link. Defaults to the sil-web URL; override only when the user's browser reaches sil-web at a different origin than the plugin does (e.g. local docker staging).",
+      "placeholder": "https://sil.4gpts.com",
       "advanced": true
     }
   },

--- a/src/__tests__/lib/origin-resolution.test.ts
+++ b/src/__tests__/lib/origin-resolution.test.ts
@@ -30,29 +30,38 @@ import {
   setApiUrl,
   getWebUrl,
   setWebUrl,
+  getWebPublicUrl,
+  setWebPublicUrl,
   applyPluginConfigOverrides,
 } from "../../lib/config.js";
 
 let priorSilApiBase: string | undefined;
 let priorSilApiUrl: string | undefined;
+let priorSilWebPublicUrl: string | undefined;
 
 beforeEach(() => {
   priorSilApiBase = process.env["SIL_API_URL"];
   priorSilApiUrl = process.env["SIL_WEB_URL"];
-  // Start each test from the pristine default for BOTH resolvers.
+  priorSilWebPublicUrl = process.env["SIL_WEB_PUBLIC_URL"];
+  // Start each test from the pristine default for ALL THREE resolvers.
   setApiUrl("");
   setWebUrl("");
+  setWebPublicUrl("");
   delete process.env["SIL_API_URL"];
   delete process.env["SIL_WEB_URL"];
+  delete process.env["SIL_WEB_PUBLIC_URL"];
 });
 
 afterEach(() => {
   setApiUrl("");
   setWebUrl("");
+  setWebPublicUrl("");
   if (priorSilApiBase === undefined) delete process.env["SIL_API_URL"];
   else process.env["SIL_API_URL"] = priorSilApiBase;
   if (priorSilApiUrl === undefined) delete process.env["SIL_WEB_URL"];
   else process.env["SIL_WEB_URL"] = priorSilApiUrl;
+  if (priorSilWebPublicUrl === undefined) delete process.env["SIL_WEB_PUBLIC_URL"];
+  else process.env["SIL_WEB_PUBLIC_URL"] = priorSilWebPublicUrl;
 });
 
 describe("getApiUrl — resolution order (pluginConfig → env → default)", () => {
@@ -122,5 +131,129 @@ describe("applyPluginConfigOverrides — wires sil_api_url independently", () =>
     applyPluginConfigOverrides({ sil_web_url: "https://web.example.com" });
     // sil_api_url absent from pluginConfig → env layer still wins.
     expect(new URL(getApiUrl()).origin).toBe("https://env.example.com");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sil-web PUBLIC origin (the browser-facing auth_url origin for sil_register).
+//
+// A THIRD origin seam, distinct from getWebUrl()/getApiUrl(). Its defining
+// trait is NOT a hardcoded default like the other two — it FALLS BACK TO
+// getWebUrl(): a single-origin deployment sets nothing and the browser origin
+// IS the internal origin. It diverges only when a split-network topology
+// (local docker staging) sets sil_web_public_url / SIL_WEB_PUBLIC_URL.
+//
+// Contract this block pins for the implementation (src/lib/config.ts):
+//   - getWebPublicUrl(): string   resolves sil_web_public_url → SIL_WEB_PUBLIC_URL
+//                                  → getWebUrl()  (the FALLBACK, not a constant)
+//   - setWebPublicUrl(url): void  test/override hook (empty string ⇒ unset)
+//   - applyPluginConfigOverrides reads `sil_web_public_url` off SilPluginConfig
+//     (string, non-empty) and feeds setWebPublicUrl, independently of the others.
+// ---------------------------------------------------------------------------
+
+describe("getWebPublicUrl — falls back to getWebUrl() (NOT a hardcoded default)", () => {
+  it("with nothing set, equals getWebUrl()'s own default (the fallback)", () => {
+    // No public override, no public env, no web override, no web env: the public
+    // origin must be EXACTLY getWebUrl()'s resolved value, not a separate constant.
+    expect(getWebPublicUrl()).toBe(getWebUrl());
+  });
+
+  it("tracks getWebUrl across getWebUrl's OWN env resolution (SIL_WEB_URL set, no public)", () => {
+    // The fallback is live, not a snapshot: move getWebUrl via its env layer and
+    // the public origin must follow it (since nothing public is set).
+    process.env["SIL_WEB_URL"] = "https://internal.example.com";
+    expect(new URL(getWebUrl()).origin).toBe("https://internal.example.com");
+    expect(getWebPublicUrl()).toBe(getWebUrl());
+    expect(new URL(getWebPublicUrl()).origin).toBe("https://internal.example.com");
+  });
+
+  it("tracks getWebUrl across getWebUrl's OWN config override (setWebUrl, no public)", () => {
+    // Same fallback, driven by the config layer of getWebUrl this time.
+    setWebUrl("https://web-config.example.com");
+    expect(getWebPublicUrl()).toBe(getWebUrl());
+    expect(new URL(getWebPublicUrl()).origin).toBe("https://web-config.example.com");
+  });
+});
+
+describe("getWebPublicUrl — resolution order (config → env → getWebUrl fallback)", () => {
+  it("uses the SIL_WEB_PUBLIC_URL env override when set, INDEPENDENTLY of getWebUrl", () => {
+    // Public env set + a DIFFERENT web origin: the public resolver returns its
+    // own env value and does NOT inherit the web origin (the whole point of the
+    // split — browser origin ≠ internal origin).
+    process.env["SIL_WEB_URL"] = "https://internal.example.com";
+    process.env["SIL_WEB_PUBLIC_URL"] = "https://public.example.com";
+    expect(new URL(getWebPublicUrl()).origin).toBe("https://public.example.com");
+    // And it is genuinely independent: getWebUrl stays on its own value.
+    expect(new URL(getWebUrl()).origin).toBe("https://internal.example.com");
+    expect(getWebPublicUrl()).not.toBe(getWebUrl());
+  });
+
+  it("a setWebPublicUrl override beats the env (config wins)", () => {
+    process.env["SIL_WEB_PUBLIC_URL"] = "https://env-public.example.com";
+    setWebPublicUrl("https://config-public.example.com");
+    expect(new URL(getWebPublicUrl()).origin).toBe("https://config-public.example.com");
+  });
+
+  it("applyPluginConfigOverrides({ sil_web_public_url }) beats the env (config > env)", () => {
+    // Mirror the web/api precedence tests: the pluginConfig override route wins
+    // over the env var, exactly as it does for sil_web_url / sil_api_url.
+    process.env["SIL_WEB_PUBLIC_URL"] = "https://env-public.example.com";
+    applyPluginConfigOverrides({
+      sil_web_public_url: "https://config-public.example.com",
+    });
+    expect(new URL(getWebPublicUrl()).origin).toBe("https://config-public.example.com");
+  });
+
+  it("full precedence chain: config > env > getWebUrl fallback, peeled one layer at a time", () => {
+    // Establish a getWebUrl baseline so the fallback is a recognizable value.
+    setWebUrl("https://web-fallback.example.com");
+    process.env["SIL_WEB_PUBLIC_URL"] = "https://env-public.example.com";
+    setWebPublicUrl("https://config-public.example.com");
+
+    // 1) config present → config wins.
+    expect(new URL(getWebPublicUrl()).origin).toBe("https://config-public.example.com");
+    // 2) peel config → env wins.
+    setWebPublicUrl("");
+    expect(new URL(getWebPublicUrl()).origin).toBe("https://env-public.example.com");
+    // 3) peel env → getWebUrl fallback wins (NOT a hardcoded public default).
+    delete process.env["SIL_WEB_PUBLIC_URL"];
+    expect(getWebPublicUrl()).toBe(getWebUrl());
+    expect(new URL(getWebPublicUrl()).origin).toBe("https://web-fallback.example.com");
+  });
+});
+
+describe("getWebPublicUrl — empty-string tolerance (same invariant as the other keys)", () => {
+  it("setWebPublicUrl('') unsets the config layer, falling through to env", () => {
+    process.env["SIL_WEB_PUBLIC_URL"] = "https://env-public.example.com";
+    setWebPublicUrl("https://config-public.example.com");
+    setWebPublicUrl(""); // empty ⇒ unset the config layer
+    expect(new URL(getWebPublicUrl()).origin).toBe("https://env-public.example.com");
+  });
+
+  it("applyPluginConfigOverrides({ sil_web_public_url: '' }) does NOT clobber a prior value", () => {
+    // The empty-string-tolerant invariant the web/api keys have: an empty value
+    // in pluginConfig leaves the prior source in place rather than blanking it.
+    setWebPublicUrl("https://config-public.example.com");
+    applyPluginConfigOverrides({ sil_web_public_url: "" });
+    expect(new URL(getWebPublicUrl()).origin).toBe("https://config-public.example.com");
+  });
+
+  it("ignores a missing sil_web_public_url (leaves the prior source in place)", () => {
+    process.env["SIL_WEB_PUBLIC_URL"] = "https://env-public.example.com";
+    // sil_web_public_url absent from pluginConfig → env layer still wins; the
+    // other keys in the same call do not perturb the public resolver.
+    applyPluginConfigOverrides({ sil_web_url: "https://web.example.com" });
+    expect(new URL(getWebPublicUrl()).origin).toBe("https://env-public.example.com");
+  });
+});
+
+describe("getWebPublicUrl — independent of getApiUrl (three distinct seams)", () => {
+  it("does not inherit, and is not inherited by, the sil-api override", () => {
+    // The three seams are mutually independent: setting the api origin must not
+    // move the public origin, and setting the public origin must not move api.
+    setApiUrl("https://sil-api-only.example.com");
+    setWebPublicUrl("https://public-only.example.com");
+    expect(new URL(getApiUrl()).origin).toBe("https://sil-api-only.example.com");
+    expect(new URL(getWebPublicUrl()).origin).toBe("https://public-only.example.com");
   });
 });

--- a/src/__tests__/tools/identity.test.ts
+++ b/src/__tests__/tools/identity.test.ts
@@ -40,7 +40,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { registerIdentityTools } from "../../tools/identity.js";
-import { setWebUrl } from "../../lib/config.js";
+import { setWebUrl, setWebPublicUrl } from "../../lib/config.js";
 import { getDataDir } from "../../lib/credentials.js";
 import {
   createMockPluginApi,
@@ -84,20 +84,30 @@ function walkFiles(dir: string): string[] {
   return out;
 }
 
+let priorSilWebPublicUrl: string | undefined;
+
 beforeEach(() => {
   dataDir = mkdtempSync(join(tmpdir(), "sil-register-test-"));
   priorSilDataDir = process.env["SIL_DATA_DIR"];
   process.env["SIL_DATA_DIR"] = dataDir;
-  // Reset config singleton + env so each test starts at the default host.
+  priorSilWebPublicUrl = process.env["SIL_WEB_PUBLIC_URL"];
+  // Reset config singletons + env so each test starts at the default host —
+  // BOTH the internal sil-web origin AND the browser-facing public origin
+  // (a leaked public override would silently move the auth_url across tests).
   setWebUrl("");
+  setWebPublicUrl("");
   delete process.env["SIL_WEB_URL"];
+  delete process.env["SIL_WEB_PUBLIC_URL"];
 });
 
 afterEach(() => {
   if (priorSilDataDir === undefined) delete process.env["SIL_DATA_DIR"];
   else process.env["SIL_DATA_DIR"] = priorSilDataDir;
   setWebUrl("");
+  setWebPublicUrl("");
   delete process.env["SIL_WEB_URL"];
+  if (priorSilWebPublicUrl === undefined) delete process.env["SIL_WEB_PUBLIC_URL"];
+  else process.env["SIL_WEB_PUBLIC_URL"] = priorSilWebPublicUrl;
   rmSync(dataDir, { recursive: true, force: true });
   vi.restoreAllMocks();
 });
@@ -231,6 +241,131 @@ describe("sil_register — host override resolution (pluginConfig → env → de
     expect(origin).not.toBe("https://config.example.com");
     expect(origin).not.toBe("https://env.example.com");
     expect(origin.startsWith("https://")).toBe(true);
+  });
+});
+
+describe("sil_register — public/internal origin split (auth_url vs claim poll)", () => {
+  // THE falsifiable test for this seam. The browser-facing auth_url must use the
+  // PUBLIC origin (getWebPublicUrl), while the background claim poll keeps hitting
+  // the INTERNAL origin (getWebUrl). They diverge ONLY when sil_web_public_url /
+  // SIL_WEB_PUBLIC_URL is set; that divergence is the whole point of the seam, so
+  // we assert BOTH sides off a single registration call.
+  //
+  // The claim-poll origin is observed structurally: claimSession builds
+  //   `${internalOrigin}/api/v1/sessions/${sessionId}/claim`
+  // so we capture the URL fetch is called with on the first poll tick. fetch is
+  // stubbed to never settle (so nothing reaches the network and no tokens are
+  // written); one fake-timer advance is enough to build + dispatch the claim
+  // request and capture its URL.
+
+  const INTERNAL = "https://internal.example.com";
+  const PUBLIC = "https://public.example.com";
+
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  let claimUrls: string[];
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    claimUrls = [];
+    fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation((input: unknown) => {
+        // Capture every URL the poll dispatches so we can assert the claim origin.
+        claimUrls.push(typeof input === "string" ? input : String(input));
+        return new Promise<Response>(() => {});
+      });
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("auth_url uses the PUBLIC origin while the claim poll uses the INTERNAL origin", async () => {
+    process.env["SIL_WEB_URL"] = INTERNAL;
+    process.env["SIL_WEB_PUBLIC_URL"] = PUBLIC;
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", {}));
+
+    // --- Browser side: auth_url origin is the PUBLIC one ---
+    const authUrl = new URL(payload["auth_url"] as string);
+    expect(authUrl.origin).toBe(PUBLIC);
+    // The path + the load-bearing query params survive the public-origin swap.
+    expect(authUrl.pathname).toBe("/authorize");
+    expect(authUrl.searchParams.get("session")).toBe(payload["session_id"]);
+    expect(authUrl.searchParams.get("session")).toMatch(UUID_RE);
+    expect(authUrl.searchParams.get("code_challenge")).toMatch(CHALLENGE_RE);
+    expect([...authUrl.searchParams.keys()].sort()).toEqual([
+      "code_challenge",
+      "session",
+    ]);
+
+    // --- Server side: the claim poll hits the INTERNAL origin ---
+    // Advance one poll tick so claimSession builds + dispatches the claim request.
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(claimUrls.length).toBeGreaterThan(0);
+    const claimUrl = new URL(claimUrls[0]!);
+    expect(claimUrl.origin).toBe(INTERNAL);
+    // It is the claim endpoint for THIS session, and it is NOT the public origin.
+    expect(claimUrl.pathname).toBe(
+      `/api/v1/sessions/${payload["session_id"] as string}/claim`,
+    );
+    expect(claimUrl.origin).not.toBe(PUBLIC);
+  });
+
+  it("a setWebPublicUrl config override (not env) still splits auth_url from the poll", async () => {
+    // Drive the split through the config layer the way applyPluginConfigOverrides
+    // would, proving the split is a property of getWebPublicUrl resolution, not of
+    // the env var specifically.
+    setWebUrl(INTERNAL);
+    setWebPublicUrl(PUBLIC);
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", {}));
+    expect(new URL(payload["auth_url"] as string).origin).toBe(PUBLIC);
+
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(claimUrls.length).toBeGreaterThan(0);
+    expect(new URL(claimUrls[0]!).origin).toBe(INTERNAL);
+  });
+
+  it("BACKWARD-COMPAT: with SIL_WEB_PUBLIC_URL unset, auth_url uses SIL_WEB_URL exactly as before", async () => {
+    // No public override anywhere → the public origin falls back to getWebUrl, so
+    // a single-origin deployment is byte-for-byte unchanged: auth_url AND the poll
+    // both sit on SIL_WEB_URL.
+    process.env["SIL_WEB_URL"] = INTERNAL;
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", {}));
+    const authUrl = new URL(payload["auth_url"] as string);
+    expect(authUrl.origin).toBe(INTERNAL);
+    expect(authUrl.pathname).toBe("/authorize");
+    expect(authUrl.searchParams.get("session")).toBe(payload["session_id"]);
+
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(claimUrls.length).toBeGreaterThan(0);
+    // Both sides on the SAME origin when nothing public is set (no divergence).
+    expect(new URL(claimUrls[0]!).origin).toBe(INTERNAL);
+    expect(new URL(claimUrls[0]!).origin).toBe(authUrl.origin);
+  });
+
+  it("BACKWARD-COMPAT: with nothing set, the default-host auth_url is unchanged by the new seam", async () => {
+    // The pre-seam default-host behaviour: no SIL_WEB_URL, no SIL_WEB_PUBLIC_URL.
+    // auth_url and the poll share the default origin — the seam adds no divergence.
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", {}));
+    const authOrigin = new URL(payload["auth_url"] as string).origin;
+    expect(authOrigin.startsWith("https://")).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(claimUrls.length).toBeGreaterThan(0);
+    expect(new URL(claimUrls[0]!).origin).toBe(authOrigin);
   });
 });
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -8,6 +8,8 @@
  *     1. `api.pluginConfig.sil_web_url`  2. `SIL_WEB_URL`  3. `DEFAULT_WEB_URL`
  *   sil-API (commerce/identity reads — `sil_whoami`):
  *     1. `api.pluginConfig.sil_api_url`  2. `SIL_API_URL`  3. `DEFAULT_API_URL`
+ *   sil-WEB PUBLIC (the browser-facing `auth_url` origin — `sil_register` only):
+ *     1. `api.pluginConfig.sil_web_public_url`  2. `SIL_WEB_PUBLIC_URL`  3. `getWebUrl()`
  *
  * The two-origin reality is load-bearing (see the sil-whoami card): refresh
  * is on sil-web (the only holder of the Auth0 client secret), the identity
@@ -51,6 +53,7 @@ export type ConfigSource = "config" | "env" | "default";
 export interface SilPluginConfig {
   sil_web_url?: string;
   sil_api_url?: string;
+  sil_web_public_url?: string;
 }
 
 export function setWebUrl(url: string): void {
@@ -65,6 +68,22 @@ export function getWebUrlSource(): ConfigSource {
   if (_webUrl !== null) return "config";
   if (process.env["SIL_WEB_URL"]) return "env";
   return "default";
+}
+
+// Browser-facing sil-web origin for the registration `auth_url` (sil_register).
+// DISTINCT from getWebUrl() only when the URL the USER's browser opens differs
+// from the origin the plugin itself calls server-side — e.g. local docker
+// staging, where the plugin reaches sil-web by an internal name (sil-web:3000)
+// but the browser must use the host-published origin (localhost:13000). Falls
+// back to getWebUrl(), so a single-origin deployment (production) sets nothing.
+let _webPublicUrl: string | null = null;
+
+export function setWebPublicUrl(url: string): void {
+  _webPublicUrl = url === "" ? null : url;
+}
+
+export function getWebPublicUrl(): string {
+  return _webPublicUrl ?? process.env["SIL_WEB_PUBLIC_URL"] ?? getWebUrl();
 }
 
 export function setApiUrl(url: string): void {
@@ -104,11 +123,14 @@ export function applyPluginConfigOverrides(
   // PluginAPI.pluginConfig is `Record<string, unknown>` because the SDK
   // cannot know each plugin's schema, so callers cast to SilPluginConfig
   // at the boundary. The cast trusts a JSON file on disk — keep the guard.
-  const { sil_web_url, sil_api_url } = pluginConfig;
+  const { sil_web_url, sil_api_url, sil_web_public_url } = pluginConfig;
   if (typeof sil_web_url === "string" && sil_web_url.length > 0) {
     setWebUrl(sil_web_url);
   }
   if (typeof sil_api_url === "string" && sil_api_url.length > 0) {
     setApiUrl(sil_api_url);
+  }
+  if (typeof sil_web_public_url === "string" && sil_web_public_url.length > 0) {
+    setWebPublicUrl(sil_web_public_url);
   }
 }

--- a/src/tools/identity.ts
+++ b/src/tools/identity.ts
@@ -13,9 +13,11 @@
  *   2. Mint PKCE in-process. session_id (UUID), verifier (base64url 32 bytes),
  *      challenge = S256(verifier). The verifier is held ONLY in the poll step
  *      closure below — it never touches disk.
- *   3. Build the auth URL `<apiUrl>/authorize?session=<id>&code_challenge=<chal>`.
- *      The plugin does NOT pre-POST to sil-web: the pending session row is
- *      INSERTed server-side when the USER's browser opens this URL.
+ *   3. Build the auth URL `<webPublicUrl>/authorize?session=<id>&code_challenge=<chal>`
+ *      from the PUBLIC (browser-facing) origin — distinct from the internal origin
+ *      the claim poll uses when a split topology sets it. The plugin does NOT
+ *      pre-POST to sil-web: the pending session row is INSERTed server-side when
+ *      the USER's browser opens this URL.
  *   4. Start a fire-and-forget bounded poll of the claim endpoint, then return
  *      promptly with `{ status: "awaiting_browser", auth_url, session_id }`.
  *   5. On the poll's terminal success, persist tokens.json + config.json
@@ -31,7 +33,7 @@
 import type { PluginAPI } from "openclaw/plugin-sdk";
 import { Type } from "typebox";
 
-import { getWebUrl, getApiUrl } from "../lib/config.js";
+import { getApiUrl, getWebPublicUrl, getWebUrl } from "../lib/config.js";
 import {
   clearTokens,
   hasTokens,
@@ -87,23 +89,29 @@ function registerRegister(api: PluginAPI): void {
       const sessionId = newSessionId();
       const verifier = newVerifier();
       const challenge = deriveChallenge(verifier);
-      const apiUrl = getWebUrl();
 
-      // 3 — build the auth URL. Opening it (by the user's browser) is what
-      // creates the pending session server-side; the plugin does not pre-POST.
+      // The plugin's own server-side call (the claim poll) uses the INTERNAL
+      // sil-web origin; the auth_url the USER's browser opens uses the PUBLIC
+      // origin. Same value unless a split-network topology (e.g. local docker
+      // staging) sets sil_web_public_url / SIL_WEB_PUBLIC_URL.
+      const claimOrigin = getWebUrl();
+      const browserOrigin = getWebPublicUrl();
+
+      // 3 — build the auth URL (PUBLIC origin). Opening it (by the user's
+      // browser) is what creates the pending session server-side; no pre-POST.
       const authUrl =
-        `${stripTrailingSlash(apiUrl)}/authorize`
+        `${stripTrailingSlash(browserOrigin)}/authorize`
         + `?session=${sessionId}&code_challenge=${challenge}`;
 
-      // 4 — fire-and-forget bounded poll. Not awaited: execute() returns now.
-      // The poll step maps each claim outcome to the loop's done/continue
-      // signal AND performs persistence on success (so the atomic write
-      // completes inside the awaited tick, before onDone fires); the verifier
-      // is captured here and never leaves memory.
+      // 4 — fire-and-forget bounded poll (INTERNAL origin). Not awaited:
+      // execute() returns now. The poll step maps each claim outcome to the
+      // loop's done/continue signal AND performs persistence on success (so the
+      // atomic write completes inside the awaited tick, before onDone fires);
+      // the verifier is captured here and never leaves memory.
       startPoll({
         intervalMs: POLL_INTERVAL_MS,
         deadlineMs: POLL_DEADLINE_MS,
-        poll: () => claimStep(apiUrl, sessionId, verifier),
+        poll: () => claimStep(claimOrigin, sessionId, verifier),
         onDone: (result) => handleDone(api, sessionId, result),
       });
 


### PR DESCRIPTION
## What

Adds `sil_web_public_url` — the **browser-facing** sil-web origin that `sil_register` uses to build its `auth_url`, distinct from the internal `sil_web_url` the plugin calls server-side.

## Why

`sil_register` returns an `auth_url` for the **user's browser** to open, but builds it from `getWebUrl()` — the same origin the plugin uses for its own server-side claim poll. In a single-origin deployment (production, `https://sil.4gpts.com`) that's fine. In a **split-network topology** they differ, and the browser gets handed an unreachable URL:

- local docker staging: the plugin reaches sil-web by the internal compose name `http://sil-web:3000`; the user's host browser can only reach `http://localhost:13000`. Clicking the `auth_url` → `DNS_PROBE_FINISHED_NXDOMAIN`.

## The seam

- **`config.ts`** — `getWebPublicUrl()` resolves `pluginConfig.sil_web_public_url` → `SIL_WEB_PUBLIC_URL` → **falls back to `getWebUrl()`**. So a single-origin deployment sets nothing and behaves exactly as before.
- **`identity.ts`** — `sil_register`'s `auth_url` uses `getWebPublicUrl()` (browser origin); the background claim poll keeps `getWebUrl()` (internal origin). The split is the whole point — the browser and the plugin reach the *same* sil-web by different names, coordinated by `session_id`.
- **`openclaw.plugin.json`** — `sil_web_public_url` added to `configSchema` + `uiHints`.

## Backward-compatible by construction

`getWebPublicUrl()` falls back to `getWebUrl()`, so with the key unset nothing changes — the existing `sil_register` tests (which set no public origin) stay green, and production is unaffected.

## Tests

- **config resolution/precedence** — fallback to `getWebUrl()` (not a hardcoded default), `SIL_WEB_PUBLIC_URL` env, config-override-beats-env, empty-string tolerance.
- **the register split (the linchpin)** — with internal ≠ public origins, one `sil_register` call yields an `auth_url` on the **public** origin *and* a claim poll on the **internal** origin (both sides asserted); backward-compat with the key unset.
- qa-developer teeth-checked both: regressing the impl turns exactly the relevant tests RED. Full suite **462 green**, typecheck clean.

`CHANGELOG.md` `## [Unreleased]` updated; no version cut (release is a separate `pnpm version` step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
