### PR TITLE
feature: replace ships_from with local_merchants in sil_search

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Namespaced `sil_*` so they never collide with other plugins. Your agent calls th
 
 | Tool | What it does |
 |---|---|
-| `sil_search` | Search for purchasable products. A free-text `query` plus optional filters: `category`, `price_min`/`price_max`, `ship_to` (delivery destination — leave empty to ship to your registered address), `ships_from` (merchant origin country), `condition` (`new` / `secondhand`), and `available`. Returns a ranked list of variants — each with `id`, `title`, `price`, `availability`, `checkout_url`, `source` — and a pagination `cursor`. Location filters take ISO codes (`US`, `CA`), not place names. |
+| `sil_search` | Search for purchasable products. A free-text `query` plus optional filters: `category`, `price_min`/`price_max`, `ship_to` (delivery destination — leave empty to ship to your registered address), `condition` (`new` / `secondhand`), `available`, and `local_merchants` (best-effort bias toward shops in the user's own country — pair with a same-language query). Returns a ranked list of variants — each with `id`, `title`, `price`, `availability`, `checkout_url`, `source` — and a pagination `cursor`. Location filters take ISO codes (`US`, `CA`), not place names. |
 | `sil_product_get` | Resolve `ids` you already hold to full products in UCP shape — description, options, and the featured purchasable variant with fresh `price`, `availability`, and `checkout_url`. Re-fetch right before buying; those values are point-in-time, not guarantees. Ids that no longer resolve come back in `not_found`. |
 
 ---

--- a/src/__tests__/catalog-search.integration.test.ts
+++ b/src/__tests__/catalog-search.integration.test.ts
@@ -412,14 +412,18 @@ describe("sil_search — param → request mapping (bare path, sil-api origin, B
 
 /**
  * Card `add-ship-to-filter-args-to-the-sil-search-tool` (epic
- * `location-aware-search-2026-06`): the wired tool forwards four new optional
+ * `location-aware-search-2026-06`): the wired tool forwards the new optional
  * serviceability/localization args end-to-end — agent arg → wire key — with the
  * `ship_to` → `filters.ships_to` rename, omit-when-absent, and no client-injected
  * defaults. These assert the full round-trip through the REAL tool + sil-client,
  * capturing the request body the tool sends to sil-api (the only mock is fetch).
+ *
+ * Card `replace-ships-from-with-local-merchants` deleted `ships_from`, so it is no
+ * longer among the forwarded filters here; its end-to-end absence (even for a stray
+ * arg) and the `local_merchants` top-level forward are in their own blocks below.
  */
-describe("sil_search — the four new filter args forward end-to-end (agent arg → wire key)", () => {
-  it("all four supplied (with query) → captured body carries filters.ships_to / ships_from / condition / available, the rename applied", async () => {
+describe("sil_search — the new filter args forward end-to-end (agent arg → wire key)", () => {
+  it("all supplied (with query) → captured body carries filters.ships_to / condition / available, the rename applied", async () => {
     seedTokens("at", "rt");
     const rec = installRouter((kind) =>
       kind === "search"
@@ -432,7 +436,6 @@ describe("sil_search — the four new filter args forward end-to-end (agent arg 
     await getTool(api, TOOL).execute("c1", {
       query: "office chair",
       ship_to: { country: "US", region: "NY", postal_code: "10001" },
-      ships_from: { country: "US" },
       condition: ["new"],
       available: false,
     });
@@ -440,11 +443,11 @@ describe("sil_search — the four new filter args forward end-to-end (agent arg 
     expect(rec.search.length).toBe(1);
     const body = rec.search[0]!.body as Record<string, unknown>;
     // The whole filters block, exact — proves the agent arg `ship_to` lands on the
-    // wire as the plural `ships_to` (rename), the other three keep their name, and
+    // wire as the plural `ships_to` (rename), the others keep their name, and
     // available:false survives the full pipeline (read-site narrow → buildSearchBody).
+    // No `ships_from` — it was deleted end-to-end.
     expect(body["filters"]).toEqual({
       ships_to: { country: "US", region: "NY", postal_code: "10001" },
-      ships_from: { country: "US" },
       condition: ["new"],
       available: false,
     });
@@ -490,6 +493,198 @@ describe("sil_search — the four new filter args forward end-to-end (agent arg 
       categories: ["Furniture"],
       ships_to: { country: "DE" },
     });
+  });
+});
+
+/**
+ * Card `replace-ships-from-with-local-merchants` (epic `local-merchants-2026-06`):
+ * `local_merchants: true` forwards END-TO-END through the real wired tool + sil-client
+ * as a TOP-LEVEL request field (sibling of `query`/`filters`/`pagination`), never
+ * under `filters`, and the plugin attaches NO country and performs NO identity read
+ * to do it (AC[integration]). The only mock is `fetch` (installRouter) — the full
+ * pipeline runs.
+ */
+describe("sil_search — local_merchants forwards end-to-end TOP-LEVEL, with no country and no identity round-trip", () => {
+  it("local_merchants:true (with query) → captured body carries top-level local_merchants:true; filters has none", async () => {
+    seedTokens("at", "rt");
+    const rec = installRouter((kind) =>
+      kind === "search"
+        ? { status: 200, body: searchEnvelope([PRODUCT_A]) }
+        : { status: 500, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", { query: "καρέκλα", local_merchants: true }),
+    );
+
+    expect(rec.search.length).toBe(1);
+    const body = rec.search[0]!.body as Record<string, unknown>;
+    // Top-level home AND filters-absence asserted together (the anti-false-green pair).
+    expect(body["local_merchants"]).toBe(true);
+    const filters = (body["filters"] ?? {}) as Record<string, unknown>;
+    expect(filters).not.toHaveProperty("local_merchants");
+    expect(payload["status"]).toBe("ok");
+  });
+
+  it("local_merchants:true attaches NO country anywhere on the request and triggers NO identity / sil_whoami round-trip", async () => {
+    // The whole point of a server-resolved boolean (Discovery fact c): the plugin
+    // must NOT fetch or pass a country to honor the flag. Proof: the ONLY outbound
+    // call is the single /catalog/search; there is no identity read, and the request
+    // body/URL carry no country field attributable to the flag.
+    seedTokens("at", "rt");
+    const rec = installRouter((kind) =>
+      kind === "search"
+        ? { status: 200, body: searchEnvelope([PRODUCT_A]) }
+        : { status: 500, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    await getTool(api, TOOL).execute("c1", { query: "shoes", local_merchants: true });
+
+    // Exactly ONE outbound request — the search. No second (identity) round-trip.
+    expect(rec.all.length).toBe(1);
+    expect(rec.search.length).toBe(1);
+    // No identity endpoint was hit on account of the flag.
+    const hitWhoami = rec.all.some((r) => /whoami|\/identity|\/me\b|\/auth\/me/i.test(r.url));
+    expect(hitWhoami).toBe(false);
+    // The flag injected NO country anywhere — not as a top-level key, not in filters.
+    const body = rec.search[0]!.body as Record<string, unknown>;
+    expect(body).not.toHaveProperty("country");
+    const filters = (body["filters"] ?? {}) as Record<string, unknown>;
+    expect(filters).not.toHaveProperty("country");
+    // The only flag-attributable addition is the boolean itself.
+    expect(body["local_merchants"]).toBe(true);
+  });
+
+  it("local_merchants:false (with query) → NO local_merchants key on the wire end-to-end (omit-when-falsy)", async () => {
+    seedTokens("at", "rt");
+    const rec = installRouter((kind) =>
+      kind === "search"
+        ? { status: 200, body: searchEnvelope([PRODUCT_A]) }
+        : { status: 500, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    await getTool(api, TOOL).execute("c1", { query: "chair", local_merchants: false });
+
+    const body = rec.search[0]!.body as Record<string, unknown>;
+    expect(body).not.toHaveProperty("local_merchants");
+    expect(body).toEqual({ query: "chair" });
+  });
+
+  it("a wrong-TYPE local_merchants (string) is DROPPED end-to-end — narrowed out before the wire, never coerced to true", async () => {
+    seedTokens("at", "rt");
+    const rec = installRouter((kind) =>
+      kind === "search"
+        ? { status: 200, body: searchEnvelope([PRODUCT_A]) }
+        : { status: 500, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    await getTool(api, TOOL).execute("c1", { query: "chair", local_merchants: "true" });
+
+    const body = rec.search[0]!.body as Record<string, unknown>;
+    expect(body).not.toHaveProperty("local_merchants");
+    expect(body).toEqual({ query: "chair" });
+  });
+});
+
+/**
+ * Card `replace-ships-from-with-local-merchants`: a stray `ships_from` argument is
+ * NOT forwarded anywhere in the body end-to-end (the deleted lever is closed against
+ * at the schema/narrowing, so it never reaches sil-api or the Global Catalog).
+ */
+describe("sil_search — a stray ships_from argument never reaches the wire end-to-end", () => {
+  it("a `ships_from` arg alongside a real query → absent from the forwarded body (not top-level, not filters)", async () => {
+    seedTokens("at", "rt");
+    const rec = installRouter((kind) =>
+      kind === "search"
+        ? { status: 200, body: searchEnvelope([PRODUCT_A]) }
+        : { status: 500, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    await getTool(api, TOOL).execute("c1", { query: "chair", ships_from: { country: "US" } });
+
+    const body = rec.search[0]!.body as Record<string, unknown>;
+    expect(body).not.toHaveProperty("ships_from");
+    const filters = (body["filters"] ?? {}) as Record<string, unknown>;
+    expect(filters).not.toHaveProperty("ships_from");
+    expect(JSON.stringify(body)).not.toContain("ships_from");
+    // The stray arg changed nothing — byte-exactly today's bare-query body.
+    expect(body).toEqual({ query: "chair" });
+  });
+});
+
+/**
+ * Card `replace-ships-from-with-local-merchants` (AC[integration], best-effort
+ * semantics): the bias is ENTIRELY sil-api's. When `local_merchants: true` is
+ * forwarded and sil-api returns a ranked list, the plugin shapes the result WITHOUT
+ * adding any client-side "is local" tag/flag and WITHOUT re-ranking or dropping any
+ * result to enforce locality (LEAN search contract — present the server's order).
+ * A false "all local" guarantee at the surface is exactly the failure that killed
+ * ships_from; the plugin must not manufacture one.
+ */
+describe("sil_search — result-shaping adds NO client-side locality tag and does NOT re-rank/drop for locality", () => {
+  it("with local_merchants:true, the shaped products are the server's order verbatim — no locality tag, none dropped, none reordered", async () => {
+    seedTokens("at", "rt");
+    // The server returns A then B (its ranking). The plugin must present A then B —
+    // it must not reorder to "promote locals", nor drop B for being non-local.
+    installRouter((kind) =>
+      kind === "search"
+        ? { status: 200, body: searchEnvelope([PRODUCT_A, PRODUCT_B]) }
+        : { status: 500, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", { query: "chair", local_merchants: true }),
+    );
+
+    expect(payload["status"]).toBe("ok");
+    const products = payload["products"] as Array<Record<string, unknown>>;
+    // Nothing dropped for locality; server order preserved.
+    expect(products).toHaveLength(2);
+    expect(products[0]!["id"]).toBe("gid://product/a");
+    expect(products[1]!["id"]).toBe("gid://product/b");
+    // No client-side "is local" tag/flag injected onto any product or its variant.
+    const blob = JSON.stringify(payload).toLowerCase();
+    for (const forbidden of ["is_local", "islocal", '"local":', "is_domestic", "local_match", "locality"]) {
+      expect(blob).not.toContain(forbidden);
+    }
+    // The shaped product carries only the contract fields — no extra locality key.
+    expect(Object.keys(products[0]!).sort()).toEqual(["id", "source", "title", "variant"]);
+  });
+
+  it("the shaped result is IDENTICAL whether local_merchants is true or omitted — the plugin's shaping is locality-agnostic (server owns the bias)", async () => {
+    async function shaped(localMerchants: boolean | undefined): Promise<Record<string, unknown>> {
+      seedTokens("at", "rt");
+      installRouter((kind) =>
+        kind === "search"
+          ? { status: 200, body: searchEnvelope([PRODUCT_A, PRODUCT_B]) }
+          : { status: 500, body: {} },
+      );
+      const api = createMockPluginApi();
+      registerCatalogTools(api);
+      const args: Record<string, unknown> = { query: "chair" };
+      if (localMerchants !== undefined) args["local_merchants"] = localMerchants;
+      const p = payloadOf(await getTool(api, TOOL).execute("c1", args));
+      vi.restoreAllMocks();
+      return p;
+    }
+
+    const withFlag = await shaped(true);
+    const withoutFlag = await shaped(undefined);
+    // The plugin does no locality post-processing, so the SHAPED payload (products +
+    // their projection + order) is byte-identical — only the request body differs.
+    expect(withFlag).toEqual(withoutFlag);
   });
 });
 
@@ -579,24 +774,6 @@ describe("sil_search — bad FORMAT is rejected client-side with a structured er
     expect(payload["error"]).toBe("invalid_filter");
   });
 
-  it("ships_from.country = 'Germany' (a name, not alpha-2) + a real query → invalid_request, ZERO network", async () => {
-    seedTokens("at", "rt");
-    const rec = installRouter(() => ({ status: 200, body: searchEnvelope([PRODUCT_A]) }));
-    const api = createMockPluginApi();
-    registerCatalogTools(api);
-
-    const payload = payloadOf(
-      await getTool(api, TOOL).execute("c1", {
-        query: "chair",
-        ships_from: { country: "Germany" },
-      }),
-    );
-
-    expect(rec.all.length).toBe(0);
-    expect(payload["status"]).toBe("invalid_request");
-    expect(payload["error"]).toBe("invalid_filter");
-  });
-
   it("a bad postal injection value ('94107; DROP TABLE') is rejected client-side, never reaching the network", async () => {
     // The format guard is also an injection backstop: a postal token carrying SQL /
     // punctuation fails the pattern and is rejected before any wire call.
@@ -665,13 +842,11 @@ describe("sil_search — a valid lowercase country is accepted, normalized UPPER
     await getTool(api, TOOL).execute("c1", {
       query: "chair",
       ship_to: { country: "us", region: "CA", postal_code: "94107" },
-      ships_from: { country: "gb" },
     });
 
     expect(rec.search.length).toBe(1);
     expect((rec.search[0]!.body as Record<string, unknown>)["filters"]).toEqual({
       ships_to: { country: "US", region: "CA", postal_code: "94107" },
-      ships_from: { country: "GB" },
     });
   });
 });
@@ -769,7 +944,7 @@ describe("sil_search — new args do NOT relax the ≥1-input guard (refinements
     expect(payload["status"]).toBe("invalid_request");
   });
 
-  it("condition + ships_from together but NO query/category/price → invalid_request, ZERO network calls", async () => {
+  it("condition + ship_to together but NO query/category/price → invalid_request, ZERO network calls", async () => {
     seedTokens("at", "rt");
     const rec = installRouter(() => ({ status: 200, body: searchEnvelope([PRODUCT_A]) }));
     const api = createMockPluginApi();
@@ -778,12 +953,32 @@ describe("sil_search — new args do NOT relax the ≥1-input guard (refinements
     const payload = payloadOf(
       await getTool(api, TOOL).execute("c1", {
         condition: ["secondhand"],
-        ships_from: { country: "US" },
+        ship_to: { country: "US" },
       }),
     );
 
     expect(rec.all.length).toBe(0);
     expect(payload["status"]).toBe("invalid_request");
+  });
+
+  it("local_merchants:true ALONE (no query/category/price) → invalid_request / empty_search_input, ZERO network (the bias is a refinement, not an input)", async () => {
+    // Card AC[integration]: a bare `{ local_merchants: true }` must STILL reject
+    // empty_search_input client-side — `hasUsableInput` is unchanged, so the flag
+    // does not constitute a search any more than `cursor`/`ship_to` do. End-to-end
+    // proof through the real wired tool (a router that 200s any search, so reaching
+    // the network would resolve `ok` — `rec.all.length === 0` is the proof it didn't).
+    seedTokens("at", "rt");
+    const rec = installRouter(() => ({ status: 200, body: searchEnvelope([PRODUCT_A]) }));
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", { local_merchants: true }),
+    );
+
+    expect(rec.all.length).toBe(0);
+    expect(payload["status"]).toBe("invalid_request");
+    expect(payload["error"]).toBe("empty_search_input");
   });
 
   it("a real `query` PLUS the new args passes the guard and REACHES the network", async () => {
@@ -836,12 +1031,13 @@ describe("sil_search — new args do NOT relax the ≥1-input guard (refinements
  */
 describe("sil_search — the new args are request-shaping only; the outcome taxonomy is unchanged", () => {
   /** The args bundle attached to every outcome below — proving none of them
-   * perturb the classification. */
+   * perturb the classification. Includes `local_merchants: true` (the new top-level
+   * flag) and the surviving filters; `ships_from` is gone (deleted end-to-end). */
   const NEW_ARGS = {
     ship_to: { country: "US", region: "CA", postal_code: "94107" },
-    ships_from: { country: "US" },
     condition: ["new"],
     available: false,
+    local_merchants: true,
   } as const;
 
   it("200 result WITH the new args → status ok with ranked products (unchanged)", async () => {
@@ -925,13 +1121,17 @@ describe("sil_search — the new args are request-shaping only; the outcome taxo
     expect(rec.refresh.length).toBe(1);
     expect(bearerToken(rec.search[1]!)).toBe("rotated-at");
     // The retry carried the SAME mapped filters as the first attempt (the new args
-    // survive the retry, renamed, under the rotated token).
-    expect((rec.search[1]!.body as Record<string, unknown>)["filters"]).toEqual({
+    // survive the retry, renamed, under the rotated token). No `ships_from` (deleted).
+    const retryBody = rec.search[1]!.body as Record<string, unknown>;
+    expect(retryBody["filters"]).toEqual({
       ships_to: { country: "US", region: "CA", postal_code: "94107" },
-      ships_from: { country: "US" },
       condition: ["new"],
       available: false,
     });
+    // …and the top-level `local_merchants` flag survives the retry too — at the TOP
+    // LEVEL, never folded into the retried `filters`.
+    expect(retryBody["local_merchants"]).toBe(true);
+    expect((retryBody["filters"] as Record<string, unknown>)).not.toHaveProperty("local_merchants");
   });
 
   it("5xx WITH the new args → retryable, NO recovery:sil_register (unchanged)", async () => {
@@ -1354,7 +1554,7 @@ describe("sil_search — outcome c: upstream rejected the request → NON-retrya
             status: 400,
             body: {
               error: "source_rejected",
-              message: "Source 'shopify' rejected the request: filter `ships_from` is not supported.",
+              message: "Source 'shopify' rejected the request: filter `gift_wrap` is not supported.",
             },
           }
         : { status: 200, body: {} },
@@ -1371,7 +1571,7 @@ describe("sil_search — outcome c: upstream rejected the request → NON-retrya
     // NOT the search-specific generic default from extractApiError.
     expect(payload["error"]).toBe("source_rejected");
     const message = String(payload["message"]);
-    expect(message).toContain("ships_from");
+    expect(message).toContain("gift_wrap");
     expect(message).not.toMatch(/Provide a search query or at least one filter/i);
     // No retry hint, no re-register — stop and fix the request.
     expect(payload["recovery"]).not.toBe("sil_register");
@@ -1435,7 +1635,7 @@ describe("sil_search — DISTINGUISHABILITY: six failure/success cases are pairw
     });
     const cReject = await envelopeFor({
       status: 400,
-      body: { error: "source_rejected", message: "The request was rejected: filter `ships_from` is not supported." },
+      body: { error: "source_rejected", message: "The request was rejected: filter `gift_wrap` is not supported." },
     });
     const emptyMatch = await envelopeFor({ status: 200, body: searchEnvelope([]) });
 

--- a/src/__tests__/lib/search-client.test.ts
+++ b/src/__tests__/lib/search-client.test.ts
@@ -200,11 +200,17 @@ describe("searchCatalog — param → CatalogSearchRequest body mapping (no enve
 
 /**
  * The card `add-ship-to-filter-args-to-the-sil-search-tool` (epic
- * `location-aware-search-2026-06`) adds four optional serviceability/localization
- * filters to `SearchParams`: `ship_to`, `ships_from`, `condition`, `available`.
+ * `location-aware-search-2026-06`) adds optional serviceability/localization
+ * filters to `SearchParams`: `ship_to`, `condition`, `available`.
  * `buildSearchBody` maps each into `filters.*`, with ONE load-bearing rename:
  * the agent arg `ship_to` (singular) becomes the wire key `filters.ships_to`
- * (plural). The other three keep their name under `filters.*`.
+ * (plural). The other two keep their name under `filters.*`.
+ *
+ * Card `replace-ships-from-with-local-merchants` (epic `local-merchants-2026-06`)
+ * DELETED `ships_from` — so it is no longer mapped into `filters.*` here. Its
+ * absence from the whole forwarded body (even when a stray arg is passed) is pinned
+ * in the dedicated "ships_from is GONE" block below; the `local_merchants` boolean
+ * that replaces it rides at the TOP LEVEL (its own block), never under `filters`.
  *
  * Wire-shape source of truth: the Shopify Global-Catalog extension
  * (`vendor/shopify/docs/agents/catalog/global-catalog-extension.md:26-33`) and
@@ -246,11 +252,6 @@ describe("searchCatalog — ship-to + serviceability filters map into filters.* 
     expect(cap[0]!.body).toEqual({ query: "chair", filters: { ships_to: { country: "DE" } } });
   });
 
-  it("maps `ships_from` → `filters.ships_from` (same name on both sides), value forwarded as given", async () => {
-    await searchCatalog(SIL_API, "tok", { query: "chair", ships_from: { country: "US" } });
-    expect(cap[0]!.body).toEqual({ query: "chair", filters: { ships_from: { country: "US" } } });
-  });
-
   it("maps `condition` (array) → `filters.condition`, forwarded as the supplied array", async () => {
     await searchCatalog(SIL_API, "tok", { query: "chair", condition: ["new", "secondhand"] });
     expect(cap[0]!.body).toEqual({ query: "chair", filters: { condition: ["new", "secondhand"] } });
@@ -270,7 +271,7 @@ describe("searchCatalog — ship-to + serviceability filters map into filters.* 
     expect(cap[0]!.body).toEqual({ query: "chair", filters: { available: false } });
   });
 
-  it("maps ALL FOUR new filters at once alongside the existing ones (full body, exact)", async () => {
+  it("maps ALL new filters at once alongside the existing ones (full body, exact)", async () => {
     await searchCatalog(SIL_API, "tok", {
       query: "office chair",
       category: "Furniture",
@@ -279,19 +280,18 @@ describe("searchCatalog — ship-to + serviceability filters map into filters.* 
       cursor: "cur-1",
       limit: 25,
       ship_to: { country: "US", region: "NY", postal_code: "10001" },
-      ships_from: { country: "US" },
       condition: ["new"],
       available: false,
     });
     // The exact merged body — the new filters sit beside categories/price under
     // `filters`, the rename applied, `available:false` preserved, no extra keys.
+    // (No `ships_from` — it was deleted; its absence here is part of the deletion.)
     expect(cap[0]!.body).toEqual({
       query: "office chair",
       filters: {
         categories: ["Furniture"],
         price: { min: 10000, max: 200000 },
         ships_to: { country: "US", region: "NY", postal_code: "10001" },
-        ships_from: { country: "US" },
         condition: ["new"],
         available: false,
       },
@@ -299,11 +299,11 @@ describe("searchCatalog — ship-to + serviceability filters map into filters.* 
     });
   });
 
-  it("omits EACH new filter when absent — a bare query carries no ships_to/ships_from/condition/available and no `filters` skeleton", async () => {
+  it("omits EACH new filter when absent — a bare query carries no ships_to/condition/available and no `filters` skeleton", async () => {
     await searchCatalog(SIL_API, "tok", { query: "lamp" });
     const body = cap[0]!.body as Record<string, unknown>;
     // No filters object at all (nothing to put in it) — the omit-when-absent rule
-    // the existing `category`/`price` mapping already follows extends to all four.
+    // the existing `category`/`price` mapping already follows extends to each.
     expect(body).toEqual({ query: "lamp" });
     expect(body["filters"]).toBeUndefined();
   });
@@ -316,7 +316,6 @@ describe("searchCatalog — ship-to + serviceability filters map into filters.* 
     const filters = (cap[0]!.body as Record<string, unknown>)["filters"] as Record<string, unknown>;
     expect(filters).not.toHaveProperty("available");
     expect(filters).not.toHaveProperty("ships_to");
-    expect(filters).not.toHaveProperty("ships_from");
     expect(filters).not.toHaveProperty("condition");
   });
 
@@ -329,11 +328,11 @@ describe("searchCatalog — ship-to + serviceability filters map into filters.* 
 
   it("a filter-only request of ONLY a new filter carries `filters` and NO `query` key", async () => {
     // `buildSearchBody` is mapping-only (the ≥1-input guard lives in the tool, not
-    // here). Given only `ships_from`, the body must carry it under `filters` and
+    // here). Given only `ship_to`, the body must carry it under `filters` and
     // omit `query` entirely — the same shape the `category`-only case produces.
-    await searchCatalog(SIL_API, "tok", { ships_from: { country: "US" } });
+    await searchCatalog(SIL_API, "tok", { ship_to: { country: "US" } });
     const body = cap[0]!.body as Record<string, unknown>;
-    expect(body["filters"]).toEqual({ ships_from: { country: "US" } });
+    expect(body["filters"]).toEqual({ ships_to: { country: "US" } });
     expect(body["query"]).toBeUndefined();
   });
 });
@@ -375,11 +374,6 @@ describe("searchCatalog — country is NORMALIZED UPPERCASE on the wire (alpha-2
     expect(cap[0]!.body).toEqual({ query: "chair", filters: { ships_to: { country: "US" } } });
   });
 
-  it("uppercases ships_from.country on the wire too (`gb` → `GB`)", async () => {
-    await searchCatalog(SIL_API, "tok", { query: "chair", ships_from: { country: "gb" } });
-    expect(cap[0]!.body).toEqual({ query: "chair", filters: { ships_from: { country: "GB" } } });
-  });
-
   it("normalizes country case but forwards region + postal_code VERBATIM (they are already format-valid here)", async () => {
     // The wire normalizes ONLY country case; region/postal are passed through as
     // received (format is the read site's gate — by the time a value reaches the
@@ -395,20 +389,169 @@ describe("searchCatalog — country is NORMALIZED UPPERCASE on the wire (alpha-2
     });
   });
 
-  it("normalizes country in the all-filters body (the merged shape keeps US/US uppercase, available:false preserved)", async () => {
+  it("normalizes country in the all-filters body (the merged shape keeps US uppercase, available:false preserved)", async () => {
     await searchCatalog(SIL_API, "tok", {
       query: "office chair",
       ship_to: { country: "us", region: "NY", postal_code: "10001" },
-      ships_from: { country: "us" },
       condition: ["new"],
       available: false,
     });
     expect((cap[0]!.body as Record<string, unknown>)["filters"]).toEqual({
       ships_to: { country: "US", region: "NY", postal_code: "10001" },
-      ships_from: { country: "US" },
       condition: ["new"],
       available: false,
     });
+  });
+});
+
+/**
+ * Card `replace-ships-from-with-local-merchants` (epic `local-merchants-2026-06`):
+ * `buildSearchBody` emits `local_merchants: true` at the TOP LEVEL of the request
+ * body — a SIBLING of `query`/`filters`/`pagination`, NEVER under `filters`.
+ *
+ * THE load-bearing wire invariant (Discovery "Chosen approach" + Risk "Wrong wire
+ * placement"): `local_merchants` is a sil-PRIVATE ranking signal, NOT a UCP /
+ * Global-Catalog filter. `filters` is forwarded to the cross-shop Global Catalog,
+ * whose OPEN `SearchFilters` (`additionalProperties: true`) would SILENTLY accept an
+ * unknown `local_merchants` key and ignore it → the flag becomes a no-op, and a
+ * presence-only test against the wrong placement would LOOK correct. So every
+ * assertion here pins top-level presence AND `filters`-absence TOGETHER — that pair
+ * is the only thing that catches the wrong-placement false-green.
+ *
+ * Emit ONLY when true: `local_merchants:false` == the server's unbiased default ==
+ * today's behavior, so it is OMITTED (omit-when-falsy — the OPPOSITE of
+ * `available:false`, which is a meaningful include-unavailable signal that survives;
+ * Discovery "Open questions"). Absent → omitted. A wrong TYPE → dropped, not coerced.
+ */
+describe("searchCatalog — local_merchants rides TOP-LEVEL, never under filters (the load-bearing wire invariant)", () => {
+  let cap: Captured[];
+  beforeEach(() => {
+    cap = [];
+    spyFetch(cap);
+  });
+
+  it("local_merchants:true → body.local_merchants === true AT THE TOP LEVEL, and filters has NO local_merchants (asserted TOGETHER — the anti-false-green pair)", async () => {
+    await searchCatalog(SIL_API, "tok", { query: "chair", local_merchants: true });
+    const body = cap[0]!.body as Record<string, unknown>;
+    // (1) present at the top level, beside `query`, as a literal `true`.
+    expect(body["local_merchants"]).toBe(true);
+    // (2) and CRUCIALLY not under `filters` — a wrong placement here would be a
+    // silent no-op the Global Catalog swallows. Asserting (1) ALONE would pass even
+    // if the key were ALSO/ONLY under filters; the pair is what makes this honest.
+    const filters = (body["filters"] ?? {}) as Record<string, unknown>;
+    expect(filters).not.toHaveProperty("local_merchants");
+  });
+
+  it("local_merchants:true with NO other filters → body is exactly { query, local_merchants: true } — no `filters` skeleton conjured to hold it", async () => {
+    // The strongest placement assertion: a byte-exact whole-body equality. If the
+    // impl routed the flag through `filters`, this body would carry a `filters` key
+    // and FAIL — the equality pins both the top-level home AND the absence of filters.
+    await searchCatalog(SIL_API, "tok", { query: "chair", local_merchants: true });
+    expect(cap[0]!.body).toEqual({ query: "chair", local_merchants: true });
+  });
+
+  it("local_merchants:true coexists with real filters — flag at top level, filters untouched (no leak into filters)", async () => {
+    await searchCatalog(SIL_API, "tok", {
+      query: "chair",
+      category: "Furniture",
+      ship_to: { country: "us" },
+      local_merchants: true,
+    });
+    const body = cap[0]!.body as Record<string, unknown>;
+    // Whole-body exact: local_merchants sits beside query/filters; filters carries
+    // ONLY the real filters, with no local_merchants smuggled in.
+    expect(body).toEqual({
+      query: "chair",
+      local_merchants: true,
+      filters: { categories: ["Furniture"], ships_to: { country: "US" } },
+    });
+  });
+
+  it("local_merchants:false → the key is OMITTED entirely (omit-when-falsy; false == the server's unbiased default)", async () => {
+    await searchCatalog(SIL_API, "tok", { query: "chair", local_merchants: false });
+    const body = cap[0]!.body as Record<string, unknown>;
+    // Unlike available:false, a false bias carries NO signal — it must NOT be echoed
+    // anywhere: not at the top level, not under filters.
+    expect(body).not.toHaveProperty("local_merchants");
+    const filters = (body["filters"] ?? {}) as Record<string, unknown>;
+    expect(filters).not.toHaveProperty("local_merchants");
+    // A bare query with a false flag is byte-exactly today's body — no trace of the flag.
+    expect(body).toEqual({ query: "chair" });
+  });
+
+  it("local_merchants OMITTED → the key is absent (no client-injected default; today's unbiased body)", async () => {
+    await searchCatalog(SIL_API, "tok", { query: "chair" });
+    const body = cap[0]!.body as Record<string, unknown>;
+    expect(body).not.toHaveProperty("local_merchants");
+    expect(body).toEqual({ query: "chair" });
+  });
+
+  it("a wrong-TYPE local_merchants (string) is DROPPED — not coerced, not forwarded, anywhere", async () => {
+    await searchCatalog(SIL_API, "tok", {
+      query: "chair",
+      // @ts-expect-error — a drifted on-disk call passes the wrong type; the wire
+      // build must narrow it out (typeof === "boolean"), never truthiness-coerce it.
+      local_merchants: "true",
+    });
+    const body = cap[0]!.body as Record<string, unknown>;
+    expect(body).not.toHaveProperty("local_merchants");
+    const filters = (body["filters"] ?? {}) as Record<string, unknown>;
+    expect(filters).not.toHaveProperty("local_merchants");
+    expect(body).toEqual({ query: "chair" });
+  });
+
+  it("a wrong-TYPE local_merchants (number 1) is DROPPED — a truthy non-boolean must not slip through", async () => {
+    await searchCatalog(SIL_API, "tok", {
+      query: "chair",
+      // @ts-expect-error — number is not boolean; must be dropped, not treated as true.
+      local_merchants: 1,
+    });
+    const body = cap[0]!.body as Record<string, unknown>;
+    expect(body).not.toHaveProperty("local_merchants");
+    expect(body).toEqual({ query: "chair" });
+  });
+
+  it("a wrong-TYPE local_merchants (object) is DROPPED — proves it's a bare boolean, not a { country }-style object", async () => {
+    await searchCatalog(SIL_API, "tok", {
+      query: "chair",
+      // @ts-expect-error — an object (e.g. a mistaken { country }) is not a boolean.
+      local_merchants: { country: "GR" },
+    });
+    const body = cap[0]!.body as Record<string, unknown>;
+    expect(body).not.toHaveProperty("local_merchants");
+    expect(body).toEqual({ query: "chair" });
+  });
+});
+
+/**
+ * Card `replace-ships-from-with-local-merchants`: `ships_from` is GONE end-to-end.
+ * A drifted on-disk call that still passes a `ships_from` argument must NOT have it
+ * forwarded ANYWHERE in the request body — `SearchParams` no longer carries the
+ * field and `buildSearchBody` no longer maps it, so it is dropped before the wire
+ * (AC[integration]: "ships_from is NOT present anywhere in the forwarded body").
+ */
+describe("searchCatalog — a stray ships_from argument is absent from the entire forwarded body", () => {
+  let cap: Captured[];
+  beforeEach(() => {
+    cap = [];
+    spyFetch(cap);
+  });
+
+  it("a stray `ships_from` arg alongside a real query → it appears NOWHERE in the body (not top-level, not under filters)", async () => {
+    await searchCatalog(SIL_API, "tok", {
+      query: "chair",
+      // @ts-expect-error — `ships_from` was deleted from SearchParams; a drifted call
+      // may still pass it, but the wire build must not forward it.
+      ships_from: { country: "US" },
+    });
+    const body = cap[0]!.body as Record<string, unknown>;
+    expect(body).not.toHaveProperty("ships_from");
+    const filters = (body["filters"] ?? {}) as Record<string, unknown>;
+    expect(filters).not.toHaveProperty("ships_from");
+    // The deleted lever leaves no byte in the wire body at all.
+    expect(JSON.stringify(body)).not.toContain("ships_from");
+    // The body is byte-exactly today's bare-query body — the stray arg changed nothing.
+    expect(body).toEqual({ query: "chair" });
   });
 });
 

--- a/src/__tests__/tools/search.test.ts
+++ b/src/__tests__/tools/search.test.ts
@@ -173,20 +173,25 @@ describe("sil_search — tool registration shape", () => {
 });
 
 /**
- * Card `add-ship-to-filter-args-to-the-sil-search-tool`: the schema gains four
+ * Card `add-ship-to-filter-args-to-the-sil-search-tool`: the schema gains
  * optional serviceability/localization params, each with a self-describing
  * per-field `description` (agents read field descriptions independently of the
  * tool description, so each must stand alone). Shapes pinned to the architect's
  * immutable contract + the Shopify Global-Catalog extension
  * (`vendor/shopify/docs/agents/catalog/global-catalog-extension.md:26-33`):
  *   - `ship_to`     : object { country (required), region?, postal_code? }
- *   - `ships_from`  : object { country (required) }
  *   - `condition`   : array of strings
  *   - `available`   : boolean
- * All four are `Type.Optional` — the whole param is omittable; `country` is
- * required only WITHIN the ship_to/ships_from objects.
+ * All are `Type.Optional` — the whole param is omittable; `country` is
+ * required only WITHIN the ship_to object.
+ *
+ * Card `replace-ships-from-with-local-merchants` DELETED `ships_from` end-to-end
+ * (live correlation tests settled it is the wrong lever) — so this block no longer
+ * declares or shapes a `ships_from` param. Its absence is asserted explicitly in
+ * the "ships_from is GONE" block below; `local_merchants` (the boolean bias that
+ * replaces it) is in its own block further down.
  */
-describe("sil_search — schema exposes the four new optional filter params (shapes + per-field descriptions)", () => {
+describe("sil_search — schema exposes the new optional filter params (shapes + per-field descriptions)", () => {
   function searchProps(): Record<string, Record<string, unknown>> {
     const api = createMockPluginApi();
     registerCatalogTools(api);
@@ -196,9 +201,9 @@ describe("sil_search — schema exposes the four new optional filter params (sha
     return params.properties ?? {};
   }
 
-  it("declares ship_to / ships_from / condition / available as properties", () => {
+  it("declares ship_to / condition / available as properties", () => {
     const keys = Object.keys(searchProps());
-    for (const expected of ["ship_to", "ships_from", "condition", "available"]) {
+    for (const expected of ["ship_to", "condition", "available"]) {
       expect(keys).toContain(expected);
     }
   });
@@ -214,15 +219,6 @@ describe("sil_search — schema exposes the four new optional filter params (sha
     // `country` is required WITHIN the object (the override needs a destination);
     // region/postal_code are optional refinements.
     expect(shipTo!["required"]).toEqual(["country"]);
-  });
-
-  it("ships_from is an object whose `country` is required", () => {
-    const shipsFrom = searchProps()["ships_from"];
-    expect(shipsFrom).toBeDefined();
-    expect(shipsFrom!["type"]).toBe("object");
-    const sub = (shipsFrom!["properties"] ?? {}) as Record<string, unknown>;
-    expect(Object.keys(sub)).toContain("country");
-    expect(shipsFrom!["required"]).toEqual(["country"]);
   });
 
   it("condition is an array of strings", () => {
@@ -241,7 +237,7 @@ describe("sil_search — schema exposes the four new optional filter params (sha
 
   it("each new param carries a non-empty, self-describing `description`", () => {
     const props = searchProps();
-    for (const k of ["ship_to", "ships_from", "condition", "available"]) {
+    for (const k of ["ship_to", "condition", "available"]) {
       expect(props[k]).toBeDefined();
       const desc = props[k]!["description"];
       expect(typeof desc).toBe("string");
@@ -315,13 +311,6 @@ describe("sil_search — schema pins the tightened format patterns (both sides e
     expect(shipToSub()["postal_code"]!["pattern"]).toBe(POSTAL_PATTERN);
   });
 
-  it("ships_from.country carries the SAME alpha-2 pattern as ship_to.country", () => {
-    const shipsFrom = searchProps()["ships_from"];
-    expect(shipsFrom).toBeDefined();
-    const sub = (shipsFrom!["properties"] ?? {}) as Record<string, Record<string, unknown>>;
-    expect(sub["country"]!["pattern"]).toBe(COUNTRY_PATTERN);
-  });
-
   it("the alpha-2 country pattern actually ACCEPTS 2-letter codes and REJECTS country names (the pattern is enforceable, not decorative)", () => {
     // Compile the schema's own pattern and exercise it — a pattern that is present
     // but wrong (e.g. too loose) would pass the string-equality checks above yet
@@ -389,11 +378,10 @@ describe("sil_search — description encodes the empty=registered-default steeri
     expect(d).toMatch(/override|different|else|another destination|elsewhere/);
   });
 
-  it("documents ships_from, condition, and available each as optional filters by what they constrain (no implied prior tool call)", () => {
+  it("documents condition and available each as optional filters by what they constrain (no implied prior tool call)", () => {
     const d = description().toLowerCase();
-    // origin country / product condition / availability — each named.
-    expect(d).toMatch(/ships_from/);
-    expect(d).toMatch(/origin|seller|merchant|ships from/);
+    // product condition / availability — each named. (`ships_from` is GONE — its
+    // absence from the tool description is asserted in the "ships_from is GONE" block.)
     expect(d).toMatch(/condition/);
     expect(d).toMatch(/new|used|secondhand|condition/);
     expect(d).toMatch(/available|availability|unavailable|in stock|out of stock/);
@@ -484,17 +472,203 @@ describe("sil_search — each location field's per-field description self-descri
     expect(desc.toLowerCase()).toMatch(/not.*(place|name)|code.*not.*name/);
   });
 
-  it("ships_from.country field description names the 2-letter ISO 3166-1 alpha-2 code form", () => {
-    const sub = (searchProps()["ships_from"]!["properties"] ?? {}) as Record<string, Record<string, unknown>>;
-    const desc = String(sub["country"]!["description"] ?? "");
-    expect(desc.toLowerCase()).toMatch(/alpha-2|alpha 2|3166-1|2-letter|two-letter/);
-    expect(desc).toMatch(/\bUS\b|\bGB\b|\bDE\b/);
-  });
-
   it("condition field description names exactly the new / secondhand value set", () => {
     const desc = String(searchProps()["condition"]!["description"] ?? "").toLowerCase();
     expect(desc).toMatch(/new/);
     expect(desc).toMatch(/secondhand/);
+  });
+});
+
+/**
+ * Card `replace-ships-from-with-local-merchants` (epic `local-merchants-2026-06`):
+ * `sil_search` gains a `local_merchants` OPTIONAL BOOLEAN that biases results toward
+ * shops based in the user's own country — best-effort, server-ranked. The plugin
+ * owns ONLY the surface: the param shape + the agent-facing per-field description.
+ *
+ * The DESCRIPTION is the entire behavioral deliverable (an LLM is the only consumer;
+ * it reads the field description to decide when to set the flag and what it can
+ * promise). Three load-bearing facts MUST be unmistakable (Discovery "Behavioral
+ * framing", AC[unit]):
+ *   (a) BEST-EFFORT BIAS, never a filter/guarantee that every result is local;
+ *   (b) issue the `query` in the USER'S LANGUAGE to surface local shops;
+ *   (c) the agent passes NO country and must NOT call sil_whoami — sil resolves the
+ *       user's country server-side from their registered address.
+ * Asserted against the registered `parameters` JSON-schema (the same introspection
+ * the shape tests above use; `Type.Optional(Type.Boolean({ description }))` puts the
+ * description on the property node).
+ */
+describe("sil_search — schema exposes `local_merchants` as an optional boolean with a per-field description", () => {
+  function searchProps(): Record<string, Record<string, unknown>> {
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+    const params = getTool(api, TOOL).parameters as {
+      properties?: Record<string, Record<string, unknown>>;
+    };
+    return params.properties ?? {};
+  }
+  /** The `local_merchants` per-field description string (the deliverable). */
+  function localMerchantsDesc(): string {
+    const prop = searchProps()["local_merchants"];
+    expect(prop, "local_merchants must be a registered param").toBeDefined();
+    return String(prop!["description"] ?? "");
+  }
+
+  it("declares `local_merchants` as a property", () => {
+    expect(Object.keys(searchProps())).toContain("local_merchants");
+  });
+
+  it("`local_merchants` is typed as a boolean (a plain bool bias, NOT a { country } object)", () => {
+    const prop = searchProps()["local_merchants"];
+    expect(prop).toBeDefined();
+    expect(prop!["type"]).toBe("boolean");
+    // It must NOT be an object carrying a country — a country arg would re-create the
+    // identity round-trip this epic exists to delete (Discovery "Why a boolean bias").
+    expect(prop!["type"]).not.toBe("object");
+    expect(prop!["properties"]).toBeUndefined();
+  });
+
+  it("`local_merchants` is OPTIONAL — omittable from the call (NOT in the schema's required set)", () => {
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+    const params = getTool(api, TOOL).parameters as { required?: unknown };
+    const required = Array.isArray(params.required) ? (params.required as string[]) : [];
+    expect(required).not.toContain("local_merchants");
+  });
+
+  it("`local_merchants` carries a non-empty, self-describing per-field description", () => {
+    expect(localMerchantsDesc().length).toBeGreaterThan(0);
+  });
+
+  it("fact (a): the description frames it as a BEST-EFFORT BIAS, not a guaranteed filter — and explicitly disclaims exclusivity", () => {
+    const d = localMerchantsDesc().toLowerCase();
+    // It must name the SOFT-bias mechanic …
+    expect(d).toMatch(/bias|nudge|prefer|toward|favou?r/);
+    // … AND carry the explicit disclaimer that it is NOT a filter / NOT a guarantee
+    // and does NOT make every result local (the lesson that killed ships_from — the
+    // surface must be honest so the agent never inherits a false promise).
+    expect(d).toMatch(/not a filter|does not restrict|do not restrict|doesn't restrict|not.*guarantee|no guarantee|not exclusiv|may still appear|won't be detected|will not be detected/);
+  });
+
+  it("fact (b): the description tells the agent to issue the `query` in the USER'S LANGUAGE to surface local shops", () => {
+    const d = localMerchantsDesc().toLowerCase();
+    expect(d).toMatch(/language/);
+    expect(d).toMatch(/query/);
+    // The concrete steer: a same-language query surfaces local shops (the example
+    // makes the instruction unambiguous to the agent).
+    expect(d).toMatch(/user'?s (own )?language|same.language|their (own )?language|in the user'?s language/);
+  });
+
+  it("fact (c): the description says the agent passes NO country and must NOT call sil_whoami (sil resolves it server-side)", () => {
+    const d = localMerchantsDesc();
+    // Names the anti-pattern (sil_whoami) and forbids it …
+    expect(d).toMatch(/sil_whoami/);
+    expect(d.toLowerCase()).toMatch(/do not|don'?t|never|no need|without|no country/);
+    // … and says the country is resolved server-side (so the agent owns no such fact).
+    expect(d.toLowerCase()).toMatch(/server.side|sil resolves|resolved by sil|registered address/);
+  });
+
+  it("the `local_merchants` copy never promises EXCLUSIVITY — the soft-bias framing is unmistakable (forbidden-words check)", () => {
+    // AC[unit]: it must NOT use "only"/"filter"/"restrict to"/"guarantee" in a way
+    // that promises results are exclusively local. The honest disclaimer NEEDS those
+    // words in NEGATED form ("NOT a filter", "does NOT restrict results to them",
+    // "does NOT guarantee every result is local"), so we must NOT flag a promissory
+    // phrase that is part of a NEGATED clause. Strategy: blank out negated spans
+    // first (a negation word through the end of its clause), THEN look for any
+    // remaining BARE promissory claim. This catches "guarantees every result is
+    // local" while allowing "does NOT guarantee every result is local".
+    const raw = localMerchantsDesc().toLowerCase();
+    // Remove negated clauses: a negation token ("not"/"no"/"never"/"n't"/"without")
+    // up to the next clause boundary (— , . ; : or end). This neutralizes the honest
+    // disclaimers so only affirmative (promissory) claims remain to be judged.
+    const affirmativeOnly = raw.replace(
+      /(?:\bnot\b|\bno\b|\bnever\b|n't|\bwithout\b)[^—.,;:]*/g,
+      " ",
+    );
+    const promissory = [
+      /\bonly local\b/,
+      /\ball (the )?results? (are|will be) local/,
+      /\bexclusively local\b/,
+      /\bguarantee(d|s)?\b[^—.,;:]*\blocal\b/,
+      /\brestricts? (results? )?to\b/,
+      /\bfilters? (results? )?to (only )?local\b/,
+      /\ball (of )?(the )?(sellers?|shops?|merchants?) (are|will be) local/,
+    ];
+    for (const p of promissory) {
+      expect(affirmativeOnly, `must not promise exclusivity via ${p}`).not.toMatch(p);
+    }
+    // And the disclaimer is affirmatively present (so an impl can't pass by simply
+    // omitting all framing — the soft-bias caveat MUST be stated). Checked on the
+    // RAW copy (the negation IS the disclaimer we want to see).
+    expect(raw).toMatch(/not a filter|does not restrict|do not restrict|not.*guarantee|no guarantee|may still appear|won'?t be detected|not exclusiv/);
+  });
+});
+
+/**
+ * Card `replace-ships-from-with-local-merchants`: the tool-LEVEL description steers
+ * the agent on `local_merchants` (best-effort local bias + query-in-user's-language)
+ * and contains NO sentence describing `ships_from` (AC[unit]). The tool description is
+ * a distinct surface from the per-field one; both must be clean of the deleted lever.
+ */
+describe("sil_search — tool-level description steers on local_merchants and is free of ships_from", () => {
+  function description(): string {
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+    return getTool(api, TOOL).description;
+  }
+
+  it("the tool description mentions `local_merchants` and frames it as a (best-effort) local bias", () => {
+    const d = description().toLowerCase();
+    expect(d).toMatch(/local_merchants/);
+    expect(d).toMatch(/local|domestic|home.country/);
+  });
+
+  it("the tool description steers the agent to query in the user's language for local shops", () => {
+    const d = description().toLowerCase();
+    expect(d).toMatch(/language/);
+  });
+
+  it("the tool description contains NO `ships_from` sentence (the deleted lever is gone from the agent-facing prose)", () => {
+    expect(description()).not.toMatch(/ships_from/i);
+  });
+});
+
+/**
+ * Card `replace-ships-from-with-local-merchants`: `ships_from` is GONE end-to-end —
+ * no schema param, and a stray `ships_from` argument is NOT silently accepted (the
+ * closed schema / params narrowing drops it before the wire). AC[unit] +
+ * AC[integration] (the wire-absence half is also pinned in the integration suites).
+ */
+describe("sil_search — ships_from is GONE from the schema (no param, the agent can no longer pass it)", () => {
+  function searchProps(): Record<string, Record<string, unknown>> {
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+    const params = getTool(api, TOOL).parameters as {
+      properties?: Record<string, Record<string, unknown>>;
+    };
+    return params.properties ?? {};
+  }
+
+  it("the schema has NO `ships_from` property (closed against it)", () => {
+    expect(Object.keys(searchProps())).not.toContain("ships_from");
+  });
+
+  it("a stray `ships_from` argument is DROPPED — it never reaches the wire body", async () => {
+    seedTokens();
+    const bodies: unknown[] = [];
+    captureBodyFetch(bodies);
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    // A drifted on-disk call still passes `ships_from`; the params narrowing must
+    // drop it (the schema no longer knows the key), so it appears NOWHERE in the body
+    // — not at the top level and not under `filters`.
+    await getTool(api, TOOL).execute("c1", { query: "chair", ships_from: { country: "US" } });
+
+    const body = bodies[0] as Record<string, unknown>;
+    expect(body).not.toHaveProperty("ships_from");
+    const filters = (body["filters"] ?? {}) as Record<string, unknown>;
+    expect(filters).not.toHaveProperty("ships_from");
+    expect(JSON.stringify(body)).not.toContain("ships_from");
   });
 });
 
@@ -534,6 +708,20 @@ describe("sil_search — client-side ≥1-input guard (reject empty BEFORE any n
     const payload = payloadOf(await getTool(api, TOOL).execute("c1", { query: "" }));
     expect(fetchSpy).not.toHaveBeenCalled();
     expect(payload["status"]).not.toBe("ok");
+  });
+
+  it("a bare { local_merchants: true } STILL rejects empty_search_input — the bias is a REFINEMENT, not an input (hasUsableInput untouched)", async () => {
+    // Card AC: `local_merchants` biases an EXISTING search; it does not constitute
+    // one (exactly as `ships_from` was, exactly as `cursor`/`limit` are). A request
+    // whose ONLY content is `local_merchants: true` must be rejected client-side with
+    // `empty_search_input` and make ZERO network calls — proof the implementation did
+    // NOT touch `hasUsableInput` to let the flag through.
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", { local_merchants: true }),
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(payload["status"]).toBe("invalid_request");
+    expect(payload["error"]).toBe("empty_search_input");
   });
 });
 
@@ -616,20 +804,6 @@ describe("sil_search — readSearchParams drops wrong-typed new filter args (nar
     const filters = (body["filters"] ?? {}) as Record<string, unknown>;
     expect(filters).not.toHaveProperty("ships_to");
     expect(filters).not.toHaveProperty("ship_to");
-  });
-
-  it("`ships_from` as a primitive (number) is dropped — no filters.ships_from on the wire", async () => {
-    seedTokens();
-    const bodies: unknown[] = [];
-    captureBodyFetch(bodies);
-    const api = createMockPluginApi();
-    registerCatalogTools(api);
-
-    await getTool(api, TOOL).execute("c1", { query: "chair", ships_from: 42 });
-
-    const body = bodies[0] as Record<string, unknown>;
-    const filters = (body["filters"] ?? {}) as Record<string, unknown>;
-    expect(filters).not.toHaveProperty("ships_from");
   });
 
   it("a valid `available: false` STILL survives the read site (the drop is type-driven, not value-driven)", async () => {

--- a/src/lib/sil-client.ts
+++ b/src/lib/sil-client.ts
@@ -220,25 +220,25 @@ export interface ShipTo {
   postal_code?: string;
 }
 
-/** A merchant-origin constraint. `country` is the ISO 3166-1 alpha-2 code
- * (required when present), uppercased on the wire (same country-case normalization
- * as `ShipTo`). Mirrors the Shopify `ships_from` wire shape
- * (`global-catalog-extension.md:33`); same name on both sides. */
-export interface ShipsFrom {
-  country: string;
-}
-
 /** The simplified search query an agent sends — a free-text `query` plus
  * optional filters and pagination. Maps 1:1 into the sil-api `CatalogSearchRequest`
  * body (`searchCatalog` builds the nested shape). All fields optional at this
  * layer; the at-least-one-input rule is enforced by the tool, not here.
  *
- * The four serviceability/localization filters (`ship_to`, `ships_from`,
- * `condition`, `available`) ride sil-api's OPEN `SearchFilters`
- * (`additionalProperties: true`). They are forwarded ONLY when supplied — an
- * absent filter is an omitted key, never a client-injected default (the server
- * applies `available: true` itself). `available: false` is meaningful (include
- * unavailable items) and is forwarded, never dropped as falsy. */
+ * The three serviceability/localization filters (`ship_to`, `condition`,
+ * `available`) ride sil-api's OPEN `SearchFilters` (`additionalProperties: true`).
+ * They are forwarded ONLY when supplied — an absent filter is an omitted key, never
+ * a client-injected default (the server applies `available: true` itself).
+ * `available: false` is meaningful (include unavailable items) and is forwarded,
+ * never dropped as falsy.
+ *
+ * `local_merchants` is NOT one of those filters — it is a sil-PRIVATE ranking-bias
+ * signal that rides at the TOP LEVEL of the request body (beside `query`/`filters`/
+ * `pagination`), NEVER under `filters` (filters are forwarded to the cross-shop
+ * Global Catalog, which does not understand the field → a silent no-op). It is
+ * emitted ONLY when exactly `true`: unlike `available: false`, a `false` bias
+ * carries no signal (== the server's unbiased default), so `false`/absent both omit
+ * the key. See `buildSearchBody`. */
 export interface SearchParams {
   query?: string;
   category?: string;
@@ -247,9 +247,9 @@ export interface SearchParams {
   cursor?: string;
   limit?: number;
   ship_to?: ShipTo;
-  ships_from?: ShipsFrom;
   condition?: string[];
   available?: boolean;
+  local_merchants?: boolean;
 }
 
 /** A currency-tagged price, passed through OPAQUE from sil-api's UCP `Price`
@@ -917,8 +917,8 @@ function extractForbiddenReason(body: unknown): string {
  * The tool clamps nothing and validates no cursor opacity — sil-api owns those.
  *
  * THE load-bearing rename: the agent arg `ship_to` (singular) becomes the wire key
- * `filters.ships_to` (plural). `ships_from`/`condition`/`available` keep their name
- * under `filters.*`. These four ride sil-api's OPEN `SearchFilters`
+ * `filters.ships_to` (plural). `condition`/`available` keep their name under
+ * `filters.*`. These three ride sil-api's OPEN `SearchFilters`
  * (`additionalProperties: true`), which SILENTLY accepts an unknown key — so the
  * exact emitted key name is the only thing standing between a working serviceability
  * filter and a no-op (a wrong rename fails GREEN). Each is forwarded ONLY when
@@ -927,13 +927,23 @@ function extractForbiddenReason(body: unknown): string {
  * `available: false` is narrowed with `typeof === "boolean"`, never `if (v)`, so the
  * meaningful `false` (include unavailable items) survives.
  *
+ * `local_merchants` is the ONE field that does NOT ride `filters`. It is a
+ * sil-PRIVATE ranking-bias signal, not a UCP/Global-Catalog filter — `filters` is
+ * forwarded to the cross-shop Global Catalog, whose OPEN schema would silently
+ * accept and ignore an unknown `local_merchants` key (the exact wrong-placement
+ * no-op the rename hazard above warns of). So it is emitted at the TOP LEVEL of the
+ * body (beside `query`/`filters`/`pagination`), and ONLY when exactly `true`: unlike
+ * `available: false` (a meaningful include-unavailable signal that survives), a
+ * `false` bias carries NO signal (== the server's unbiased default), so `false` and
+ * absent both omit the key (narrow on the VALUE, not just the type — emit iff true).
+ *
  * COUNTRY-CASE NORMALIZATION is the wire layer's job (the read site owns FORMAT
- * rejection): `ships_to.country` and `ships_from.country` are emitted UPPERCASE
- * (`us` → `US`), the alpha-2 contract `@sil/schemas` `ShipTo`/`ShipFrom` mirrors
- * byte-for-byte. A lowercase code on the wire would diverge from the sibling and
- * (depending on the server's case-sensitivity) silently mis-filter. `region` and
- * `postal_code` are forwarded VERBATIM — they passed their pattern at the read site,
- * and the wire normalizes only country case.
+ * rejection): `ships_to.country` is emitted UPPERCASE (`us` → `US`), the alpha-2
+ * contract `@sil/schemas` `ShipTo` mirrors byte-for-byte. A lowercase code on the
+ * wire would diverge from the sibling and (depending on the server's
+ * case-sensitivity) silently mis-filter. `region` and `postal_code` are forwarded
+ * VERBATIM — they passed their pattern at the read site, and the wire normalizes
+ * only country case.
  */
 function buildSearchBody(params: SearchParams): Record<string, unknown> {
   const body: Record<string, unknown> = {};
@@ -948,17 +958,22 @@ function buildSearchBody(params: SearchParams): Record<string, unknown> {
   if (typeof params.price_max === "number") price["max"] = params.price_max;
   if (Object.keys(price).length > 0) filters["price"] = price;
 
-  // The four serviceability/localization filters — the `ship_to` → `ships_to`
-  // rename happens here; the other three keep their name. Country is uppercased
-  // on emit (region/postal forwarded verbatim); the other three pass through as-is.
+  // The three serviceability/localization filters — the `ship_to` → `ships_to`
+  // rename happens here; the other two keep their name. Country is uppercased on
+  // emit (region/postal forwarded verbatim); the other two pass through as-is.
   if (params.ship_to !== undefined) filters["ships_to"] = withUppercaseCountry(params.ship_to);
-  if (params.ships_from !== undefined) {
-    filters["ships_from"] = withUppercaseCountry(params.ships_from);
-  }
   if (params.condition !== undefined) filters["condition"] = params.condition;
   if (typeof params.available === "boolean") filters["available"] = params.available;
 
   if (Object.keys(filters).length > 0) body["filters"] = filters;
+
+  // `local_merchants` is a sil-PRIVATE ranking bias — it rides at the TOP LEVEL of
+  // the body (a sibling of `query`/`filters`/`pagination`), NEVER under `filters`
+  // (those are forwarded to the Global Catalog, which would silently swallow it).
+  // Emitted ONLY when exactly `true`: a `false`/absent bias carries no signal (it is
+  // the server's unbiased default), so — unlike `available:false` — it is omitted.
+  // Narrow on the VALUE, not just the type: `=== true`, never a truthiness coerce.
+  if (params.local_merchants === true) body["local_merchants"] = true;
 
   const pagination: Record<string, unknown> = {};
   if (typeof params.cursor === "string") pagination["cursor"] = params.cursor;
@@ -968,10 +983,10 @@ function buildSearchBody(params: SearchParams): Record<string, unknown> {
   return body;
 }
 
-/** Emit a ship-to/ships-from object with its alpha-2 `country` UPPERCASED on the
- * wire (`us` → `US`); every other field (`region`/`postal_code` on `ShipTo`) is
- * preserved verbatim. The spread-then-overwrite keeps the shape generic over both
- * {@link ShipTo} and {@link ShipsFrom} without reshaping or dropping a field. */
+/** Emit a ship-to object with its alpha-2 `country` UPPERCASED on the wire
+ * (`us` → `US`); every other field (`region`/`postal_code` on {@link ShipTo}) is
+ * preserved verbatim. The spread-then-overwrite keeps the shape generic over any
+ * `{ country }`-bearing value without reshaping or dropping a field. */
 function withUppercaseCountry<T extends { country: string }>(value: T): T {
   return { ...value, country: value.country.toUpperCase() };
 }

--- a/src/tools/catalog.ts
+++ b/src/tools/catalog.ts
@@ -60,22 +60,21 @@ import {
   type LookupOutcome,
   type SearchOutcome,
   type SearchParams,
-  type ShipsFrom,
   type ShipTo,
 } from "../lib/sil-client.js";
 import { jsonResult } from "../lib/tool-result.js";
 
 /**
- * The TIGHTENED ship-to/ships-from format contract (founder re-spec 2026-06-11),
- * pinned as a `pattern` BOTH the local schema and sil-api's `@sil/schemas`
- * `ShipTo`/`ShipFrom` enforce IDENTICALLY (byte-for-byte) — so the plugin rejects a
- * malformed value client-side instead of forwarding free text and eating an opaque,
- * fail-late sil-api 400. These same patterns are the schema `pattern` (so the host
- * validates) AND the read-site format gate (so a drifted on-disk call is rejected),
- * defined once here to keep the two in lockstep. The sil-services sibling
+ * The TIGHTENED ship-to format contract (founder re-spec 2026-06-11), pinned as a
+ * `pattern` BOTH the local schema and sil-api's `@sil/schemas` `ShipTo` enforce
+ * IDENTICALLY (byte-for-byte) — so the plugin rejects a malformed value client-side
+ * instead of forwarding free text and eating an opaque, fail-late sil-api 400. These
+ * same patterns are the schema `pattern` (so the host validates) AND the read-site
+ * format gate (so a drifted on-disk call is rejected), defined once here to keep the
+ * two in lockstep. The sil-services sibling
  * (`attach-buyer-ship-to-context-server-side-in-sil-ap`) MUST mirror these exactly;
  * the sil-stage eval verifies it end-to-end.
- *   - country (ships_to + ships_from): ISO 3166-1 alpha-2, a 2-letter code.
+ *   - country (ships_to): ISO 3166-1 alpha-2, a 2-letter code.
  *   - region: ISO 3166-2 subdivision code (CA/NY/BY/97), bounded — NOT a place name.
  *   - postal_code: a single self-contained pattern (a length-cap lookahead 2–12
  *     chars, separators counted, + a structural body of alnum runs joined by single
@@ -119,12 +118,17 @@ function registerSearch(api: PluginAPI): void {
       + " code, NOT a country name); `region` (optional) = the ISO 3166-2 subdivision"
       + " code (CA, NY, BY — a code, NOT a place name); `postal_code` (optional) ="
       + " the destination postal/ZIP code. The other optional filters need no prior"
-      + " tool call: `ships_from` (`{ country }`, the same 2-letter ISO 3166-1"
-      + " alpha-2 code — US/GB/DE) restricts to a merchant ORIGIN country; `condition`"
-      + " (array; the values are exactly \"new\" or \"secondhand\", lowercase) filters"
-      + " by product condition; `available` (boolean) controls availability — the"
-      + " server returns only sale-ready items by default, so set `available: false`"
-      + " to INCLUDE out-of-stock/unavailable items. Requires registration (run"
+      + " tool call: `condition` (array; the values are exactly \"new\" or"
+      + " \"secondhand\", lowercase) filters by product condition; `available`"
+      + " (boolean) controls availability — the server returns only sale-ready items"
+      + " by default, so set `available: false` to INCLUDE out-of-stock/unavailable"
+      + " items. `local_merchants` (boolean) is a BEST-EFFORT BIAS toward shops based"
+      + " in the user's OWN country (home-country / domestic / local sellers) — set it"
+      + " ONLY when the shopper asks for local/domestic shops; it nudges local shops up"
+      + " the ranking but does NOT restrict results to them, so never tell the user the"
+      + " results are all local. To actually surface local shops, ALSO issue the"
+      + " `query` in the USER'S LANGUAGE (a Greek-language query surfaces Greek shops);"
+      + " pass NO country — sil resolves it server-side. Requires registration (run"
       + " sil_register first).",
     parameters: Type.Object({
       query: Type.Optional(
@@ -199,22 +203,23 @@ function registerSearch(api: PluginAPI): void {
           },
         ),
       ),
-      ships_from: Type.Optional(
-        Type.Object(
-          {
-            country: Type.String({
-              pattern: COUNTRY_PATTERN,
-              description:
-                "Merchant origin country as a 2-letter ISO 3166-1 alpha-2 CODE (US,"
-                + " GB, DE) — a code, NOT a country name.",
-            }),
-          },
-          {
-            description:
-              "Restrict results to products that ship FROM a given merchant origin"
-              + " country (alpha-2 ISO code). Omit for no origin constraint.",
-          },
-        ),
+      local_merchants: Type.Optional(
+        Type.Boolean({
+          description:
+            "Bias results toward shops based in the USER'S OWN country (home-country"
+            + " / domestic / local sellers) — set true ONLY when the shopper asks for"
+            + " local or domestic shops (e.g. \"buy from a Greek shop\", \"support"
+            + " local businesses\"). This is a BEST-EFFORT BIAS, NOT a filter: it"
+            + " nudges local shops up the ranking but does NOT restrict results to them"
+            + " and does NOT guarantee every result is local — some local shops won't"
+            + " be detected and some non-local shops may still appear, so never tell"
+            + " the user the results are all local sellers. To actually surface local"
+            + " shops, also issue the `query` in the USER'S LANGUAGE (a Greek-language"
+            + " query surfaces Greek shops; an English query will not). You pass NO"
+            + " country — sil resolves the user's country server-side from their"
+            + " registered address, so do NOT call sil_whoami or pass a country. Omit"
+            + " (or false) for the normal unbiased ranking.",
+        }),
       ),
       condition: Type.Optional(
         Type.Array(Type.String(), {
@@ -520,20 +525,21 @@ type SearchParamsRead =
  * a drifted on-disk call must not slip a non-string into the query mapping. No
  * `any`, no unchecked `as`.
  *
- * The four serviceability/localization filters narrow by their own type: `ship_to`/
- * `ships_from` to an object with a string `country` (a primitive/number is
- * DROPPED), `condition` to a string[] (a bare string is dropped), `available` to a
- * boolean (a string is dropped). The drop is TYPE-driven, never value-driven, so a
- * valid `available: false` survives — it is a boolean, the meaningful "include
- * unavailable items" signal, not a falsy value to discard.
+ * The serviceability/localization filters narrow by their own type: `ship_to` to an
+ * object with a string `country` (a primitive/number is DROPPED), `condition` to a
+ * string[] (a bare string is dropped), `available` and `local_merchants` to a boolean
+ * (a string is dropped). The drop is TYPE-driven, never value-driven, so a valid
+ * `available: false` survives — it is a boolean, the meaningful "include unavailable
+ * items" signal, not a falsy value to discard.
  *
- * Beyond TYPE narrowing, `ship_to`/`ships_from` also FORMAT-validate every provided
- * string field (country alpha-2, region 3166-2, postal bounded) against the shared
- * patterns: a present-but-malformed value returns an `invalid` read so the tool
- * rejects the request client-side with a clear `invalid_filter` error (better agent
- * UX than an opaque, fail-late sil-api 400). `condition` is NOT format-validated —
- * its wire stays OPEN (an unrecognized value still forwards; steering to
- * new/secondhand lives in the description only). The first bad field wins. */
+ * Beyond TYPE narrowing, `ship_to` also FORMAT-validates every provided string field
+ * (country alpha-2, region 3166-2, postal bounded) against the shared patterns: a
+ * present-but-malformed value returns an `invalid` read so the tool rejects the
+ * request client-side with a clear `invalid_filter` error (better agent UX than an
+ * opaque, fail-late sil-api 400). `condition` is NOT format-validated — its wire
+ * stays OPEN (an unrecognized value still forwards; steering to new/secondhand lives
+ * in the description only). `local_merchants` is a plain boolean bias (no format, no
+ * country) — its whole steer lives in the description. The first bad field wins. */
 function readSearchParams(params: Record<string, unknown>): SearchParamsRead {
   const result: SearchParams = {};
   const query = params["query"];
@@ -553,14 +559,17 @@ function readSearchParams(params: Record<string, unknown>): SearchParamsRead {
   if (shipTo.kind === "invalid") return { kind: "invalid", field: shipTo.field };
   if (shipTo.kind === "ok") result.ship_to = shipTo.value;
 
-  const shipsFrom = readShipsFrom(params["ships_from"]);
-  if (shipsFrom.kind === "invalid") return { kind: "invalid", field: shipsFrom.field };
-  if (shipsFrom.kind === "ok") result.ships_from = shipsFrom.value;
-
   const condition = readCondition(params["condition"]);
   if (condition !== null) result.condition = condition;
   const available = params["available"];
   if (typeof available === "boolean") result.available = available;
+  // `local_merchants` is a plain boolean bias narrowed exactly like `available`:
+  // a wrong type is DROPPED (treated as absent), never coerced. A valid `false`
+  // survives the read site (type-driven, not value-driven); the omit-when-falsy
+  // discipline for the BIAS itself lives at the wire (`buildSearchBody`), since
+  // unlike `available:false`, a false bias carries no ranking signal.
+  const localMerchants = params["local_merchants"];
+  if (typeof localMerchants === "boolean") result.local_merchants = localMerchants;
 
   return { kind: "ok", params: result };
 }
@@ -602,21 +611,6 @@ function readShipTo(raw: unknown): FilterRead<ShipTo> {
     result.postal_code = postalCode;
   }
   return { kind: "ok", value: result };
-}
-
-/** Narrow a `ships_from` arg to {@link ShipsFrom}. A non-object/missing-country is
- * `absent` (DROPPED, wrong-TYPE discipline); a provided `country` string that fails
- * the alpha-2 pattern is `invalid` (REJECT). Country is uppercased on the wire, not
- * here. */
-function readShipsFrom(raw: unknown): FilterRead<ShipsFrom> {
-  const obj = asRecord(raw);
-  if (obj === null) return { kind: "absent" };
-  const country = obj["country"];
-  if (typeof country !== "string" || country.length === 0) return { kind: "absent" };
-  if (!matchesPattern(country, COUNTRY_PATTERN)) {
-    return { kind: "invalid", field: "ships_from.country" };
-  }
-  return { kind: "ok", value: { country } };
 }
 
 /** Test a value against one of the shared schema patterns, anchored exactly as the


### PR DESCRIPTION
## Card
`cards/replace-ships-from-with-local-merchants.md` (epic `local-merchants-2026-06`; lives in the `card/replace-ships-from-with-local-merchants` branch — gitignored, so the body is not in this diff). See the card for the full Intent + Discovery + In-Dev/Review handoffs.

## Summary
`ships_from` is the wrong lever and is **deleted end-to-end** from the plugin's catalog surface (no shim — live correlation tests settled that a declared shipping-origin filter on a dropshipper-dominated catalog barely narrows and surfaces non-local sellers). In its place, `sil_search` gains a **`local_merchants` optional boolean** that biases results toward shops based in the user's own country — best-effort, **server-ranked**. The plugin owns only the surface: the param shape, the agent-facing description, and the wire emission. Ranking lives in the sil-api sibling.

- **Delete `ships_from`** in `src/tools/catalog.ts` (the `ShipsFrom` import, schema param, `readShipsFrom` reader + its call, description clause, doc-comments) and `src/lib/sil-client.ts` (the `ShipsFrom` interface, `SearchParams.ships_from`, the `buildSearchBody` branch, doc-comments), and the `README.md` `sil_search` row. Grep gate over `src/tools src/lib README.md` is empty.
- **Add `local_merchants`** as a `Type.Optional(Type.Boolean({ … }))` param (verbatim best-effort / query-in-user's-language / no-country copy), narrowed with `typeof === "boolean"` (mirrors `available`), with a tool-level description steer. `hasUsableInput` is untouched — the bias is a refinement, not an input, so a bare `{ local_merchants: true }` still rejects `empty_search_input`.
- **Wire:** `buildSearchBody` emits `body["local_merchants"] = true` at the **top level** (sibling of `query`/`filters`/`pagination`), **only when `=== true`**; `false`/absent/wrong-type omit the key (unlike `available:false`, a `false` bias carries no signal).

No client-side locality logic — the bias is entirely sil-api's; the result-shaping is locality-agnostic (no "is local" tag, no re-rank/drop), pinned by the integration suite.

## ⚠ Cross-card WIRE CONTRACT — sil-api sibling `drop-ships-from-and-rank-local-merchants`
The catalog-search request body carries **`local_merchants: true` as a TOP-LEVEL field beside `query`/`filters`/`pagination`, NOT under `filters`**. sil-api must read it from the **request-body top level** and must **NOT forward it to the Global Catalog** (it is sil-private — the Global Catalog's open filter set would silently swallow it). The sibling must also drop its own `ships_from` handling. If the two sides disagree on placement/key, the boolean lands but is silently ignored (both tests green, behavior a no-op) — so this placement is load-bearing. The two cards may merge in either order; only the end-to-end *effect* needs both.

## Test plan
- [x] `pnpm test` → 505 passing. The 3 card-target files (`tools/search.test.ts`, `lib/search-client.test.ts`, `catalog-search.integration.test.ts`) are 153/153 — all 19 new assertions green.
- [x] `pnpm typecheck` clean (the `@ts-expect-error`s on `ships_from` / non-boolean `local_merchants` now fire — the type-level deletion is real).
- [x] `pnpm build` clean; `dist/index.js` emitted.
- [x] The wire invariant is asserted as a PAIR everywhere (top-level presence AND `filters`-absence together) — the only thing that catches the wrong-placement-under-filters false-green.
- ℹ The 10 red `repo-scaffold.integration.test.ts` tests are a gitignored-worktree env artifact (that suite reads repo-root `CLAUDE.md` / `docs/*/INDEX.md`, gitignored and absent in the worktree checkout) — independent of this card, pre-existing.

Zero test files were modified (the test-guard hook enforces it; the tests are the spec). Test files retain `ships_from` only in deletion-proof regression guards — by design.

## Distillation target
Knowledge capture happens **after Review PASS** in the `distilling` stage — `solutions-architect` runs in this same worktree, commits to this branch, and pushes here, so the PR ends up containing implementation + tests + distillation in one mergeable unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)