### PR TITLE
bug: name the source in catalog error surfacing

### DIFF
--- a/src/__tests__/catalog-lookup.integration.test.ts
+++ b/src/__tests__/catalog-lookup.integration.test.ts
@@ -1015,6 +1015,324 @@ describe("sil_product_get — the failure outcomes surface as distinguishable er
   });
 });
 
+/**
+ * CARD `name-the-source-in-catalog-error-surfacing` (epic
+ * `catalog-source-error-taxonomy-2026-06`) — the RED integration ceiling, SYMMETRIC
+ * with the sil_search block in `catalog-search.integration.test.ts`. The two catalog
+ * tools share ONE agent-facing error vocabulary, so outcomes a/b/c (and the 429
+ * sub-case) MUST read identically through `sil_product_get` — or the agent learns
+ * two error languages for the same failure (architect Risk "lookup vs search
+ * divergence"). Same root cause: the source-failure body is discarded at
+ * `classifyLookupResponse` (sil-client.ts:574) before `transient()` (catalog.ts:725)
+ * runs. Same mock boundary (`installRouter` → `fetch`); nothing asserts a stub.
+ *
+ *   (a) sil/network down → retryable, GENERIC copy, NO source name, NO sil_register.
+ *   (b) a named SOURCE down/rate-limited → retryable, NAMES the source, NEVER
+ *       "sil is unavailable", NO sil_register.
+ *   (c) upstream REJECTED → NON-retryable invalid_request carrying the real upstream
+ *       cause, NO retry hint, NO sil_register.
+ *
+ * EXPECT RED today for outcome (b) (the source is discarded → generic copy); the (a)
+ * assertions and regression guards already pass (they pin the invariants the rework
+ * must not break).
+ */
+describe("sil_product_get — outcome a: sil/network down → GENERIC retryable, names NO source, no sil_register", () => {
+  it("5xx with NO source on the body → generic 'sil is temporarily unavailable', NO source name, NO sil_register", async () => {
+    seedTokens("at", "rt");
+    installRouter((kind) =>
+      kind === "lookup"
+        ? { status: 500, body: { error: "internal_error", message: "Something went wrong inside sil." } }
+        : { status: 200, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] }));
+
+    expect(payload["status"]).toBe("retryable");
+    const message = String(payload["message"]);
+    expect(message.toLowerCase()).toMatch(/sil is (temporarily )?unavailable|try .*again/);
+    expect(payload["recovery"]).not.toBe("sil_register");
+    expect(JSON.stringify(payload).toLowerCase()).not.toMatch(/sil_register/);
+  });
+
+  it("network throw → generic retryable, NO source name, no sil_register, EXACTLY one round-trip (no retry storm)", async () => {
+    seedTokens("at", "rt");
+    const rec = installRouter((kind) => (kind === "lookup" ? "network-error" : { status: 200, body: {} }));
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] }));
+
+    expect(rec.lookup.length).toBe(1);
+    expect(rec.refresh.length).toBe(0);
+    expect(payload["status"]).toBe("retryable");
+    expect(payload["recovery"]).not.toBe("sil_register");
+    const message = String(payload["message"]).toLowerCase();
+    expect(message).toMatch(/sil is (temporarily )?unavailable|try .*again/);
+    for (const src of ["shopify", "etsy", "global-catalog"]) {
+      expect(message).not.toContain(src);
+    }
+  });
+});
+
+describe("sil_product_get — outcome b: a named source down/rate-limited → source-named retryable, NEVER 'sil is unavailable'", () => {
+  it("5xx source_unavailable WITH a `source` → retryable whose message NAMES the source and NEVER says 'sil is unavailable'", async () => {
+    seedTokens("at", "rt");
+    installRouter((kind) =>
+      kind === "lookup"
+        ? {
+            status: 500,
+            body: {
+              error: "source_unavailable",
+              message: "Catalog source 'shopify' is temporarily unavailable.",
+              source: "shopify",
+            },
+          }
+        : { status: 200, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] }));
+
+    expect(payload["status"]).toBe("retryable");
+    const message = String(payload["message"]);
+    expect(message).toContain("shopify");
+    expect(message.toLowerCase()).not.toMatch(/sil is (temporarily )?unavailable/);
+    expect(message.toLowerCase()).not.toMatch(/sil is down/);
+    expect(payload["recovery"]).not.toBe("sil_register");
+    expect(JSON.stringify(payload).toLowerCase()).not.toMatch(/sil_register/);
+  });
+
+  it("rate-limited source (upstream 429 → source_unavailable 5xx) WITH a `source` → outcome b: retryable, names the source, never 'sil is down', never non-retryable", async () => {
+    seedTokens("at", "rt");
+    installRouter((kind) =>
+      kind === "lookup"
+        ? {
+            status: 503,
+            body: {
+              error: "source_unavailable",
+              message: "Catalog source 'global-catalog' is rate-limited; retry shortly.",
+              source: "global-catalog",
+            },
+          }
+        : { status: 200, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] }));
+
+    expect(payload["status"]).toBe("retryable");
+    expect(payload["status"]).not.toBe("invalid_request");
+    const message = String(payload["message"]);
+    expect(message).toContain("global-catalog");
+    expect(message.toLowerCase()).not.toMatch(/sil is (temporarily )?unavailable|sil is down/);
+    expect(payload["recovery"]).not.toBe("sil_register");
+  });
+
+  it("outcome b carries NO recovery:sil_register hint (a degraded source is not an auth problem)", async () => {
+    seedTokens("at", "rt");
+    installRouter((kind) =>
+      kind === "lookup"
+        ? {
+            status: 500,
+            body: { error: "source_unavailable", message: "Source 'etsy' is unavailable.", source: "etsy" },
+          }
+        : { status: 200, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] }));
+
+    expect(payload["status"]).toBe("retryable");
+    expect(payload["recovery"]).not.toBe("sil_register");
+    expect(JSON.stringify(payload).toLowerCase()).not.toMatch(/sil_register/);
+  });
+});
+
+describe("sil_product_get — outcome c: upstream rejected the request → NON-retryable invalid_request carrying the real cause", () => {
+  it("4xx source_rejected → invalid_request carrying the upstream { error, message }, NO retry hint, NO sil_register", async () => {
+    // Outcome c for lookup carries the upstream cause VERBATIM — and must NOT be
+    // replaced by extractApiError's generic default (which, note, is the
+    // search-specific "Provide a search query …" copy reused on the lookup 400-path;
+    // see the architect's flagged-out-of-scope note). The contract: a deterministic
+    // rejection is non-retryable and surfaces the real reason.
+    seedTokens("at", "rt");
+    installRouter((kind) =>
+      kind === "lookup"
+        ? {
+            status: 400,
+            body: {
+              error: "source_rejected",
+              message: "Source 'shopify' rejected the request: identifier scheme not supported.",
+            },
+          }
+        : { status: 200, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] }));
+
+    expect(payload["status"]).toBe("invalid_request");
+    expect(payload["status"]).not.toBe("retryable");
+    expect(payload["error"]).toBe("source_rejected");
+    const message = String(payload["message"]);
+    expect(message).toContain("identifier scheme not supported");
+    // NOT the search-specific generic default.
+    expect(message).not.toMatch(/Provide a search query or at least one filter/i);
+    expect(payload["recovery"]).not.toBe("sil_register");
+    expect(JSON.stringify(payload).toLowerCase()).not.toMatch(/sil_register/);
+  });
+
+  it("outcome c is NON-retryable AND carries no sil_register — distinct from both retryable arms (a/b)", async () => {
+    seedTokens("at", "rt");
+    installRouter((kind) =>
+      kind === "lookup"
+        ? { status: 400, body: { error: "source_rejected", message: "Deterministic rejection from the source." } }
+        : { status: 200, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] }));
+
+    expect(payload["status"]).toBe("invalid_request");
+    expect(payload["status"]).not.toBe("retryable");
+    expect(payload["recovery"]).not.toBe("sil_register");
+  });
+});
+
+describe("sil_product_get — DISTINGUISHABILITY: six failure/success cases are pairwise distinct agent envelopes (highest-value)", () => {
+  it("{a-5xx, a-network, b-source, b-429, c-reject, all-missed-200} produce pairwise-distinguishable envelopes", async () => {
+    // The per-tool half of the load-bearing distinguishability property. The lookup
+    // SUCCESS analogue of search's empty match is the ALL-MISSED 200 (products [] +
+    // not_found): a success the agent does not retry. No two of a/b/c/ok collapse.
+    async function envelopeFor(reply: Reply): Promise<Record<string, unknown>> {
+      seedTokens("at", "rt");
+      installRouter((kind) => (kind === "lookup" ? reply : { status: 200, body: {} }));
+      const api = createMockPluginApi();
+      registerCatalogTools(api);
+      const p = payloadOf(await getTool(api, TOOL).execute("c1", { ids: ["x"] }));
+      vi.restoreAllMocks();
+      return p;
+    }
+
+    const aGeneric = await envelopeFor({ status: 500, body: { error: "internal_error", message: "internal" } });
+    const aNetwork = await (async () => {
+      seedTokens("at", "rt");
+      installRouter((kind) => (kind === "lookup" ? "network-error" : { status: 200, body: {} }));
+      const api = createMockPluginApi();
+      registerCatalogTools(api);
+      const p = payloadOf(await getTool(api, TOOL).execute("c1", { ids: ["x"] }));
+      vi.restoreAllMocks();
+      return p;
+    })();
+    const bSource = await envelopeFor({
+      status: 500,
+      body: { error: "source_unavailable", message: "Source 'shopify' is unavailable.", source: "shopify" },
+    });
+    const b429 = await envelopeFor({
+      status: 503,
+      body: { error: "source_unavailable", message: "Source 'global-catalog' rate-limited.", source: "global-catalog" },
+    });
+    const cReject = await envelopeFor({
+      status: 400,
+      body: { error: "source_rejected", message: "The request was rejected: identifier scheme not supported." },
+    });
+    const allMissed = await envelopeFor({
+      status: 200,
+      body: lookupEnvelope([], [notFoundMsg("x")]),
+    });
+
+    expect(cReject["status"]).toBe("invalid_request");
+    expect(allMissed["status"]).toBe("ok");
+    expect(allMissed["products"]).toEqual([]);
+    expect(allMissed["not_found"]).toEqual(["x"]);
+
+    expect(aGeneric["status"]).toBe("retryable");
+    expect(aNetwork["status"]).toBe("retryable");
+    expect(bSource["status"]).toBe("retryable");
+    expect(b429["status"]).toBe("retryable");
+
+    function namesSource(p: Record<string, unknown>): boolean {
+      const m = String(p["message"] ?? "").toLowerCase();
+      return ["shopify", "etsy", "global-catalog"].some((s) => m.includes(s));
+    }
+    expect(namesSource(aGeneric)).toBe(false);
+    expect(namesSource(aNetwork)).toBe(false);
+    expect(namesSource(bSource)).toBe(true);
+    expect(namesSource(b429)).toBe(true);
+
+    const fingerprint = (p: Record<string, unknown>): string =>
+      `${String(p["status"])}::${namesSource(p) ? "named" : "generic"}`;
+    expect(
+      new Set([
+        fingerprint(aGeneric),
+        fingerprint(bSource),
+        fingerprint(cReject),
+        fingerprint(allMissed),
+      ]).size,
+    ).toBe(4);
+    expect(fingerprint(aGeneric)).toBe(fingerprint(aNetwork));
+    expect(fingerprint(bSource)).toBe(fingerprint(b429));
+  });
+});
+
+describe("sil_product_get — regression guards: the a/b/c rework must NOT move the all-missed or the recovered-401 path", () => {
+  it("all-missed (200, products [] + not_found) stays status ok — never a/b/c", async () => {
+    seedTokens("at", "rt");
+    installRouter((kind) =>
+      kind === "lookup"
+        ? { status: 200, body: lookupEnvelope([], [notFoundMsg("gone-1"), notFoundMsg("gone-2")]) }
+        : { status: 500, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { ids: ["gone-1", "gone-2"] }));
+
+    expect(payload["status"]).toBe("ok");
+    expect(payload["products"]).toEqual([]);
+    expect(payload["not_found"]).toEqual(["gone-1", "gone-2"]);
+    for (const bad of ["retryable", "invalid_request", "must_reregister", "not_registered"]) {
+      expect(payload["status"]).not.toBe(bad);
+    }
+    expect(payload["recovery"]).toBeUndefined();
+  });
+
+  it("recovered 401 (refresh-and-retry-once succeeds) stays invisible — normal ok, NO refreshed/recovery field, NO a/b/c", async () => {
+    seedTokens("expired-at", "valid-rt");
+    const rec = installRouter((kind, nth) => {
+      if (kind === "lookup") {
+        return nth === 0
+          ? { status: 401, body: { error: "unauthorized" } }
+          : { status: 200, body: lookupEnvelope([PRODUCT_A]) };
+      }
+      if (kind === "refresh") {
+        return { status: 200, body: { access_token: "rotated-at", refresh_token: "rotated-rt" } };
+      }
+      return { status: 500, body: {} };
+    });
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] }));
+
+    expect(payload["status"]).toBe("ok");
+    expect((payload["products"] as unknown[]).length).toBe(1);
+    expect(payload["refreshed"]).toBeUndefined();
+    expect(payload["recovery"]).toBeUndefined();
+    expect(payload["source"]).toBeUndefined();
+    expect(payload["detail"]).toBeUndefined();
+    expect(rec.lookup.length).toBe(2);
+    expect(rec.refresh.length).toBe(1);
+  });
+});
+
 describe("sil_product_get — not registered (no tokens.json) makes ZERO network calls", () => {
   it("returns a terminal not_registered hint (recovery sil_register) and never touches fetch", async () => {
     // No tokens seeded. A not-registered lookup has nothing to authenticate with, so

--- a/src/__tests__/catalog-search.integration.test.ts
+++ b/src/__tests__/catalog-search.integration.test.ts
@@ -1171,6 +1171,369 @@ describe("sil_search — the three distinct sil-api outcomes surface as three di
   });
 });
 
+/**
+ * CARD `name-the-source-in-catalog-error-surfacing` (epic
+ * `catalog-source-error-taxonomy-2026-06`) — the RED integration ceiling.
+ *
+ * The product promise: THREE causally-distinct failures become THREE
+ * distinguishable agent envelopes (the legibility contract — card "Behavioral
+ * framing"). Today all three collapse into the single generic retryable
+ * "sil is temporarily unavailable" copy because the source-failure body is
+ * discarded at the wire classifier (`classifySearchResponse` sil-client.ts:530),
+ * one step before `transient()` (catalog.ts:725) runs.
+ *
+ *   (a) sil / network / transport down → status retryable, GENERIC "sil is
+ *       temporarily unavailable", NO source name, NO sil_register hint.
+ *   (b) a specific catalog SOURCE down or rate-limited (429-as-source_unavailable)
+ *       → status retryable, the message NAMES the source, NEVER "sil is …
+ *       unavailable", NO sil_register.
+ *   (c) upstream REJECTED the request (a deterministic 4xx, e.g. source_rejected)
+ *       → NON-retryable invalid_request carrying the REAL upstream { error, message }
+ *       (not extractApiError's search-specific default), NO retry hint, NO sil_register.
+ *
+ * These assert on the agent-observable ENVELOPE (status + message CONTENT), which
+ * is where the distinguishability lives and which `tsc` cannot verify (architect
+ * Risk "message-content regression is invisible to type-checking"). The ONLY mock
+ * is `fetch` (`installRouter`) — the full real tool + sil-client pipeline runs; per
+ * `complete-work-is-stub-free`, nothing asserts a stub response.
+ *
+ * EXPECT RED today: outcome (b)'s message is the generic copy (source discarded),
+ * and outcome (c) arrives as a 5xx-shaped retryable until the classifier carries
+ * the source and the sibling ships the 4xx. The (a) assertions and the regression
+ * guards already pass — they pin the invariants the a/b/c rework must NOT break.
+ */
+describe("sil_search — outcome a: sil/network down → GENERIC retryable, names NO source, no sil_register", () => {
+  it("5xx with NO source on the body → generic 'sil is temporarily unavailable', NO source name, NO sil_register", async () => {
+    // A sil-INTERNAL 5xx (no source on the failure body) is outcome a — the agent
+    // retries the same call; the copy must stay generic and must NOT fabricate a
+    // source name it was never handed (attribution honesty).
+    seedTokens("at", "rt");
+    installRouter((kind) =>
+      kind === "search"
+        ? { status: 500, body: { error: "internal_error", message: "Something went wrong inside sil." } }
+        : { status: 200, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { query: "chair" }));
+
+    expect(payload["status"]).toBe("retryable");
+    const message = String(payload["message"]);
+    // The GENERIC sil-unavailable copy (this is what outcome a SHOULD say).
+    expect(message.toLowerCase()).toMatch(/sil is (temporarily )?unavailable|try .*again/);
+    // No re-register hint — re-registering fixes neither a 5xx nor anything else here.
+    expect(payload["recovery"]).not.toBe("sil_register");
+    expect(JSON.stringify(payload).toLowerCase()).not.toMatch(/sil_register/);
+  });
+
+  it("network throw → generic retryable, NO source name, no sil_register, EXACTLY one round-trip (no retry storm)", async () => {
+    // A thrown fetch (timeout / abort / DNS hang / connection refused) is outcome a.
+    // The no-source half of the no-fabrication guard at the wire boundary: the
+    // catch returns a bare sourceless retryable, so the agent gets the generic copy.
+    seedTokens("at", "rt");
+    const rec = installRouter((kind) => (kind === "search" ? "network-error" : { status: 200, body: {} }));
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { query: "chair" }));
+
+    // Exactly ONE round-trip — a thrown fetch must not spin an internal retry storm.
+    expect(rec.search.length).toBe(1);
+    expect(rec.refresh.length).toBe(0); // a first-call network blip is not a 401
+    expect(payload["status"]).toBe("retryable");
+    expect(payload["recovery"]).not.toBe("sil_register");
+    // The generic copy — and it must NOT name any of the canary sources.
+    const message = String(payload["message"]).toLowerCase();
+    expect(message).toMatch(/sil is (temporarily )?unavailable|try .*again/);
+    for (const src of ["shopify", "etsy", "global-catalog"]) {
+      expect(message).not.toContain(src);
+    }
+  });
+});
+
+describe("sil_search — outcome b: a named source down/rate-limited → source-named retryable, NEVER 'sil is unavailable'", () => {
+  it("5xx source_unavailable WITH a `source` → retryable whose message NAMES the source and NEVER says 'sil is unavailable'", async () => {
+    // The headline product behavior: a SOURCE outage is reported as THAT source
+    // being degraded, not as sil being down. The agent (and the user reading its
+    // words) must not conclude the whole platform is unavailable when one source is.
+    seedTokens("at", "rt");
+    installRouter((kind) =>
+      kind === "search"
+        ? {
+            status: 500,
+            body: {
+              error: "source_unavailable",
+              message: "Catalog source 'shopify' is temporarily unavailable.",
+              source: "shopify",
+            },
+          }
+        : { status: 200, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { query: "chair" }));
+
+    expect(payload["status"]).toBe("retryable");
+    const message = String(payload["message"]);
+    // NAMES the source.
+    expect(message).toContain("shopify");
+    // NEVER the generic "sil is (temporarily) unavailable" / "sil is down" copy —
+    // this is the masking the card exists to remove.
+    expect(message.toLowerCase()).not.toMatch(/sil is (temporarily )?unavailable/);
+    expect(message.toLowerCase()).not.toMatch(/sil is down/);
+    // Still retryable, still NOT a re-register (the source is transiently degraded;
+    // auth is fine).
+    expect(payload["recovery"]).not.toBe("sil_register");
+    expect(JSON.stringify(payload).toLowerCase()).not.toMatch(/sil_register/);
+  });
+
+  it("rate-limited source (upstream 429 → source_unavailable 5xx) WITH a `source` → outcome b: retryable, names the source, never 'sil is down', never non-retryable", async () => {
+    // 429 is the canonical trap: it is transient pressure, NOT a malformed request,
+    // so it MUST stay retryable (outcome b) and name the source — never get swept
+    // into the non-retryable c arm with the other 4xx, never read as "sil is down".
+    seedTokens("at", "rt");
+    installRouter((kind) =>
+      kind === "search"
+        ? {
+            status: 503,
+            body: {
+              error: "source_unavailable",
+              message: "Catalog source 'global-catalog' is rate-limited; retry shortly.",
+              source: "global-catalog",
+            },
+          }
+        : { status: 200, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { query: "chair" }));
+
+    expect(payload["status"]).toBe("retryable"); // transient, never invalid_request
+    expect(payload["status"]).not.toBe("invalid_request");
+    const message = String(payload["message"]);
+    expect(message).toContain("global-catalog");
+    expect(message.toLowerCase()).not.toMatch(/sil is (temporarily )?unavailable|sil is down/);
+    expect(payload["recovery"]).not.toBe("sil_register");
+  });
+
+  it("outcome b carries NO recovery:sil_register hint (a degraded source is not an auth problem)", async () => {
+    seedTokens("at", "rt");
+    installRouter((kind) =>
+      kind === "search"
+        ? {
+            status: 500,
+            body: { error: "source_unavailable", message: "Source 'etsy' is unavailable.", source: "etsy" },
+          }
+        : { status: 200, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { query: "chair" }));
+
+    expect(payload["status"]).toBe("retryable");
+    expect(payload["recovery"]).not.toBe("sil_register");
+    expect(JSON.stringify(payload).toLowerCase()).not.toMatch(/sil_register/);
+  });
+});
+
+describe("sil_search — outcome c: upstream rejected the request → NON-retryable invalid_request carrying the real cause", () => {
+  it("4xx source_rejected → invalid_request carrying the upstream { error, message }, NO retry hint, NO sil_register", async () => {
+    // A deterministic upstream rejection (a malformed filter the source refuses) is
+    // outcome c — the agent must STOP and fix the request, never loop it. It is the
+    // hard pivot: non-retryable, carrying the server's real cause so the agent can
+    // act on it. The upstream message must be CARRIED THROUGH, not replaced by
+    // extractApiError's search-specific default ("Provide a search query …").
+    seedTokens("at", "rt");
+    installRouter((kind) =>
+      kind === "search"
+        ? {
+            status: 400,
+            body: {
+              error: "source_rejected",
+              message: "Source 'shopify' rejected the request: filter `ships_from` is not supported.",
+            },
+          }
+        : { status: 200, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { query: "chair" }));
+
+    // NON-retryable — the agent must not retry a deterministic rejection.
+    expect(payload["status"]).toBe("invalid_request");
+    expect(payload["status"]).not.toBe("retryable");
+    // Carries the REAL upstream cause (error code + the server's message verbatim),
+    // NOT the search-specific generic default from extractApiError.
+    expect(payload["error"]).toBe("source_rejected");
+    const message = String(payload["message"]);
+    expect(message).toContain("ships_from");
+    expect(message).not.toMatch(/Provide a search query or at least one filter/i);
+    // No retry hint, no re-register — stop and fix the request.
+    expect(payload["recovery"]).not.toBe("sil_register");
+    expect(JSON.stringify(payload).toLowerCase()).not.toMatch(/sil_register/);
+  });
+
+  it("outcome c is NON-retryable AND carries no sil_register — distinct from both retryable arms (a/b)", async () => {
+    seedTokens("at", "rt");
+    installRouter((kind) =>
+      kind === "search"
+        ? { status: 400, body: { error: "source_rejected", message: "Deterministic rejection from the source." } }
+        : { status: 200, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { query: "chair" }));
+
+    expect(payload["status"]).toBe("invalid_request");
+    expect(payload["status"]).not.toBe("retryable");
+    expect(payload["recovery"]).not.toBe("sil_register");
+  });
+});
+
+describe("sil_search — DISTINGUISHABILITY: six failure/success cases are pairwise distinct agent envelopes (highest-value)", () => {
+  it("{a-5xx, a-network, b-source, b-429, c-reject, empty-200} produce pairwise-distinguishable envelopes", async () => {
+    // The single highest-value assertion (extends the existing 'three distinct
+    // status strings' test at :1137 into the full a/b split + 429 + c). Drives all
+    // six through the real wiring and proves no two collapse into the same
+    // agent-observable signal:
+    //   - a and b SHARE status "retryable" but DIFFER on whether `message` names a source;
+    //   - c is the only "invalid_request";
+    //   - the empty match is the only "ok" (with products []).
+    async function envelopeFor(reply: Reply): Promise<Record<string, unknown>> {
+      seedTokens("at", "rt");
+      installRouter((kind) => (kind === "search" ? reply : { status: 200, body: {} }));
+      const api = createMockPluginApi();
+      registerCatalogTools(api);
+      const p = payloadOf(await getTool(api, TOOL).execute("c1", { query: "x" }));
+      vi.restoreAllMocks();
+      return p;
+    }
+
+    const aGeneric = await envelopeFor({ status: 500, body: { error: "internal_error", message: "internal" } });
+    const aNetwork = await (async () => {
+      seedTokens("at", "rt");
+      installRouter((kind) => (kind === "search" ? "network-error" : { status: 200, body: {} }));
+      const api = createMockPluginApi();
+      registerCatalogTools(api);
+      const p = payloadOf(await getTool(api, TOOL).execute("c1", { query: "x" }));
+      vi.restoreAllMocks();
+      return p;
+    })();
+    const bSource = await envelopeFor({
+      status: 500,
+      body: { error: "source_unavailable", message: "Source 'shopify' is unavailable.", source: "shopify" },
+    });
+    const b429 = await envelopeFor({
+      status: 503,
+      body: { error: "source_unavailable", message: "Source 'global-catalog' rate-limited.", source: "global-catalog" },
+    });
+    const cReject = await envelopeFor({
+      status: 400,
+      body: { error: "source_rejected", message: "The request was rejected: filter `ships_from` is not supported." },
+    });
+    const emptyMatch = await envelopeFor({ status: 200, body: searchEnvelope([]) });
+
+    // c is the lone non-retryable error; the empty match is the lone success.
+    expect(cReject["status"]).toBe("invalid_request");
+    expect(emptyMatch["status"]).toBe("ok");
+    expect(emptyMatch["products"]).toEqual([]);
+
+    // a and b are BOTH retryable …
+    expect(aGeneric["status"]).toBe("retryable");
+    expect(aNetwork["status"]).toBe("retryable");
+    expect(bSource["status"]).toBe("retryable");
+    expect(b429["status"]).toBe("retryable");
+
+    // … but distinguishable by message attribution: a is generic-sourceless, b names
+    // a source. A reducible "fingerprint" per envelope: status + whether it names a
+    // source. The set of fingerprints across the six must be the full {a,b,c,ok}.
+    function namesSource(p: Record<string, unknown>): boolean {
+      const m = String(p["message"] ?? "").toLowerCase();
+      return ["shopify", "etsy", "global-catalog"].some((s) => m.includes(s));
+    }
+    expect(namesSource(aGeneric)).toBe(false);
+    expect(namesSource(aNetwork)).toBe(false);
+    expect(namesSource(bSource)).toBe(true);
+    expect(namesSource(b429)).toBe(true);
+
+    const fingerprint = (p: Record<string, unknown>): string =>
+      `${String(p["status"])}::${namesSource(p) ? "named" : "generic"}`;
+    // a → retryable::generic ; b → retryable::named ; c → invalid_request::generic ;
+    // ok → ok::generic. Four distinct fingerprints — no two of a/b/c/ok collapse.
+    expect(
+      new Set([
+        fingerprint(aGeneric),
+        fingerprint(bSource),
+        fingerprint(cReject),
+        fingerprint(emptyMatch),
+      ]).size,
+    ).toBe(4);
+    // And the two a-variants share a fingerprint with each other (both generic
+    // retryable) — they are the SAME signal, correctly.
+    expect(fingerprint(aGeneric)).toBe(fingerprint(aNetwork));
+    expect(fingerprint(bSource)).toBe(fingerprint(b429));
+  });
+});
+
+describe("sil_search — regression guards: the a/b/c rework must NOT move the empty-match or the recovered-401 path", () => {
+  it("empty match (200, products []) stays status ok — never a/b/c", async () => {
+    seedTokens("at", "rt");
+    installRouter((kind) =>
+      kind === "search" ? { status: 200, body: searchEnvelope([]) } : { status: 500, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { query: "nope-xyzzy" }));
+
+    expect(payload["status"]).toBe("ok");
+    expect(payload["products"]).toEqual([]);
+    // Not any error arm.
+    for (const bad of ["retryable", "invalid_request", "must_reregister", "not_registered"]) {
+      expect(payload["status"]).not.toBe(bad);
+    }
+    expect(payload["recovery"]).toBeUndefined();
+  });
+
+  it("recovered 401 (refresh-and-retry-once succeeds) stays invisible — normal ok, NO refreshed/recovery field, NO a/b/c", async () => {
+    // The orthogonal 401 path must not move. A recovered 401 is a normal success
+    // with no a/b/c envelope and no refreshed/recovery field leaking to the agent.
+    seedTokens("expired-at", "valid-rt");
+    const rec = installRouter((kind, nth) => {
+      if (kind === "search") {
+        return nth === 0
+          ? { status: 401, body: { error: "unauthorized" } }
+          : { status: 200, body: searchEnvelope([PRODUCT_A]) };
+      }
+      if (kind === "refresh") {
+        return { status: 200, body: { access_token: "rotated-at", refresh_token: "rotated-rt" } };
+      }
+      return { status: 500, body: {} };
+    });
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { query: "chair" }));
+
+    expect(payload["status"]).toBe("ok");
+    expect((payload["products"] as unknown[]).length).toBe(1);
+    // No a/b/c error envelope leaked, no payload refreshed/recovery field.
+    expect(payload["refreshed"]).toBeUndefined();
+    expect(payload["recovery"]).toBeUndefined();
+    expect(payload["source"]).toBeUndefined();
+    expect(payload["detail"]).toBeUndefined();
+    // The choreography is unchanged: one refresh + one retry.
+    expect(rec.search.length).toBe(2);
+    expect(rec.refresh.length).toBe(1);
+  });
+});
+
 describe("sil_search — 401 → transparent refresh-and-retry-once (outcome 1: the agent never sees the 401)", () => {
   it("401 → refresh once via sil-web → rotate tokens.json → retry the search once with the NEW token → normal ranked result", async () => {
     // AC[integration]: outcome 1 — a registered agent whose access token is

--- a/src/__tests__/lib/lookup-classify.test.ts
+++ b/src/__tests__/lib/lookup-classify.test.ts
@@ -256,6 +256,123 @@ describe("classifyLookupResponse — the four distinct outcomes stay distinct", 
   });
 });
 
+/**
+ * CARD `name-the-source-in-catalog-error-surfacing` (epic
+ * `catalog-source-error-taxonomy-2026-06`) — the RED unit floor, SYMMETRIC with
+ * `search-classify.test.ts`. The two catalog tools share ONE agent-facing error
+ * vocabulary, so the `retryable`-carries-source contract MUST hold identically on
+ * `classifyLookupResponse` / `LookupOutcome` — or the agent learns two error
+ * languages for the same failure.
+ *
+ * THE BUG (same as search): `classifyLookupResponse` collapses every 5xx /
+ * non-{200,400,401} into a bodyless `{ kind: "retryable" }`, discarding the
+ * `source` a `source_unavailable` 5xx body carries. The fix WIDENS the variant to
+ * `{ kind: "retryable"; source?: string; detail?: string }` (NOT replaced — every
+ * existing `.kind === "retryable"` assertion above stays valid) and populates it
+ * ONLY when the body carries a real `source`. Same no-fabrication guard.
+ *
+ * SCOPE NOTE — pure over `(status, body)`; the network-throw "no source" half lives
+ * at the integration tier (`catalog-lookup.integration.test.ts`), since
+ * `lookupCatalog`'s `catch` returns a bare sourceless `{ kind: "retryable" }`.
+ */
+describe("classifyLookupResponse — a source-attributed 5xx SURFACES its source on the retryable outcome (outcome b)", () => {
+  it("500 source_unavailable WITH a `source` → retryable carrying that source (and a detail)", () => {
+    const out = classifyLookupResponse(500, {
+      error: "source_unavailable",
+      message: "Catalog source 'shopify' is temporarily unavailable.",
+      source: "shopify",
+    });
+    expect(out.kind).toBe("retryable");
+    if (out.kind === "retryable") {
+      expect(out.source).toBe("shopify");
+      expect(typeof out.detail).toBe("string");
+      expect((out.detail as string).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("a 502/503/504 source_unavailable WITH a `source` ALSO surfaces it (not just 500)", () => {
+    for (const code of [502, 503, 504]) {
+      const out = classifyLookupResponse(code, {
+        error: "source_unavailable",
+        message: "Catalog source 'etsy' is temporarily unavailable.",
+        source: "etsy",
+      });
+      expect(out.kind).toBe("retryable");
+      if (out.kind === "retryable") {
+        expect(out.source).toBe("etsy");
+      }
+    }
+  });
+
+  it("the upstream 429-as-source_unavailable (a rate-limited source, surfaced as 5xx) ALSO carries its source (outcome b/429)", () => {
+    const out = classifyLookupResponse(503, {
+      error: "source_unavailable",
+      message: "Catalog source 'global-catalog' is rate-limited; retry shortly.",
+      source: "global-catalog",
+    });
+    expect(out.kind).toBe("retryable");
+    if (out.kind === "retryable") {
+      expect(out.source).toBe("global-catalog");
+    }
+  });
+});
+
+describe("classifyLookupResponse — the no-fabrication guard: a sourceless retryable NEVER invents a source (outcome a)", () => {
+  it("500 WITH NO `source` field → bare retryable, NO source (a sil-internal failure is outcome a, not b)", () => {
+    const out = classifyLookupResponse(500, {
+      error: "internal_error",
+      message: "Something went wrong inside sil.",
+    });
+    expect(out.kind).toBe("retryable");
+    if (out.kind === "retryable") {
+      expect(out.source).toBeUndefined();
+    }
+  });
+
+  it("500 with a garbage / non-object body → bare retryable, NO source", () => {
+    for (const body of [null, "boom", 42, [], {}]) {
+      const out = classifyLookupResponse(500, body);
+      expect(out.kind).toBe("retryable");
+      if (out.kind === "retryable") {
+        expect(out.source).toBeUndefined();
+      }
+    }
+  });
+
+  it("500 whose `source` is present but NOT a non-empty string → NO source (never coerce a bad field)", () => {
+    for (const source of [null, 123, "", {}, []]) {
+      const out = classifyLookupResponse(500, {
+        error: "source_unavailable",
+        message: "A catalog source is unavailable.",
+        source,
+      });
+      expect(out.kind).toBe("retryable");
+      if (out.kind === "retryable") {
+        expect(out.source).toBeUndefined();
+      }
+    }
+  });
+
+  it("an unmapped non-200 (e.g. 502 with an empty body) → bare retryable, NO source", () => {
+    const out = classifyLookupResponse(502, {});
+    expect(out.kind).toBe("retryable");
+    if (out.kind === "retryable") {
+      expect(out.source).toBeUndefined();
+    }
+  });
+
+  it("NEVER scrapes a source out of the human `message` string — a source named only in prose stays unsurfaced", () => {
+    const out = classifyLookupResponse(500, {
+      error: "source_unavailable",
+      message: "Catalog source 'shopify' is temporarily unavailable.",
+    });
+    expect(out.kind).toBe("retryable");
+    if (out.kind === "retryable") {
+      expect(out.source).toBeUndefined();
+    }
+  });
+});
+
 describe("classifyLookupResponse — unfound ids are a SUCCESS surfaced as not_found, never an error", () => {
   it("a mix of found + unfound → ok with the found products AND not_found:[the unfound ids]", () => {
     // UCP §Identifiers Not Found: return success with the found products plus info

--- a/src/__tests__/lib/search-classify.test.ts
+++ b/src/__tests__/lib/search-classify.test.ts
@@ -226,6 +226,156 @@ describe("classifySearchResponse — the three distinct sil-api outcomes stay di
   });
 });
 
+/**
+ * CARD `name-the-source-in-catalog-error-surfacing` (epic
+ * `catalog-source-error-taxonomy-2026-06`) — the RED unit floor.
+ *
+ * THE BUG this pins: `classifySearchResponse` collapses every 5xx / non-{200,400,401}
+ * into a BODYLESS `{ kind: "retryable" }`, discarding the `{ error, message, source }`
+ * a `source_unavailable` 5xx body carries. So `transient()` downstream
+ * (catalog.ts:725) can never name the failed source — three causally-distinct
+ * failures read as one generic "sil is temporarily unavailable" envelope.
+ *
+ * The fix WIDENS the `retryable` variant (it is NOT replaced — every existing
+ * `.kind === "retryable"` assertion above stays valid) to:
+ *     { kind: "retryable"; source?: string; detail?: string }
+ * and populates `source`/`detail` in the classifier ONLY when the 5xx body carries
+ * a real `source` field. This block is the immutable spec for that shape and for
+ * the no-fabrication guard (architect Risk "regenerating the masking in reverse").
+ *
+ * SCOPE NOTE — this classifier is pure over `(status, body)`; it NEVER sees a raw
+ * network throw (that is `searchCatalog`'s `catch`, which returns a bare
+ * `{ kind: "retryable" }` literal — structurally sourceless). So the "network throw
+ * → no source" half of the card's no-fabrication guard is asserted at the
+ * integration tier (the network-throw case in catalog-search.integration.test.ts);
+ * here we pin the bodyless / garbage / no-`source` 5xx cases the classifier owns.
+ */
+describe("classifySearchResponse — a source-attributed 5xx SURFACES its source on the retryable outcome (outcome b)", () => {
+  it("500 source_unavailable WITH a `source` → retryable carrying that source (and a detail)", () => {
+    // The structured contract outcome (b) consumes: sil-api's source-down 5xx body
+    // (`source_unavailable`) carries which catalog/product source failed. The
+    // classifier MUST surface it so `transient()` can NAME the source instead of
+    // emitting the generic "sil is down". RED today: the classifier returns a bare
+    // `{ kind: "retryable" }` and throws the `source` away.
+    const out = classifySearchResponse(500, {
+      error: "source_unavailable",
+      message: "Catalog source 'shopify' is temporarily unavailable.",
+      source: "shopify",
+    });
+    expect(out.kind).toBe("retryable");
+    if (out.kind === "retryable") {
+      expect(out.source).toBe("shopify");
+      // `detail` carries the upstream cause (error/message) so the consumer has
+      // something concrete to relay; its exact composition is the dev's to shape,
+      // but it MUST be a non-empty string that surfaces the failure.
+      expect(typeof out.detail).toBe("string");
+      expect((out.detail as string).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("a 502/503/504 source_unavailable WITH a `source` ALSO surfaces it (not just 500)", () => {
+    // sil-api may surface an upstream outage as any 5xx; the source-carry must not
+    // be hardcoded to 500. Each of these, when the body names a source, surfaces it.
+    for (const code of [502, 503, 504]) {
+      const out = classifySearchResponse(code, {
+        error: "source_unavailable",
+        message: "Catalog source 'etsy' is temporarily unavailable.",
+        source: "etsy",
+      });
+      expect(out.kind).toBe("retryable");
+      if (out.kind === "retryable") {
+        expect(out.source).toBe("etsy");
+      }
+    }
+  });
+
+  it("the upstream 429-as-source_unavailable (a rate-limited source, surfaced as 5xx) ALSO carries its source (outcome b/429)", () => {
+    // The sibling classifies an upstream HTTP 429 as `source_unavailable` (a 5xx) so
+    // a throttle stays RETRYABLE (a 429 reaching the plugin AS a 4xx would route to
+    // the non-retryable invalid_request arm — wrong for a transient throttle). When
+    // it carries a source, the classifier surfaces it exactly like any source outage.
+    const out = classifySearchResponse(503, {
+      error: "source_unavailable",
+      message: "Catalog source 'global-catalog' is rate-limited; retry shortly.",
+      source: "global-catalog",
+    });
+    expect(out.kind).toBe("retryable");
+    if (out.kind === "retryable") {
+      expect(out.source).toBe("global-catalog");
+    }
+  });
+});
+
+describe("classifySearchResponse — the no-fabrication guard: a sourceless retryable NEVER invents a source (outcome a)", () => {
+  it("500 WITH NO `source` field → bare retryable, NO source (a sil-internal failure is outcome a, not b)", () => {
+    // A sil-internal 5xx (the source-failure body is NOT present) must stay the
+    // GENERIC retryable — attaching a source here would mis-name a source on a
+    // sil-down event, re-introducing wrong attribution in the OPPOSITE direction
+    // (architect Risk). The populate gates on the PRESENCE of a real `source`.
+    const out = classifySearchResponse(500, {
+      error: "internal_error",
+      message: "Something went wrong inside sil.",
+    });
+    expect(out.kind).toBe("retryable");
+    if (out.kind === "retryable") {
+      expect(out.source).toBeUndefined();
+    }
+  });
+
+  it("500 with a garbage / non-object body → bare retryable, NO source", () => {
+    // A malformed 5xx body (no parseable `source`) can never name a source. Each of
+    // these falls back to outcome a — generic retryable, source undefined.
+    for (const body of [null, "boom", 42, [], {}]) {
+      const out = classifySearchResponse(500, body);
+      expect(out.kind).toBe("retryable");
+      if (out.kind === "retryable") {
+        expect(out.source).toBeUndefined();
+      }
+    }
+  });
+
+  it("500 whose `source` is present but NOT a non-empty string → NO source (never coerce a bad field)", () => {
+    // The source field must be a real, non-empty string. A null/number/empty/object
+    // `source` is not a usable identifier — the classifier must NOT surface it (and
+    // must not stringify a non-string). Degrade to outcome a, not a fabricated name.
+    for (const source of [null, 123, "", {}, []]) {
+      const out = classifySearchResponse(500, {
+        error: "source_unavailable",
+        message: "A catalog source is unavailable.",
+        source,
+      });
+      expect(out.kind).toBe("retryable");
+      if (out.kind === "retryable") {
+        expect(out.source).toBeUndefined();
+      }
+    }
+  });
+
+  it("an unmapped non-200 (e.g. 502 with an empty body) → bare retryable, NO source", () => {
+    // The generic transport-failure landing: a 5xx with no body at all is outcome a.
+    const out = classifySearchResponse(502, {});
+    expect(out.kind).toBe("retryable");
+    if (out.kind === "retryable") {
+      expect(out.source).toBeUndefined();
+    }
+  });
+
+  it("NEVER scrapes a source out of the human `message` string — a source named only in prose stays unsurfaced", () => {
+    // The architect ruled out string-scraping the message ("catalog source 'X' is
+    // unavailable"): it is brittle and couples the plugin to sil-api's wording. The
+    // source MUST arrive as the structured `source` field. A body that names a
+    // source ONLY inside `message` (no `source` key) is outcome a — no source.
+    const out = classifySearchResponse(500, {
+      error: "source_unavailable",
+      message: "Catalog source 'shopify' is temporarily unavailable.",
+    });
+    expect(out.kind).toBe("retryable");
+    if (out.kind === "retryable") {
+      expect(out.source).toBeUndefined();
+    }
+  });
+});
+
 describe("classifySearchResponse — empty match is SUCCESS, not error", () => {
   it("200 { ucp, products: [] } → ok with an EMPTY products list and NO cursor", () => {
     // UCP: an empty search returns an empty array — "this is not an error". The

--- a/src/lib/sil-client.ts
+++ b/src/lib/sil-client.ts
@@ -311,12 +311,22 @@ export interface SearchResult {
  * refresh trigger — the caller routes it through {@link refreshAndRetryOnce}
  * (transparent refresh-and-retry-once), the SAME choreography `sil_whoami` uses;
  * it is no longer terminal for the catalog tools.
+ *
+ * The `retryable` variant optionally carries `source`/`detail`: a 5xx whose body
+ * is a `source_unavailable` SourceError names which catalog source failed, so the
+ * consumer (`transient()` in catalog.ts) can distinguish a *source* outage (name
+ * it — outcome b) from sil/network itself being down (generic copy — outcome a).
+ * Both are retryable — the only difference is attribution; this is a *message*
+ * split within one status, not a new outcome kind. `source` is attached ONLY when
+ * the body carries a real non-empty `source` field (never fabricated, never
+ * scraped from `message`); a sil-internal 5xx, a bodyless/garbage non-200, and a
+ * network-error throw all stay bare `{ kind: "retryable" }` (outcome a).
  */
 export type SearchOutcome =
   | { kind: "ok"; products: SearchProduct[]; cursor?: string }
   | { kind: "unauthorized" }
   | { kind: "invalid_request"; error: string; message: string }
-  | { kind: "retryable" };
+  | { kind: "retryable"; source?: string; detail?: string };
 
 /** Which request id resolved to a looked-up variant, and how. Lookup's defining
  * feature over search: the response does NOT preserve request order and one id
@@ -403,7 +413,7 @@ export type LookupOutcome =
   | { kind: "ok"; products: LookupProduct[]; not_found?: string[] }
   | { kind: "unauthorized" }
   | { kind: "invalid_request"; error: string; message: string }
-  | { kind: "retryable" };
+  | { kind: "retryable"; source?: string; detail?: string };
 
 /**
  * Classify a claim response from its HTTP status AND body. The discriminant for
@@ -527,7 +537,7 @@ export function classifySearchResponse(status: number, body: unknown): SearchOut
     return { kind: "invalid_request", error, message };
   }
   if (status === 401) return { kind: "unauthorized" };
-  if (status !== 200) return { kind: "retryable" };
+  if (status !== 200) return retryableFromBody(body);
 
   const result = extractSearchResult(body);
   if (result === null) return { kind: "retryable" };
@@ -571,7 +581,7 @@ export function classifyLookupResponse(status: number, body: unknown): LookupOut
     return { kind: "invalid_request", error, message };
   }
   if (status === 401) return { kind: "unauthorized" };
-  if (status !== 200) return { kind: "retryable" };
+  if (status !== 200) return retryableFromBody(body);
 
   const result = extractLookupResult(body);
   if (result === null) return { kind: "retryable" };
@@ -1280,6 +1290,42 @@ function extractCursor(raw: unknown): string | null {
   if (obj["has_next_page"] !== true) return null;
   const cursor = obj["cursor"];
   return typeof cursor === "string" && cursor.length > 0 ? cursor : null;
+}
+
+/**
+ * Build the `retryable` outcome for a non-200, non-{400,401} response, attaching
+ * the failed catalog `source` (+ a `detail` carrying the upstream cause) ONLY when
+ * the 5xx body is a real `source_unavailable` SourceError that names a source.
+ *
+ * This is the seam where outcome (a) (sil/network down → bare retryable, generic
+ * copy) and outcome (b) (a named source down → source-named retryable) become
+ * distinguishable — see {@link SearchOutcome}. The gate is the PRESENCE of a real
+ * non-empty-string `source` field on the body, NEVER the `message` prose: a
+ * sil-internal 5xx (no `source`), a bodyless/garbage non-200, or a `source` that is
+ * null/number/empty/object/array all fall back to the bare sourceless retryable.
+ * Attaching a source to a non-source 5xx would re-introduce wrong attribution in
+ * the opposite direction (a sil-down event falsely named as a source outage), so
+ * the populate must never fabricate or coerce.
+ *
+ * `detail` is the upstream cause the consumer can relay — the body's `message`
+ * when present, else its `error` code. It is only set alongside a real `source`
+ * (an outcome-a retryable carries neither field).
+ */
+function retryableFromBody(body: unknown): { kind: "retryable"; source?: string; detail?: string } {
+  const obj = asRecord(body);
+  const source = obj?.["source"];
+  if (typeof source !== "string" || source.length === 0) {
+    return { kind: "retryable" };
+  }
+  const message = obj?.["message"];
+  const error = obj?.["error"];
+  const detail =
+    typeof message === "string" && message.length > 0
+      ? message
+      : typeof error === "string" && error.length > 0
+        ? error
+        : source;
+  return { kind: "retryable", source, detail };
 }
 
 /** Pull sil-api's structured `{ error, message }` out of a 400 body, defaulting

--- a/src/tools/catalog.ts
+++ b/src/tools/catalog.ts
@@ -310,8 +310,11 @@ function mapSearchOutcome(api: PluginAPI, outcome: SearchOutcome) {
       api.logger.info("sil_search_invalid_request", { error: outcome.error });
       return invalidRequest(outcome.error, outcome.message);
     case "retryable":
-      api.logger.info("sil_search_retryable", {});
-      return transient("sil_search");
+      // A source-attributed 5xx names the failed source (outcome b); a sil/network
+      // blip carries no source and stays the generic copy (outcome a). The log marker
+      // records the source when present so a flaky source is visible to operators.
+      api.logger.info("sil_search_retryable", outcome.source ? { source: outcome.source } : {});
+      return transient("sil_search", outcome.source, outcome.detail);
     case "unauthorized":
       return mustReregister("sil_search");
   }
@@ -446,8 +449,13 @@ function mapLookupOutcome(api: PluginAPI, outcome: LookupOutcome) {
       api.logger.info("sil_product_get_invalid_request", { error: outcome.error });
       return invalidRequest(outcome.error, outcome.message);
     case "retryable":
-      api.logger.info("sil_product_get_retryable", {});
-      return transient("sil_product_get");
+      // Symmetric with sil_search: a source-attributed 5xx names the source (outcome
+      // b); a sil/network blip is the generic copy (outcome a). One error vocabulary.
+      api.logger.info(
+        "sil_product_get_retryable",
+        outcome.source ? { source: outcome.source } : {},
+      );
+      return transient("sil_product_get", outcome.source, outcome.detail);
     case "unauthorized":
       return mustReregister("sil_product_get");
   }
@@ -719,12 +727,40 @@ function mustReregister(tool: string) {
   });
 }
 
-/** Transient: a network/5xx blip — try again, NOT a re-register (a false terminal
- * on a transient would send the agent down a recovery path that can't fix it).
- * The `tool` name keeps the retry guidance actionable; the taxonomy is shared. */
-function transient(tool: string) {
+/** Transient: a retryable blip — try again, NOT a re-register (a false terminal on
+ * a transient would send the agent down a recovery path that can't fix it). The two
+ * causally-distinct transient failures share `status: "retryable"` (both succeed on
+ * backoff) but split on ATTRIBUTION, which is the whole point of this card:
+ *
+ *   - `source` ABSENT (outcome a) — sil itself / the network / transport is down,
+ *     OR a refresh-leg blip. The agent retries the same call; the copy stays the
+ *     GENERIC "sil is temporarily unavailable" and names no source it cannot
+ *     identify (attribution honesty).
+ *   - `source` PRESENT (outcome b) — a specific catalog source is down or
+ *     rate-limited. The copy NAMES that source and must NEVER say "sil is …
+ *     unavailable" / "sil is down": sil is healthy, one source is degraded, often
+ *     for seconds, and mis-attributing it to sil makes the agent abandon a working
+ *     platform. `detail` (the upstream cause) is relayed when present.
+ *
+ * The source is named ONLY when the wire actually carried it (the classifier gates
+ * on a real `source` field — see `retryableFromBody` in sil-client). The named-source
+ * copy is SELF-AUTHORED around the source token rather than echoing the raw upstream
+ * `detail` prose verbatim — the upstream wording is sil-api's to change and could
+ * itself contain "sil is …" phrasing that would muddy the attribution; `detail` is
+ * surfaced as a separate, clearly-delimited field instead. The `tool` name keeps the
+ * retry guidance actionable; the status taxonomy is shared. */
+function transient(tool: string, source?: string, detail?: string) {
+  if (source === undefined) {
+    return jsonResult({
+      status: "retryable",
+      message: `sil is temporarily unavailable. Please try ${tool} again.`,
+    });
+  }
   return jsonResult({
     status: "retryable",
-    message: `sil is temporarily unavailable. Please try ${tool} again.`,
+    message:
+      `The catalog source "${source}" is temporarily unavailable.`
+      + ` sil itself is fine — retry ${tool} shortly.`,
+    ...(detail !== undefined ? { detail } : {}),
   });
 }


### PR DESCRIPTION
## Card
`cards/name-the-source-in-catalog-error-surfacing.md` (lives in the `card/name-the-source-in-catalog-error-surfacing` branch — see the body for the full intent + handoffs). Epic `catalog-source-error-taxonomy-2026-06`.

## Problem
When a catalog source rejects a request or is down, `sil_search` / `sil_product_get` told the agent `{ status: "retryable", message: "sil is temporarily unavailable…" }` for **three causally-distinct failures at once**. The agent mis-attributed a single-source outage to the whole platform (and abandoned a healthy sil), and retried deterministic rejections that can never succeed.

## The three-signal taxonomy this restores
| # | Cause | Agent envelope |
|---|---|---|
| **a** | sil / network / transport down (incl. a refresh-leg blip) | `retryable`, **generic** "sil is temporarily unavailable" — names no source |
| **b** | a specific catalog **source** down or rate-limited (incl. upstream 429-as-`source_unavailable`) | `retryable`, message **NAMES the source**, never "sil is unavailable" |
| **c** | upstream **rejected** the request (deterministic 4xx, e.g. `source_rejected`) | **non-retryable** `invalid_request` carrying the real upstream `{ error, message }` |

a and b share `status: "retryable"` (both succeed on backoff) and split only on attribution; c is the hard pivot to non-retryable. The 429 sub-case is **b, not c** — transient pressure, not a malformed request.

## The two-file fix
The masking originated one layer **upstream** of the founder's hypothesis — at the wire classifier, which discarded the source-failure body before `transient()` ever ran.

- **`src/lib/sil-client.ts`** — widen the `retryable` arm of `SearchOutcome` + `LookupOutcome` to `{ kind: "retryable"; source?: string; detail?: string }`. New `retryableFromBody()` helper attaches `source` (+ `detail`) on the non-200 branch **only when the body carries a real non-empty-string `source` field** — never fabricated, never scraped from the `message` prose. A sil-internal 5xx, a bodyless/garbage non-200, and the network-error throw all stay bare (outcome a). This is where a and b become distinguishable.
- **`src/tools/catalog.ts`** — `transient()` takes the source signal and branches: a named source → source-named retryable that never says "sil is unavailable" (b); no source → the generic copy (a). Threaded through `mapSearchOutcome` / `mapLookupOutcome`. **The two refresh-leg `retryable` sites stay GENERIC** (a refresh blip is sil/network, outcome a — pass no source).

Outcome **c** needed **no new logic** — the existing 400-arm + `invalidRequest()` already route a 4xx to non-retryable `invalid_request`. `search` and `lookup` are kept symmetric; `refreshAndRetryOnce` is untouched.

## Test plan
- [x] `pnpm typecheck` — clean (the widened union typechecks across all consumers)
- [x] Four touched suites (`search-classify`, `lookup-classify`, `catalog-search.integration`, `catalog-lookup.integration`): **166 pass** (12 formerly-RED now green, 154 unchanged green)
- [x] `pnpm build` — clean compile to `dist/`
- [x] Full suite: 481 pass; the only 10 failures are the pre-existing `repo-scaffold.integration.test.ts` worktree-environment artifact (gitignored `docs/`/`CLAUDE.md` not checked out into the worktree), proven independent of this change and out of scope for this card.

## Ships independently
This is the **plugin half**. It ships now and degrades gracefully (b → a) until the sibling lands. Outcome **(c)'s end-to-end green** and **(b)'s *reliable* source-naming** additionally depend on the sibling card `classify-catalog-source-errors` shipping (c) the rejection as a **4xx** with a real `{ error, message }`, and (b) the **`source` field on the 5xx body** (`replySourceError` currently drops it — flagged in the card's Signals to orchestrator). The integration tests mock those wire shapes to prove the routes now.

## Distillation target
Knowledge capture happens **after Review PASS** in the `distilling` stage — `solutions-architect` runs in this same worktree, commits to this same branch, and pushes here so the PR ends up containing implementation + tests + distillation in one mergeable unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)