### PR TITLE
bug: surface user_not_provisioned in catalog tools + fix the re-register recovery

### DIFF
--- a/src/__tests__/catalog-lookup.integration.test.ts
+++ b/src/__tests__/catalog-lookup.integration.test.ts
@@ -1397,3 +1397,128 @@ describe("sil_product_get — the access token is sent on the read but NEVER lea
     expect(logs).not.toMatch(/Bearer/i);
   });
 });
+
+/**
+ * CARD `surface-user-not-provisioned-and-fix-recovery` — the RED integration
+ * ceiling for `sil_product_get`, SYMMETRIC with the sil_search block in
+ * `catalog-search.integration.test.ts`. Catalog parity is the whole point: a fix
+ * that lands only in `sil_search` leaves `sil_product_get` still false-transient
+ * (AC2/AC7 catch exactly that). Same two bugs, same forbidden envelope, same
+ * exact-equality token-clear gate; only the tool and request shape differ.
+ *
+ *   AC2  — 403 user_not_provisioned → forbidden (reason + recovery), NEVER retryable.
+ *   AC7  — that same 403 CLEARS the dead token (recovery terminates regardless of
+ *          which catalog tool revealed the state).
+ *   AC10 — 403 principal_mismatch → forbidden but the token SURVIVES (the credential
+ *          stays recoverable; the clear is scoped to user_not_provisioned ONLY).
+ *
+ * The only mock is `fetch` (installRouter). A 403 must NEVER enter the refresh
+ * path (AC3 — it is `forbidden`, not `unauthorized`). EXPECT RED today (the
+ * lookup classifier has no 403 arm, so a 403 reads as `retryable` and nothing
+ * clears).
+ */
+describe("sil_product_get — a 403 user_not_provisioned surfaces FORBIDDEN and clears the dead token (AC2, AC7)", () => {
+  it("403 user_not_provisioned → forbidden envelope (reason + recovery:sil_register), NEVER retryable (AC2)", async () => {
+    // AC2: catalog parity — sil_product_get speaks the SAME forbidden vocabulary
+    // as sil_search and sil_whoami, never the false-transient.
+    seedTokens("valid-but-unprovisioned-at", "valid-rt");
+    installRouter((kind) =>
+      kind === "lookup"
+        ? { status: 403, body: { error: "user_not_provisioned" } }
+        : { status: 200, body: { access_token: "x", refresh_token: "y" } },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] }),
+    );
+
+    expect(payload["status"]).toBe("forbidden");
+    expect(payload["status"]).not.toBe("retryable");
+    expect(payload["reason"]).toBe("user_not_provisioned");
+    expect(payload["recovery"]).toBe("sil_register");
+    expect(payload["products"]).toBeUndefined();
+    const message = String(payload["message"]).toLowerCase();
+    expect(message).toMatch(/provision|onboard|forbidden|not.*set.up/);
+    expect(message).not.toMatch(/temporar|transient|unavailable|try.again.later/);
+  });
+
+  it("the 403 is FORBIDDEN, NOT unauthorized — NO /auth/refresh call, exactly one lookup (AC3)", async () => {
+    // AC3: a 403 must not enter the refresh-and-retry-once path. The router 200s
+    // any refresh, so rec.refresh.length === 0 proves no refresh was attempted.
+    seedTokens("valid-but-unprovisioned-at", "valid-rt");
+    const rec = installRouter((kind) =>
+      kind === "lookup"
+        ? { status: 403, body: { error: "user_not_provisioned" } }
+        : { status: 200, body: { access_token: "rotated", refresh_token: "rotated-rt" } },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] });
+
+    expect(rec.refresh.length).toBe(0);
+    expect(rec.lookup.length).toBe(1);
+  });
+
+  it("the dead token is CLEARED on user_not_provisioned — tokens.json is gone (AC7)", async () => {
+    // AC7: recovery terminates regardless of which catalog tool revealed the
+    // state. Same clear as sil_search; asserted by file absence + null read.
+    seedTokens("valid-but-unprovisioned-at", "valid-rt");
+    installRouter((kind) =>
+      kind === "lookup"
+        ? { status: 403, body: { error: "user_not_provisioned" } }
+        : { status: 200, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] });
+
+    expect(existsSync(getTokensPath())).toBe(false);
+    expect(readTokens()).toBeNull();
+  });
+});
+
+describe("sil_product_get — a 403 principal_mismatch is forbidden but does NOT clear the token (AC10)", () => {
+  it("403 principal_mismatch → forbidden envelope carrying that reason (NEVER retryable)", async () => {
+    seedTokens("valid-at", "valid-rt");
+    installRouter((kind) =>
+      kind === "lookup"
+        ? { status: 403, body: { error: "principal_mismatch" } }
+        : { status: 200, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] }),
+    );
+
+    expect(payload["status"]).toBe("forbidden");
+    expect(payload["status"]).not.toBe("retryable");
+    expect(payload["reason"]).toBe("principal_mismatch");
+    expect(payload["recovery"]).toBe("sil_register");
+  });
+
+  it("the token SURVIVES on principal_mismatch — tokens.json is NOT cleared (AC10, the correctness boundary)", async () => {
+    // AC10: the same exact-equality gate as sil_search. principal_mismatch is
+    // recoverable; clearing it would force a destructive re-onboard on a good
+    // credential. Only reason === "user_not_provisioned" clears.
+    seedTokens("valid-at", "valid-rt");
+    installRouter((kind) =>
+      kind === "lookup"
+        ? { status: 403, body: { error: "principal_mismatch" } }
+        : { status: 200, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] });
+
+    expect(existsSync(getTokensPath())).toBe(true);
+    expect(readTokens()).not.toBeNull();
+    expect(readTokens()!.access_token).toBe("valid-at");
+  });
+});

--- a/src/__tests__/catalog-search.integration.test.ts
+++ b/src/__tests__/catalog-search.integration.test.ts
@@ -66,6 +66,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { registerCatalogTools } from "../tools/catalog.js";
+// CARD surface-user-not-provisioned: the AC8 end-to-end recovery proof drives
+// sil_register (after a sil_search 403 clears the dead token) on the SAME api +
+// data dir — so the identity tools are registered alongside the catalog tools.
+import { registerIdentityTools } from "../tools/identity.js";
 import { setWebUrl, setApiUrl, getWebUrl, getApiUrl } from "../lib/config.js";
 import { getDataDir, getTokensPath, readTokens } from "../lib/credentials.js";
 import {
@@ -2114,5 +2118,253 @@ describe("sil_search — the access token is sent on the read but NEVER leaks", 
     const logs = logBlob(api);
     expect(logs).not.toContain(AT);
     expect(logs).not.toMatch(/Bearer/i);
+  });
+});
+
+/**
+ * CARD `surface-user-not-provisioned-and-fix-recovery` — the RED integration
+ * ceiling for `sil_search`. Two bugs, both wired-through here:
+ *
+ *   Bug 1 (legibility): a sil-api 403 `user_not_provisioned` must surface as the
+ *   forbidden envelope `{ status:"forbidden", reason, message, recovery:"sil_register" }`
+ *   — IDENTICAL to what `sil_whoami` emits — never the false-transient
+ *   `{ status:"retryable", message:"…temporarily unavailable…" }`. Today the catalog
+ *   classifier has no 403 arm, so a 403 reads as `retryable` (the agent retries a
+ *   call that can NEVER succeed). EXPECT RED.
+ *
+ *   Bug 2 (recovery terminates): on a `user_not_provisioned` 403 — and ONLY that
+ *   reason — the tool clears the structurally-dead token (`clearTokens()` at the
+ *   call site) so the next `sil_register` re-onboards instead of short-circuiting
+ *   to `already_registered`. A `principal_mismatch` (or any other/unknown reason)
+ *   must NOT clear — it can be transient and the credential must survive (AC10).
+ *
+ * The ONLY mock is `fetch` (installRouter). A 403 must NEVER enter the refresh
+ * path (it is `forbidden`, not `unauthorized` — AC3); the 5xx → retryable cases
+ * stay green unchanged (AC11). The message-register parity with `sil_whoami` is
+ * asserted by the same regex pair whoami.integration.test.ts uses (AC5).
+ */
+describe("sil_search — a 403 user_not_provisioned surfaces FORBIDDEN and clears the dead token (AC1, AC3, AC5, AC6, AC11)", () => {
+  it("403 user_not_provisioned → forbidden envelope (reason + recovery:sil_register), NEVER retryable / temporarily-unavailable (AC1)", async () => {
+    // AC1: the headline legibility fix. The agent sees `forbidden`, the real
+    // reason, and the recovery hint — not the lie it was getting before.
+    seedTokens("valid-but-unprovisioned-at", "valid-rt");
+    installRouter((kind) =>
+      kind === "search"
+        ? { status: 403, body: { error: "user_not_provisioned" } }
+        : { status: 200, body: { access_token: "x", refresh_token: "y" } },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { query: "office chair" }));
+
+    expect(payload["status"]).toBe("forbidden");
+    expect(payload["status"]).not.toBe("retryable");
+    expect(payload["reason"]).toBe("user_not_provisioned");
+    expect(payload["recovery"]).toBe("sil_register");
+    // No products, no false success.
+    expect(payload["products"]).toBeUndefined();
+    // The message is an actionable onboarding/provisioning prompt — and is NOT the
+    // false-transient "temporarily unavailable, try again later" copy the bug
+    // produced (this is the exact phrasing the false-transient symptom showed).
+    const message = String(payload["message"]).toLowerCase();
+    expect(message).not.toMatch(/temporar|transient|unavailable|try.again.later/);
+    expect(message).not.toContain("temporarily unavailable");
+  });
+
+  it("the 403 is classified FORBIDDEN, NOT unauthorized — NO /auth/refresh call is made, exactly one search (AC3)", async () => {
+    // AC3: a 403 is not a 401. Refreshing a valid-but-unprovisioned token changes
+    // nothing — the tool must NOT enter the refresh-and-retry-once path. The
+    // router 200s any refresh, so a stray refresh would (wrongly) recover; the
+    // `rec.refresh.length === 0` assertion is what proves no refresh was attempted.
+    seedTokens("valid-but-unprovisioned-at", "valid-rt");
+    const rec = installRouter((kind) =>
+      kind === "search"
+        ? { status: 403, body: { error: "user_not_provisioned" } }
+        : { status: 200, body: { access_token: "rotated", refresh_token: "rotated-rt" } },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    await getTool(api, TOOL).execute("c1", { query: "chair" });
+
+    expect(rec.refresh.length).toBe(0); // NO refresh on a 403 — the load-bearing assertion
+    expect(rec.search.length).toBe(1); // exactly one read, no retry
+  });
+
+  it("the forbidden message + reason + recovery MATCH what sil_whoami emits for user_not_provisioned (one vocabulary, AC5)", async () => {
+    // AC5: parity on what the agent SEES. The catalog forbidden envelope must be
+    // byte-compatible with sil_whoami's — same reason, same recovery, same message
+    // register (matches /provision|onboard|forbidden|not.*set.up/, the same positive
+    // regex whoami.integration.test.ts asserts; NOT the transient regex).
+    seedTokens("valid-but-unprovisioned-at", "valid-rt");
+    installRouter((kind) =>
+      kind === "search"
+        ? { status: 403, body: { error: "user_not_provisioned" } }
+        : { status: 200, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { query: "chair" }));
+
+    expect(payload["reason"]).toBe("user_not_provisioned");
+    expect(payload["recovery"]).toBe("sil_register");
+    const blob = JSON.stringify(payload).toLowerCase();
+    expect(blob).toMatch(/provision|onboard|forbidden|not.*set.up/);
+    expect(blob).not.toMatch(/temporar|transient|unavailable|try.again.later/);
+  });
+
+  it("the dead token is CLEARED on user_not_provisioned — tokens.json is gone (AC6)", async () => {
+    // AC6: the recovery loop is broken. The structurally-dead token (maps to no
+    // account on this backend; a refresh cannot help) is cleared, so a subsequent
+    // sil_register no longer short-circuits to already_registered. Asserted both by
+    // file absence and a null read (the same two-pronged check whoami uses for the
+    // invalid_grant clear).
+    seedTokens("valid-but-unprovisioned-at", "valid-rt");
+    installRouter((kind) =>
+      kind === "search"
+        ? { status: 403, body: { error: "user_not_provisioned" } }
+        : { status: 200, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    await getTool(api, TOOL).execute("c1", { query: "chair" });
+
+    expect(existsSync(getTokensPath())).toBe(false);
+    expect(readTokens()).toBeNull();
+  });
+
+  it("a genuine 5xx is STILL retryable with NO recovery:sil_register — the fix re-routes ONLY the 403 (AC11)", async () => {
+    // AC11: the load-bearing invariant the bug violated, asserted from the other
+    // side — a real transient must NOT collapse into forbidden. A 5xx stays
+    // `retryable`, no recovery hint, token untouched.
+    seedTokens("at", "rt");
+    installRouter((kind) =>
+      kind === "search"
+        ? { status: 500, body: { error: "source_unavailable", message: "x" } }
+        : { status: 200, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { query: "chair" }));
+
+    expect(payload["status"]).toBe("retryable");
+    expect(payload["status"]).not.toBe("forbidden");
+    expect(payload["recovery"]).not.toBe("sil_register");
+    // A 5xx is transient — the token is NOT cleared (it may be perfectly valid).
+    expect(readTokens()).not.toBeNull();
+  });
+});
+
+describe("sil_search — a 403 principal_mismatch is forbidden but does NOT clear the token (AC4, AC10)", () => {
+  it("403 principal_mismatch → forbidden envelope carrying that reason (NEVER retryable) (AC4)", async () => {
+    // AC4: every 403 is legible — a principal_mismatch is `forbidden` with its
+    // reason surfaced, with the recovery hint, never the false-transient.
+    seedTokens("valid-at", "valid-rt");
+    installRouter((kind) =>
+      kind === "search"
+        ? { status: 403, body: { error: "principal_mismatch" } }
+        : { status: 200, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { query: "chair" }));
+
+    expect(payload["status"]).toBe("forbidden");
+    expect(payload["status"]).not.toBe("retryable");
+    expect(payload["reason"]).toBe("principal_mismatch");
+    expect(payload["recovery"]).toBe("sil_register");
+  });
+
+  it("the token SURVIVES on principal_mismatch — tokens.json is NOT cleared (AC10, the correctness boundary)", async () => {
+    // AC10: the cardinal scoping guard. principal_mismatch can be transient (an
+    // in-flight principal/agent-context resolution); the SAME valid credential
+    // must stay usable once the mismatch clears. Clearing here would force a
+    // destructive, pointless re-onboard. The clear is gated on EXACT equality
+    // reason === "user_not_provisioned" — principal_mismatch must not trip it.
+    seedTokens("valid-at", "valid-rt");
+    installRouter((kind) =>
+      kind === "search"
+        ? { status: 403, body: { error: "principal_mismatch" } }
+        : { status: 200, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    await getTool(api, TOOL).execute("c1", { query: "chair" });
+
+    // The valid token survives — not cleared on principal_mismatch.
+    expect(existsSync(getTokensPath())).toBe(true);
+    expect(readTokens()).not.toBeNull();
+    expect(readTokens()!.access_token).toBe("valid-at");
+  });
+
+  it("an UNKNOWN / generic 'forbidden' reason also does NOT clear the token (AC10, the default boundary)", async () => {
+    // AC10 (the default half): an unexpected 403 body defaults to reason
+    // "forbidden" (extractForbiddenReason's default), which does NOT equal
+    // "user_not_provisioned" — so it must NOT clear either. Only the one exact
+    // reason clears; everything else survives.
+    seedTokens("valid-at", "valid-rt");
+    installRouter((kind) =>
+      kind === "search"
+        ? { status: 403, body: { something_unexpected: true } }
+        : { status: 200, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { query: "chair" }));
+
+    expect(payload["status"]).toBe("forbidden");
+    expect(payload["reason"]).toBe("forbidden");
+    // Unknown reason → no clear.
+    expect(readTokens()).not.toBeNull();
+    expect(readTokens()!.access_token).toBe("valid-at");
+  });
+});
+
+describe("sil_search — the recovery TERMINATES end-to-end: after a user_not_provisioned clear, sil_register re-onboards (AC8)", () => {
+  it("sil_search 403 user_not_provisioned clears the token → a subsequent sil_register mints awaiting_browser, NOT already_registered", async () => {
+    // AC8: the headline end-to-end proof — the exit actually works, not just that
+    // the token vanished. Before this card, sil_register short-circuits to
+    // already_registered on ANY stored token, so the recovery hint loops forever
+    // (forbidden → sil_register → already_registered → forbidden …). With the dead
+    // token cleared by the 403, sil_register has nothing to short-circuit on and
+    // proceeds to mint a fresh registration session (`awaiting_browser`).
+    seedTokens("valid-but-unprovisioned-at", "valid-rt");
+    installRouter((kind) =>
+      kind === "search"
+        ? { status: 403, body: { error: "user_not_provisioned" } }
+        : { status: 200, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+    registerIdentityTools(api);
+
+    // Step 1 — the catalog 403 clears the dead token.
+    const searchPayload = payloadOf(
+      await getTool(api, TOOL).execute("c1", { query: "chair" }),
+    );
+    expect(searchPayload["status"]).toBe("forbidden");
+    expect(readTokens()).toBeNull(); // dead token gone
+
+    // Step 2 — sil_register now re-onboards. It arms a fire-and-forget background
+    // poll; restore the search router and trap that poll's fetch with a
+    // never-resolving promise so it cannot escape the test (the same isolation
+    // whoami.integration.test.ts uses for the post-clear sil_register).
+    vi.restoreAllMocks();
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      () => new Promise<Response>(() => {}),
+    );
+
+    const regPayload = payloadOf(await getTool(api, "sil_register").execute("c2", {}));
+
+    // The recovery exit is live: NOT already_registered, but a fresh session.
+    expect(regPayload["status"]).not.toBe("already_registered");
+    expect(regPayload["status"]).toBe("awaiting_browser");
   });
 });

--- a/src/__tests__/lib/lookup-classify.test.ts
+++ b/src/__tests__/lib/lookup-classify.test.ts
@@ -249,9 +249,76 @@ describe("classifyLookupResponse — the four distinct outcomes stay distinct", 
     expect(classifyLookupResponse(500, { error: "source_unavailable" }).kind).not.toBe("ok");
   });
 
-  it("4xx other than 400/401 → retryable, never a silent ok (defensive)", () => {
-    for (const code of [403, 404, 409, 429]) {
+  it("4xx other than 400/401/403 → retryable, never a silent ok (defensive)", () => {
+    // 403 is NO LONGER in this loop — it has its own positive `forbidden` arm
+    // below (this card); 404/409/429 stay `retryable`.
+    for (const code of [404, 409, 429]) {
+      expect(classifyLookupResponse(code, {}).kind).toBe("retryable");
       expect(classifyLookupResponse(code, {}).kind).not.toBe("ok");
+    }
+  });
+});
+
+/**
+ * CARD `surface-user-not-provisioned-and-fix-recovery` — the RED unit floor for
+ * the catalog 403 → `forbidden` arm, SYMMETRIC with `search-classify.test.ts`. The
+ * two catalog tools share ONE agent-facing error vocabulary, so the 403 →
+ * `forbidden{reason}` mapping MUST hold identically on `classifyLookupResponse` /
+ * `LookupOutcome` — or `sil_product_get` stays false-transient while `sil_search`
+ * is fixed (a fix that lands in only one classifier leaves the other lying).
+ *
+ * Same bug, same fix as search: `classifyLookupResponse` has no 403 arm (403 →
+ * `retryable` today); the fix adds `{ kind: "forbidden"; reason: string }` to
+ * `LookupOutcome` and the 403 arm reusing `extractForbiddenReason`. EXPECT RED
+ * today (the classifier returns `retryable` on a 403).
+ */
+describe("classifyLookupResponse — a 403 is FORBIDDEN carrying its reason, NEVER retryable (AC3, AC4)", () => {
+  it("403 user_not_provisioned → forbidden carrying reason:'user_not_provisioned' (NEVER retryable)", () => {
+    const out = classifyLookupResponse(403, { error: "user_not_provisioned" });
+    expect(out.kind).toBe("forbidden");
+    expect(out.kind).not.toBe("retryable");
+    if (out.kind === "forbidden") {
+      expect(out.reason).toBe("user_not_provisioned");
+    }
+  });
+
+  it("403 principal_mismatch → forbidden carrying reason:'principal_mismatch' (the reason passes through; NEVER retryable)", () => {
+    const out = classifyLookupResponse(403, { error: "principal_mismatch" });
+    expect(out.kind).toBe("forbidden");
+    expect(out.kind).not.toBe("retryable");
+    if (out.kind === "forbidden") {
+      expect(out.reason).toBe("principal_mismatch");
+    }
+  });
+
+  it("403 with an unknown / absent reason → forbidden with the default 'forbidden' marker, NEVER retryable", () => {
+    for (const body of [{}, { error: "" }, { error: 42 }, null, "boom", []]) {
+      const out = classifyLookupResponse(403, body);
+      expect(out.kind).toBe("forbidden");
+      expect(out.kind).not.toBe("retryable");
+      if (out.kind === "forbidden") {
+        expect(out.reason).toBe("forbidden");
+        expect(out.reason).not.toBe("user_not_provisioned");
+      }
+    }
+  });
+
+  it("a 403 is DISTINCT from both unauthorized (401, refreshable) and retryable (5xx, transient)", () => {
+    const forbidden403 = classifyLookupResponse(403, { error: "user_not_provisioned" }).kind;
+    const unauthorized401 = classifyLookupResponse(401, {}).kind;
+    const retryable5xx = classifyLookupResponse(500, {}).kind;
+    expect(forbidden403).toBe("forbidden");
+    expect(unauthorized401).toBe("unauthorized");
+    expect(retryable5xx).toBe("retryable");
+    expect(new Set([forbidden403, unauthorized401, retryable5xx]).size).toBe(3);
+  });
+
+  it("a 5xx is STILL retryable, never forbidden — the fix re-routes ONLY the 403 (AC11)", () => {
+    for (const code of [500, 502, 503, 504]) {
+      expect(classifyLookupResponse(code, { error: "source_unavailable" }).kind).toBe("retryable");
+      expect(classifyLookupResponse(code, { error: "source_unavailable" }).kind).not.toBe(
+        "forbidden",
+      );
     }
   });
 });

--- a/src/__tests__/lib/search-classify.test.ts
+++ b/src/__tests__/lib/search-classify.test.ts
@@ -216,12 +216,107 @@ describe("classifySearchResponse — the three distinct sil-api outcomes stay di
     expect(classifySearchResponse(500, { error: "source_unavailable" }).kind).not.toBe("ok");
   });
 
-  it("4xx other than 400/401 → retryable, never a silent ok (defensive)", () => {
-    // Unmapped 4xx (e.g. 403/404/429) is not a clean empty match. It must not
+  it("4xx other than 400/401/403 → retryable, never a silent ok (defensive)", () => {
+    // Unmapped 4xx (e.g. 404/409/429) is not a clean empty match. It must not
     // read as ok; a non-ok terminal/transient is correct (retryable is the safe
-    // non-ok landing — re-running can't make a 200-empty out of a 4xx).
-    for (const code of [403, 404, 409, 429]) {
+    // non-ok landing — re-running can't make a 200-empty out of a 4xx). 403 is
+    // NO LONGER in this loop — it has its own positive `forbidden` arm below
+    // (the whole point of this card); 404/409/429 stay `retryable`.
+    for (const code of [404, 409, 429]) {
+      expect(classifySearchResponse(code, {}).kind).toBe("retryable");
       expect(classifySearchResponse(code, {}).kind).not.toBe("ok");
+    }
+  });
+});
+
+/**
+ * CARD `surface-user-not-provisioned-and-fix-recovery` (epic
+ * `…`) — the RED unit floor for the catalog 403 → `forbidden` arm.
+ *
+ * THE BUG this pins: `classifySearchResponse` has NO 403 arm — it goes straight
+ * from the 401 check to `if (status !== 200) return retryable`, so a sil-api 403
+ * `user_not_provisioned` lands in `retryable` (a false-transient: the agent is
+ * told "temporarily unavailable, try again" forever, and retrying a
+ * valid-but-unprovisioned token can NEVER succeed). `classifyIdentityResponse`
+ * ALREADY classifies 403 → `forbidden` (sil-client.ts:501) — that one line is the
+ * entire reason `sil_whoami` is legible and the catalog tools are not.
+ *
+ * The fix ADDS a `{ kind: "forbidden"; reason: string }` variant to `SearchOutcome`
+ * (byte-identical to `IdentityOutcome`'s, sil-client.ts:204) and the 403 arm to the
+ * classifier — `if (status === 403) return { kind: "forbidden", reason:
+ * extractForbiddenReason(body) }` — reusing the SAME `extractForbiddenReason`
+ * helper. This block is the immutable spec for that arm: the `reason` passthrough
+ * (`user_not_provisioned` / `principal_mismatch`) and the unknown-body default
+ * (`"forbidden"`), classifier-level (AC3, AC4). The wired forbidden envelope +
+ * token-clear live at the integration tier (catalog-search.integration.test.ts).
+ *
+ * EXPECT RED today: every assertion below fails because the classifier returns
+ * `retryable` on a 403 (no forbidden arm exists yet).
+ */
+describe("classifySearchResponse — a 403 is FORBIDDEN carrying its reason, NEVER retryable (AC3, AC4)", () => {
+  it("403 user_not_provisioned → forbidden carrying reason:'user_not_provisioned' (NEVER retryable)", () => {
+    // AC3: the catalog classifier reaches parity with classifyIdentityResponse —
+    // a 403 is `forbidden`, not the false-transient `retryable`. The provisioning
+    // reason rides through so the tool can drive the token-clear (Bug 2's fix).
+    const out = classifySearchResponse(403, { error: "user_not_provisioned" });
+    expect(out.kind).toBe("forbidden");
+    expect(out.kind).not.toBe("retryable");
+    if (out.kind === "forbidden") {
+      expect(out.reason).toBe("user_not_provisioned");
+    }
+  });
+
+  it("403 principal_mismatch → forbidden carrying reason:'principal_mismatch' (the reason passes through; NEVER retryable)", () => {
+    // AC4: every 403 is legible, not just the provisioning one. principal_mismatch
+    // passes through as the reason — the tool uses it to decide NOT to clear
+    // (AC10: principal_mismatch is recoverable, must survive). Still `forbidden`.
+    const out = classifySearchResponse(403, { error: "principal_mismatch" });
+    expect(out.kind).toBe("forbidden");
+    expect(out.kind).not.toBe("retryable");
+    if (out.kind === "forbidden") {
+      expect(out.reason).toBe("principal_mismatch");
+    }
+  });
+
+  it("403 with an unknown / absent reason → forbidden with the default 'forbidden' marker (extractForbiddenReason's default), NEVER retryable", () => {
+    // AC4: an unexpected 403 body is STILL forbidden (legible), defaulting to the
+    // generic `"forbidden"` marker — which (correctly) does NOT equal
+    // "user_not_provisioned", so the tool will NOT clear on it (AC10's "unknown
+    // reason does not clear" boundary, proven at the classifier seam).
+    for (const body of [{}, { error: "" }, { error: 42 }, null, "boom", []]) {
+      const out = classifySearchResponse(403, body);
+      expect(out.kind).toBe("forbidden");
+      expect(out.kind).not.toBe("retryable");
+      if (out.kind === "forbidden") {
+        expect(out.reason).toBe("forbidden");
+        // Never the provisioning reason on a garbage body — the exact-equality
+        // gate downstream therefore cannot mis-fire a destructive clear.
+        expect(out.reason).not.toBe("user_not_provisioned");
+      }
+    }
+  });
+
+  it("a 403 is DISTINCT from both unauthorized (401, refreshable) and retryable (5xx, transient) — five kinds now", () => {
+    // The taxonomy assertion extended for the forbidden arm: 401 (refreshable),
+    // 403 (forbidden, terminal-but-recoverable), and 5xx (transient) are three
+    // distinct landings. A 403 collapsing into either neighbor is the bug.
+    const forbidden403 = classifySearchResponse(403, { error: "user_not_provisioned" }).kind;
+    const unauthorized401 = classifySearchResponse(401, {}).kind;
+    const retryable5xx = classifySearchResponse(500, {}).kind;
+    expect(forbidden403).toBe("forbidden");
+    expect(unauthorized401).toBe("unauthorized");
+    expect(retryable5xx).toBe("retryable");
+    expect(new Set([forbidden403, unauthorized401, retryable5xx]).size).toBe(3);
+  });
+
+  it("a 5xx is STILL retryable, never forbidden — the fix re-routes ONLY the 403 (AC11)", () => {
+    // AC11 (classifier half): the 403 arm must NOT bleed into the transient path.
+    // A genuine 5xx stays `retryable`; a 403 is `forbidden`; the two never cross.
+    for (const code of [500, 502, 503, 504]) {
+      expect(classifySearchResponse(code, { error: "source_unavailable" }).kind).toBe("retryable");
+      expect(classifySearchResponse(code, { error: "source_unavailable" }).kind).not.toBe(
+        "forbidden",
+      );
     }
   });
 });

--- a/src/__tests__/whoami.integration.test.ts
+++ b/src/__tests__/whoami.integration.test.ts
@@ -592,10 +592,20 @@ describe("sil_whoami — 403 forbidden is terminal (NEVER refreshed)", () => {
     expect(blob).not.toMatch(/temporar|transient|unavailable|try.again.later/);
   });
 
-  it("does NOT clear tokens.json on a 403 (the token is valid, just unprovisioned)", async () => {
-    // Only a CONFIRMED invalid_grant clears tokens. A 403 token is still a valid
-    // credential (the human just isn't onboarded) — clearing it would force a
-    // pointless re-register. The dead-session clear must be scoped to 401/refresh.
+  // CARD `surface-user-not-provisioned-and-fix-recovery` — NARROWED (was: "does NOT
+  // clear tokens.json on a 403"). The card makes the token-clear UNIFORM across all
+  // three sil-api tools (Decision B): the recovery loop is the same loop no matter
+  // which tool first reveals the 403, and sil_whoami is the tool that is legible
+  // TODAY — an agent that diagnoses via sil_whoami, follows recovery:"sil_register",
+  // and hits already_registered is stranded identically. So sil_whoami now ALSO
+  // clears on `user_not_provisioned` (AC9). The clear stays scoped to that EXACT
+  // reason: `principal_mismatch` (and any other/unknown reason) must NOT clear (AC10)
+  // — the credential is still valid and must stay recoverable.
+  it("DOES clear tokens.json on a 403 user_not_provisioned (the dead token is gone, so sil_register re-onboards) (AC9)", async () => {
+    // AC9: the headline uniform-clear. The held token maps to no account on this
+    // backend; a refresh cannot help (structurally dead, exactly like the
+    // invalid_grant case). Clearing it breaks the recovery loop on the
+    // whoami-diagnosed path too — the next sil_register no longer short-circuits.
     seedTokens("valid-but-unprovisioned-at", "valid-rt");
     installRouter((kind) =>
       kind === "identity"
@@ -605,11 +615,43 @@ describe("sil_whoami — 403 forbidden is terminal (NEVER refreshed)", () => {
     const api = createMockPluginApi();
     registerIdentityTools(api);
 
-    await getTool(api, TOOL).execute("c1", {});
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", {}));
 
-    // The valid token survives — not cleared on a 403.
+    // Still the legible forbidden envelope (the legibility behavior is unchanged).
+    expect(payload["status"]).toBe("forbidden");
+    expect(payload["reason"]).toBe("user_not_provisioned");
+    expect(payload["recovery"]).toBe("sil_register");
+    // The dead token is cleared — file gone + null read (the two-pronged check the
+    // invalid_grant clear above uses).
+    expect(existsSync(getTokensPath())).toBe(false);
+    expect(readTokens()).toBeNull();
+  });
+
+  it("does NOT clear tokens.json on a 403 principal_mismatch (the credential is valid and must stay recoverable) (AC10)", async () => {
+    // AC10: the scoping boundary — the clear is gated on EXACT equality
+    // reason === "user_not_provisioned". principal_mismatch can be transient (an
+    // in-flight principal/agent-context resolution); the SAME valid credential must
+    // survive so the user stays recoverable without a destructive re-onboard. (Per
+    // the architect's reachability note, sil_whoami's bodyless GET self-read should
+    // not itself emit principal_mismatch in practice — this arm is the defensive
+    // guarantee that the clear does NOT fire even if it did.)
+    seedTokens("valid-but-mismatched-at", "valid-rt");
+    installRouter((kind) =>
+      kind === "identity"
+        ? { status: 403, body: { error: "principal_mismatch" } }
+        : { status: 200, body: { access_token: "x", refresh_token: "y" } },
+    );
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", {}));
+
+    // Forbidden + legible, but the token SURVIVES.
+    expect(payload["status"]).toBe("forbidden");
+    expect(payload["reason"]).toBe("principal_mismatch");
+    expect(existsSync(getTokensPath())).toBe(true);
     expect(readTokens()).not.toBeNull();
-    expect(readTokens()!.access_token).toBe("valid-but-unprovisioned-at");
+    expect(readTokens()!.access_token).toBe("valid-but-mismatched-at");
   });
 });
 

--- a/src/lib/sil-client.ts
+++ b/src/lib/sil-client.ts
@@ -321,10 +321,20 @@ export interface SearchResult {
  * the body carries a real non-empty `source` field (never fabricated, never
  * scraped from `message`); a sil-internal 5xx, a bodyless/garbage non-200, and a
  * network-error throw all stay bare `{ kind: "retryable" }` (outcome a).
+ *
+ * The 401-vs-403 split is the load-bearing auth-branch distinction: `unauthorized`
+ * (401) is the refresh trigger; `forbidden` (403) is terminal-but-recoverable —
+ * refreshing a valid-but-unprovisioned token changes nothing. The `forbidden`
+ * variant carries the actionable `reason` (`user_not_provisioned` /
+ * `principal_mismatch`, defaulting to the generic `"forbidden"` marker on an
+ * unexpected body — byte-identical to `IdentityOutcome`'s variant), which the tool
+ * surfaces in the same forbidden envelope `sil_whoami` emits, and uses to decide
+ * whether to clear the dead token (only on `user_not_provisioned`).
  */
 export type SearchOutcome =
   | { kind: "ok"; products: SearchProduct[]; cursor?: string }
   | { kind: "unauthorized" }
+  | { kind: "forbidden"; reason: string }
   | { kind: "invalid_request"; error: string; message: string }
   | { kind: "retryable"; source?: string; detail?: string };
 
@@ -397,13 +407,16 @@ export interface LookupResult {
 
 /**
  * Outcome of a single sil-api catalog lookup (classified by status + body).
- * Models {@link SearchOutcome} — the SAME four error/success classes so the two
+ * Models {@link SearchOutcome} — the SAME error/success classes so the two
  * catalog tools present ONE agent-facing error vocabulary, NOT a divergent one.
  * The `ok` variant carries the projected `products` + optional `not_found`
  * DIRECTLY (no nested `result`). `unauthorized` (401) is the refresh trigger —
  * the caller routes it through {@link refreshAndRetryOnce} (transparent
  * refresh-and-retry-once, parity with `sil_search` and `sil_whoami`); it is no
- * longer terminal for the catalog tools.
+ * longer terminal for the catalog tools. `forbidden` (403) is terminal-but-
+ * recoverable, carrying the actionable `reason` exactly as {@link SearchOutcome}
+ * does — a 403 surfaces as the shared forbidden envelope, never the false-transient
+ * `retryable`; refreshing it would not help (it is not `unauthorized`).
  *
  * Structural deltas from `SearchOutcome`, both handled here: NO `cursor` (lookup
  * is a batch resolve, not a list) and a `not_found` id list parsed from the
@@ -412,6 +425,7 @@ export interface LookupResult {
 export type LookupOutcome =
   | { kind: "ok"; products: LookupProduct[]; not_found?: string[] }
   | { kind: "unauthorized" }
+  | { kind: "forbidden"; reason: string }
   | { kind: "invalid_request"; error: string; message: string }
   | { kind: "retryable"; source?: string; detail?: string };
 
@@ -516,6 +530,12 @@ export function classifyIdentityResponse(status: number, body: unknown): Identit
  *         retry or re-register)
  *   401 → unauthorized (the refresh trigger — the caller drives transparent
  *         refresh-and-retry-once via `refreshAndRetryOnce`, not terminal)
+ *   403 → forbidden (terminal-but-recoverable; carries the actionable reason
+ *         `user_not_provisioned`/`principal_mismatch`, defaulting to the generic
+ *         `"forbidden"` marker on an unexpected body — parity with
+ *         `classifyIdentityResponse`). A 403 is NOT a 401: it surfaces as the
+ *         shared forbidden envelope, never the false-transient `retryable`, and a
+ *         valid-but-unprovisioned token gains nothing from a refresh.
  *   5xx / other non-200 → retryable
  *   200 → read `products` off sil-api's FLAT envelope (`{ ucp, products,
  *         pagination? }` — top level, no `result` wrapper), normalize, and require
@@ -529,7 +549,7 @@ export function classifyIdentityResponse(status: number, body: unknown): Identit
  *
  * Pure and exported — unit-tested in isolation like `classifyIdentityResponse`;
  * conflating the empty-match success with a partial-200 false-green, or with the
- * 400/401/5xx error classes, is the highest-risk subtle bug in this flow.
+ * 400/401/403/5xx error classes, is the highest-risk subtle bug in this flow.
  */
 export function classifySearchResponse(status: number, body: unknown): SearchOutcome {
   if (status === 400) {
@@ -537,6 +557,7 @@ export function classifySearchResponse(status: number, body: unknown): SearchOut
     return { kind: "invalid_request", error, message };
   }
   if (status === 401) return { kind: "unauthorized" };
+  if (status === 403) return { kind: "forbidden", reason: extractForbiddenReason(body) };
   if (status !== 200) return retryableFromBody(body);
 
   const result = extractSearchResult(body);
@@ -556,6 +577,12 @@ export function classifySearchResponse(status: number, body: unknown): SearchOut
  *         which never arises on the lookup route; do not special-case it.)
  *   401 → unauthorized (the refresh trigger — the caller drives transparent
  *         refresh-and-retry-once via `refreshAndRetryOnce`, parity with search)
+ *   403 → forbidden (terminal-but-recoverable; carries the actionable reason
+ *         `user_not_provisioned`/`principal_mismatch`, defaulting to the generic
+ *         `"forbidden"` marker on an unexpected body — parity with search and
+ *         `classifyIdentityResponse`). A 403 surfaces as the shared forbidden
+ *         envelope, never the false-transient `retryable`; it is NOT a 401, so no
+ *         refresh is triggered.
  *   5xx / other non-200 → retryable
  *   200 → read `products` off sil-api's FLAT envelope (`{ ucp, products,
  *         messages? }` — top level, no `result` wrapper), normalize, and require
@@ -581,6 +608,7 @@ export function classifyLookupResponse(status: number, body: unknown): LookupOut
     return { kind: "invalid_request", error, message };
   }
   if (status === 401) return { kind: "unauthorized" };
+  if (status === 403) return { kind: "forbidden", reason: extractForbiddenReason(body) };
   if (status !== 200) return retryableFromBody(body);
 
   const result = extractLookupResult(body);

--- a/src/tools/catalog.ts
+++ b/src/tools/catalog.ts
@@ -311,6 +311,20 @@ function mapSearchOutcome(api: PluginAPI, outcome: SearchOutcome) {
   switch (outcome.kind) {
     case "ok":
       return searchResult(outcome);
+    case "forbidden":
+      // A 403 surfaces the SAME forbidden envelope `sil_whoami` emits — never the
+      // false-transient `retryable`. On `user_not_provisioned` (and ONLY that exact
+      // reason) the held token maps to no account on this backend and a refresh
+      // cannot help — structurally dead, like the invalid_grant/second_unauthorized
+      // clears below — so clear it HERE (the tool call site, never the pure
+      // classifier) and the next sil_register re-onboards instead of short-circuiting
+      // to already_registered. A `principal_mismatch` / unknown reason can be
+      // transient and stays recoverable — it MUST NOT clear (the exact-equality gate
+      // is the correctness boundary: a startsWith/truthy check would wrongly wipe a
+      // good session).
+      api.logger.warn("sil_search_forbidden", { reason: outcome.reason });
+      if (outcome.reason === "user_not_provisioned") clearTokens();
+      return forbidden(outcome.reason);
     case "invalid_request":
       api.logger.info("sil_search_invalid_request", { error: outcome.error });
       return invalidRequest(outcome.error, outcome.message);
@@ -450,6 +464,15 @@ function mapLookupOutcome(api: PluginAPI, outcome: LookupOutcome) {
   switch (outcome.kind) {
     case "ok":
       return lookupResult(outcome);
+    case "forbidden":
+      // Symmetric with sil_search (one vocabulary, AC2/AC7/AC10): a 403 is the shared
+      // forbidden envelope, and `user_not_provisioned` — and ONLY that exact reason —
+      // clears the structurally-dead token at this call site so recovery terminates
+      // regardless of which catalog tool revealed the state. `principal_mismatch` /
+      // unknown reasons survive (recoverable; the same exact-equality gate).
+      api.logger.warn("sil_product_get_forbidden", { reason: outcome.reason });
+      if (outcome.reason === "user_not_provisioned") clearTokens();
+      return forbidden(outcome.reason);
     case "invalid_request":
       api.logger.info("sil_product_get_invalid_request", { error: outcome.error });
       return invalidRequest(outcome.error, outcome.message);
@@ -719,6 +742,28 @@ function mustReregister(tool: string) {
       `Your sil session has expired. Run sil_register to sign in again, then call ${tool} again.`,
     recovery: "sil_register",
   });
+}
+
+/** Terminal-but-distinct: a 403 — the token is valid but the user isn't provisioned
+ * (or a principal mismatch / other reason). Refreshing would not help (a 403 is not
+ * a 401). Surfaces the SAME envelope `sil_whoami`'s `forbidden()` (identity.ts) emits
+ * — `{ status:"forbidden", reason, message, recovery:"sil_register" }`, byte-identical
+ * including the reason-driven message branch — so the three sil-api tools speak ONE
+ * error vocabulary (AC5). `user_not_provisioned` reads as an actionable onboarding
+ * prompt; any other reason is the generic forbidden copy carrying the reason. The
+ * recovery hint is always `sil_register` (the message names it, tool-agnostic — the
+ * parity with `sil_whoami`'s envelope is byte-exact, so it carries no per-tool name).
+ * The dead-token CLEAR is NOT here — it is the caller's decision (gated on
+ * `user_not_provisioned`), so a `principal_mismatch` that still wants the legible
+ * envelope does not have its token wiped. */
+function forbidden(reason: string) {
+  const message =
+    reason === "user_not_provisioned"
+      ? "Your sil account is not fully set up. Complete onboarding (run"
+        + " sil_register) and try again."
+      : "sil rejected this request (" + reason + "). Run sil_register to"
+        + " re-establish your session, then try again.";
+  return jsonResult({ status: "forbidden", reason, message, recovery: "sil_register" });
 }
 
 /** Transient: a retryable blip — try again, NOT a re-register (a false terminal on

--- a/src/tools/identity.ts
+++ b/src/tools/identity.ts
@@ -219,7 +219,17 @@ function identityOutcomeToResult(api: PluginAPI, outcome: IdentityOutcome) {
     case "ok":
       return identityResult(outcome.identity);
     case "forbidden":
+      // Decision B — the dead-token clear is UNIFORM across all three sil-api tools.
+      // `sil_whoami` is the tool that is legible TODAY; an agent that diagnoses the
+      // 403 via whoami, follows `recovery:"sil_register"`, and hits
+      // `already_registered` is stranded identically to the catalog path. So clear on
+      // `user_not_provisioned` HERE too (the held token maps to no account on this
+      // backend; a refresh cannot help — structurally dead, like the invalid_grant
+      // clear above). Gated on EXACT equality: `principal_mismatch` / unknown reasons
+      // can be transient and must stay recoverable, so they keep the legible forbidden
+      // envelope WITHOUT a destructive clear (AC9 clears, AC10 does not).
       api.logger.warn("sil_whoami_forbidden", { reason: outcome.reason });
+      if (outcome.reason === "user_not_provisioned") clearTokens();
       return forbidden(outcome.reason);
     case "retryable":
       api.logger.info("sil_whoami_retryable", {});


### PR DESCRIPTION
## Card
`cards/surface-user-not-provisioned-and-fix-recovery.md` (lives in the `card/surface-user-not-provisioned-and-fix-recovery` branch as a gitignored working doc — see its body for full intent + handoffs).

## The two bugs

**Bug 1 — legibility (catalog classifiers had no 403 arm).** `classifySearchResponse` + `classifyLookupResponse` (`src/lib/sil-client.ts`) went straight from the 401 check to the non-200 `retryable` landing, so a sil-api **403 `user_not_provisioned`** fell into `retryable` — a *false-transient*: the agent was told "temporarily unavailable, try again" forever, and retrying a valid-but-unprovisioned token can NEVER succeed. `classifyIdentityResponse` already classified 403 → `forbidden`, which is the entire reason `sil_whoami` was legible and the catalog tools were not.

**Bug 2 — recovery dead-ended.** `sil_register` short-circuits to `already_registered` on any stored token, so the `recovery:"sil_register"` hint looped forever for a held-but-unprovisioned token (forbidden → sil_register → already_registered → forbidden …).

## The fix

- **`src/lib/sil-client.ts`** — added `{ kind:"forbidden"; reason:string }` to both `SearchOutcome` and `LookupOutcome` (byte-identical to `IdentityOutcome`'s existing variant) and a `403 → forbidden` arm to both classifiers, reusing the existing module-private `extractForbiddenReason` (no export, no signature change). Classifiers stay pure (no I/O).
- **`src/tools/catalog.ts`** — `mapSearchOutcome`/`mapLookupOutcome` gained a `forbidden` arm emitting the SAME envelope `sil_whoami` produces (`{ status:"forbidden", reason, message, recovery:"sil_register" }`) via a catalog-local `forbidden(reason)` helper + a `sil_<tool>_forbidden` warn log. `clearTokens()` fires at the call site **only** when `reason === "user_not_provisioned"` (exact equality).
- **`src/tools/identity.ts`** — `sil_whoami`'s forbidden mapping gained the SAME `user_not_provisioned`-gated `clearTokens()` (Decision B — uniform clear across all three tools).

The clear is gated on **exact equality** `reason === "user_not_provisioned"`: a `principal_mismatch` (can be transient) or unknown/default-`"forbidden"` reason keeps the legible forbidden envelope but does NOT clear the still-valid credential.

## Acceptance criteria (AC1–AC11) — all covered, all green

- **AC1/AC2** — `sil_search` + `sil_product_get` surface a 403 `user_not_provisioned` as `forbidden` (reason + `recovery:sil_register`), never `retryable`.
- **AC3** — a 403 classifies `forbidden`, never `retryable`, and triggers NO refresh (it is not `unauthorized`; `refreshAndRetryOnce` untouched).
- **AC4** — `principal_mismatch` / unknown reasons are still `forbidden` carrying the reason (unknown → the generic `"forbidden"` default), never `retryable`.
- **AC5** — the catalog forbidden envelope is byte-identical to `sil_whoami`'s (same reason, recovery, and onboarding message register; matches `/provision|onboard|forbidden|not.*set.up/`, not the transient regex).
- **AC6/AC7/AC9** — `user_not_provisioned` clears the dead token uniformly from `sil_search`, `sil_product_get`, AND `sil_whoami`.
- **AC8** — end-to-end: after a `sil_search` 403 clears the token, `sil_register` mints `awaiting_browser`, NOT `already_registered` (the recovery exit actually works — lives in `catalog-search.integration.test.ts`).
- **AC10** — `principal_mismatch` (and unknown reasons) → token SURVIVES, across all three tools.
- **AC11** — a genuine 5xx is STILL `retryable` with no recovery hint; the fix re-routes ONLY the 403.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm build` — clean
- [x] `pnpm test` — the 18 card RED assertions are now GREEN; the 5 card test files pass in isolation (214/214). The only remaining red is the 10 pre-existing `repo-scaffold.integration.test.ts` worktree artifacts (CLAUDE.md/docs/ at the repo root, gitignored/near-empty in a worktree) — not introduced by and not in scope for this card.

## Decision B heads-up (NON-BLOCKING — founder may override)

This NARROWS `sil_whoami`'s former "does NOT clear tokens on a 403" test: `user_not_provisioned` now clears uniformly across all three tools (the recovery loop is the same loop no matter which tool first reveals the 403; a catalog-only clear would strand an agent that diagnosed via `sil_whoami`). If you intend the clear to be catalog-only, AC9 flips and the whoami test reverts — but the whoami-diagnosed recovery path then stays a dead-end. Proceeding with the uniform clear as the only coherent reading of "the recovery actually works".

## Cross-card / gating notes

- This card was **dev-gated behind #20 (`replace-ships-from-with-local-merchants` / `local_merchants`), now merged** — branched from the merged base `5f496b5` (includes #19 source-naming + #20 local_merchants).
- The sibling **`surface-product-url-and-specs-in-catalog-tools` is dev-gated behind THIS card** on the shared `src/tools/catalog.ts` — they must not run in Dev concurrently.

## Distillation target

Knowledge capture happens **after Review PASS** in the `distilling` stage — `solutions-architect` runs in this same worktree, commits to this same branch, and pushes here so the PR ends up containing implementation + tests + distillation in one mergeable unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)