### PR TITLE
bug: classify catalog 422 source_rejected as invalid_request (not retryable)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ release (`clawhub package publish --changelog`). See [README](./README.md#releas
 
 ## [Unreleased]
 
+### Fixed
+
+- **A catalog `422 source_rejected` is now classified non-retryable
+  `invalid_request`, not source-named `retryable`.** A real source *rejection*
+  (the source looked at the request and refused it — it can never succeed
+  unchanged) was falling through to `retryableFromBody`, and because the 422 body
+  carries a `source` it surfaced as the source-named `retryable` (outcome b) — a
+  false instruction that told the agent to retry a doomed request while the real
+  upstream cause was buried as a transient `detail`. Both catalog classifiers
+  (`classifySearchResponse` / `classifyLookupResponse`, backing `sil_search` /
+  `sil_product_get`) now special-case `422 → invalid_request` carrying the
+  upstream `{ error, message }`, mirroring the existing `400` arm. The narrowing
+  is exact: a `5xx`/`429 source_unavailable` stays `retryable`.
+
 ## [0.2.2] - 2026-06-13
 
 ### Fixed

--- a/src/__tests__/catalog-lookup.integration.test.ts
+++ b/src/__tests__/catalog-lookup.integration.test.ts
@@ -1206,6 +1206,134 @@ describe("sil_product_get — outcome c: upstream rejected the request → NON-r
   });
 });
 
+/**
+ * CARD `classify-catalog-422-as-invalid-request` (epic
+ * `catalog-source-error-taxonomy-2026-06`) — the RED integration ceiling for the
+ * 422 → `invalid_request` end-to-end wiring on the LOOKUP twin seam, SYMMETRIC
+ * with the sil_search block in `catalog-search.integration.test.ts`. The two
+ * catalog tools share ONE agent-facing error vocabulary, and the 422
+ * `source_rejected` comes off the SHARED source layer — so `sil_product_get` must
+ * read a source rejection identically to `sil_search` (status invalid_request,
+ * carrying the upstream message), or the agent learns two languages for one
+ * failure.
+ *
+ * WHY 422 SPECIFICALLY: same as search — the existing lookup "outcome c" block
+ * above and the DISTINGUISHABILITY block below drive `source_rejected` with HTTP
+ * **400** (already invalid_request today). The real sil-api emits **422**, which
+ * falls through to retryable (source-named) on the lookup path exactly as on
+ * search. These cases drive the production status and prove the agent payload is
+ * `status: "invalid_request"`, identical in shape to the search path.
+ *
+ * EXPECT RED today: lookup 422 → retryable (source-named) → `status: "retryable"`.
+ * The 5xx-still-retryable guard PASSES today and must stay green.
+ */
+describe("sil_product_get — a 422 source_rejected surfaces invalid_request end-to-end carrying the upstream cause (outcome c, the twin seam)", () => {
+  it("422 source_rejected { error, message, source } → status invalid_request carrying the upstream message, NEVER retryable, NO source name, NO recovery", async () => {
+    seedTokens("at", "rt");
+    const rec = installRouter((kind) =>
+      kind === "lookup"
+        ? {
+            status: 422,
+            body: {
+              error: "source_rejected",
+              message: "Source 'etsy' rejected the request: identifier scheme not supported.",
+              source: "etsy",
+            },
+          }
+        : { status: 200, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] }));
+
+    expect(rec.lookup.length).toBe(1);
+    expect(payload["status"]).toBe("invalid_request");
+    expect(payload["status"]).not.toBe("retryable");
+    expect(payload["error"]).toBe("source_rejected");
+    const message = String(payload["message"]);
+    expect(message).toContain("identifier scheme not supported");
+    // NOT the source-named transient copy (outcome b), NOT the extractApiError default.
+    expect(message.toLowerCase()).not.toMatch(/temporarily unavailable|retry .* shortly|sil is /);
+    expect(message).not.toMatch(/Provide a search query or at least one filter/i);
+    expect(payload).not.toHaveProperty("detail");
+    expect(payload["recovery"]).not.toBe("sil_register");
+    expect(JSON.stringify(payload).toLowerCase()).not.toMatch(/sil_register/);
+  });
+
+  it("the lookup 422 invalid_request is shape-IDENTICAL to the search 422 invalid_request (ONE vocabulary across both catalog tools)", async () => {
+    // The twin-seam parity assertion: the agent-facing envelope keys for a 422 source
+    // rejection must be the SAME set on sil_product_get as on sil_search — that is the
+    // whole reason this card closes both seams. We pin the key set + the status/error
+    // here; the search side pins the same in its own file.
+    seedTokens("at", "rt");
+    installRouter((kind) =>
+      kind === "lookup"
+        ? { status: 422, body: { error: "source_rejected", message: "Deterministic source rejection.", source: "etsy" } }
+        : { status: 200, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] }));
+
+    // The invalidRequest() envelope is exactly { status, error, message } — no
+    // recovery, no detail, no source. Same shape sil_search emits for its 422.
+    expect(Object.keys(payload).sort()).toEqual(["error", "message", "status"]);
+    expect(payload["status"]).toBe("invalid_request");
+    expect(payload["error"]).toBe("source_rejected");
+  });
+
+  it("the 422 invalid_request is DISTINCT from a source-named 5xx retryable (outcome b) — same `source`, opposite agent instruction", async () => {
+    // (b)-vs-(c) distinguishability end-to-end on the lookup path, same source token.
+    async function statusFor(reply: Reply): Promise<Record<string, unknown>> {
+      seedTokens("at", "rt");
+      installRouter((kind) => (kind === "lookup" ? reply : { status: 200, body: {} }));
+      const api = createMockPluginApi();
+      registerCatalogTools(api);
+      const p = payloadOf(await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] }));
+      vi.restoreAllMocks();
+      return p;
+    }
+
+    const cReject422 = await statusFor({
+      status: 422,
+      body: { error: "source_rejected", message: "Source 'etsy' rejected the request.", source: "etsy" },
+    });
+    const bUnavailable5xx = await statusFor({
+      status: 503,
+      body: { error: "source_unavailable", message: "Source 'etsy' is temporarily unavailable.", source: "etsy" },
+    });
+
+    expect(cReject422["status"]).toBe("invalid_request");
+    expect(bUnavailable5xx["status"]).toBe("retryable");
+    expect(cReject422["status"]).not.toBe(bUnavailable5xx["status"]);
+    expect(String(bUnavailable5xx["message"])).toContain("etsy");
+    expect(bUnavailable5xx).toHaveProperty("detail");
+    expect(cReject422).not.toHaveProperty("detail");
+  });
+
+  it("GUARD — a genuine 5xx source_unavailable STILL surfaces status retryable end-to-end (the fix narrows ONLY 422, not the transient path)", async () => {
+    seedTokens("at", "rt");
+    installRouter((kind) =>
+      kind === "lookup"
+        ? {
+            status: 500,
+            body: { error: "source_unavailable", message: "Source 'shopify' is temporarily unavailable.", source: "shopify" },
+          }
+        : { status: 200, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { ids: ["gid://product/a"] }));
+
+    expect(payload["status"]).toBe("retryable");
+    expect(payload["status"]).not.toBe("invalid_request");
+    expect(String(payload["message"])).toContain("shopify");
+  });
+});
+
 describe("sil_product_get — DISTINGUISHABILITY: six failure/success cases are pairwise distinct agent envelopes (highest-value)", () => {
   it("{a-5xx, a-network, b-source, b-429, c-reject, all-missed-200} produce pairwise-distinguishable envelopes", async () => {
     // The per-tool half of the load-bearing distinguishability property. The lookup

--- a/src/__tests__/catalog-search.integration.test.ts
+++ b/src/__tests__/catalog-search.integration.test.ts
@@ -1600,6 +1600,123 @@ describe("sil_search — outcome c: upstream rejected the request → NON-retrya
   });
 });
 
+/**
+ * CARD `classify-catalog-422-as-invalid-request` (epic
+ * `catalog-source-error-taxonomy-2026-06`) — the RED integration ceiling for the
+ * 422 `source_rejected` → `invalid_request` end-to-end wiring. The FINAL seam of
+ * the taxonomy, proven through the REAL `sil_search` tool + real sil-client (only
+ * `fetch` mocked).
+ *
+ * WHY 422 SPECIFICALLY (the adversarial point): the existing "outcome c" block
+ * above — and the DISTINGUISHABILITY block below — both drive `source_rejected`
+ * with HTTP **400**, which already classifies as `invalid_request` today. But the
+ * REAL sil-api emits a source rejection as **422** (`source_rejected`), and 422 is
+ * NOT special-cased — it falls through to `retryableFromBody`, and because the body
+ * carries a `source`, the agent sees `status: "retryable"` naming a source (outcome
+ * b). So the 400-based tests give a FALSE sense that outcome (c) is wired; the 422
+ * path — the one production actually exercises — is the (b)≡(c) collapse. These
+ * cases drive the status the wire really uses and prove the agent payload is
+ * `status: "invalid_request"` carrying the upstream `message`, NOT `retryable`.
+ *
+ * EXPECT RED today: 422 → retryable (source-named) end-to-end → `status:
+ * "retryable"`. The 5xx-still-retryable guard PASSES today and must stay green.
+ */
+describe("sil_search — a 422 source_rejected surfaces invalid_request end-to-end carrying the upstream cause (outcome c, the FINAL seam)", () => {
+  it("422 source_rejected { error, message, source } → status invalid_request carrying the upstream message, NEVER retryable, NO source name, NO recovery", async () => {
+    seedTokens("at", "rt");
+    const rec = installRouter((kind) =>
+      kind === "search"
+        ? {
+            status: 422,
+            body: {
+              error: "source_rejected",
+              message:
+                "Source 'shopify' rejected the request: filter `gift_wrap` is not supported by this source.",
+              source: "shopify",
+            },
+          }
+        : { status: 200, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { query: "chair" }));
+
+    // Exactly one outbound search; the agent must NOT be told to retry a doomed request.
+    expect(rec.search.length).toBe(1);
+    expect(payload["status"]).toBe("invalid_request");
+    expect(payload["status"]).not.toBe("retryable");
+    // Carries the REAL upstream cause — error code + the server's message verbatim.
+    expect(payload["error"]).toBe("source_rejected");
+    const message = String(payload["message"]);
+    expect(message).toContain("gift_wrap");
+    // NOT the source-named transient copy (outcome b) and NOT the search-specific
+    // extractApiError default (the body carried a real message).
+    expect(message.toLowerCase()).not.toMatch(/temporarily unavailable|retry .* shortly|sil is /);
+    expect(message).not.toMatch(/Provide a search query or at least one filter/i);
+    // invalid_request carries NO transient `detail` and NO re-register hint.
+    expect(payload).not.toHaveProperty("detail");
+    expect(payload["recovery"]).not.toBe("sil_register");
+    expect(JSON.stringify(payload).toLowerCase()).not.toMatch(/sil_register/);
+  });
+
+  it("the 422 invalid_request is DISTINCT from a source-named 5xx retryable (outcome b) — same `source`, opposite agent instruction", async () => {
+    // The (b)-vs-(c) distinguishability, pinned end-to-end on the SAME source token:
+    // a 422 source_rejected and a 5xx source_unavailable both name 'shopify', but the
+    // agent must read STOP (invalid_request) on the 422 and TRY-AGAIN (retryable) on
+    // the 5xx. Today they collapse — both read retryable — which is the bug.
+    async function statusFor(reply: Reply): Promise<Record<string, unknown>> {
+      seedTokens("at", "rt");
+      installRouter((kind) => (kind === "search" ? reply : { status: 200, body: {} }));
+      const api = createMockPluginApi();
+      registerCatalogTools(api);
+      const p = payloadOf(await getTool(api, TOOL).execute("c1", { query: "chair" }));
+      vi.restoreAllMocks();
+      return p;
+    }
+
+    const cReject422 = await statusFor({
+      status: 422,
+      body: { error: "source_rejected", message: "Source 'shopify' rejected the request.", source: "shopify" },
+    });
+    const bUnavailable5xx = await statusFor({
+      status: 503,
+      body: { error: "source_unavailable", message: "Source 'shopify' is temporarily unavailable.", source: "shopify" },
+    });
+
+    expect(cReject422["status"]).toBe("invalid_request");
+    expect(bUnavailable5xx["status"]).toBe("retryable");
+    expect(cReject422["status"]).not.toBe(bUnavailable5xx["status"]);
+    // The retryable (b) still names its source and carries a transient detail; the
+    // invalid_request (c) does neither — they are not the same envelope.
+    expect(String(bUnavailable5xx["message"])).toContain("shopify");
+    expect(bUnavailable5xx).toHaveProperty("detail");
+    expect(cReject422).not.toHaveProperty("detail");
+  });
+
+  it("GUARD — a genuine 5xx source_unavailable STILL surfaces status retryable end-to-end (the fix narrows ONLY 422, not the transient path)", async () => {
+    // The non-vacuous reverse-collapse tripwire at the integration tier: the 422 arm
+    // must not bleed into the 5xx transient path. PASSES today and must stay green.
+    seedTokens("at", "rt");
+    installRouter((kind) =>
+      kind === "search"
+        ? {
+            status: 500,
+            body: { error: "source_unavailable", message: "Source 'etsy' is temporarily unavailable.", source: "etsy" },
+          }
+        : { status: 200, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { query: "chair" }));
+
+    expect(payload["status"]).toBe("retryable");
+    expect(payload["status"]).not.toBe("invalid_request");
+    expect(String(payload["message"])).toContain("etsy");
+  });
+});
+
 describe("sil_search — DISTINGUISHABILITY: six failure/success cases are pairwise distinct agent envelopes (highest-value)", () => {
   it("{a-5xx, a-network, b-source, b-429, c-reject, empty-200} produce pairwise-distinguishable envelopes", async () => {
     // The single highest-value assertion (extends the existing 'three distinct

--- a/src/__tests__/lib/lookup-classify.test.ts
+++ b/src/__tests__/lib/lookup-classify.test.ts
@@ -87,7 +87,7 @@
 
 import { describe, it, expect } from "vitest";
 
-import { classifyLookupResponse } from "../../lib/sil-client.js";
+import { classifyLookupResponse, type LookupOutcome } from "../../lib/sil-client.js";
 
 /** A real lookup `variant`: UCP variant + sil-api's required non-empty
  * `checkout_url` + the REQUIRED lookup `inputs` correlation (UCP
@@ -437,6 +437,127 @@ describe("classifyLookupResponse — the no-fabrication guard: a sourceless retr
     if (out.kind === "retryable") {
       expect(out.source).toBeUndefined();
     }
+  });
+});
+
+/**
+ * CARD `classify-catalog-422-as-invalid-request` (epic
+ * `catalog-source-error-taxonomy-2026-06`) — the RED unit floor for the catalog
+ * 422 → `invalid_request` arm, SYMMETRIC with `search-classify.test.ts`. The two
+ * catalog tools share ONE agent-facing error vocabulary, and sil-api emits 422
+ * `source_rejected` on the SHARED source layer backing both `/catalog/search` and
+ * `/catalog/lookup` — so a source-rejected LOOKUP mis-maps the same (b)≡(c) way.
+ * Closing only the search seam would leave `sil_product_get` lying (a 422 reading
+ * non-retryable on one catalog tool and retryable on its companion) — a half-done
+ * taxonomy. The twin-seam verdict (CLOSE BOTH) is what makes this block mandatory.
+ *
+ * Same bug, same fix as search: `classifyLookupResponse` has no 422 arm (422 →
+ * retryable today, source-named because the body carries a `source`); the fix
+ * adds the identical `422 → invalid_request` arm reusing `extractApiError` — no new
+ * `kind`, no type change (`LookupOutcome` already carries `{ kind:
+ * "invalid_request"; error; message }`). EXPECT RED today (the classifier returns
+ * `retryable` on a 422); the 5xx/4xx guards PASS today and must stay green.
+ */
+describe("classifyLookupResponse — a 422 source_rejected is INVALID_REQUEST carrying the cause, NEVER retryable (outcome c)", () => {
+  it("422 source_rejected WITH { error, message, source } → invalid_request carrying error+message (NEVER retryable, NEVER source-named)", () => {
+    // The headline contract for the lookup twin seam — identical shape to the search
+    // path so the two tools present ONE vocabulary. RED today: 422 → retryable with
+    // the source named. The cause is carried verbatim.
+    const out = classifyLookupResponse(422, {
+      error: "source_rejected",
+      message: "Source 'etsy' rejected the request: identifier scheme not supported.",
+      source: "etsy",
+    });
+    expect(out.kind).toBe("invalid_request");
+    expect(out.kind).not.toBe("retryable");
+    if (out.kind === "invalid_request") {
+      expect(out.error).toBe("source_rejected");
+      expect(out.message).toBe(
+        "Source 'etsy' rejected the request: identifier scheme not supported.",
+      );
+    }
+  });
+
+  it("a 422 NEVER surfaces a `source` field — outcome c is non-retryable, NOT the source-named retryable (the (b)≡(c) collapse, inverted)", () => {
+    // The exact collapse this card closes, on the lookup seam: the 422 body carries a
+    // `source` (what mis-routes it to outcome b today), but the classified outcome
+    // must be `invalid_request`, which has NO `source` key.
+    const out = classifyLookupResponse(422, {
+      error: "source_rejected",
+      message: "Identifier scheme not supported.",
+      source: "etsy",
+    });
+    expect(out.kind).toBe("invalid_request");
+    expect(out).not.toHaveProperty("source");
+    expect(out).not.toHaveProperty("detail");
+  });
+
+  it("422 with a garbage / empty body ({}, null, 'boom', []) → STILL invalid_request via extractApiError's defaults (a rejection that says nothing is still non-retryable)", () => {
+    // The malformed-422 edge, symmetric with search: a rejection with no usable
+    // { error, message } is STILL non-retryable, never routed back to retryable.
+    // extractApiError fills its defaults. RED today: each returns a bare
+    // { kind: "retryable" }.
+    //
+    // NOTE (architect Risk, accepted in-scope): extractApiError's DEFAULT message is
+    // search-flavored ("…Provide a search query…") and rides this lookup path on a
+    // degenerate body. That copy nuance is consciously accepted for this card — the
+    // behavioral contract asserted here is only that the outcome is a well-formed
+    // NON-retryable invalid_request with non-empty fields, NOT the exact default
+    // wording. So this assertion does not pin the message text.
+    for (const body of [{}, null, "boom", []] as const) {
+      const out = classifyLookupResponse(422, body);
+      expect(out.kind).toBe("invalid_request");
+      expect(out.kind).not.toBe("retryable");
+      if (out.kind === "invalid_request") {
+        expect(typeof out.error).toBe("string");
+        expect(out.error.length).toBeGreaterThan(0);
+        expect(typeof out.message).toBe("string");
+        expect(out.message.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("GUARD (anti-over-narrowing) — a 5xx source_unavailable that NAMES a source STILL returns retryable carrying that source (the fix narrows ONLY 422)", () => {
+    // The non-vacuous reverse-collapse tripwire, symmetric with search: a genuine
+    // source-down 5xx (outcome b) must remain { kind: "retryable", source, detail }.
+    // A wrong-direction over-narrow trips this. PASSES today and after the fix.
+    for (const code of [500, 502, 503, 504]) {
+      const out = classifyLookupResponse(code, {
+        error: "source_unavailable",
+        message: "Catalog source 'etsy' is temporarily unavailable.",
+        source: "etsy",
+      });
+      expect(out.kind).toBe("retryable");
+      expect(out.kind).not.toBe("invalid_request");
+      if (out.kind === "retryable") {
+        expect(out.source).toBe("etsy");
+      }
+    }
+  });
+
+  it("GUARD — the unmapped 4xx defensive set [404, 409, 429] STILL routes to retryable, and NONE of them is invalid_request (422 is the ONLY 4xx narrowed)", () => {
+    // The low-side companion tripwire: only 422 leaves the retryable path. 404/409/429
+    // are not part of this card's contract and must stay `retryable`. PASSES today and
+    // after the fix.
+    for (const code of [404, 409, 429]) {
+      const out = classifyLookupResponse(code, {});
+      expect(out.kind).toBe("retryable");
+      expect(out.kind).not.toBe("invalid_request");
+    }
+  });
+
+  it("422 is DISTINCT from the source-named 5xx retryable (b) and the bare 5xx retryable (a) — three distinct landings, no collapse", () => {
+    // The taxonomy assertion for the lookup final seam — outcomes (a)/(b)/(c) are
+    // three distinct (kind, names-source?) signals; the (b)≡(c) collapse is gone.
+    const c422 = classifyLookupResponse(422, { error: "source_rejected", message: "x", source: "etsy" });
+    const bSource = classifyLookupResponse(500, { error: "source_unavailable", message: "x", source: "etsy" });
+    const aBare = classifyLookupResponse(500, { error: "internal_error", message: "x" });
+    expect(c422.kind).toBe("invalid_request");
+    expect(bSource.kind).toBe("retryable");
+    expect(aBare.kind).toBe("retryable");
+    const fingerprint = (o: LookupOutcome): string =>
+      `${o.kind}::${o.kind === "retryable" && o.source !== undefined ? "named" : "generic"}`;
+    expect(new Set([fingerprint(c422), fingerprint(bSource), fingerprint(aBare)]).size).toBe(3);
   });
 });
 

--- a/src/__tests__/lib/search-classify.test.ts
+++ b/src/__tests__/lib/search-classify.test.ts
@@ -72,7 +72,7 @@
 
 import { describe, it, expect } from "vitest";
 
-import { classifySearchResponse } from "../../lib/sil-client.js";
+import { classifySearchResponse, type SearchOutcome } from "../../lib/sil-client.js";
 
 /** A real `SilCatalogVariant` (UCP variant + required non-empty `checkout_url`);
  * `availability` is the UCP OBJECT shape `{ available?, status? }`. */
@@ -468,6 +468,154 @@ describe("classifySearchResponse — the no-fabrication guard: a sourceless retr
     if (out.kind === "retryable") {
       expect(out.source).toBeUndefined();
     }
+  });
+});
+
+/**
+ * CARD `classify-catalog-422-as-invalid-request` (epic
+ * `catalog-source-error-taxonomy-2026-06`) — the RED unit floor for the catalog
+ * 422 `source_rejected` → `invalid_request` arm. This is the FINAL seam of the
+ * source-error taxonomy: it closes the (b)≡(c) collapse the held sil-stage eval
+ * `live-eval-source-error-taxonomy` exists to RED on.
+ *
+ * THE BUG this pins: `classifySearchResponse` has NO 422 arm. After the 400 / 401
+ * / 403 arms it falls straight to `if (status !== 200) return
+ * retryableFromBody(body)` — and because a real sil-api 422 `source_rejected`
+ * body carries a non-empty `source` field, `retryableFromBody` returns
+ * `{ kind: "retryable", source, detail }` = outcome (b). So a request the source
+ * looked at and REFUSED (it can NEVER succeed unchanged) reaches the agent as
+ * "the source is temporarily unavailable, retry" — a FALSE instruction. The
+ * agent burns its retry budget on a doomed request and the real upstream cause
+ * (the `message`) is buried as a `detail` on a transient envelope.
+ *
+ * The fix ADDS a `422 → invalid_request` arm immediately after the 403 arm and
+ * before the `retryableFromBody` fallthrough, reusing the EXISTING
+ * `extractApiError(body)` (no new helper, no new outcome `kind`, no type change —
+ * `SearchOutcome` already carries `{ kind: "invalid_request"; error; message }`):
+ *     if (status === 422) {
+ *       const { error, message } = extractApiError(body);
+ *       return { kind: "invalid_request", error, message };
+ *     }
+ *
+ * ⚠ ADVERSARIAL — the new arm must gate on EXACTLY `status === 422`, never a
+ * range. A wrong-direction over-narrow (e.g. `status >= 400 && status !== 401`)
+ * that swept a 5xx `source_unavailable` (outcome b) or a 429 into non-retryable
+ * is the taxonomy lie in REVERSE — telling the agent "give up" on a transient
+ * outage. The 5xx-still-retryable guard at the bottom of this block is the
+ * non-vacuous tripwire for that; it MUST stay green before and after the fix.
+ *
+ * EXPECT RED today: the two 422 cases below fail because the classifier returns
+ * `retryable` on a 422 (no 422 arm exists yet). The 5xx guard PASSES today and
+ * must keep passing.
+ */
+describe("classifySearchResponse — a 422 source_rejected is INVALID_REQUEST carrying the cause, NEVER retryable (outcome c)", () => {
+  it("422 source_rejected WITH { error, message, source } → invalid_request carrying error+message (NEVER retryable, NEVER source-named)", () => {
+    // The headline contract: a 422 source rejection is outcome (c), non-retryable,
+    // carrying the real upstream cause. RED today — 422 falls through to
+    // retryableFromBody and, because the body names a source, returns
+    // { kind: "retryable", source, detail } (outcome b). The `error`/`message` are
+    // carried VERBATIM from the body (extractApiError reads them when present).
+    const out = classifySearchResponse(422, {
+      error: "source_rejected",
+      message: "The request was rejected: filter `gift_wrap` is not supported by this source.",
+      source: "shopify",
+    });
+    expect(out.kind).toBe("invalid_request");
+    expect(out.kind).not.toBe("retryable");
+    if (out.kind === "invalid_request") {
+      expect(out.error).toBe("source_rejected");
+      expect(out.message).toBe(
+        "The request was rejected: filter `gift_wrap` is not supported by this source.",
+      );
+    }
+  });
+
+  it("a 422 NEVER surfaces a `source` field — outcome c is non-retryable, NOT the source-named retryable (the (b)≡(c) collapse, inverted)", () => {
+    // The exact (b)≡(c) collapse this card closes, asserted at the seam: even though
+    // the 422 body carries a `source` (which is what mis-routes it to outcome b
+    // today), the classified outcome must be `invalid_request` — which has NO
+    // `source` key at all. A regression that kept routing 422 through
+    // retryableFromBody would re-expose `source`/`detail` here.
+    const out = classifySearchResponse(422, {
+      error: "source_rejected",
+      message: "Filter not supported.",
+      source: "shopify",
+    });
+    expect(out.kind).toBe("invalid_request");
+    expect(out).not.toHaveProperty("source");
+    expect(out).not.toHaveProperty("detail");
+  });
+
+  it("422 with a garbage / empty body ({}, null, 'boom', []) → STILL invalid_request via extractApiError's defaults (a rejection that says nothing is still non-retryable)", () => {
+    // The malformed-422 edge: a rejection whose body carries no usable { error,
+    // message } must STILL be non-retryable — never silently routed back to
+    // retryable. extractApiError fills its defaults (error → "invalid_request",
+    // message → the generic non-empty default), so the outcome is a well-formed
+    // invalid_request with non-empty fields. RED today: each of these returns a
+    // bare { kind: "retryable" } (retryableFromBody finds no `source`).
+    for (const body of [{}, null, "boom", []] as const) {
+      const out = classifySearchResponse(422, body);
+      expect(out.kind).toBe("invalid_request");
+      expect(out.kind).not.toBe("retryable");
+      if (out.kind === "invalid_request") {
+        // Defaults fired — both fields are present, non-empty strings (the agent
+        // always gets an actionable, if generic, cause rather than undefined).
+        expect(typeof out.error).toBe("string");
+        expect(out.error.length).toBeGreaterThan(0);
+        expect(typeof out.message).toBe("string");
+        expect(out.message.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("GUARD (anti-over-narrowing) — a 5xx source_unavailable that NAMES a source STILL returns retryable carrying that source (the fix narrows ONLY 422)", () => {
+    // The non-vacuous reverse-collapse tripwire: the 422 arm must NOT widen into a
+    // status range. A genuine source-down 5xx (outcome b) must remain
+    // { kind: "retryable", source, detail } — a wrong-direction `status >= 400`
+    // over-narrow would mis-route it to non-retryable and trip this. PASSES today
+    // (it is the current correct behavior) and must keep passing after the fix.
+    for (const code of [500, 502, 503, 504]) {
+      const out = classifySearchResponse(code, {
+        error: "source_unavailable",
+        message: "Catalog source 'shopify' is temporarily unavailable.",
+        source: "shopify",
+      });
+      expect(out.kind).toBe("retryable");
+      expect(out.kind).not.toBe("invalid_request");
+      if (out.kind === "retryable") {
+        expect(out.source).toBe("shopify");
+      }
+    }
+  });
+
+  it("GUARD — the unmapped 4xx defensive set [404, 409, 429] STILL routes to retryable, and NONE of them is invalid_request (422 is the ONLY 4xx narrowed)", () => {
+    // The companion tripwire on the low side: only 422 leaves the retryable path.
+    // 404/409/429 are NOT part of this card's contract (404 is sil-api's gateway-miss
+    // landing; an upstream 429 reaches the plugin as a 5xx source_unavailable, not a
+    // bare 429) and must stay `retryable`. A regression that narrowed the whole 4xx
+    // band into invalid_request would trip this. PASSES today and after the fix.
+    for (const code of [404, 409, 429]) {
+      const out = classifySearchResponse(code, {});
+      expect(out.kind).toBe("retryable");
+      expect(out.kind).not.toBe("invalid_request");
+    }
+  });
+
+  it("422 is DISTINCT from the source-named 5xx retryable (b) and the bare 5xx retryable (a) — three distinct landings, no collapse", () => {
+    // The taxonomy assertion for the final seam: outcome (c) 422-invalid_request,
+    // outcome (b) source-named 5xx-retryable, and outcome (a) bare 5xx-retryable are
+    // THREE distinct (kind, names-source?) signals. The (b)≡(c) collapse is the bug;
+    // this proves they no longer share a fingerprint.
+    const c422 = classifySearchResponse(422, { error: "source_rejected", message: "x", source: "shopify" });
+    const bSource = classifySearchResponse(500, { error: "source_unavailable", message: "x", source: "shopify" });
+    const aBare = classifySearchResponse(500, { error: "internal_error", message: "x" });
+    expect(c422.kind).toBe("invalid_request");
+    expect(bSource.kind).toBe("retryable");
+    expect(aBare.kind).toBe("retryable");
+    // (b) names a source, (a) does not, (c) is a different kind entirely.
+    const fingerprint = (o: SearchOutcome): string =>
+      `${o.kind}::${o.kind === "retryable" && o.source !== undefined ? "named" : "generic"}`;
+    expect(new Set([fingerprint(c422), fingerprint(bSource), fingerprint(aBare)]).size).toBe(3);
   });
 });
 

--- a/src/lib/sil-client.ts
+++ b/src/lib/sil-client.ts
@@ -558,6 +558,18 @@ export function classifySearchResponse(status: number, body: unknown): SearchOut
   }
   if (status === 401) return { kind: "unauthorized" };
   if (status === 403) return { kind: "forbidden", reason: extractForbiddenReason(body) };
+  // 422 source_rejected: the source LOOKED at this exact request and refused it —
+  // it can never succeed unchanged, so it is non-retryable invalid_request carrying
+  // the real upstream cause, NOT the source-named `retryable` the fallthrough below
+  // would produce (a 422 body names a `source`, so `retryableFromBody` would emit
+  // outcome (b) and tell the agent to retry a doomed request). This is the third
+  // arm of the 401-vs-403-vs-422 split: 401 refresh-and-retry, 403 forbidden
+  // (refresh won't help), 422 invalid_request (fix the request, don't retry).
+  // Matches EXACTLY 422 — a 5xx/429 source_unavailable stays `retryable` (outcome b).
+  if (status === 422) {
+    const { error, message } = extractApiError(body);
+    return { kind: "invalid_request", error, message };
+  }
   if (status !== 200) return retryableFromBody(body);
 
   const result = extractSearchResult(body);
@@ -609,6 +621,16 @@ export function classifyLookupResponse(status: number, body: unknown): LookupOut
   }
   if (status === 401) return { kind: "unauthorized" };
   if (status === 403) return { kind: "forbidden", reason: extractForbiddenReason(body) };
+  // 422 source_rejected: the twin seam of `classifySearchResponse` — sil-api emits
+  // 422 on the SHARED source layer backing both catalog routes, so a source-rejected
+  // lookup is the same non-retryable invalid_request, carrying the upstream cause,
+  // NOT the source-named `retryable` the fallthrough would produce. Same one error
+  // vocabulary across both catalog tools (see this fn's doc-comment). Matches EXACTLY
+  // 422 — a 5xx/429 source_unavailable stays `retryable` (outcome b).
+  if (status === 422) {
+    const { error, message } = extractApiError(body);
+    return { kind: "invalid_request", error, message };
+  }
   if (status !== 200) return retryableFromBody(body);
 
   const result = extractLookupResult(body);


### PR DESCRIPTION
## The bug

A real catalog **source rejection** — sil-api returns HTTP **422** `source_rejected` with body `{ error, message, source }` (the source looked at this exact request and refused it; it can NEVER succeed unchanged) — reached the agent as a **source-named retryable** (taxonomy outcome b), not the non-retryable `invalid_request` (outcome c).

The mechanism: neither catalog classifier had a 422 arm. After `400 → 401 → 403`, a 422 fell straight to `if (status !== 200) return retryableFromBody(body)` — and because a 422 `source_rejected` body carries a non-empty `source` field, `retryableFromBody` returned `{ kind: "retryable", source, detail }`. So the agent was told "the source is temporarily unavailable, retry," burned its retry budget on a doomed request, and the real upstream cause (the server `message`) survived only as a `detail` on a transient envelope. This is the **(b)≡(c) collapse**.

## The fix

Add an exact `status === 422` arm to **both** `classifySearchResponse` and `classifyLookupResponse` (`src/lib/sil-client.ts`), immediately after the `403` arm and before the `retryableFromBody` fallthrough, mirroring the existing `400` arm byte-for-byte:

```ts
if (status === 422) {
  const { error, message } = extractApiError(body);
  return { kind: "invalid_request", error, message };
}
```

- Reuses the existing module-private `extractApiError` (the same helper the `400` arm uses).
- **No new outcome `kind`, no type change, no new helper** — the `invalid_request` variant already exists on both `SearchOutcome` and `LookupOutcome`.
- The narrowing is **exact**: a `5xx`/`429` `source_unavailable` (outcome b) and the `[404, 409, 429]` defensive set stay `retryable`. Matching a range would be the taxonomy lie in reverse.
- `src/tools/catalog.ts` is **untouched** — `mapSearchOutcome`/`mapLookupOutcome` already route `invalid_request` → `invalidRequest(error, message)` (envelope `{ status, error, message }`).

## Twin-seam rationale

sil-api emits 422 `source_rejected` on the **shared source layer** backing both `/catalog/search` and `/catalog/lookup`, and the two catalog tools deliberately present **one** agent-facing error vocabulary. Closing only the search seam would leave `sil_product_get` lying — a source rejection reading non-retryable on one tool and retryable on its companion. Both arms land in this one card.

## Cross-sibling effect

Closing this seam unblocks the held sil-stage eval `live-eval-source-error-taxonomy` — its **(c) leg + negative control** stay RED until this merges (the (b)≡(c) collapse is exactly what that eval exists to RED on). This is the **final seam** of epic `catalog-source-error-taxonomy-2026-06`; both dependency cards (sil-services `classify-catalog-source-errors`, sil-openclaw `name-the-source-in-catalog-error-surfacing`) are already on `main`.

## Test plan

Tests authored RED-first (commit `406112f`), made GREEN here. No test files modified in this commit.

- [x] **Unit** (`search-classify.test.ts`, `lookup-classify.test.ts`): 422 + `{error,message,source}` → `invalid_request` carrying error+message verbatim, NO `source`/`detail`; garbage-body 422 (`{}`,`null`,`"boom"`,`[]`) → still `invalid_request` via `extractApiError` defaults; the (a)/(b)/(c) three-distinct-fingerprints assertion.
- [x] **Guards (must stay green — non-vacuous reverse-collapse tripwires):** a 5xx `source_unavailable` naming a source STILL → `retryable` carrying it (`[500,502,503,504]`); `[404,409,429]` STILL → `retryable`, none `invalid_request`.
- [x] **Integration** (`catalog-search.integration.test.ts`, `catalog-lookup.integration.test.ts`): wired 422 → `status: "invalid_request"` carrying the upstream `message`, no `detail`, no `sil_register`; (b)-vs-(c) distinguishability on the same `source` token; cross-tool shape parity (`Object.keys === ["error","message","status"]`).
- [x] `pnpm typecheck` clean, `pnpm build` clean.
- [x] `pnpm test`: 549 passed / 10 failed — the 10 are the pre-existing `repo-scaffold.integration.test.ts` failures (assert `CLAUDE.md`/`docs/**` exist at repo root; fail by design in a gitignored worktree), not this card's. The 4 card test files pass 216/216 in isolation.

## Distillation target

Knowledge capture happens after Review PASS in the `distilling` stage. The WHY (the 401-vs-403-vs-422 split) is captured inline on each arm, since `docs/` is gitignored in this repo's worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)