### PR TITLE
bug: Harden plugin registration round-trip

### DIFF
--- a/src/__tests__/lib/poller.test.ts
+++ b/src/__tests__/lib/poller.test.ts
@@ -176,3 +176,78 @@ describe("startPoll — no timer leak (the core invariant)", () => {
     expect(poll.mock.calls.length).toBeGreaterThanOrEqual(3);
   });
 });
+
+describe("startPoll — fix C: the persist-failure terminal is a RETURNED done:true, never a throw", () => {
+  // FIX C, architect risk "poller retry semantics drift" (card line 151). The
+  // poller is GENERIC over the step result — it knows only `done`. Fix C
+  // classifies a token-PERSIST failure as a TERMINAL inside `claimStep` (a
+  // RETURNED `{ done:true, outcome:"persist_failed", error }`), NOT as a thrown
+  // error that reaches the poller's catch. The poller MUST NOT change: these two
+  // assertions pin both halves of that invariant, so a future refactor that
+  // tried to "handle persistence in the poller" (reclassifying a throw as
+  // terminal) would break them.
+  //
+  // These are REGRESSION GUARDS of the generic loop's contract — they hold
+  // against the current poller and must keep holding through fix C (the fix
+  // touches claimStep + the tool, never poller.ts).
+
+  it("a step that THROWS is still treated as NON-terminal (done:false) — the loop keeps polling, NOT a terminal", async () => {
+    // The current catch maps a thrown step to { done:false } (a genuine claim
+    // network blip → retry within budget). Fix C must NOT make a throw terminal:
+    // a thrown step keeps the loop alive. (The persist failure is terminal
+    // because claimStep RETURNS it, not because the poller caught a throw.)
+    const onDone = vi.fn();
+    const poll = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("EACCES: permission denied")) // a throw
+      .mockRejectedValueOnce(new Error("transient network blip"))
+      .mockResolvedValue({ done: true, outcome: "success" });
+
+    startPoll({ intervalMs: 1000, deadlineMs: 60_000, poll, onDone });
+    await vi.advanceTimersByTimeAsync(5000);
+
+    // The throwing ticks did NOT settle the loop — it kept polling and only the
+    // later RETURNED terminal settled it.
+    expect(poll.mock.calls.length).toBeGreaterThanOrEqual(3);
+    expect(onDone).toHaveBeenCalledTimes(1);
+    expect(onDone).toHaveBeenCalledWith(
+      expect.objectContaining({ done: true, outcome: "success" }),
+    );
+  });
+
+  it("a step that RETURNS { done:true, outcome:'persist_failed', error } settles terminally exactly once, with the error carried to onDone, and leaves no timer", async () => {
+    // The shape fix C's claimStep returns on a write failure. The generic poller
+    // must settle on it like any other terminal — fire onDone EXACTLY once with
+    // the full step result (including the `error` carrying path+cause), stop
+    // polling, and leak no timer.
+    const onDone = vi.fn();
+    const poll = vi
+      .fn()
+      .mockResolvedValueOnce({ done: false }) // one claim tick first
+      .mockResolvedValue({
+        done: true,
+        outcome: "persist_failed",
+        error: "/unwritable/dir/tokens.json: EACCES",
+      });
+
+    startPoll({ intervalMs: 1000, deadlineMs: 60_000, poll, onDone });
+    await vi.advanceTimersByTimeAsync(5000);
+
+    const callsAtSettle = poll.mock.calls.length;
+    expect(onDone).toHaveBeenCalledTimes(1);
+    // The full step result — outcome AND the descriptive error — reaches onDone
+    // (handleDone needs the error to log path+cause loudly).
+    expect(onDone).toHaveBeenCalledWith(
+      expect.objectContaining({
+        done: true,
+        outcome: "persist_failed",
+        error: "/unwritable/dir/tokens.json: EACCES",
+      }),
+    );
+
+    // Truly terminal: no further polling, no leaked timer.
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(poll.mock.calls.length).toBe(callsAtSettle);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/src/__tests__/register-claim.integration.test.ts
+++ b/src/__tests__/register-claim.integration.test.ts
@@ -89,19 +89,25 @@ function payloadOf(result: { content: { text?: string }[] }): Record<string, unk
 }
 
 /**
- * Flush the credential write that `onDone` fires un-awaited after a claim
- * settles. The success path persists via async fs (writeFile→rename→chmod);
- * those are REAL libuv ops that don't drain under fake timers. After a
- * terminal the poller has already cleared its interval (no live fake timer),
- * so we can safely drop to the real clock, yield a few macrotasks for the
- * write chain to land, and return. Tests that read tokens.json after a
- * success MUST await this first — otherwise they race the disk write.
+ * Flush the credential write the success path performs after a claim settles.
+ * `writeTokens`/`writeConfig` (credentials.ts) are async wrappers over
+ * SYNCHRONOUS fs internals (writeFileSync→renameSync→chmodSync), AWAITED inside
+ * `claimStep` (identity.ts:323-327) so the files are on disk before the poll
+ * settles. We still yield a few macrotasks on the real clock after a terminal
+ * (the poller has already cleared its interval, so no live fake timer remains)
+ * to be robust to slow CI disks before reading tokens.json.
  *
- * NOTE for the dev pair: this settle dance is necessary BECAUSE the tool's
- * `handleDone` does not await `writeTokens`/`writeConfig` (identity.ts:165).
- * Functionally fine on a real clock, but it means a disk-write failure on
- * the success path is an unhandled rejection with no agent-visible signal —
- * flagged in the QA handoff for the review pass, not weakened here.
+ * FIX C (this card) — the decisive defect addressed by the C tests below: that
+ * awaited persist is NOT error-checked, and the poller's catch (poller.ts:105-109)
+ * treats ANY step throw as a transient `{done:false}` retry. So an unwritable
+ * `$SIL_DATA_DIR` makes the write throw, the loop keeps polling, and the run ends
+ * as a generic `timeout` — a permission/space error masquerading as "the user
+ * never finished," and `sil_whoami` then reports a bare `not_registered`. The C
+ * tests make that write fail (a real unwritable data dir) and assert the
+ * terminal becomes a descriptive `persist_failed` (path+cause) — NOT timeout,
+ * NOT not_registered. (Earlier revisions of this note mis-stated the persist as
+ * un-awaited "in onDone / identity.ts:165"; the persist is in fact awaited in
+ * claimStep — the swallow is the poller catch, not an un-awaited promise.)
  */
 async function settleAsyncIo(): Promise<void> {
   vi.useRealTimers();
@@ -660,6 +666,194 @@ describe("SC8 (in-repo) — two instances, two data dirs, independent tokens", (
       rmSync(dirA, { recursive: true, force: true });
       rmSync(dirB, { recursive: true, force: true });
     }
+  });
+});
+
+// ===========================================================================
+// FIX C — fail-loud token persistence (the decisive defect). Card lines 186-192.
+//
+// After auth succeeds, `claimStep` awaits writeTokens/writeConfig (identity.ts
+// :323-327) but does NOT error-check them, and the poller's catch (poller.ts
+// :105-109) swallows ANY step throw as a transient `{done:false}` retry. So an
+// unwritable / missing-and-uncreatable / full `$SIL_DATA_DIR` makes the write
+// throw, the loop keeps polling, and the run settles as a generic `timeout` — a
+// permission/space error masquerading as "the user never finished". And
+// `sil_whoami` reports a bare `not_registered` (identity.ts:170-172) because a
+// failed write leaves exactly the no-tokens.json state a never-registered user
+// has, so the two are indistinguishable.
+//
+// The fix (three coupled moves): claimStep wraps ONLY the persist in try/catch →
+// a NEW terminal `{ done:true, outcome:"persist_failed", error:"<path>: <cause>" }`
+// + an in-process persist-failure marker; handleDone logs it LOUDLY at error
+// (`sil_register_persist_failed`, distinct from timeout/expired/already_claimed);
+// sil_whoami's not-registered branch returns a distinct `persistence_failed`
+// state when the in-process marker is set. The writable happy path is unchanged.
+//
+// HOW THE WRITE IS MADE TO FAIL (production-faithful, NO logic mocked): a real
+// unwritable data dir. We place a regular FILE where the data dir should be, so
+// writeJsonAtomic's `mkdirSync(dir, { recursive:true })` throws ENOTDIR — a
+// genuine filesystem failure carrying the path + cause. fetch stays mocked at
+// the boundary (a successful claim); the poller + claimStep + writeTokens all
+// run for real. This is the unwritable-`$SIL_DATA_DIR` repro from the card.
+//
+// EXPECT RED against current code: the write throw is swallowed by the poller
+// catch → the loop keeps polling → settles as `timeout` (logs
+// `sil_register_timeout`), NEVER `sil_register_persist_failed`; and an
+// in-process sil_whoami returns `not_registered`, not a distinct
+// persistence-failed state.
+// ===========================================================================
+describe("FIX C — a token-write failure is a terminal, descriptive persist_failed (NOT a retry, NOT timeout)", () => {
+  let parentDir: string;
+  let unwritableDataDir: string;
+
+  beforeEach(() => {
+    // Build a data-dir path whose PARENT is a regular file → mkdirSync throws
+    // ENOTDIR when writeJsonAtomic tries to create it. This is a real,
+    // un-fakeable filesystem failure (no fs mocking, no logic stubbing).
+    parentDir = mkdtempSync(join(tmpdir(), "sil-persistfail-"));
+    const blockerFile = join(parentDir, "blocker");
+    writeFileSync(blockerFile, "i am a file, not a directory");
+    unwritableDataDir = join(blockerFile, "sil-data"); // child of a file → ENOTDIR
+    process.env["SIL_DATA_DIR"] = unwritableDataDir;
+  });
+
+  afterEach(() => {
+    rmSync(parentDir, { recursive: true, force: true });
+  });
+
+  it("settles as persist_failed (logged LOUDLY at error with path + cause), NOT timeout, and stops polling — C-1 + C-2", async () => {
+    const fx = installFetch(() => ({ status: 200, body: SUCCESS_BODY }));
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+
+    await getTool(api, TOOL).execute("c1", {});
+    // Drive a few ticks so the claim succeeds and the (failing) persist is
+    // attempted — well short of the 30-min deadline.
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    // C-1: the failure is TERMINAL, not a transient retry — the loop stopped and
+    // does NOT keep ticking (a swallowed throw would keep polling toward timeout).
+    const callsAfterClaim = fx.callCount();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(fx.callCount()).toBe(callsAfterClaim);
+    expect(vi.getTimerCount()).toBe(0);
+
+    // C-1: nothing persisted (the write failed), and crucially the run did NOT
+    // end as a generic `timeout` — the persistence error must not masquerade as
+    // "the user never finished".
+    expect(readTokens()).toBeNull();
+    const infoMarkers = (api.logger.info as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => c[0],
+    );
+    expect(infoMarkers).not.toContain("sil_register_timeout");
+
+    // C-2: the terminal is logged LOUDLY and DISTINCTLY — an error-level marker,
+    // distinguishable from timeout/expired/already_claimed, carrying the path +
+    // cause so an operator sees persistence failed (not user abandonment).
+    const errorCalls = (api.logger.error as ReturnType<typeof vi.fn>).mock.calls;
+    const errorMarkers = errorCalls.map((c) => c[0]);
+    expect(errorMarkers).toContain("sil_register_persist_failed");
+    // It is NOT mislabelled as any of the other terminals.
+    expect(errorMarkers).not.toContain("sil_register_timeout");
+    // The structured args name the path AND the cause (EACCES/ENOSPC/ENOTDIR…).
+    const persistErrCall = errorCalls.find((c) => c[0] === "sil_register_persist_failed");
+    expect(persistErrCall).toBeDefined();
+    const errBlob = JSON.stringify(persistErrCall);
+    // The path of the file that could not be written appears …
+    expect(errBlob).toContain("sil-data");
+    // … and a real errno cause is named (the ENOTDIR our unwritable dir produces).
+    expect(errBlob).toMatch(/ENOTDIR|EACCES|ENOSPC|ENOENT|not a directory|permission/i);
+    // No token material leaks into the loud error marker (privacy holds on it too).
+    expect(errBlob).not.toContain("fresh-at");
+    expect(errBlob).not.toContain("fresh-rt");
+  });
+
+  it("an in-process sil_whoami distinguishes persistence-failed from not_registered (path + cause + fix-then-reregister recovery) — C-3", async () => {
+    // Same registering process: after the persist fails, sil_whoami (called in
+    // THIS process, where the in-process marker is set) must return a state
+    // DISTINCT from `not_registered` — telling the user persistence failed and
+    // the recovery is "fix the data dir, then re-register", NOT a bare
+    // "run sil_register" that would just fail to persist again.
+    installFetch((url) => {
+      // Should not be reached by whoami (it has no tokens), but answer safely.
+      if (url.includes("/identity")) return { status: 200, body: {} };
+      return { status: 200, body: SUCCESS_BODY };
+    });
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+
+    // Register → claim succeeds → persist fails → in-process marker set.
+    await getTool(api, TOOL).execute("c1", {});
+    await vi.advanceTimersByTimeAsync(10_000);
+    // The poll settled (persist_failed terminal); drop to the real clock so the
+    // subsequent whoami call isn't fighting fake timers.
+    vi.useRealTimers();
+
+    const whoamiPayload = payloadOf(await getTool(api, "sil_whoami").execute("w1", {}));
+
+    // It is NOT the bare never-registered terminal …
+    expect(whoamiPayload["status"]).not.toBe("not_registered");
+    // … it is a DISTINCT persistence-failed state.
+    expect(whoamiPayload["status"]).toBe("persistence_failed");
+    // … carrying the path + cause so the user knows WHAT to fix …
+    const blob = JSON.stringify(whoamiPayload);
+    expect(blob).toContain("sil-data");
+    expect(blob).toMatch(/ENOTDIR|EACCES|ENOSPC|ENOENT|not a directory|permission/i);
+    // … and the actionable recovery is "fix the data dir, THEN re-register" —
+    // distinct from a bare "run sil_register".
+    expect(blob.toLowerCase()).toMatch(/fix|writ|data.?dir|permission|directory/);
+    expect(blob).toContain("sil_register");
+    // No identity is presented (auth's tokens never reached disk).
+    expect(whoamiPayload["identity"]).toBeUndefined();
+    expect(whoamiPayload["name"]).toBeUndefined();
+  });
+});
+
+describe("FIX C — the writable happy path is UNCHANGED (no regression from the fail-loud change) — C-5", () => {
+  // C-5 (card line 192): with a fully-writable $SIL_DATA_DIR, auth+persist behave
+  // EXACTLY as before — tokens.json + config.json land, the terminal is the
+  // existing `success` marker (NOT persist_failed), a subsequent sil_register
+  // reports already_registered, and there is no new error log on the happy path.
+  // This guards the architect's "over-wide try/catch reclassifying a success as
+  // persist_failed" risk. It is GREEN today and MUST stay green through fix C.
+  it("on a writable data dir, persists tokens+config, logs success (NOT persist_failed), and sil_register then reports already_registered", async () => {
+    const fx = installFetch(() => ({ status: 200, body: SUCCESS_BODY }));
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+
+    await getTool(api, TOOL).execute("c1", {});
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    // Exactly-once + no leak on the fake clock.
+    const callsAfterSuccess = fx.callCount();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(fx.callCount()).toBe(callsAfterSuccess);
+    expect(vi.getTimerCount()).toBe(0);
+
+    // The credential write lands on the real clock.
+    await settleAsyncIo();
+    const tokens = await waitForTokens();
+    expect(tokens).not.toBeNull();
+    expect(tokens!.access_token).toBe("fresh-at");
+    const config = readJsonInDataDir<Record<string, unknown>>("config.json");
+    expect(JSON.stringify(config)).toContain("user-42");
+
+    // The terminal is the existing SUCCESS marker — NOT persist_failed.
+    const infoMarkers = (api.logger.info as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => c[0],
+    );
+    expect(infoMarkers).toContain("sil_register_claimed");
+    const errorMarkers = (api.logger.error as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => c[0],
+    );
+    expect(errorMarkers).not.toContain("sil_register_persist_failed");
+
+    // And a subsequent sil_register short-circuits to already_registered (the
+    // tokens truly stuck), with sil_whoami NOT reporting a persistence failure.
+    const reg2 = payloadOf(await getTool(api, TOOL).execute("c2", {}));
+    expect(reg2["status"]).toBe("already_registered");
+    const who = payloadOf(await getTool(api, "sil_whoami").execute("w1", {}));
+    expect(who["status"]).not.toBe("persistence_failed");
   });
 });
 

--- a/src/__tests__/tools/register-link-presentation.test.ts
+++ b/src/__tests__/tools/register-link-presentation.test.ts
@@ -1,0 +1,330 @@
+/**
+ * UNIT — sil_register atomic-link presentation (tier: unit, mock api + temp
+ * data dir, fetch stubbed so the background poll never escapes the test).
+ *
+ * Covers acceptance fix **A — atomic, unbreakable registration link** (card
+ * lines 172-177). The reported production break: `sil_register` returns the
+ * auth URL `…/authorize?session=…&code_challenge=…` INLINE in a human-readable
+ * `message` prose string, and a chat-surface auto-linker terminates the link at
+ * the `&`, dropping `code_challenge` — so the opened link 400s
+ * `invalid_code_challenge`.
+ *
+ * The fix is purely PRESENTATION (the URL is correct on the wire): present the
+ * link on its OWN line, wrapped in angle brackets `<…>` (the RFC-3986 / Markdown
+ * convention that bounds a greedy linker around the whole URL, `&` included),
+ * while keeping `auth_url` the canonical, byte-for-byte UNWRAPPED structured
+ * field that agents parse. The verifier (the claim secret) must never appear in
+ * any result field while doing so.
+ *
+ * Tier rationale: A is asserted on the RETURNED tool-result shape (no I/O, no
+ * network), so it is unit. The poll→claim lifecycle is the integration tier's
+ * job (register-claim.integration.test.ts).
+ *
+ * Hermetic via the SIL_DATA_DIR temp-dir override + the config-reset machinery
+ * mirrored from the sil_register unit tests; fetch is stubbed to a
+ * never-resolving promise so the armed background poll can't reach the network
+ * nor settle during the test. Fake timers ensure no live timer leaks.
+ *
+ * Contract this file pins for the implementation (expert-developer):
+ *   - sil_register's fresh-registration result still carries `auth_url` as a
+ *     complete, UNWRAPPED string `<host>/authorize?session=<uuid>&code_challenge=<43-char S256>`;
+ *   - the human-facing presented link (the `message`, or whichever field a human
+ *     renders) carries that full URL on its OWN line, angle-bracket wrapped, so a
+ *     greedy auto-linker that stops a BARE url at `&` still captures `code_challenge`;
+ *   - NO PKCE verifier appears in ANY result field.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { registerIdentityTools } from "../../tools/identity.js";
+import { setWebUrl } from "../../lib/config.js";
+import {
+  createMockPluginApi,
+  getTool,
+  type MockPluginAPI,
+} from "../helpers/mock-plugin-api.js";
+
+const TOOL = "sil_register";
+const CHALLENGE_RE = /[A-Za-z0-9_-]{43}/;
+
+let dataDir: string;
+let priorSilDataDir: string | undefined;
+
+/** Parse a ToolResult's JSON payload. */
+function payloadOf(result: {
+  content: { text?: string }[];
+}): Record<string, unknown> {
+  const text = result.content[0]?.text;
+  if (typeof text !== "string") {
+    throw new Error(`tool result has no text payload: ${String(text)}`);
+  }
+  return JSON.parse(text) as Record<string, unknown>;
+}
+
+/**
+ * A GREEDY chat auto-linker, modelling the EXACT class of renderer that caused
+ * the production break: it linkifies a bare `http(s)://…` run of "URL-safe"
+ * characters and TERMINATES the link at the first `&` (treating `&` as a prose
+ * separator / entity boundary). On a BARE inline URL this drops
+ * `&code_challenge=…`. The fix's angle-bracket `<…>` wrap is meant to give the
+ * linker an explicit "this whole span is one link" delimiter so the captured
+ * target includes everything up to the closing `>` — `&code_challenge` included.
+ *
+ * Returns the list of link targets the renderer would produce from `text`.
+ * Models both behaviours:
+ *   - an angle-bracket-delimited `<URL>` → the WHOLE URL is one link target
+ *     (the bracket bounds it, so `&` inside is captured);
+ *   - an undelimited bare URL → the link target STOPS at the first `&`.
+ */
+function greedyAutoLink(text: string): string[] {
+  const targets: string[] = [];
+
+  // 1) Angle-bracket-delimited links: <scheme://...> — the entire inner span
+  //    is one target (this is what the fix relies on; `&` inside is kept).
+  const bracketed = /<((?:https?:\/\/)[^>\s]+)>/g;
+  let m: RegExpExecArray | null;
+  const bracketSpans: Array<[number, number]> = [];
+  while ((m = bracketed.exec(text)) !== null) {
+    targets.push(m[1]!);
+    bracketSpans.push([m.index, m.index + m[0].length]);
+  }
+
+  // 2) Bare (undelimited) URLs anywhere NOT already inside a <...> span. A bare
+  //    URL is linkified only up to the first `&` (the greedy-linker bug). We
+  //    blank out the bracketed spans first so a `<...>` URL isn't also matched
+  //    here as a bare URL.
+  let bare = text;
+  for (const [start, end] of bracketSpans) {
+    bare = bare.slice(0, start) + " ".repeat(end - start) + bare.slice(end);
+  }
+  // Match a bare URL run, stopping at whitespace OR `&` (the truncation bug).
+  const bareUrl = /https?:\/\/[^\s&<>]+/g;
+  while ((m = bareUrl.exec(bare)) !== null) {
+    targets.push(m[0]);
+  }
+
+  return targets;
+}
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), "sil-register-link-"));
+  priorSilDataDir = process.env["SIL_DATA_DIR"];
+  process.env["SIL_DATA_DIR"] = dataDir;
+  // Reset config singleton + env so each test starts at the default host.
+  setWebUrl("");
+  delete process.env["SIL_WEB_URL"];
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+  if (priorSilDataDir === undefined) delete process.env["SIL_DATA_DIR"];
+  else process.env["SIL_DATA_DIR"] = priorSilDataDir;
+  setWebUrl("");
+  delete process.env["SIL_WEB_URL"];
+  rmSync(dataDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+/**
+ * Arm a fresh registration and return the parsed result payload. fetch hangs
+ * (never resolves) so the background poll can't escape; fake timers keep any
+ * armed interval from leaking past the test.
+ */
+async function freshRegister(api: MockPluginAPI): Promise<Record<string, unknown>> {
+  return payloadOf(await getTool(api, TOOL).execute("c1", {}));
+}
+
+describe("sil_register — A: auth_url stays the complete, UNWRAPPED machine field", () => {
+  let api: MockPluginAPI;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      () => new Promise<Response>(() => {}),
+    );
+    api = createMockPluginApi();
+    registerIdentityTools(api);
+  });
+
+  it("auth_url is exactly <host>/authorize?session=<uuid>&code_challenge=<43-char S256> — no <> wrap, no encoding", async () => {
+    // A-1: the existing `auth_url` contract is preserved byte-for-byte. Agents
+    // parse THIS field, so it must remain a plain, parseable URL — never the
+    // angle-bracket-wrapped human presentation, never percent-encoded.
+    const payload = await freshRegister(api);
+    const authUrl = payload["auth_url"];
+    expect(typeof authUrl).toBe("string");
+    const s = authUrl as string;
+
+    // Not wrapped in angle brackets — the wrapping is for the human surface ONLY.
+    expect(s.startsWith("<")).toBe(false);
+    expect(s.endsWith(">")).toBe(false);
+    expect(s).not.toContain("<");
+    expect(s).not.toContain(">");
+
+    // It is a parseable URL carrying BOTH params, unencoded `&` separator.
+    const url = new URL(s);
+    expect(url.pathname).toBe("/authorize");
+    expect(url.searchParams.get("session")).toBe(payload["session_id"]);
+    const challenge = url.searchParams.get("code_challenge");
+    expect(challenge).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    // EXACTLY the two query params — no extras, and the verifier is NOT one.
+    expect([...url.searchParams.keys()].sort()).toEqual([
+      "code_challenge",
+      "session",
+    ]);
+    // The raw string uses a literal `&` (not `&amp;` / `%26`) between the two —
+    // mangling the wire URL is the explicitly-ruled-out alternative.
+    expect(s).toContain(`&code_challenge=${challenge}`);
+    expect(s).not.toContain("&amp;");
+    expect(s).not.toContain("%26");
+  });
+});
+
+describe("sil_register — A: the human-presented link is one atomic, unbreakable target", () => {
+  let api: MockPluginAPI;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      () => new Promise<Response>(() => {}),
+    );
+    api = createMockPluginApi();
+    registerIdentityTools(api);
+  });
+
+  it("the presented message carries the FULL url (both session + code_challenge), on its own line, angle-bracket wrapped", async () => {
+    // A-2: the human-facing presented link must carry the full URL including
+    // BOTH params as a single atomic target — on its own line, wrapped in
+    // angle brackets so a chat auto-linker captures the entire URL.
+    const payload = await freshRegister(api);
+    const message = payload["message"];
+    expect(typeof message).toBe("string");
+    const msg = message as string;
+    const authUrl = payload["auth_url"] as string;
+
+    // The full, unwrapped URL value appears in the message (both params present).
+    expect(msg).toContain(authUrl);
+    expect(msg).toContain(`session=${payload["session_id"]}`);
+    expect(msg).toMatch(CHALLENGE_RE);
+
+    // It is angle-bracket wrapped: the exact `<authUrl>` token appears.
+    expect(msg).toContain(`<${authUrl}>`);
+
+    // … and it sits on its OWN line — the line that contains the wrapped URL
+    // contains ONLY the wrapped URL (no trailing prose that a linker could fold
+    // the `&` into, and no leading prose glued to the `<`).
+    const ownLine = msg
+      .split("\n")
+      .map((l) => l.trim())
+      .find((l) => l.includes(authUrl));
+    expect(ownLine).toBeDefined();
+    expect(ownLine).toBe(`<${authUrl}>`);
+  });
+
+  it("survives a GREEDY auto-linker that truncates a BARE url at the first & — the extracted target still has code_challenge (the EXACT production regression)", async () => {
+    // A-3: THE load-bearing RED for this card — the precise reported break. Run
+    // the presented message through a greedy auto-linker that stops a BARE URL
+    // at the first `&`. Because the URL is angle-bracket delimited, the linker
+    // must capture the WHOLE URL, so the extracted/linkified target STILL
+    // contains `code_challenge=…`.
+    //
+    // EXPECT RED against current code: today `message` is the prose
+    // `"Open this URL in a browser to register: <authUrl>"` with a BARE url, so
+    // the greedy linker truncates the target at the `&` and `code_challenge` is
+    // dropped — exactly the production 400.
+    const payload = await freshRegister(api);
+    const authUrl = payload["auth_url"] as string;
+    const message = payload["message"] as string;
+    const expectedChallenge = new URL(authUrl).searchParams.get("code_challenge")!;
+
+    const targets = greedyAutoLink(message);
+
+    // The linker produced at least one target …
+    expect(targets.length).toBeGreaterThan(0);
+    // … and AT LEAST ONE captured target carries the full URL INCLUDING
+    // code_challenge (the bracket delimiter defeats the &-truncation).
+    const carriesChallenge = targets.filter((t) =>
+      t.includes(`code_challenge=${expectedChallenge}`),
+    );
+    expect(carriesChallenge.length).toBeGreaterThan(0);
+
+    // The headline regression assertion, stated as a guard: it must NOT be the
+    // case that EVERY linkified target was truncated at the `&` (which is what
+    // the bare-URL prose produces today). At least one target keeps the
+    // challenge — so the opened link cannot 400 invalid_code_challenge.
+    const allTruncated = targets.every(
+      (t) => !t.includes("code_challenge"),
+    );
+    expect(allTruncated).toBe(false);
+
+    // Self-check the linker model is faithful: the SAME greedy linker, run over
+    // the BARE url (the current buggy presentation), DOES truncate at `&` —
+    // proving the test would catch a regression to a bare URL, not a no-op.
+    const bareTargets = greedyAutoLink(`Open this URL to register: ${authUrl}`);
+    expect(bareTargets.some((t) => t.includes("code_challenge"))).toBe(false);
+  });
+});
+
+describe("sil_register — A: the atomic-link presentation never leaks the PKCE verifier", () => {
+  let api: MockPluginAPI;
+  let sentVerifier: string | null;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    sentVerifier = null;
+    // Capture the verifier the only place it legitimately leaves the process —
+    // the claim POST body — so we can assert that SPECIFIC value is absent from
+    // every result field, not merely the substring "verifier".
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      (_input: unknown, init?: { body?: unknown }) => {
+        if (init && typeof init.body === "string") {
+          try {
+            const parsed = JSON.parse(init.body) as { code_verifier?: string };
+            if (typeof parsed.code_verifier === "string") {
+              sentVerifier = parsed.code_verifier;
+            }
+          } catch {
+            /* non-JSON body — ignore */
+          }
+        }
+        return new Promise<Response>(() => {});
+      },
+    );
+    api = createMockPluginApi();
+    registerIdentityTools(api);
+  });
+
+  it("no result field (auth_url, message, session_id, instructions, …) contains the verifier or the word 'verifier'", async () => {
+    // A-4: the atomic-link change must not leak the claim secret. The verifier
+    // lives only in the poll closure; it must never enter auth_url/message/etc.
+    const payload = await freshRegister(api);
+
+    // Drive one poll tick so the claim body (carrying the verifier) is built and
+    // captured by the fetch spy above.
+    await vi.advanceTimersByTimeAsync(5000);
+
+    const blob = JSON.stringify(payload);
+    // No field literally named/containing "verifier".
+    expect(blob).not.toMatch(/verifier/i);
+    // And — the strong form — the SPECIFIC minted verifier value is absent from
+    // every field of the result (auth_url, message, instructions included).
+    if (sentVerifier) {
+      expect(blob).not.toContain(sentVerifier);
+      // Belt-and-braces per field that a human or agent reads.
+      expect(payload["auth_url"] as string).not.toContain(sentVerifier);
+      expect(payload["message"] as string).not.toContain(sentVerifier);
+      expect(String(payload["instructions"] ?? "")).not.toContain(sentVerifier);
+    }
+  });
+});

--- a/src/__tests__/tools/whoami.test.ts
+++ b/src/__tests__/tools/whoami.test.ts
@@ -187,6 +187,31 @@ describe("sil_whoami — not registered (no tokens.json) short-circuit", () => {
     expect(result).toBeTypeOf("object");
     expect(result.content[0]?.text).toBeTypeOf("string");
   });
+
+  // FIX C, criterion C-4 (card line 191) — the never-registered case must keep
+  // its existing terminal `not_registered` contract. Fix C adds a NEW
+  // "registered-but-persistence-failed" state to the not-registered branch
+  // (identity.ts:170-172); this guard pins that the genuine never-registered
+  // case is NOT swallowed or replaced by that new state. In a FRESH process with
+  // no in-process persist-failure marker set and no tokens.json, whoami must
+  // still return exactly `not_registered` with `sil_register` as the recovery.
+  //
+  // This is a REGRESSION GUARD (green today, must stay green through fix C): it
+  // is the boundary the new persistence_failed branch must not cross.
+  it("returns the EXACT `not_registered` status (NOT persistence_failed) with sil_register recovery — C-4 no-regression", async () => {
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", {}));
+    // The exact existing terminal status — unchanged by fix C.
+    expect(payload["status"]).toBe("not_registered");
+    // It must NOT have been replaced/aliased by the new failed-persistence state.
+    expect(payload["status"]).not.toBe("persistence_failed");
+    // The recovery is the existing "run sil_register" (a bare re-register, since
+    // nothing was ever persisted — there is no data dir to fix).
+    expect(payload["recovery"]).toBe("sil_register");
+    // No path/cause leaks into a genuine never-registered outcome (those belong
+    // ONLY to the persistence_failed state).
+    const blob = JSON.stringify(payload).toLowerCase();
+    expect(blob).not.toMatch(/eacces|enospc|enotdir|persistence.?failed/);
+  });
 });
 
 describe("sil_whoami — success result carries ONLY identity (no credential echo)", () => {

--- a/src/__tests__/whoami.integration.test.ts
+++ b/src/__tests__/whoami.integration.test.ts
@@ -803,3 +803,188 @@ describe("sil_whoami — rotated tokens never leak to logs or the result", () =>
     }
   });
 });
+
+// ===========================================================================
+// FIX B — web-origin visibility (warn, never reject). Card lines 179-184.
+//
+// A stray `SIL_WEB_URL` env or `sil_web_url` pluginConfig silently overrides the
+// safe default web origin (`https://sil.4gpts.com`); a dead/staging origin then
+// breaks the registration link with no clue why. The fix: `sil_whoami` surfaces
+// the resolved WEB origin + its `source ∈ {default, env, config}` on the success
+// payload (so a wrong origin is diagnosable BEFORE anything 404s), and emits a
+// visible warn ONLY when the source is non-default — staging/self-host is
+// legitimate, so it is WARNED, NEVER rejected.
+//
+// SCOPE (locked, card line 100/118): B surfaces the **sil-web** origin
+// (getWebUrl/getWebUrlSource — the origin the broken link is built from). The
+// sil-api origin (the whoami READ target) is OUT of scope.
+//
+// These are sil_whoami-execute behaviours wired through the fetch boundary →
+// integration tier. The identity read is mocked OK so execute() reaches its
+// success payload (where the origin block lives); the WEB origin is what each
+// test varies. The global beforeEach pins setApiUrl(SIL_API) — kept so the read
+// resolves — and setWebUrl(SIL_WEB), which each test re-points to drive the
+// source under test (the global afterEach resets both + both env vars).
+//
+// EXPECT RED against current code: sil_whoami's success payload is
+// `{ status:"ok", identity }` (identity.ts:245-247) with NO web_origin /
+// web_origin_source block and NO origin warn at any source.
+// ===========================================================================
+
+/** The success-path origin-visibility block the fix must attach. Returns the
+ * { web_origin, web_origin_source } pulled off the (string-only) result. */
+function originBlock(
+  payload: Record<string, unknown>,
+): { origin: unknown; source: unknown } {
+  return { origin: payload["web_origin"], source: payload["web_origin_source"] };
+}
+
+/** Every `api.logger.warn(marker, …)` first-arg, collected. The origin warning
+ * is a warn-level marker (warn, NOT error — staging is legitimate). */
+function warnMarkers(api: MockPluginAPI): string[] {
+  return vi.mocked(api.logger.warn).mock.calls.map((c) => String(c[0]));
+}
+
+/** True iff ANY warn call (marker or its structured args) references the web
+ * origin being non-default — i.e. the operator/agent can SEE a non-default
+ * origin is in effect. Matches on the origin string OR an origin/web-url marker. */
+function warnsAboutOrigin(api: MockPluginAPI, origin: string): boolean {
+  return vi
+    .mocked(api.logger.warn)
+    .mock.calls.some((c) => {
+      const blob = JSON.stringify(c);
+      return (
+        blob.includes(origin) ||
+        /web.?url|web.?origin|origin|non.?default|override/i.test(String(c[0]))
+      );
+    });
+}
+
+describe("sil_whoami — B: web-origin visibility on the DEFAULT origin (silent, no noise)", () => {
+  it("surfaces web_origin + web_origin_source='default' and emits NO origin warning", async () => {
+    // The common path: no SIL_WEB_URL env, no sil_web_url config → default
+    // origin, surfaced but SILENT (a warn on every whoami on the default origin
+    // would be pure noise).
+    setWebUrl(""); // drop the global config pin → resolve to the default
+    delete process.env["SIL_WEB_URL"]; // ensure no env override either
+    seedTokens("valid-at", "valid-rt");
+    installRouter((kind) =>
+      kind === "identity"
+        ? { status: 200, body: identityEnvelope() }
+        : { status: 500, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", {}));
+
+    // Read still succeeds (origin visibility does not perturb the happy read).
+    expect(payload["status"]).toBe("ok");
+
+    // The resolved web origin + source are surfaced as STRINGS.
+    const { origin, source } = originBlock(payload);
+    expect(typeof origin).toBe("string");
+    expect(new URL(origin as string).origin).toBe(new URL(getWebUrl()).origin);
+    expect(source).toBe("default");
+
+    // No origin warning on the default — the safe path is silent.
+    expect(warnsAboutOrigin(api, getWebUrl())).toBe(false);
+    // Defensive: NO warn marker mentions web-url/origin at all on the default.
+    expect(
+      warnMarkers(api).some((m) => /web.?url|web.?origin|origin/i.test(m)),
+    ).toBe(false);
+  });
+});
+
+describe("sil_whoami — B: a non-default origin via the SIL_WEB_URL env warns (never rejects)", () => {
+  it("surfaces web_origin + source='env', emits a VISIBLE warn, and still returns the identity (no reject/error)", async () => {
+    // Drive the env source: an explicit SIL_WEB_URL with NO config layer.
+    setWebUrl(""); // clear the config pin so env is the resolved source
+    process.env["SIL_WEB_URL"] = "https://sil-web.staging.example.com";
+    seedTokens("valid-at", "valid-rt");
+    installRouter((kind) =>
+      kind === "identity"
+        ? { status: 200, body: identityEnvelope() }
+        : { status: 500, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", {}));
+
+    // NEVER rejects/errors on a non-default origin — the read SUCCEEDS and the
+    // identity is surfaced (a staging/self-host origin is first-class).
+    expect(payload["status"]).toBe("ok");
+    expect(JSON.stringify(payload)).toContain("Ada Lovelace");
+
+    // The resolved origin + env source are surfaced as strings.
+    const { origin, source } = originBlock(payload);
+    expect(typeof origin).toBe("string");
+    expect(new URL(origin as string).origin).toBe("https://sil-web.staging.example.com");
+    expect(source).toBe("env");
+
+    // … and a VISIBLE warn fired (an operator/agent can see a non-default
+    // origin is in effect). It is warn-level — NOT error (staging is legitimate).
+    expect(warnsAboutOrigin(api, "https://sil-web.staging.example.com")).toBe(true);
+    expect(vi.mocked(api.logger.error)).not.toHaveBeenCalled();
+  });
+});
+
+describe("sil_whoami — B: a non-default origin via the sil_web_url pluginConfig warns (never rejects)", () => {
+  it("surfaces web_origin + source='config', emits a VISIBLE warn, and still returns the identity", async () => {
+    // Drive the config source (the way applyPluginConfigOverrides would set it).
+    setWebUrl("https://sil-web.selfhost.example.com");
+    seedTokens("valid-at", "valid-rt");
+    installRouter((kind) =>
+      kind === "identity"
+        ? { status: 200, body: identityEnvelope() }
+        : { status: 500, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", {}));
+
+    expect(payload["status"]).toBe("ok");
+    const { origin, source } = originBlock(payload);
+    expect(typeof origin).toBe("string");
+    expect(new URL(origin as string).origin).toBe("https://sil-web.selfhost.example.com");
+    expect(source).toBe("config"); // config-source override is legitimate, exactly like env
+
+    expect(warnsAboutOrigin(api, "https://sil-web.selfhost.example.com")).toBe(true);
+    // Never an error/reject on a config override.
+    expect(vi.mocked(api.logger.error)).not.toHaveBeenCalled();
+  });
+});
+
+describe("sil_whoami — B: a non-default origin is RELAYABLE to the user (not silently dropped)", () => {
+  it("the origin + source + warning are carried to the agent (payload field AND/OR a warn-level log)", async () => {
+    // The whole point of the fix: a wrong origin must be DIAGNOSABLE. The
+    // origin-visibility output must reach the agent — as part of the
+    // agent-facing result AND/OR a warn-level log — never silently dropped.
+    setWebUrl("https://sil-web.wrong-host.example.com");
+    seedTokens("valid-at", "valid-rt");
+    installRouter((kind) =>
+      kind === "identity"
+        ? { status: 200, body: identityEnvelope() }
+        : { status: 500, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", {}));
+
+    const inPayload = JSON.stringify(payload).includes(
+      "https://sil-web.wrong-host.example.com",
+    );
+    const inWarnLog = warnsAboutOrigin(api, "https://sil-web.wrong-host.example.com");
+
+    // Surfaced in the result, in a warn log, or both — but NOT swallowed.
+    expect(inPayload || inWarnLog).toBe(true);
+    // The product intent is the agent-facing surface carries it: the origin
+    // block is on the result payload (so the agent can relay it without
+    // needing log access).
+    expect(payload["web_origin"]).toBeDefined();
+    expect(payload["web_origin_source"]).toBeDefined();
+  });
+});

--- a/src/lib/poller.ts
+++ b/src/lib/poller.ts
@@ -103,9 +103,15 @@ export function startPoll(opts: StartPollOptions): PollHandle {
     try {
       result = await opts.poll();
     } catch {
-      // A throw from the injected step is treated as non-terminal: the
-      // sil-client wrapper already maps network errors to a retryable result,
-      // so this is belt-and-braces; let the next tick (within budget) retry.
+      // A throw from the injected step is treated as non-terminal — the next
+      // tick (within budget) retries. This is correct ONLY for the claim call:
+      // the sil-client wrapper already maps network errors to a `retryable`
+      // result, so a genuine throw here is a rare transient. A TERMINAL failure
+      // that must NOT be retried (e.g. the token-persist failure) is never a
+      // throw that reaches this catch — `claimStep` classifies it and RETURNS a
+      // `{ done: true, outcome: "persist_failed", error }` terminal, so the
+      // poller stays generic over `done` and the terminal settles like any
+      // other. Do not move classification of a throw into this catch.
       result = { done: false };
     } finally {
       inFlight = false;

--- a/src/tools/identity.ts
+++ b/src/tools/identity.ts
@@ -33,9 +33,10 @@
 import type { PluginAPI } from "openclaw/plugin-sdk";
 import { Type } from "typebox";
 
-import { getWebUrl, getApiUrl } from "../lib/config.js";
+import { getWebUrl, getWebUrlSource, getApiUrl } from "../lib/config.js";
 import {
   clearTokens,
+  getTokensPath,
   hasTokens,
   readConfig,
   readTokens,
@@ -85,16 +86,24 @@ function registerRegister(api: PluginAPI): void {
         });
       }
 
+      // A fresh registration attempt clears any prior in-process persist-failure
+      // marker: this process is starting over, so a stale marker from an earlier
+      // failed attempt must not make a later genuine `not_registered` (or this
+      // attempt's own outcome) masquerade as `persistence_failed`. (FIX C.)
+      clearPersistFailure();
+
       // 2 — mint PKCE. The verifier stays in this closure (never on disk).
       const sessionId = newSessionId();
       const verifier = newVerifier();
       const challenge = deriveChallenge(verifier);
-      const apiUrl = getWebUrl();
+      // The sil-WEB origin (auth authority) — this is what the auth URL is built
+      // from. The local was historically misnamed `apiUrl`; it is the web origin.
+      const webUrl = getWebUrl();
 
       // 3 — build the auth URL. Opening it (by the user's browser) is what
       // creates the pending session server-side; the plugin does not pre-POST.
       const authUrl =
-        `${stripTrailingSlash(apiUrl)}/authorize`
+        `${stripTrailingSlash(webUrl)}/authorize`
         + `?session=${sessionId}&code_challenge=${challenge}`;
 
       // 4 — fire-and-forget bounded poll. Not awaited: execute() returns now.
@@ -105,7 +114,7 @@ function registerRegister(api: PluginAPI): void {
       startPoll({
         intervalMs: POLL_INTERVAL_MS,
         deadlineMs: POLL_DEADLINE_MS,
-        poll: () => claimStep(apiUrl, sessionId, verifier),
+        poll: () => claimStep(webUrl, sessionId, verifier),
         onDone: (result) => handleDone(api, sessionId, result),
       });
 
@@ -113,7 +122,14 @@ function registerRegister(api: PluginAPI): void {
 
       return jsonResult({
         status: "awaiting_browser",
-        message: `Open this URL in a browser to register: ${authUrl}`,
+        // Present the auth URL as ONE atomic, unbreakable link: on its own line,
+        // angle-bracket wrapped, so a greedy chat auto-linker captures the WHOLE
+        // URL (the `&code_challenge` included) instead of truncating at the `&`
+        // and 400-ing `invalid_code_challenge`. `auth_url` below stays the
+        // canonical, UNWRAPPED machine field agents parse. (FIX A.)
+        message:
+          "Open this URL in a browser to register:\n"
+          + presentAuthLink(authUrl),
         auth_url: authUrl,
         session_id: sessionId,
         instructions:
@@ -166,11 +182,36 @@ function registerWhoami(api: PluginAPI): void {
       + " the recovery action (run sil_register).",
     parameters: Type.Object({}),
     async execute() {
-      // 1 — not registered: terminal, zero network calls.
+      // 1 — not registered: terminal, zero network calls. If THIS process saw a
+      // token-persist failure (auth succeeded but the write failed), surface the
+      // distinct `persistence_failed` state instead — the no-tokens.json state on
+      // disk is identical for both, so the in-process marker is the only signal
+      // that tells them apart (FIX C; cold-restart correctly degrades to
+      // not_registered — see the persistence_failed/notRegistered helpers).
       const stored = readTokens();
       if (stored === null) {
-        return notRegistered();
+        const failure = getPersistFailure();
+        return failure !== null ? persistenceFailed(failure) : notRegistered();
       }
+
+      // B (origin visibility): resolve the sil-WEB origin (the origin the
+      // registration link is built from) + its source, surface it on the success
+      // payload so a wrong/staging origin is diagnosable BEFORE anything 404s,
+      // and emit a single warn when the source is non-default. Warn-only — a
+      // staging/self-host origin is legitimate, so it is NEVER rejected. Scope is
+      // the WEB origin only; the sil-api read origin is out of scope. (FIX B.)
+      const webOrigin = getWebUrl();
+      const webOriginSource = getWebUrlSource();
+      if (webOriginSource !== "default") {
+        api.logger.warn("sil_whoami_web_origin_override", {
+          web_origin: webOrigin,
+          web_origin_source: webOriginSource,
+        });
+      }
+      const originBlock = {
+        web_origin: webOrigin,
+        web_origin_source: webOriginSource,
+      };
 
       // 2 — read identity; on a 401 refresh-and-retry ONCE via the shared
       // choreography (the SAME `refreshAndRetryOnce` path sil_search /
@@ -190,7 +231,7 @@ function registerWhoami(api: PluginAPI): void {
           // emit the operator marker so a thrashing session is visible in logs —
           // logs-only, no token material, NOT a payload field (the agent never sees it).
           if (recovered.refreshed) api.logger.info("sil_whoami_refreshed", {});
-          return identityOutcomeToResult(api, recovered.outcome);
+          return identityOutcomeToResult(api, recovered.outcome, originBlock);
         case "must_reregister":
           // The refresh token is dead (invalid_grant) → clear the now-known-dead
           // pair so the user's sil_register recovery is not blocked by stale
@@ -212,12 +253,26 @@ function registerWhoami(api: PluginAPI): void {
   });
 }
 
+/** The web-origin visibility block attached to the success payload (FIX B):
+ * the resolved sil-web origin + its source, so a wrong/staging origin is
+ * diagnosable. Strings only — never any token material. */
+interface OriginBlock {
+  web_origin: string;
+  web_origin_source: string;
+}
+
 /** Map a non-401 identity outcome to the agent-facing result. (401 is handled
- * inline by the refresh path; it never reaches here.) */
-function identityOutcomeToResult(api: PluginAPI, outcome: IdentityOutcome) {
+ * inline by the refresh path; it never reaches here.) The origin block rides the
+ * SUCCESS payload (the point is pre-failure diagnosis); the terminal/transient
+ * envelopes don't carry it. */
+function identityOutcomeToResult(
+  api: PluginAPI,
+  outcome: IdentityOutcome,
+  originBlock: OriginBlock,
+) {
   switch (outcome.kind) {
     case "ok":
-      return identityResult(outcome.identity);
+      return identityResult(outcome.identity, originBlock);
     case "forbidden":
       // Decision B — the dead-token clear is UNIFORM across all three sil-api tools.
       // `sil_whoami` is the tool that is legible TODAY; an agent that diagnoses the
@@ -241,9 +296,11 @@ function identityOutcomeToResult(api: PluginAPI, outcome: IdentityOutcome) {
   }
 }
 
-/** Success: the identity payload ONLY — no token, no Bearer header. */
-function identityResult(identity: Identity) {
-  return jsonResult({ status: "ok", identity });
+/** Success: the identity payload + the web-origin visibility block (FIX B) —
+ * no token, no Bearer header. The origin block (strings only) lets the agent
+ * relay the resolved origin + its source so a wrong origin is diagnosable. */
+function identityResult(identity: Identity, originBlock: OriginBlock) {
+  return jsonResult({ status: "ok", identity, ...originBlock });
 }
 
 /** Not registered: a distinct, actionable outcome naming the recovery tool. No
@@ -254,6 +311,27 @@ function notRegistered() {
     message:
       "Not registered on sil. Run sil_register to authenticate, then call"
       + " sil_whoami again.",
+    recovery: "sil_register",
+  });
+}
+
+/**
+ * Registered-but-persistence-failed (FIX C): auth succeeded in THIS process but
+ * the token write failed, so nothing reached disk. DISTINCT from `not_registered`
+ * because the recovery differs — the user must FIX THE DATA DIR (the path + cause
+ * name what to fix), THEN re-register; a bare "run sil_register" would just fail
+ * to persist again, looping. `error` carries the "<path>: <cause>" from the
+ * in-process marker. No identity fields (the tokens never landed).
+ */
+function persistenceFailed(error: string) {
+  return jsonResult({
+    status: "persistence_failed",
+    message:
+      "Registration authenticated but the credentials could NOT be written to"
+      + " disk, so it did not stick. Fix the data directory (it must be writable"
+      + " — check permissions / free space / that $SIL_DATA_DIR is a directory),"
+      + " then run sil_register again.",
+    error,
     recovery: "sil_register",
   });
 }
@@ -289,11 +367,42 @@ function transient() {
   });
 }
 
-/** The terminal step shape carried through the poller to `onDone`. */
+/** The terminal step shape carried through the poller to `onDone`. `persist_failed`
+ * is FIX C's new terminal: auth succeeded but the token write failed — distinct
+ * from the wire terminals (it is not a `ClaimOutcome["kind"]`) and from a
+ * `timeout`. `error` carries the "<path>: <cause>" for the loud log + whoami. */
 interface ClaimStep extends Record<string, unknown> {
   done: boolean;
-  outcome?: ClaimOutcome["kind"];
+  outcome?: ClaimOutcome["kind"] | "persist_failed";
   user_id?: string;
+  error?: string;
+}
+
+/**
+ * In-process persist-failure marker (FIX C). A failed token write leaves NO
+ * `tokens.json` on disk — exactly the state a never-registered user has — so the
+ * two are indistinguishable from disk alone. This module-level marker is the only
+ * signal that tells `sil_whoami` "auth succeeded in THIS process but persistence
+ * failed" apart from a bare `not_registered`. It is intentionally in-process only:
+ * the failure mode IS an unwritable data dir, so an on-disk sentinel would fail to
+ * write for the same reason — and after a cold restart `not_registered` is the
+ * TRUE state (no creds exist), with a re-run of `sil_register` re-surfacing the
+ * write failure loudly. Set by `claimStep` on the persist_failed terminal; reset
+ * on a fresh `sil_register` start so a stale marker can't mislabel a later genuine
+ * not_registered (and resettable in tests via that same fresh-start path).
+ */
+let _persistFailure: string | null = null;
+
+function setPersistFailure(error: string): void {
+  _persistFailure = error;
+}
+
+function getPersistFailure(): string | null {
+  return _persistFailure;
+}
+
+function clearPersistFailure(): void {
+  _persistFailure = null;
 }
 
 /**
@@ -320,11 +429,25 @@ async function claimStep(
     case "not_found":
       return { done: false };
     case "success":
-      await writeTokens({
-        access_token: outcome.access_token,
-        refresh_token: outcome.refresh_token,
-      });
-      await writeConfig({ user: outcome.user });
+      // Persist the bearer pair + identity. FIX C: wrap ONLY the persist calls
+      // (never the whole step — a too-wide catch could mislabel a genuine claim
+      // success). A write failure (unwritable / missing-and-uncreatable / full
+      // $SIL_DATA_DIR) is TERMINAL, not transient: re-polling the claim cannot
+      // make the data dir writable, and the claim is single-use server-side. So
+      // return a descriptive `persist_failed` terminal (path + cause) and set the
+      // in-process marker — instead of letting the throw reach the poller's catch,
+      // which would swallow it as a retry and end the run as a misleading timeout.
+      try {
+        await writeTokens({
+          access_token: outcome.access_token,
+          refresh_token: outcome.refresh_token,
+        });
+        await writeConfig({ user: outcome.user });
+      } catch (err) {
+        const error = `${getTokensPath()}: ${describeCause(err)}`;
+        setPersistFailure(error);
+        return { done: true, outcome: "persist_failed", error };
+      }
       return { done: true, outcome: "success", user_id: outcome.user.id };
     case "expired":
     case "already_claimed":
@@ -353,6 +476,19 @@ function handleDone(
     return;
   }
 
+  // FIX C: a token-persist failure is logged LOUDLY at error — the most severe
+  // terminal, distinct from the routine info/warn terminals — carrying the path +
+  // cause (in `step.error`) so an operator sees persistence failed, NOT that the
+  // user abandoned the flow. The tokens never reached disk, so there is no token
+  // material to leak; only the session id + the path/cause error are logged.
+  if (step.outcome === "persist_failed") {
+    api.logger.error("sil_register_persist_failed", {
+      session_id: sessionId,
+      error: typeof step.error === "string" ? step.error : "",
+    });
+    return;
+  }
+
   if ("timedOut" in step && step.timedOut === true) {
     api.logger.info("sil_register_timeout", { session_id: sessionId });
     return;
@@ -374,4 +510,37 @@ function handleDone(
 
 function stripTrailingSlash(url: string): string {
   return url.endsWith("/") ? url.slice(0, -1) : url;
+}
+
+/**
+ * Render an errno-style cause from a caught (unknown) persist error, for the
+ * loud log + whoami `persistence_failed` state (FIX C). A Node fs error carries
+ * a `.code` (EACCES/ENOSPC/ENOTDIR/ENOENT…) and a `.message` that already names
+ * the code and the human cause ("not a directory") — surface the code first
+ * (prominent for an operator) then the full message. Carries NO token material:
+ * an fs error names paths/errnos only, and the tokens never reached this point.
+ */
+function describeCause(err: unknown): string {
+  if (err instanceof Error) {
+    const code = (err as NodeJS.ErrnoException).code;
+    return code ? `${code}: ${err.message}` : err.message;
+  }
+  return String(err);
+}
+
+/**
+ * Present an auth URL as a single atomic link target for a human-rendered chat
+ * surface: angle-bracket wrapped (`<…>`). The angle brackets are the RFC-3986 /
+ * Markdown convention that bounds a URL so a greedy auto-linker captures the
+ * WHOLE span — including the `&code_challenge=…` query param — instead of
+ * terminating the link at the first `&` (the reported production break that
+ * dropped `code_challenge` and 400-ed `invalid_code_challenge`). The caller puts
+ * the returned token on its OWN line so no surrounding prose can be folded into
+ * the link. Pure (no I/O) — the [unit] seam for the atomic-link contract. The
+ * structured `auth_url` field is the UNWRAPPED canonical URL; this is the
+ * human-presentation form only, and it carries the same params byte-for-byte (it
+ * never re-encodes, never adds the verifier).
+ */
+function presentAuthLink(authUrl: string): string {
+  return `<${authUrl}>`;
 }


### PR DESCRIPTION
## Card

`cards/harden-plugin-registration-round-trip.md` (epic `registration-link-hardening-2026-06`, card 1 of 3). Three robustness gaps in the `sil_register` → `sil_whoami` round-trip, all converging on `src/tools/identity.ts` — bundled into one card because they share that surface. A production registration link broke; triage surfaced these three faces of the same fragility.

## Summary

**A — atomic, unbreakable registration link.** The reported break: `sil_register` returned the auth URL inline in a human-readable `message` prose string, and a chat-surface auto-linker terminated the link at the `&`, dropping `code_challenge` → the opened link 400-ed `invalid_code_challenge`. Fix (presentation only — the URL was always correct on the wire): a new pure helper `presentAuthLink(authUrl)` wraps the URL in angle brackets `<…>`, and `message` puts it on its own line, so a greedy linker captures the whole URL (`&code_challenge` included). `auth_url` stays the canonical, **unwrapped** machine field byte-for-byte; no PKCE verifier leaks into any field.

**B — web-origin visibility (warn, never reject).** A stray `SIL_WEB_URL` env / `sil_web_url` pluginConfig silently overrode the safe default web origin; a dead/staging origin then broke the link with no clue why. Fix: `sil_whoami`'s **success** payload now carries `{ web_origin, web_origin_source }` (strings, from `getWebUrl()`/`getWebUrlSource()`), surfaced *before* anything 404s, and a single `warn` (`sil_whoami_web_origin_override`) fires **only** when the source is non-default. Staging/self-host is legitimate — warned, **never** rejected or errored. Scoped to the sil-**web** origin only (the sil-api read origin is out of scope). `config.ts` unchanged (it already exposed origin + source).

**C — fail-loud token persistence (the decisive defect).** After auth succeeded, `writeTokens`/`writeConfig` were awaited in `claimStep` but not error-checked, and the poller's catch treated **any** step throw as a transient retry — so an unwritable/missing/full `$SIL_DATA_DIR` made the write throw, the loop kept polling, and the run ended as a misleading `timeout`; `sil_whoami` then reported a bare `not_registered` (indistinguishable on disk from never-registered). Fix (three coupled moves):
- `claimStep` wraps **only** the persist calls → a terminal `{ done: true, outcome: "persist_failed", error: "<path>: <cause>" }` + an in-process persist-failure marker.
- `handleDone` logs it **loudly** at `error` (`sil_register_persist_failed`, path + cause, no token material) — distinct from `timeout`/`expired`/`already_claimed`.
- `sil_whoami`'s not-registered branch returns a distinct `persistence_failed` state (path + cause + fix-the-data-dir recovery) when the marker is set; the marker **resets on a fresh `sil_register` start** so a stale marker can't mislabel a later genuine `not_registered`. Cold restart correctly degrades to `not_registered`.
- The **poller stays generic** over `done` (no signature change) — the persist failure is a *returned terminal* from `claimStep`, never a throw that reaches the catch. Its catch comment is refreshed to say so.

The writable happy path is byte-for-byte unchanged (guarded by C-5). Cosmetic: the `getWebUrl()` local in `sil_register` renamed `apiUrl` → `webUrl` (it is the sil-web origin).

## Test coverage (RED → GREEN)

All written by qa-developer first (RED, commit `548ca48`); this PR implements to GREEN without touching any test.
- **A** (`src/__tests__/tools/register-link-presentation.test.ts`, unit): `auth_url` byte-exact + unwrapped, `message` carries the URL on its own line angle-bracket wrapped, a greedy auto-linker still extracts `code_challenge`, no verifier leak.
- **B** (`src/__tests__/whoami.integration.test.ts`, integration): origin block + source `{default|env|config}` on the success payload; warn only on non-default; never rejects/errors; relayable to the agent.
- **C** (`src/__tests__/register-claim.integration.test.ts`, integration + `src/__tests__/lib/poller.test.ts`, unit): a real unwritable data dir (ENOTDIR) → terminal descriptive `persist_failed` logged loudly at error (path + cause), not a swallowed retry, not timeout; in-process `sil_whoami` returns `persistence_failed`; poller regression guards (a throw stays non-terminal; a returned `persist_failed` settles terminally); C-4 never-registered unchanged; C-5 writable happy path unchanged.

## Test plan
- [x] `pnpm test` → `10 failed | 592 passed (602)` — the 8 feature REDs + 6 green-guards now pass
- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean

The **10 remaining failures are all `repo-scaffold.integration.test.ts`** — a pre-existing worktree artifact (it stats gitignored `CLAUDE.md` / `docs/` that are absent in a worktree checkout), unrelated to this PR.

## Distillation target
Knowledge capture happens **after Review PASS** in the `distilling` stage — `solutions-architect` runs in this same worktree, commits to this same branch, and pushes here so the PR ends up containing implementation + tests + distillation in one mergeable unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)