### PR TITLE
fix: sil_register keeps polling on premature 404 (not_found is no longer terminal)

### DIFF
--- a/docs/knowledge/INDEX.md
+++ b/docs/knowledge/INDEX.md
@@ -6,8 +6,8 @@ Sorted by `updated_at` descending (newest first). One row per doc in this folder
 
 | ID | Title | Tags | Updated |
 |---|---|---|---|
+| [[sil-response-classification]] | Classify sil responses on body shape, not HTTP status — anti-false-green guard is `Array.isArray(products)`, NOT a `result` wrapper (search/lookup read flat, identity dual-reads); never `res.ok`. Classifier is wire-pure; poll TERMINALITY lives at the loop (claim 404=keep-polling, deadline=timeout, 400=`invalid_request` fail-fast) | sil-api, sil-web, http, classification, false-green, envelope, poll, terminality, claim | 2026-06-12 |
 | [[sil-api-catalog-contract]] | sil-api catalog reads — FLAT `{ ucp, products, … }` envelope (no `result` wrapper), bare POST /catalog/{search,lookup}, OPEN `SearchFilters` (serviceability filters fail GREEN on a wrong key), `ships_to`/`ships_from` FORMAT regexes mirror `@sil/schemas` byte-for-byte (no shared pkg; reject-client-side), @sil/schemas is wire truth (not @ucp-js/sdk) | sil-api, catalog, search, lookup, contract, wire-types, envelope, filters, serviceability, ship-to, format, cross-sibling, gotcha | 2026-06-11 |
-| [[sil-response-classification]] | Classify sil responses on body shape, not HTTP status — anti-false-green guard is `Array.isArray(products)`, NOT a `result` wrapper (search/lookup read flat, identity dual-reads) | sil-api, sil-web, http, classification, false-green, envelope | 2026-06-10 |
 | [[sil-api-identity-contract]] | sil-api identity read — GET /identity returns a FLAT `{ ucp, id, name, addresses }` envelope (extractIdentity dual-reads `result ?? envelope`), request gotchas, deferred e2e | sil-api, identity, jwt, envelope, cross-sibling, e2e | 2026-06-10 |
 | [[typecheck-is-the-only-test-type-gate]] | pnpm typecheck is the only gate that type-checks tests (build excludes them, test strips types) | tooling, typescript, vitest, tsconfig, gotcha, false-green, ci-gate | 2026-06-08 |
 

--- a/docs/knowledge/sil-response-classification.md
+++ b/docs/knowledge/sil-response-classification.md
@@ -1,11 +1,11 @@
 ---
 id: sil-response-classification
-title: Classify sil responses on body shape, not HTTP status — anti-false-green guard is Array.isArray(products), NOT a result wrapper (search/lookup read flat, identity dual-reads); never res.ok
-tags: [sil-api, sil-web, http, classification, gotcha, false-green, envelope]
+title: Classify sil responses on body shape, not HTTP status — anti-false-green guard is Array.isArray(products), NOT a result wrapper (search/lookup read flat, identity dual-reads); never res.ok. Classifier is wire-pure; poll TERMINALITY lives at the loop (claim 404=keep-polling, deadline=timeout, 400=invalid_request fail-fast)
+tags: [sil-api, sil-web, http, classification, gotcha, false-green, envelope, poll, terminality, claim]
 card: sil-whoami-tool
-commit: d2b6393
-updated_at: 2026-06-10
-updated_by_card: catalog-plugin-tools-read-sil-api-flat-envelope
+commit: 82a1bca
+updated_at: 2026-06-12
+updated_by_card: sil-register-stops-polling-on-premature-not-found
 ---
 
 Every sil HTTP response is classified by a **pure, exported, unit-tested classifier** that branches on HTTP status **and, for `200`, the response body shape** — never on `res.ok`. This exists because sil returns semantically-distinct outcomes under the *same* HTTP status, so the status code alone is not enough to decide what happened.
@@ -15,6 +15,8 @@ The classifiers all live in `src/lib/sil-client.ts`: `classifyClaimResponse`, `c
 ## The 200-is-ambiguous traps (why body shape, not status)
 
 1. **Claim: `200`-pending vs `200`-success.** `POST /api/v1/sessions/{id}/claim` returns HTTP `200` both while the browser leg is still in progress (`{status:"pending"}`) and when the tokens are ready (`{access_token, refresh_token, user}`). The discriminant is **the presence of both tokens in the body** (`classifyClaimResponse`, `sil-client.ts:136`) — *not* the status. A malformed/partial `200` falls to the **safe non-terminal** `pending`, never to a false `success` that would persist a non-credential as tokens.
+
+   **`classifyClaimResponse` is wire-pure — terminality is NOT its job (see "Terminality lives at the loop" below).** The classifier emits `success` / `pending` / `already_claimed` (409) / `expired` (410) / `not_found` (404) / `invalid_request` (400 + any other unexpected non-`{200,409,410,404,5xx}`) / `retryable` (5xx, network) — these are *wire meanings*, not poll verdicts. **`not_found` is NOT a terminal** even though it names a 4xx: a claim `404` is the *normal pre-session early state* (the session row is `INSERT`ed server-side only when the user opens the auth URL, so the first poll always 404s before the human acts — `wrong-verifier ≡ unknown-session`, a uniform 404 with no existence oracle), so `claimStep` keeps polling on it exactly like `pending`. The one branch that *is* a hard terminal in the classifier is `invalid_request`: a structurally-malformed request re-polling can never fix, so it fails fast rather than spinning to the deadline (it is unreachable from this client today — the plugin always sends a valid 43-char verifier — so it is contract-drift insurance, logged at WARN). See [[sil-api-identity-contract]] for the claim wire contract.
 
 2. **Identity: anti-false-green `200`.** The authenticated self-read is **`GET /identity`** (a bodyless GET — `fetchIdentity`, `sil-client.ts:584`), which returns HTTP `200` with the real `{name, addresses}` payload. The discriminant is the **non-empty `name`**: `extractIdentity` (`sil-client.ts:818`) requires a non-empty `name` string AND that `addresses` is an **array** (which **may be empty** — `addresses: []` is a real, authenticated identity for a user who onboarded a name but no address; see below). Any `200` that yields no usable `name` — sil-api's *enrich-stub* shape `{kind, verified, subject, attributes, note}` that `POST /identity` still returns (no name), or a partial/garbage `200` — classifies as `retryable`, **never `ok`**. This is the load-bearing guard: **the test suite cannot go green while `sil_whoami` reads the stub shape** — i.e. it cannot false-green while the product promise (real PII over the wire) is unmet. The verb is itself load-bearing: POST hits the enrich-stub (no name), GET hits the real self-read. See [[sil-api-identity-contract]].
 
@@ -29,6 +31,14 @@ The classifiers all live in `src/lib/sil-client.ts`: `classifyClaimResponse`, `c
 ## When you add a new sil call
 
 Write a pure `classifyXResponse(status, body)` returning a discriminated union, export it, unit-test it in isolation (especially every `200` sub-case), and have the `fetchX` wrapper delegate to it. Map network errors / timeouts / aborts to the union's `retryable` variant — never let them throw past the wrapper.
+
+## Terminality lives at the loop, not in the classifier (for any polled outcome)
+
+A `classifyXResponse` reports **what the wire said**; whether that outcome **ends a poll** is decided one layer up, in the loop's step mapper (e.g. `claimStep`, `identity.ts:307`) — not in the classifier. Keep the classifier wire-pure: a 404 IS `not_found` on the wire, and the classifier says so; it is `claimStep` that decides `not_found` keeps polling. Collapsing the two layers is the exact bug card `sil-register-stops-polling-on-premature-not-found` fixed — `claimStep` had grouped the wire-truth `not_found` with the genuine terminals, so the first premature 404 (always fired ~3s in, before the human opened the browser) killed registration. The rule that follows:
+
+- **The only terminals of a registration poll are a successful claim and the deadline.** Everything else — `pending`, `not_found`, `retryable` — keeps polling (`claimStep` → `{ done: false }`). A session that never appears is **not** surfaced as `not_found`; it ends as `timeout` when the 30-min `POLL_DEADLINE_MS` elapses (`poller.ts` checks the deadline at the head of every `tick`, so perpetual `{ done: false }` is bounded, never an infinite loop). Surfacing a transient early state as a permanent verdict is a category error.
+- **A keep-polling outcome and a fail-fast terminal must be DISTINCT union variants** — never folded. `not_found` (re-pollable: the session may yet appear) and `invalid_request` (a 400 / unexpected non-2xx that re-polling can never fix) are different kinds precisely so the malformed request fails fast instead of riding the keep-polling path and spinning to a misleading `timeout`. When you add a polled outcome, decide its terminality at the step mapper, and give "keep polling" and "fail fast" separate kinds.
+- **The step mapper's `switch (outcome.kind)` has no `default`** (`claimStep`) — `tsc` exhaustiveness forces every new variant to be classified as keep-polling vs. terminal at compile time. Preserve that: don't add a `default` arm, or a new wire variant could silently fall through to the wrong terminality.
 
 ## Empty-addresses: a valid identity, gated by `name` (resolved)
 

--- a/src/__tests__/lib/sil-client.test.ts
+++ b/src/__tests__/lib/sil-client.test.ts
@@ -23,7 +23,10 @@
  *   claim   200 {status:"pending"}                → pending (keep polling)
  *   claim   409 {error:"already_claimed"}         → already_claimed (terminal)
  *   claim   410 {error:"session_expired"}         → expired (terminal)
- *   claim   404 {error:"not_found"}               → not_found (terminal)
+ *   claim   404 {error:"not_found"}               → not_found (the early pre-session
+ *                                                   state; classifier-pure here,
+ *                                                   keep-polling at the loop)
+ *   claim   400 / other unexpected non-2xx        → invalid_request (non-polling terminal)
  *   claim   5xx / network throw                   → retryable
  *   refresh 200 {access_token,refresh_token}      → success
  *   refresh 401 {error:"invalid_grant"}           → invalid_grant (terminal)
@@ -37,10 +40,22 @@
  *       | { kind: "already_claimed" }
  *       | { kind: "expired" }
  *       | { kind: "not_found" }
+ *       | { kind: "invalid_request" }   // 400 / unexpected non-{200,409,410,404,5xx}
  *       | { kind: "retryable" }
  * (If the dev folds this into identity.ts instead of a sil-client.ts
  * module, re-export `classifyClaimResponse` so this isolation test still
  * binds — the classifier itself is the immutable spec, not its file.)
+ *
+ * THE behavioural split this card pins (`sil-register-stops-polling-on-
+ * premature-not-found`): the 404 stays `not_found` ON THE WIRE (unchanged
+ * here) — its terminality moves to the loop (`claimStep` now keeps polling
+ * on `not_found`, an integration concern). What changes IN the classifier is
+ * the 400/unexpected-4xx fallthrough: it was folded into `not_found`, and now
+ * becomes its OWN non-polling terminal `invalid_request` — so a genuinely
+ * malformed claim request can never ride the keep-polling `not_found` path
+ * and spin for the full 30-min deadline. `not_found` (the early pre-session
+ * state) keeps polling; `invalid_request` (a structurally-bad request that
+ * re-polling can never fix) fails fast. They MUST be distinct kinds.
  */
 
 import { describe, it, expect } from "vitest";
@@ -126,6 +141,59 @@ describe("classifyClaimResponse — terminal status codes", () => {
       classifyClaimResponse(404, {}).kind,
     ]);
     expect(kinds.size).toBe(3);
+  });
+});
+
+describe("classifyClaimResponse — a malformed 400 is its OWN non-polling terminal (NOT not_found)", () => {
+  // The card's split (`sil-register-stops-polling-on-premature-not-found`,
+  // resolved open question): when 404 becomes keep-polling at the loop, a 400
+  // MUST NOT ride along. A 400 means "this request is malformed" — re-polling
+  // can never fix it (the same bad body 400s every tick), so folding it into
+  // the now-keep-polling `not_found` would spin a known-bug for the full 30-min
+  // deadline before a misleading `timeout`. The classifier therefore splits
+  // 400 (and any other unexpected non-{200,409,410,404,5xx} status) out of the
+  // `not_found` branch into its OWN non-polling terminal `invalid_request`.
+  //
+  // EXPECT RED against the current classifier: `sil-client.ts:414-417` folds
+  // 400/unexpected-4xx into `return { kind: "not_found" }`, so today
+  // `classifyClaimResponse(400, …).kind` is `"not_found"`, not `"invalid_request"`.
+
+  it("400 → invalid_request (a distinct terminal, NOT not_found)", () => {
+    const out = classifyClaimResponse(400, { error: "bad_request" });
+    expect(out.kind).toBe("invalid_request");
+    // The load-bearing half: it must NOT be folded into the keep-polling 404 path.
+    expect(out.kind).not.toBe("not_found");
+  });
+
+  it("400 invalid_request is NOT a 200-class outcome (not pending, not success)", () => {
+    // Keep-polling (`pending`/`not_found`/`retryable`) and success are all
+    // reserved for other statuses — a 400 is a hard, immediate terminal.
+    const kind = classifyClaimResponse(400, {}).kind;
+    expect(kind).not.toBe("pending");
+    expect(kind).not.toBe("success");
+  });
+
+  it("any other unexpected non-{200,409,410,404,5xx} status → invalid_request, never not_found", () => {
+    // The catch-all fallthrough (`status !== 200` after the known codes are
+    // handled): 401/403/418/451 and friends are not part of the claim wire
+    // contract — they are a contract drift, and like 400 must fail fast as
+    // `invalid_request`, never re-polled as `not_found`.
+    for (const status of [401, 403, 418, 422, 451]) {
+      const out = classifyClaimResponse(status, { error: "unexpected" });
+      expect(out.kind).toBe("invalid_request");
+      expect(out.kind).not.toBe("not_found");
+    }
+  });
+
+  it("404 stays not_found while 400 becomes invalid_request — the two are DISTINCT kinds", () => {
+    // The whole point of the split: the early pre-session 404 (keep-polling at
+    // the loop) and the malformed-request 400 (fail-fast terminal) must never
+    // collapse to one kind. Today they DO (both `not_found`) — this is the RED.
+    const notFound = classifyClaimResponse(404, { error: "not_found" }).kind;
+    const invalid = classifyClaimResponse(400, { error: "bad_request" }).kind;
+    expect(notFound).toBe("not_found");
+    expect(invalid).toBe("invalid_request");
+    expect(notFound).not.toBe(invalid);
   });
 });
 

--- a/src/__tests__/register-claim.integration.test.ts
+++ b/src/__tests__/register-claim.integration.test.ts
@@ -56,7 +56,7 @@ import { join } from "node:path";
 
 import { registerIdentityTools } from "../tools/identity.js";
 import { refreshStoredTokens } from "../lib/sil-client.js";
-import { setWebUrl, getWebUrl } from "../lib/config.js";
+import { setWebUrl, getWebUrl, setApiUrl } from "../lib/config.js";
 import { getDataDir, readTokens } from "../lib/credentials.js";
 import {
   createMockPluginApi,
@@ -173,6 +173,7 @@ afterEach(() => {
   vi.useRealTimers();
   vi.restoreAllMocks();
   setWebUrl("");
+  setApiUrl(""); // tests that pin the sil-api origin (the early-404→whoami leg) reset it here
   if (priorSilDataDir === undefined) delete process.env["SIL_DATA_DIR"];
   else process.env["SIL_DATA_DIR"] = priorSilDataDir;
   rmSync(dataDir, { recursive: true, force: true });
@@ -266,10 +267,16 @@ describe("claim lifecycle — 200 pending keeps polling (NOT terminal)", () => {
 });
 
 describe("claim lifecycle — terminal status codes stop the loop", () => {
+  // NOTE (`sil-register-stops-polling-on-premature-not-found`): 404 was REMOVED
+  // from this terminal table. A claim 404 is the normal pre-session early state
+  // (the row is INSERTed server-side only when the user opens the auth URL), so
+  // it now KEEPS POLLING — its keep-polling/timeout behaviour is asserted in the
+  // dedicated "premature 404 keeps polling" + "perpetual 404 → timeout" blocks
+  // below, NOT here. Only the genuine terminals (410 expired / 409 already_claimed)
+  // remain in this table.
   for (const { code, body } of [
     { code: 410, body: { error: "session_expired", message: "Ask your agent to start again." } },
     { code: 409, body: { error: "already_claimed", message: "This session was already claimed." } },
-    { code: 404, body: { error: "not_found", message: "Session not found." } },
   ]) {
     it(`HTTP ${code} → stops polling, persists NO tokens, no timer remains`, async () => {
       const fx = installFetch(() => ({ status: code, body }));
@@ -289,6 +296,234 @@ describe("claim lifecycle — terminal status codes stop the loop", () => {
       expect(vi.getTimerCount()).toBe(0);
     });
   }
+});
+
+describe("claim lifecycle — a premature 404 KEEPS POLLING (the headline regression)", () => {
+  // `sil-register-stops-polling-on-premature-not-found`: the bug is that the
+  // FIRST poll tick fires (~3s) before the human has opened the auth URL, so the
+  // session row does not exist yet and the claim 404s — and the loop wrongly
+  // treats that 404 as terminal (`claimStep` → `done:true`, `handleDone` logs
+  // `sil_register_not_found`) and dies ~3s in, before the user could plausibly
+  // have acted. A 404 is the NORMAL early state; it must keep polling exactly
+  // like `pending`, bounded by the deadline.
+  //
+  // EXPECT RED against the current code (`identity.ts:312-315` groups `not_found`
+  // with the terminals): on the first 404 tick the loop SETTLES — the timer is
+  // gone, `sil_register_not_found` is logged, and the later success is never
+  // claimed, so `tokens.json` never appears and `sil_whoami` cannot resolve.
+
+  const SIL_API = "https://sil-api.test.example.com";
+  /** The agreed real identity-read body, in sil-api's UCP envelope `result`. */
+  const IDENTITY_ENVELOPE = {
+    protocol: "ucp",
+    version: "0.1",
+    domain: "identity",
+    result: {
+      name: "Polled User",
+      addresses: [{ line1: "1 Late Click Lane", city: "London", country: "GB" }],
+    },
+  };
+
+  it("does NOT settle on the FIRST 404 — the loop is still alive, nothing persisted, no terminal logged", async () => {
+    // Every tick 404s (the user has not acted). After the first tick, the loop
+    // must STILL be polling (a live timer remains) — the 404 is non-terminal.
+    const fx = installFetch(() => ({
+      status: 404,
+      body: { error: "not_found", message: "Session not found." },
+    }));
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+
+    await getTool(api, TOOL).execute("c1", {});
+    // Drive a couple of ticks (interval is 3s) — well short of the 30-min deadline.
+    await vi.advanceTimersByTimeAsync(8_000);
+
+    // The 404 ticks fired …
+    expect(fx.callCount()).toBeGreaterThanOrEqual(2);
+    // … but the loop did NOT settle: a live timer remains for the next tick.
+    expect(vi.getTimerCount()).toBeGreaterThan(0);
+    // Nothing persisted (no success yet) …
+    expect(readTokens()).toBeNull();
+    // … and crucially NO terminal `sil_register_not_found` was logged — a 404 is
+    // not a terminal anymore, so neither handleDone branch for it may fire.
+    const warnMarkers = (api.logger.warn as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => c[0],
+    );
+    const infoMarkers = (api.logger.info as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => c[0],
+    );
+    expect(warnMarkers).not.toContain("sil_register_not_found");
+    expect(infoMarkers).not.toContain("sil_register_not_found");
+  });
+
+  it("polls through early 404s, then a later 200 success persists credentials exactly once and sil_whoami resolves", async () => {
+    setApiUrl(SIL_API); // pin the identity-read origin for the whoami leg
+    let claimTicks = 0;
+    const fx = installFetch((url) => {
+      // The sil_whoami leg (real timers, after the claim settles) reads sil-api.
+      if (url.includes("/identity")) {
+        return { status: 200, body: IDENTITY_ENVELOPE };
+      }
+      // The claim leg: first two ticks 404 (user not acted), third tick succeeds.
+      claimTicks += 1;
+      if (claimTicks < 3) {
+        return { status: 404, body: { error: "not_found", message: "Session not found." } };
+      }
+      return { status: 200, body: SUCCESS_BODY };
+    });
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+
+    await getTool(api, TOOL).execute("c1", {});
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    // It kept polling through every early 404 (≥3 claim calls) and ultimately
+    // claimed the success — 404 behaves exactly like `pending`.
+    expect(claimTicks).toBeGreaterThanOrEqual(3);
+
+    // Exactly-once + no-leak on the fake clock, immediately after the claim tick.
+    const claimsAfterSuccess = claimTicks;
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(claimTicks).toBe(claimsAfterSuccess); // no further claim poll
+    expect(vi.getTimerCount()).toBe(0); // no leaked timer
+
+    // The un-awaited credential write lands on the real clock — drain it first.
+    await settleAsyncIo();
+    const tokens = await waitForTokens();
+    expect(tokens).not.toBeNull();
+    expect(tokens!.access_token).toBe("fresh-at");
+    expect(tokens!.refresh_token).toBe("fresh-rt");
+
+    // config.json was written exactly once with the claimed user.
+    const config = readJsonInDataDir<Record<string, unknown>>("config.json");
+    expect(JSON.stringify(config)).toContain("user-42");
+
+    // A subsequent sil_whoami resolves the identity (registration truly completed).
+    const whoamiPayload = payloadOf(await getTool(api, "sil_whoami").execute("w1", {}));
+    expect(whoamiPayload["status"]).toBe("ok");
+    const identity = whoamiPayload["identity"] as { name?: string } | undefined;
+    expect(identity?.name).toBe("Polled User");
+
+    // And the terminal `sil_register_not_found` was NEVER logged on the way there.
+    const infoMarkers = (api.logger.info as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => c[0],
+    );
+    const warnMarkers = (api.logger.warn as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => c[0],
+    );
+    expect(infoMarkers).not.toContain("sil_register_not_found");
+    expect(warnMarkers).not.toContain("sil_register_not_found");
+    // The success terminal IS logged (proves the loop reached success, not a stall).
+    expect(infoMarkers).toContain("sil_register_claimed");
+  });
+
+  it("treats 404 and pending as equivalently non-terminal — interleaved 404s and a pending still reach success", async () => {
+    // A mix proves the two early states are interchangeable: 404 (session not
+    // created yet) and pending (created, user mid-onboarding) both keep polling.
+    let n = 0;
+    const fx = installFetch(() => {
+      n += 1;
+      // tick1: 404, tick2: pending, tick3: 404, tick4: success.
+      if (n === 1) return { status: 404, body: { error: "not_found" } };
+      if (n === 2) return { status: 200, body: { status: "pending" } };
+      if (n === 3) return { status: 404, body: { error: "not_found" } };
+      return { status: 200, body: SUCCESS_BODY };
+    });
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+
+    await getTool(api, TOOL).execute("c1", {});
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    // Polled through all four pre-success ticks and persisted the credentials.
+    expect(fx.callCount()).toBeGreaterThanOrEqual(4);
+    await settleAsyncIo();
+    expect((await waitForTokens())!.access_token).toBe("fresh-at");
+  });
+});
+
+describe("claim lifecycle — claimStep maps a 404 not_found outcome to keep-polling (done:false)", () => {
+  // The single-tick mapping the card's `[unit]` criterion pins: claimStep against
+  // a `not_found` claim outcome returns `{ done: false }` (grouped with
+  // `pending`/`retryable`), NOT a `done:true` terminal. `claimStep` is module-
+  // private and must stay so (no production export added just for a test), so the
+  // mapping is exercised through its only real caller — the sil_register poll
+  // loop — by isolating a SINGLE 404 tick and asserting the loop kept going
+  // (the observable footprint of `done:false`).
+  //
+  // EXPECT RED: today `claimStep` returns `{ done:true, outcome:"not_found" }`,
+  // so a single 404 tick settles the loop (timer cleared, terminal logged).
+  it("a single 404 tick does not end the loop — done:false keeps the timer armed and logs no terminal", async () => {
+    let firstTickDone = false;
+    const fx = installFetch(() => {
+      // 404 on the first tick; if the loop (wrongly) keeps calling we keep 404ing,
+      // but we assert state right after the first tick has settled-or-not.
+      firstTickDone = true;
+      return { status: 404, body: { error: "not_found" } };
+    });
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+
+    await getTool(api, TOOL).execute("c1", {});
+    // Advance just past one interval so exactly the first tick has run.
+    await vi.advanceTimersByTimeAsync(3_500);
+
+    expect(firstTickDone).toBe(true);
+    expect(fx.callCount()).toBeGreaterThanOrEqual(1);
+    // done:false → the loop is still scheduled (a terminal would have cleared it).
+    expect(vi.getTimerCount()).toBeGreaterThan(0);
+    // No terminal was reported for the 404 (no persisted tokens, no terminal log).
+    expect(readTokens()).toBeNull();
+    const allMarkers = [
+      ...(api.logger.info as ReturnType<typeof vi.fn>).mock.calls,
+      ...(api.logger.warn as ReturnType<typeof vi.fn>).mock.calls,
+    ].map((c) => c[0]);
+    expect(allMarkers).not.toContain("sil_register_not_found");
+  });
+});
+
+describe("claim lifecycle — a session that NEVER appears (perpetual 404) ends as timeout", () => {
+  // The bound the card requires: keep-polling-on-404 must still terminate. If the
+  // user never opens the URL, every tick 404s and the loop settles as `timeout`
+  // at the 30-min deadline — logging `sil_register_timeout`, NEVER
+  // `sil_register_not_found` — persisting nothing and leaving no live timer.
+  // Mirrors the perpetual-`pending` → timeout test above.
+  //
+  // EXPECT RED: today the FIRST 404 settles the loop as a `not_found` terminal
+  // (logs `sil_register_not_found`), so the deadline/timeout path is never
+  // reached and `sil_register_timeout` is never logged.
+  it("404 on every tick → settles timeout at the deadline (logs sil_register_timeout, NOT sil_register_not_found), no tokens, no leaked timer", async () => {
+    const fx = installFetch(() => ({
+      status: 404,
+      body: { error: "not_found", message: "Session not found." },
+    }));
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+
+    await getTool(api, TOOL).execute("c1", {});
+    // Advance past the 30-min deadline (the session TTL the budget must not outlive).
+    await vi.advanceTimersByTimeAsync(45 * 60 * 1000);
+
+    const callsAtDeadline = fx.callCount();
+    // The clock keeps running; no further poll may fire — the loop is bounded.
+    await vi.advanceTimersByTimeAsync(30 * 60 * 1000);
+    expect(fx.callCount()).toBe(callsAtDeadline);
+
+    // No leftover timer after timeout, and nothing persisted (user never finished).
+    expect(vi.getTimerCount()).toBe(0);
+    expect(readTokens()).toBeNull();
+
+    // The terminal is TIMEOUT, not not_found.
+    const infoMarkers = (api.logger.info as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => c[0],
+    );
+    const warnMarkers = (api.logger.warn as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => c[0],
+    );
+    expect(infoMarkers).toContain("sil_register_timeout");
+    expect(infoMarkers).not.toContain("sil_register_not_found");
+    expect(warnMarkers).not.toContain("sil_register_not_found");
+  });
 });
 
 describe("claim lifecycle — transient failures retry within budget", () => {

--- a/src/lib/sil-client.ts
+++ b/src/lib/sil-client.ts
@@ -10,10 +10,17 @@
  *   POST /api/v1/sessions/{id}/claim   body { code_verifier }
  *     200 { access_token, refresh_token, user:{id} }  → success    (EXACTLY once)
  *     200 { status: "pending" }                       → pending
- *     409                                             → already_claimed
- *     410                                             → expired
+ *     409                                             → already_claimed (terminal)
+ *     410                                             → expired (terminal)
  *     404                                             → not_found (wrong verifier
- *                                                       ≡ unknown session, uniform)
+ *                                                       ≡ unknown session, uniform);
+ *                                                       the NORMAL pre-session early
+ *                                                       state — KEEP POLLING at the
+ *                                                       loop (non-terminal); only the
+ *                                                       deadline ends it (as timeout)
+ *     400 / other unexpected non-2xx                  → invalid_request (non-polling
+ *                                                       terminal — fail fast; a bad
+ *                                                       request can't be re-polled)
  *     5xx / network / abort                           → retryable
  *
  *   POST /api/v1/auth/refresh          body { refresh_token }
@@ -151,6 +158,7 @@ export type ClaimOutcome =
   | { kind: "already_claimed" }
   | { kind: "expired" }
   | { kind: "not_found" }
+  | { kind: "invalid_request" }
   | { kind: "retryable" };
 
 /** Outcome of a single refresh attempt. */
@@ -401,7 +409,16 @@ export type LookupOutcome =
  * Classify a claim response from its HTTP status AND body. The discriminant for
  * the two-200s split is the PRESENCE OF BOTH TOKENS in the body — never the
  * status code. A 200 that is not a complete token pair is `pending` (the safe
- * non-terminal landing); 409/410/404 are distinct terminals; 5xx is retryable.
+ * non-terminal landing). 409/410 are distinct terminals; 5xx is retryable.
+ *
+ * 404 is `not_found` ON THE WIRE — but it is the NORMAL pre-session early state
+ * (the session row is INSERTed server-side only when the user opens the auth
+ * URL), so its terminality lives at the LOOP, not here: `claimStep` keeps polling
+ * on `not_found` and only the 30-min deadline ends a never-appearing session (as
+ * `timeout`). A 400 / any other unexpected non-{200,409,410,404,5xx} status is a
+ * structurally-malformed request that re-polling can never fix, so it is its OWN
+ * non-polling terminal `invalid_request` (fail fast) rather than riding the
+ * keep-polling `not_found` path and spinning for the full deadline.
  *
  * Pure and exported — this is the highest-risk subtle branch, unit-tested in
  * isolation (sil-client.test.ts).
@@ -412,9 +429,11 @@ export function classifyClaimResponse(status: number, body: unknown): ClaimOutco
   if (status === 404) return { kind: "not_found" };
   if (status >= 500) return { kind: "retryable" };
   if (status !== 200) {
-    // 400 (malformed request) or any other unexpected 4xx: terminal not_found
-    // (re-polling can't fix a bad request); surface a re-run hint, not a spin.
-    return { kind: "not_found" };
+    // 400 (malformed request) or any other unexpected non-2xx: a NON-polling
+    // terminal — re-polling can't fix a structurally-bad request, so fail fast
+    // and loud rather than spinning to the deadline. Distinct from the early
+    // 404 `not_found`, which DOES keep polling.
+    return { kind: "invalid_request" };
   }
 
   // 200 — classify by body shape. Both tokens required for a clean success;

--- a/src/tools/identity.ts
+++ b/src/tools/identity.ts
@@ -19,9 +19,11 @@
  *   4. Start a fire-and-forget bounded poll of the claim endpoint, then return
  *      promptly with `{ status: "awaiting_browser", auth_url, session_id }`.
  *   5. On the poll's terminal success, persist tokens.json + config.json
- *      atomically. Other terminals (expired / already_claimed / not_found /
+ *      atomically. Other terminals (expired / already_claimed / invalid_request /
  *      timeout) persist nothing; the agent learns the outcome by re-calling
- *      sil_register (→ already_registered) or sil_whoami.
+ *      sil_register (→ already_registered) or sil_whoami. A claim 404 (`not_found`)
+ *      is NOT a terminal — it is the normal pre-session early state and keeps the
+ *      poll ticking; a session that never appears ends as `timeout` at the deadline.
  *
  * register() must stay synchronous and side-effect-free beyond registering the
  * tool — no fetch, no timer, no unawaited promise here. The poll timer is armed
@@ -286,11 +288,15 @@ interface ClaimStep extends Record<string, unknown> {
 
 /**
  * One poll step: claim, then map the outcome to the loop's done/continue signal.
- * `pending`/`retryable` keep the loop alive (`done:false`). A successful claim
- * is persisted HERE — tokens.json + config.json written atomically inside this
- * awaited tick — so the files are on disk before the loop settles; the step then
- * carries only the user_id forward (the tokens never travel past this closure).
- * Other terminals (expired / already_claimed / not_found) persist nothing.
+ * `pending`/`retryable`/`not_found` keep the loop alive (`done:false`). The 404
+ * `not_found` is the NORMAL pre-session early state (the session row is INSERTed
+ * server-side only when the user opens the auth URL), so it keeps polling exactly
+ * like `pending`, bounded by the 30-min deadline — a session that never appears
+ * settles as `timeout`, never as `not_found`. A successful claim is persisted
+ * HERE — tokens.json + config.json written atomically inside this awaited tick —
+ * so the files are on disk before the loop settles; the step then carries only
+ * the user_id forward (the tokens never travel past this closure). The terminals
+ * (expired / already_claimed / invalid_request) persist nothing.
  */
 async function claimStep(
   apiUrl: string,
@@ -301,6 +307,7 @@ async function claimStep(
   switch (outcome.kind) {
     case "pending":
     case "retryable":
+    case "not_found":
       return { done: false };
     case "success":
       await writeTokens({
@@ -311,7 +318,7 @@ async function claimStep(
       return { done: true, outcome: "success", user_id: outcome.user.id };
     case "expired":
     case "already_claimed":
-    case "not_found":
+    case "invalid_request":
       return { done: true, outcome: outcome.kind };
   }
 }
@@ -341,11 +348,14 @@ function handleDone(
     return;
   }
 
-  // expired / already_claimed / not_found — log the terminal so the outcome is
-  // never silent; the agent learns it on its next sil_register / sil_whoami.
+  // expired / already_claimed / invalid_request — log the terminal so the outcome
+  // is never silent; the agent learns it on its next sil_register / sil_whoami.
+  // `invalid_request` logs at WARN: a malformed claim request is unreachable from
+  // this client today, so it signals a contract-drift bug, not a user outcome —
+  // make it loud (the genuine `expired`/`already_claimed` are routine, at info).
   const outcome = typeof step.outcome === "string" ? step.outcome : "unknown";
   const marker = `sil_register_${outcome}`;
-  if (outcome === "not_found") {
+  if (outcome === "invalid_request") {
     api.logger.warn(marker, { session_id: sessionId });
   } else {
     api.logger.info(marker, { session_id: sessionId });


### PR DESCRIPTION
## The bug

`sil_register`'s background claim-poll treated a claim **404 (`not_found`) as terminal**, so the loop died ~3s in — on the very first poll tick, **before** the human had opened the auth URL. The pending session row is INSERTed server-side only when the user opens the URL, so the first poll always 404s in the normal interactive flow; the loop then settled (logging `sil_register_not_found`), the user signed into a session no poller was watching, `tokens.json` was never written, and `sil_whoami` returned null. This broke the primary registration path.

## The fix (plugin-side poll classification; 2 files, poller untouched)

- **`src/tools/identity.ts` — `claimStep`:** `not_found` moves from the terminal group into the keep-polling group with `pending`/`retryable` (`done:false`). A 404 is the normal pre-session early state and now keeps polling, exactly like `pending`.
- **`src/lib/sil-client.ts` — `classifyClaimResponse`:** the 404 → `not_found` wire mapping is **unchanged** (404 genuinely *is* `not_found` on the wire — the classifier stays pure). What changes is the `400 / other-unexpected-non-2xx` fallthrough, which moves out of `not_found` into a **new non-polling terminal `{ kind: "invalid_request" }`** — a structurally-malformed request can never be fixed by re-polling, so it fails fast rather than spinning to a misleading 30-min `timeout`. Added the `invalid_request` variant to the `ClaimOutcome` union; `claimStep` handles it as a `done:true` terminal, `handleDone` logs it at `warn` (it signals contract drift, unreachable from this client today).
- **No backwards-compat shim:** the old terminal `not_found` branch (and its `handleDone` `warn`) are deleted outright, not gated.
- Stale doc comments that called `not_found` a terminal were updated across both files.

## The deadline-backstop invariant (why keep-polling-on-404 is safe)

`src/lib/poller.ts` is **deliberately untouched**. Its bounded loop + 30-min `POLL_DEADLINE_MS` are the safety net: perpetual `{ done: false }` still settles as `{ timedOut: true, outcome: "timeout" }` at the deadline, leaving `vi.getTimerCount() === 0`. A session that never appears terminates as `timeout`, never `not_found` — and it can never loop forever. The new terminal is wired with confidence because the `switch (outcome.kind)` over `ClaimOutcome` has no `default`, so `tsc` exhaustiveness forces `invalid_request` to be handled (a missed case fails the build).

## Test plan

- [x] `[integration]` early-404-then-success — the headline regression: first ticks 404, a later tick 200-succeeds; the loop did NOT settle on the first 404, kept polling, persisted `tokens.json`/`config.json` exactly once, and a subsequent `sil_whoami` resolves the identity (no `sil_register_not_found` logged on the way).
- [x] `[integration]` terminal-table flip — the 404 row moved OUT of "terminal status codes stop the loop" (409/410 retained); first-404-does-not-settle (live timer remains) is its own block.
- [x] `[integration]` perpetual-404 → timeout — 404 every tick settles `timeout` at the deadline (logs `sil_register_timeout`, NOT `sil_register_not_found`), no tokens, no leaked timer, no poll after the deadline.
- [x] `[integration]` 404/pending interleaved still reach success (the two early states are equivalently non-terminal).
- [x] `[unit]` classifier 400-split — `classifyClaimResponse(400, …) → invalid_request` (and any other unexpected non-{200,409,410,404,5xx} status); 404 stays `not_found`; the two are distinct kinds. The unreachable 400 is NOT integration-tested (it can't be elicited from the real client).
- [x] `pnpm typecheck` clean · `pnpm test` **455 passed (455)** · `pnpm build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)