### PR TITLE
bug: steer registration auth link to the system browser (proactive webview handoff)

### DIFF
--- a/src/__tests__/register-claim.integration.test.ts
+++ b/src/__tests__/register-claim.integration.test.ts
@@ -448,6 +448,125 @@ describe("claim lifecycle — a premature 404 KEEPS POLLING (the headline regres
   });
 });
 
+describe("system-browser steer — the awaiting_browser return carries the steer in BOTH fields while the claim→persist→whoami round-trip is unchanged (bounce-webview-auth-links-to-the-system-browser)", () => {
+  // INTEGRATION criterion: through the REAL sil_register execute (real PKCE mint,
+  // real auth-URL build, real poll, real persistence) + a real sil_whoami, the
+  // awaiting_browser return must carry the system-browser steer in BOTH `message`
+  // and `instructions`, AND the end-to-end claim→token-persist→whoami round-trip
+  // must be byte-for-byte the same as before this card — same session_id, same
+  // persisted tokens, same `ok` identity. This card adds NO new state, NO new
+  // tool, NO wire change — only the two copy fields. Mocks only the host-SDK +
+  // `fetch` boundary (via installFetch), never the logic.
+  //
+  // RED today: the awaiting_browser `message`/`instructions` carry no steer, so
+  // the steer assertions fail; the round-trip assertions stay GREEN (this card
+  // changes none of that path).
+
+  const SIL_API_STEER = "https://sil-api.steer.example.com";
+  const IDENTITY_ENVELOPE_STEER = {
+    protocol: "ucp",
+    version: "0.1",
+    domain: "identity",
+    result: {
+      name: "Polled User",
+      addresses: [{ line1: "1 Late Click Lane", city: "London", country: "GB" }],
+    },
+  };
+
+  // The semantic-content matchers (same contract as the unit tier): the steer
+  // names a default/system browser AND warns away from an in-app/built-in/
+  // embedded webview, case-insensitively. Wording latitude left to the dev.
+  const POSITIVE_STEER_RE = /\b(default|system)\b[\s\S]{0,40}\bbrowser\b/i;
+  const NEGATIVE_SURFACE_RE = /\b(in-?app|built-?in|embedded|webview|this app)\b/i;
+
+  it("steers to the system browser in message AND instructions, and the round-trip (session_id, persist, whoami) is unchanged", async () => {
+    setApiUrl(SIL_API_STEER); // pin the identity-read origin for the whoami leg
+    let claimTicks = 0;
+    installFetch((url) => {
+      if (url.includes("/identity")) {
+        return { status: 200, body: IDENTITY_ENVELOPE_STEER };
+      }
+      claimTicks += 1;
+      if (claimTicks < 2) {
+        return { status: 404, body: { error: "not_found", message: "Session not found." } };
+      }
+      return { status: 200, body: SUCCESS_BODY };
+    });
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+
+    // ── The awaiting_browser return carries the steer in BOTH copy fields. ──
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", {}));
+    expect(payload["status"]).toBe("awaiting_browser");
+
+    const message = payload["message"] as string;
+    const instructions = payload["instructions"] as string;
+    // message: positive + negative halves of the steer.
+    expect(message).toMatch(POSITIVE_STEER_RE);
+    expect(message).toMatch(NEGATIVE_SURFACE_RE);
+    // instructions: the same steer so the agent can't paraphrase back to "a browser".
+    expect(instructions).toMatch(POSITIVE_STEER_RE);
+    expect(instructions).toMatch(NEGATIVE_SURFACE_RE);
+
+    // auth_url rides through byte-unchanged (the #24 invariant; the steer is copy
+    // around the link, never the wire value) — it carries both params, unwrapped.
+    const authUrl = payload["auth_url"] as string;
+    const sessionId = payload["session_id"] as string;
+    const u = new URL(authUrl);
+    expect(u.pathname).toBe("/authorize");
+    expect(u.searchParams.get("session")).toBe(sessionId);
+    expect(u.searchParams.get("code_challenge")).toMatch(/^[A-Za-z0-9_-]{43}$/);
+
+    // ── The claim→persist round-trip is UNCHANGED. ──
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(claimTicks).toBeGreaterThanOrEqual(2); // polled through the early 404
+    expect(vi.getTimerCount()).toBe(0); // settled, no leaked timer
+
+    await settleAsyncIo();
+    const tokens = await waitForTokens();
+    expect(tokens).not.toBeNull();
+    expect(tokens!.access_token).toBe("fresh-at");
+    expect(tokens!.refresh_token).toBe("fresh-rt");
+    const config = readJsonInDataDir<Record<string, unknown>>("config.json");
+    expect(JSON.stringify(config)).toContain("user-42");
+
+    // ── sil_whoami resolves the same identity (registration truly completed). ──
+    const whoami = payloadOf(await getTool(api, "sil_whoami").execute("w1", {}));
+    expect(whoami["status"]).toBe("ok");
+    expect((whoami["identity"] as { name?: string }).name).toBe("Polled User");
+  });
+
+  it("a SECOND sil_register after completion confirms already_registered (the confirmation path is unchanged) — and no longer steers a browser (nothing to open)", async () => {
+    // The card's "same already_registered confirmation path" guarantee: once the
+    // first registration has persisted tokens, a re-run of sil_register short-
+    // circuits to already_registered with the claimed user — no auth URL, no
+    // poll, and therefore no browser steer (there is nothing to open). This pins
+    // that the steer is scoped to the awaiting_browser return ONLY and does not
+    // bleed into the already_registered confirmation.
+    setApiUrl(SIL_API_STEER);
+    installFetch((url) => {
+      if (url.includes("/identity")) return { status: 200, body: IDENTITY_ENVELOPE_STEER };
+      return { status: 200, body: SUCCESS_BODY };
+    });
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+
+    // First register → awaiting_browser, claim succeeds, tokens persist.
+    await getTool(api, TOOL).execute("c1", {});
+    await vi.advanceTimersByTimeAsync(10_000);
+    await settleAsyncIo();
+    expect((await waitForTokens())!.access_token).toBe("fresh-at");
+
+    // Second register → already_registered confirmation (unchanged path).
+    const second = payloadOf(await getTool(api, TOOL).execute("c2", {}));
+    expect(second["status"]).toBe("already_registered");
+    expect((second["user"] as { id?: string }).id).toBe("user-42");
+    // The confirmation carries no auth_url and no awaiting_browser steer copy.
+    expect(second["auth_url"]).toBeUndefined();
+    expect(second["message"]).toBeUndefined();
+  });
+});
+
 describe("claim lifecycle — claimStep maps a 404 not_found outcome to keep-polling (done:false)", () => {
   // The single-tick mapping the card's `[unit]` criterion pins: claimStep against
   // a `not_found` claim outcome returns `{ done: false }` (grouped with

--- a/src/__tests__/tools/register-link-presentation.test.ts
+++ b/src/__tests__/tools/register-link-presentation.test.ts
@@ -276,6 +276,172 @@ describe("sil_register — A: the human-presented link is one atomic, unbreakabl
   });
 });
 
+describe("sil_register — system-browser steer (bounce-webview-auth-links-to-the-system-browser)", () => {
+  let api: MockPluginAPI;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      () => new Promise<Response>(() => {}),
+    );
+    api = createMockPluginApi();
+    registerIdentityTools(api);
+  });
+
+  // ── Resilient steer matchers ───────────────────────────────────────────────
+  // The CONTRACT is "both halves present, case-insensitive" — the steer names a
+  // concrete default/system browser to use AND warns away from an app's
+  // built-in/in-app/embedded webview. Wording is the expert-developer's call
+  // within product-owner's intent ("default browser (Safari/Chrome), not this
+  // app's built-in browser"; neutral setup-step tone). These matchers pin the
+  // semantic content WITHOUT brittle exact-string equality, so any faithful
+  // phrasing reaches GREEN. They DELIBERATELY do not anchor on the precise term
+  // "system browser" (the open question flags plain "default browser" as the
+  // likely clearer phrasing) — either reads as the positive half.
+
+  /** Positive half: steers TO the user's own default/system browser, naming a
+   * concrete one (Safari / Chrome) so a non-technical user knows the action. */
+  const POSITIVE_STEER_RE = /\b(default|system)\b[\s\S]{0,40}\bbrowser\b/i;
+  /** Concrete browser named so the action is unmissable for a non-technical user. */
+  const NAMED_BROWSER_RE = /\b(safari|chrome)\b/i;
+  /** Negative half: steers AWAY from an in-app / built-in / embedded webview —
+   * the cookie-blocking surface. Matches "built-in browser", "in-app browser",
+   * "embedded webview", "this app's browser", etc. The "not" + the surface noun
+   * are the two load-bearing tokens. */
+  const NEGATIVE_NOT_RE = /\bnot\b/i;
+  const NEGATIVE_SURFACE_RE = /\b(in-?app|built-?in|embedded|webview|this app)\b/i;
+
+  it("message carries the system-browser steer — positive (default/system browser, named) AND negative (NOT the in-app/built-in browser) halves", async () => {
+    // RED today: the current message is the generic "Open this URL in a browser
+    // to register:" — it has NO default/system-browser steer and NO "not the
+    // in-app browser" warning, so a user reading inside a chat client's webview
+    // taps the link right there and dead-ends on Auth0's blocked cookie. The fix
+    // adds an unmissable steer to the human-facing copy.
+    const payload = await freshRegister(api);
+    const message = payload["message"];
+    expect(typeof message).toBe("string");
+    const msg = message as string;
+
+    // Positive half — steer TO the default/system browser, named concretely.
+    expect(msg).toMatch(POSITIVE_STEER_RE);
+    expect(msg).toMatch(NAMED_BROWSER_RE);
+
+    // Negative half — steer AWAY from the in-app/built-in/embedded webview.
+    expect(msg).toMatch(NEGATIVE_NOT_RE);
+    expect(msg).toMatch(NEGATIVE_SURFACE_RE);
+
+    // It must NOT remain the bare pre-card generic-browser copy. (A faithful fix
+    // may keep the verb "browser" elsewhere, but it can no longer say ONLY
+    // "Open this URL in a browser" with nothing steering the choice.)
+    expect(msg).not.toBe(`Open this URL in a browser to register:\n<${payload["auth_url"]}>`);
+  });
+
+  it("instructions carries the matching steer so the agent relays 'open in the default browser, not the in-app browser'", async () => {
+    // RED today: the current instructions are bare "Share the auth URL with the
+    // user. The plugin is polling…" — an agent paraphrasing that to the human
+    // re-introduces the generic "a browser" gap. The agent-facing copy must
+    // carry the same steer as `message` so the two cannot diverge (criterion 2).
+    const payload = await freshRegister(api);
+    const instructions = payload["instructions"];
+    expect(typeof instructions).toBe("string");
+    const ins = instructions as string;
+
+    // Positive half — the agent is primed to relay "default/system browser".
+    expect(ins).toMatch(POSITIVE_STEER_RE);
+    // Negative half — and to relay "not the in-app/built-in/embedded browser".
+    expect(ins).toMatch(NEGATIVE_NOT_RE);
+    expect(ins).toMatch(NEGATIVE_SURFACE_RE);
+
+    // It must NOT remain the exact pre-card instructions (which carry no steer).
+    expect(ins).not.toBe(
+      "Share the auth URL with the user. The plugin is polling in the"
+      + " background — once the user finishes signing in, call sil_register"
+      + " again to confirm (it will report already_registered).",
+    );
+  });
+
+  it("the steer is a separate lead line BEFORE the link line — it is NOT folded onto the atomic `<authUrl>` line (no #24 regression)", async () => {
+    // Regression guard for criterion 5 / the #24 atomic-link contract, expressed
+    // against the NEW copy: adding the steer must not glue prose onto the link's
+    // own line. The line carrying the URL must STILL be exactly `<authUrl>` and
+    // nothing else, and the steer text must live on a DIFFERENT (earlier) line.
+    // This stays GREEN against any faithful implementation (steer as a lead line
+    // before `\n<url>`); it goes RED only if the dev folds the steer onto the
+    // link line — the precise greedy-auto-linker truncation #24 fixed.
+    const payload = await freshRegister(api);
+    const msg = payload["message"] as string;
+    const authUrl = payload["auth_url"] as string;
+    const lines = msg.split("\n");
+
+    // The link sits alone on its own line, exactly `<authUrl>`.
+    const linkLineIdx = lines.findIndex((l) => l.trim().includes(authUrl));
+    expect(linkLineIdx).toBeGreaterThanOrEqual(0);
+    expect(lines[linkLineIdx]!.trim()).toBe(`<${authUrl}>`);
+
+    // The steer (the negative-surface token) appears on a DIFFERENT line, BEFORE
+    // the link line — never on the link line itself. (A non-technical reader sees
+    // the steer first, then the bare atomic link.)
+    const steerLineIdx = lines.findIndex((l) => NEGATIVE_SURFACE_RE.test(l));
+    expect(steerLineIdx).toBeGreaterThanOrEqual(0);
+    expect(steerLineIdx).toBeLessThan(linkLineIdx);
+    // The link line carries none of the steer prose.
+    expect(NEGATIVE_SURFACE_RE.test(lines[linkLineIdx]!)).toBe(false);
+    expect(POSITIVE_STEER_RE.test(lines[linkLineIdx]!)).toBe(false);
+  });
+
+  it("the new steer copy survives the greedy auto-linker with code_challenge intact (the #24 truncation defense holds with the steer added)", async () => {
+    // Belt-and-braces over A-3: with the steer prose now present in `message`,
+    // run the WHOLE message through the greedy auto-linker and assert the
+    // bracketed URL is still captured WHOLE (code_challenge included). If a future
+    // implementer folds the steer onto the link line, the bracket span breaks and
+    // this goes RED alongside the line-placement guard above. GREEN today only
+    // because A-2/A-3 hold; it must stay GREEN after the steer lands.
+    const payload = await freshRegister(api);
+    const message = payload["message"] as string;
+    const authUrl = payload["auth_url"] as string;
+    const expectedChallenge = new URL(authUrl).searchParams.get("code_challenge")!;
+
+    const targets = greedyAutoLink(message);
+    expect(targets.length).toBeGreaterThan(0);
+    const carriesChallenge = targets.filter((t) =>
+      t.includes(`code_challenge=${expectedChallenge}`),
+    );
+    expect(carriesChallenge.length).toBeGreaterThan(0);
+
+    // auth_url itself is untouched by the steer — byte-for-byte the unwrapped,
+    // un-re-encoded canonical URL (the #24 invariant; A-1 owns the full assertion,
+    // this is the steer-context regression guard).
+    expect(authUrl.startsWith("<")).toBe(false);
+    expect(authUrl).not.toContain("<");
+    expect(authUrl).not.toContain("&amp;");
+    expect(authUrl).not.toContain("%26");
+    expect(authUrl).toContain(`&code_challenge=${expectedChallenge}`);
+  });
+
+  it("the steer ships UNCONDITIONALLY — no host signal gates it (always-instruct verdict)", async () => {
+    // Criterion 6 / the always-instruct verdict: the mock api exposes no
+    // client/UA/surface signal (the real host surface has none either —
+    // openclaw.d.ts:23-44), and `sil_register` takes NO params. So there is
+    // nothing to gate on; calling execute() with the empty params it declares
+    // must ALWAYS produce the steer. We assert it across two independent fresh
+    // calls (distinct sessions) to pin "unconditional", not "happened once".
+    const a = await freshRegister(api);
+    const b = payloadOf(await getTool(api, TOOL).execute("c2", {}));
+
+    for (const p of [a, b]) {
+      const m = p["message"] as string;
+      const i = p["instructions"] as string;
+      expect(m).toMatch(POSITIVE_STEER_RE);
+      expect(m).toMatch(NEGATIVE_SURFACE_RE);
+      expect(i).toMatch(POSITIVE_STEER_RE);
+      expect(i).toMatch(NEGATIVE_SURFACE_RE);
+    }
+    // Two distinct registration attempts (different sessions) — the steer is not
+    // a one-shot, it is emitted on every awaiting_browser return.
+    expect(a["session_id"]).not.toBe(b["session_id"]);
+  });
+});
+
 describe("sil_register — A: the atomic-link presentation never leaks the PKCE verifier", () => {
   let api: MockPluginAPI;
   let sentVerifier: string | null;

--- a/src/tools/identity.ts
+++ b/src/tools/identity.ts
@@ -122,20 +122,31 @@ function registerRegister(api: PluginAPI): void {
 
       return jsonResult({
         status: "awaiting_browser",
-        // Present the auth URL as ONE atomic, unbreakable link: on its own line,
-        // angle-bracket wrapped, so a greedy chat auto-linker captures the WHOLE
-        // URL (the `&code_challenge` included) instead of truncating at the `&`
-        // and 400-ing `invalid_code_challenge`. `auth_url` below stays the
-        // canonical, UNWRAPPED machine field agents parse. (FIX A.)
+        // The steer lead line routes the user into their OWN default browser
+        // BEFORE the Auth0 leg (where Auth0's session cookie works on its own
+        // domain), instead of an in-app/embedded webview that partitions it and
+        // dead-ends the login. It is a SEPARATE line ABOVE the link, so the link
+        // line stays exactly `<authUrl>` — ONE atomic, angle-bracket-wrapped
+        // target that a greedy chat auto-linker captures WHOLE (`&code_challenge`
+        // included) instead of truncating at the `&` and 400-ing
+        // `invalid_code_challenge`. `auth_url` below stays the canonical,
+        // UNWRAPPED machine field agents parse. (FIX A + system-browser steer.)
         message:
-          "Open this URL in a browser to register:\n"
+          BROWSER_STEER_HUMAN
+          + "\n"
           + presentAuthLink(authUrl),
         auth_url: authUrl,
         session_id: sessionId,
+        // The agent-facing steer MUST agree with the human `message` (both built
+        // from the shared BROWSER_STEER_NEGATIVE clause) so an agent relaying the
+        // instruction can't paraphrase it back to a generic "a browser" and
+        // re-open the cookie-blocking-webview gap.
         instructions:
-          "Share the auth URL with the user. The plugin is polling in the"
-          + " background — once the user finishes signing in, call sil_register"
-          + " again to confirm (it will report already_registered).",
+          "Share the auth URL with the user and tell them to "
+          + BROWSER_STEER_AGENT
+          + " The plugin is polling in the background — once the user finishes"
+          + " signing in, call sil_register again to confirm (it will report"
+          + " already_registered).",
       });
     },
   });
@@ -544,3 +555,33 @@ function describeCause(err: unknown): string {
 function presentAuthLink(authUrl: string): string {
   return `<${authUrl}>`;
 }
+
+/**
+ * System-browser steer copy (the proactive webview → default-browser handoff).
+ *
+ * Auth0's hosted login sets its session cookie on its OWN domain; an app's
+ * embedded/in-app webview routinely partitions or blocks that cookie, so opening
+ * the auth URL there dead-ends the login. The plugin CANNOT detect the surface —
+ * the host `api` exposes no client/UA/surface signal (see openclaw.d.ts) and a
+ * tool's execute receives no request context — so the steer ships UNCONDITIONALLY
+ * at presentation time, BEFORE the Auth0 leg (not as a post-failure recovery; that
+ * reactive path is sil-services #50). Phrased as a neutral setup step, not a
+ * warning — onboarding first-impression is the metric.
+ *
+ * One shared NEGATIVE clause feeds both the human `message` and the agent
+ * `instructions` so the two copies cannot drift — an agent paraphrasing must
+ * carry the same "not the in-app browser" half, never collapse it back to a
+ * generic "a browser". Plain "default browser (Safari/Chrome)" is used over the
+ * term "system browser": it names the concrete action a non-technical user can
+ * follow on their own device.
+ */
+const BROWSER_STEER_NEGATIVE =
+  "your device's default browser (Safari, Chrome, …), not this app's"
+  + " built-in / in-app browser";
+
+/** Human-facing lead line — the line ABOVE the atomic link in `message`. */
+const BROWSER_STEER_HUMAN = `Open this link in ${BROWSER_STEER_NEGATIVE}:`;
+
+/** Agent-facing steer — embedded mid-sentence in `instructions` (lower-cased lead
+ * so it reads naturally after "tell them to …"). */
+const BROWSER_STEER_AGENT = `open the link in ${BROWSER_STEER_NEGATIVE}.`;


### PR DESCRIPTION
## Card
`cards/bounce-webview-auth-links-to-the-system-browser.md` (lives in the `card/bounce-webview-auth-links-to-the-system-browser` branch — see the body for full intent + handoffs). Epic `registration-link-hardening-2026-06` (4th card; siblings #24 sil-openclaw, #49/#50 sil-services, all done).

## Problem
A `sil_register` auth link opened inside an app's embedded/in-app webview dead-ends: Auth0's hosted login sets its session cookie on its own domain, and an embedded webview partitions/blocks that cookie, so the Auth0 leg can't complete. sil-services #50 ships the *reactive* `/callback` recovery; this card is the *proactive* handoff — steer the user into the system browser **before** the Auth0 leg, so the dead-end never happens.

## Verdict: always-instruct, unconditionally (no webview detection)
The plugin **cannot** detect the surface — the host `api` (`src/types/openclaw.d.ts`) exposes no client/UA/surface signal, and a tool's `execute` receives no request context. So the steer ships **unconditionally** at presentation time. This is the production-correct answer, not a fallback (Discovery verdict).

## Summary (pure-presentation, copy-only — one file)
- `src/tools/identity.ts`, the `awaiting_browser` return:
  - **`message`** gains a steer lead line — *"Open this link in your device's default browser (Safari, Chrome, …), not this app's built-in / in-app browser:"* — placed **above** the atomic angle-bracket link line.
  - **`instructions`** gains the matching agent-facing steer so a relaying agent can't paraphrase it back to a generic "a browser".
- Both are assembled from one shared `BROWSER_STEER_NEGATIVE` clause (tiny pure constants beside `presentAuthLink`, the unit seam) so the two copies **cannot drift**.

## Preserved invariants (#24)
- `auth_url` value **byte-for-byte unchanged** — unwrapped, both params, literal `&` (not `&amp;`/`%26`).
- The link stays **one atomic `<authUrl>` on its own line** — the steer is a *separate* lead line; nothing is folded onto the link span (the greedy-auto-linker truncation defense holds, verified through the same greedy-linker model #24 used).
- **No manifest change, no new tool** (`manifest-contract.integration.test.ts` stays green). No webview detection, no `config.ts`/wire change.

## Test plan
- [x] `pnpm test` — 5 previously-RED steer tests now PASS (3 unit in `register-link-presentation.test.ts`, 2 integration in `register-claim.integration.test.ts`); #24 A-1/A-2/A-3, FIX-C, and `manifest-contract` stay green. 599 passing; the only failures are ~10 `repo-scaffold.integration.test.ts` baseline artifacts (gitignored `CLAUDE.md`/`docs` absent in the worktree checkout — a known artifact, not a regression).
- [x] `pnpm typecheck` clean; `pnpm build` clean (`dist/index.js` emitted).
- [x] Live-verified the real built artifact's `awaiting_browser` return renders the steer + atomic link correctly.
- No test file was edited (TDD discipline; `src/__tests__/` diff vs the RED commit is empty).

## Distillation target
Knowledge capture happens **after Review PASS** in the `distilling` stage — `solutions-architect` runs in this same worktree, commits to this branch, and pushes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)