### PR TITLE
feature: create a valid sil-wired OpenClaw agent profile (agent-creation engine + behaviour artefacts)

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -10,6 +10,7 @@
   "contracts": {
     "tools": [
       "sil_product_get",
+      "sil_profile_materialize",
       "sil_register",
       "sil_search",
       "sil_whoami"
@@ -47,7 +48,7 @@
   },
   "security": {
     "shipsRuntimeCode": true,
-    "packagingNote": "Compiled JavaScript ships under ./dist. register() stays synchronous and opens nothing — it only registers tools. ALL I/O happens inside a tool's execute(): sil_register calls sil-web over the network, writes tokens.json + config.json to the plugin data directory (owner-only, 0600), and arms a bounded background poll timer that stops on the first terminal claim outcome or after the session deadline. sil_whoami reads the stored access token and calls sil-api for the user's identity, refreshing transparently via sil-web on a 401 (at most one refresh + one retry per call, no timer); a confirmed-dead session clears tokens.json. sil_search and sil_product_get read the stored access token and call sil-api's catalog endpoints (search / lookup) with it — read-only, no token write, no timer, a single round-trip (a 401 is a terminal re-register hint, no refresh). The PKCE verifier is held only in memory and is never written to disk. Tokens and identity PII are never logged.",
+    "packagingNote": "Compiled JavaScript ships under ./dist. register() stays synchronous and opens nothing — it only registers tools. ALL I/O happens inside a tool's execute(): sil_register calls sil-web over the network, writes tokens.json + config.json to the plugin data directory (owner-only, 0600), and arms a bounded background poll timer that stops on the first terminal claim outcome or after the session deadline. sil_whoami reads the stored access token and calls sil-api for the user's identity, refreshing transparently via sil-web on a 401 (at most one refresh + one retry per call, no timer); a confirmed-dead session clears tokens.json. sil_search and sil_product_get read the stored access token and call sil-api's catalog endpoints (search / lookup) with it — read-only, no token write, no timer, a single round-trip (a 401 is a terminal re-register hint, no refresh). sil_profile_materialize makes no network call and reads no token: it writes a created shopping expert's behaviour artefacts (persona.md, optional playbook.md, profile.json) atomically into $SIL_DATA_DIR/agents/<agentId>/ (owner-only, 0600) — the agent's host-config wiring is driven separately by the host CLI, never by this plugin. The PKCE verifier is held only in memory and is never written to disk. Tokens and identity PII are never logged.",
     "registersLongLivedService": false,
     "serviceIds": [],
     "runsTimers": true,
@@ -57,7 +58,7 @@
       "https://sil.4gpts.com"
     ],
     "filesystemScope": [
-      "$SIL_DATA_DIR (default $XDG_DATA_HOME/sil, else ~/.local/share/sil) — tokens.json, config.json"
+      "$SIL_DATA_DIR (default $XDG_DATA_HOME/sil, else ~/.local/share/sil) — tokens.json, config.json, agents/<agentId>/{persona.md,playbook.md,profile.json} (shopping-expert behaviour artefacts written by sil_profile_materialize)"
     ],
     "credentialsOnDisk": [
       "tokens.json (access + refresh token)",

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sil
-description: This skill should be used when the user wants to shop on sil — register an identity, see who they are, search the catalog for purchasable products, or look up specific products by id. The plugin exposes sil_register, sil_whoami, sil_search, and sil_product_get.
+description: This skill should be used when the user wants to shop on sil — register an identity, see who they are, search the catalog for purchasable products, or look up specific products by id — or when they want to create a dedicated sil-wired shopping expert (a new OpenClaw agent profile). The plugin exposes sil_register, sil_whoami, sil_search, sil_product_get, and sil_profile_materialize.
 metadata:
   openclaw:
     emoji: "\U0001F6D2"
@@ -55,7 +55,71 @@ All four return the canonical envelope: a single text content block whose JSON b
 | `invalid_request` | The query/ids were rejected (e.g. empty input). | Fix the input and call again — do NOT re-register. |
 | `retryable` | A transient network/5xx blip. | Try the same call again — do NOT re-register. |
 
-## 4. Adding a real tool
+## 4. Create a sil-wired shopping expert (agent-creation engine)
+
+When the user wants a **dedicated shopping expert** — "make me a shopping expert for buying gifts", "set up a grocery re-order agent", "create a sil shopping agent" — you author and persist a **valid OpenClaw agent profile**: a real new agent under the host `agents` config, with the **sil plugin enabled** and the **sil skill attached**, plus the expert's behaviour artefacts in the sil data directory — so the created agent can shop with **no further setup**.
+
+You are the engine. The host config write is **you driving the host's own `openclaw …` CLI** — the sil plugin never writes the host config itself. Run these steps **in order, top to bottom** — the order is the spec.
+
+### The profile spec (input)
+
+Elicit or confirm a spec before you start (the full interview is a separate concern; here the spec is your input):
+
+| Field | Meaning | Required? |
+|---|---|---|
+| **agentId** | The new agent's id (lower-kebab, e.g. `gift-buyer`). Becomes `agents.list[].id`. Must be **unique** and is never `main` (host-reserved). | Required |
+| **name** | Human-readable expert name ("Gift Buyer"). | Required |
+| **persona / instructions** | Who this expert is and how it shops — its expertise, tone, standing rules. | Required (non-empty) |
+| **workspace** | The agent's workspace directory (e.g. `~/.openclaw/workspace-gift-buyer`). | Required for the non-interactive add |
+| **playbook (sub-skill)** | An optional generated **domain sub-skill** — a shopping playbook for this expert's niche. | Optional |
+
+The **sil plugin** and the **sil skill** are always attached (that is what makes it *sil-wired*). Creating an expert is **local and offline** — it does **not** require or perform sil registration, reads no token, and writes nothing to identity storage. The expert registers the user later, on first shop, via `sil_register`. Do **not** present registration as a prerequisite for creating the profile.
+
+### Engine steps (run in this exact order)
+
+1. **Validate the spec FIRST — before anything is written.** Check `agentId` is present, lower-kebab, unique-looking, and not `main`; `name` is present; `persona`/instructions is non-empty; `workspace` is present. If any check fails, stop with the **`invalid_request`** outcome naming the offending field and **write nothing** — no agent, no artefacts. Nothing partial. This validation runs ahead of every host command, so a bad spec never reaches the host.
+
+2. **Collision check — read before write.** Run `openclaw agents list --json` and confirm no existing agent already uses `agentId`. If one does, stop with the **`collision`** outcome and **do not** run `openclaw agents add` — never overwrite or clobber an existing agent's persona or wiring. Surface the collision so the user can rename. (This list-check precedes the add, so a same-name agent is caught before any change.)
+
+3. **Create the agent shell (host CLI).** Run:
+   ```
+   openclaw agents add <agentId> --workspace <workspace> --non-interactive --json
+   ```
+   This creates the real `agents.list[]` entry and the agent's workspace bootstrap files (`SOUL.md`, `AGENTS.md`, …), inheriting model and tool profile from `agents.defaults`. `--non-interactive --json` is required so you can drive it without a prompt and read the structured result.
+
+4. **Materialize the behaviour artefacts into the sil data directory.** Call **`sil_profile_materialize`** with `{ agentId, name, persona, playbook? }`. It writes the expert's behaviour artefacts atomically into **`$SIL_DATA_DIR`** (the sil data directory — the plugin's own disclosed scope) under `agents/<agentId>/`:
+   - **`persona.md`** — the persona/instructions that power the expert's behaviour;
+   - **`playbook.md`** — the generated domain **sub-skill**, when supplied;
+   - **`profile.json`** — the manifest the sil skill reads at runtime to load them.
+   These behaviour artefacts live in `$SIL_DATA_DIR`, kept **out of** the thin host `agents` wiring entry. The tool's own outcomes are `ok` / `invalid_request` / `persistence_failed` — on `invalid_request` it wrote nothing; on `persistence_failed` it left nothing partial.
+
+5. **Make the persona the agent's system framing.** Copy the materialized `persona.md` into the new agent's workspace `SOUL.md` (its persona bootstrap file), so the host injects the persona into the expert's system prompt.
+
+6. **Wire the sil skill and plugin into the agent (host CLI).** Attach the sil skill and enable the sil plugin for the created agent:
+   ```
+   openclaw config set 'agents.list[<i>].skills' '["sil"]' --strict-json
+   openclaw config set plugins.entries.sil.enabled true --merge
+   ```
+   The skill attach makes the agent **know how** to drive the tools; the plugin enable makes the four `sil_*` tools available to it (they come for free once the `sil` plugin is enabled). Keep `sil` in the agent's skill list and do not deny the `sil_*` tools in its tool profile.
+
+7. **Validate with the host's OWN check, THEN declare created.** Run `openclaw config validate --json`. "Valid" means *the host says yes* — never assert it yourself. Only when validation passes do you report the **`created`** outcome. If `openclaw config validate` returns `ok: false` (or any CLI step failed), report **`persistence_failed`** with the failing **path** and **cause**, and leave nothing partial behind. This validate-after-add step is what guarantees the host will load the profile.
+
+8. **Tell the user it is ready.** On `created`, tell the user the expert exists and how to open it. When they open the new agent, the host loads it: the sil plugin is enabled, the sil skill is attached, `SOUL.md` carries the persona, and the sil skill reads `$SIL_DATA_DIR/agents/<agentId>/profile.json` to load the persona + playbook — the expert calls `sil_search` / `sil_product_get` (and `sil_register` / `sil_whoami` as needed) on the user's intent with **no further setup**.
+
+### Status taxonomy (agent-creation engine)
+
+| `status` | Meaning | What to do |
+|---|---|---|
+| `created` | The agent was added, the behaviour artefacts materialized, the sil plugin + skill wired, and `openclaw config validate` accepted it. | Tell the user the expert is ready and how to open it. |
+| `invalid_request` | The spec failed validation (missing/blank field). **Nothing was written.** | Name the field, fix it, run again. Do NOT proceed to `openclaw agents add`. |
+| `collision` | An agent with that id already exists (from `openclaw agents list`). | Surface it; pick a different id. **Never overwrite / clobber** the existing agent. |
+| `persistence_failed` | A write or `openclaw config validate` step failed. The reported **path** + **cause** name what to fix. **Nothing partial** was left behind. | Fix the path/cause (writable config, valid spec), then create the expert again. |
+
+### Runtime — how a created expert loads its behaviour
+
+When you (the sil skill) start a session inside a created expert, read `$SIL_DATA_DIR/agents/<agentId>/profile.json`, then load the `persona.md` (reaffirm the standing instructions) and `playbook.md` sub-skill (the domain shopping playbook) it points at. That is what lets the expert shop on its niche with no further setup.
+
+## 5. Adding a real tool
 
 The mechanical steps live in the repo's `CLAUDE.md` ("How to add a tool"); the short version is three steps: register the tool inside a `registerXTools(api)` group in `src/tools/`, wire that group into `register()` in `src/index.ts`, and add the tool's name to `openclaw.plugin.json#contracts.tools`. The manifest↔code drift-guard test fails if those disagree, which keeps the pattern self-enforcing.
 

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -96,12 +96,15 @@ describe("plugin entry — registration contract", () => {
 
   it("wires the real tool groups into register() — registers exactly the real tool set", () => {
     // register() runs the real tool groups (no mock), so it populates the
-    // api with exactly the four real tools and NO example stub. This pins
+    // api with exactly the five real tools and NO example stub. This pins
     // the wiring AND the card's "absence" goal: sil_ping / sil_echo gone.
+    // sil_profile_materialize (agent-creation engine, card:
+    // create-a-valid-sil-wired-openclaw-agent-profile) joins the set.
     const api = createMockPluginApi();
     capturedRegisterFn!(api);
     expect([...api._tools.keys()].sort()).toEqual([
       "sil_product_get",
+      "sil_profile_materialize",
       "sil_register",
       "sil_search",
       "sil_whoami",

--- a/src/__tests__/lib/profile-store.test.ts
+++ b/src/__tests__/lib/profile-store.test.ts
@@ -1,0 +1,318 @@
+/**
+ * UNIT — materializeProfile() behaviour-artefact writer (tier: unit, real temp
+ * dir via the SIL_DATA_DIR override, no network, no host).
+ *
+ * Card: create-a-valid-sil-wired-openclaw-agent-profile (founder steer:
+ * behaviour artefacts in the sil data directory). This is the plugin's half of
+ * the agent-creation engine — the host-config wiring is host-CLI-driven; the
+ * BEHAVIOUR artefacts (persona.md, optional playbook.md, profile.json) are the
+ * sil-owned write into $SIL_DATA_DIR/agents/<agentId>/.
+ *
+ * The invariants pinned here ARE the card's correctness bar for the artefact
+ * layer:
+ *   1. A valid spec materializes persona.md + profile.json (and playbook.md when
+ *      supplied) under $SIL_DATA_DIR/agents/<agentId>/, owner-only (0600), in a
+ *      0700 dir, with a typed manifest pointing at the artefacts.
+ *   2. Validate-FIRST: every invalid field returns `invalid_request` naming the
+ *      field and writes NOTHING — no agent directory appears (Product
+ *      invariant 7, atomic outcome).
+ *   3. Atomic on failure: a mid-write failure leaves NOTHING partial behind
+ *      (persistence_failed with <dir>: <cause>).
+ *   4. Identity boundary: materializing reads/writes no token (no coupling).
+ *
+ * Hermetic via the SIL_DATA_DIR temp-dir override (the repo's standard knob).
+ *
+ * Contract this file pins for the implementation (expert-developer),
+ * `src/lib/profile-store.ts`:
+ *   - getAgentArtefactDir(agentId): $SIL_DATA_DIR/agents/<agentId> (never hardcoded)
+ *   - materializeProfile(spec): MaterializeResult — discriminated, never throws;
+ *     validate-first (invalid_request, write nothing); atomic (persistence_failed,
+ *     nothing partial); ok writes persona.md + profile.json + optional playbook.md.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  writeFileSync,
+  mkdirSync,
+  chmodSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  materializeProfile,
+  getAgentArtefactDir,
+  type ProfileManifest,
+} from "../../lib/profile-store.js";
+import { getDataDir, getTokensPath } from "../../lib/credentials.js";
+
+let dataDir: string;
+let priorSilDataDir: string | undefined;
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), "sil-profile-store-"));
+  priorSilDataDir = process.env["SIL_DATA_DIR"];
+  process.env["SIL_DATA_DIR"] = dataDir;
+});
+
+afterEach(() => {
+  if (priorSilDataDir === undefined) delete process.env["SIL_DATA_DIR"];
+  else process.env["SIL_DATA_DIR"] = priorSilDataDir;
+  // Restore perms so rmSync can clean a dir a cleanup test chmod'd read-only.
+  try {
+    chmodSync(dataDir, 0o700);
+  } catch {
+    /* best-effort */
+  }
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+const GOOD = {
+  agentId: "gift-buyer",
+  name: "Gift Buyer",
+  persona: "You specialise in gifts under €50; always check stock before recommending.",
+  playbook: "Use sil_search for browsing; sil_product_get to re-check stock before buying.",
+} as const;
+
+function readManifest(agentId: string): ProfileManifest {
+  const path = join(getAgentArtefactDir(agentId), "profile.json");
+  return JSON.parse(readFileSync(path, "utf8")) as ProfileManifest;
+}
+
+/** Every file under `dir`, recursively (relative paths). Used to prove no
+ * `.tmp` sibling survives a write and no artefact survives a failed write. */
+function walkFiles(dir: string, base = dir): string[] {
+  if (!existsSync(dir)) return [];
+  const out: string[] = [];
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) out.push(...walkFiles(full, base));
+    else out.push(full.slice(base.length + 1));
+  }
+  return out;
+}
+
+describe("materializeProfile — valid spec writes the behaviour artefacts", () => {
+  it("writes persona.md, playbook.md, and profile.json under $SIL_DATA_DIR/agents/<agentId>/", () => {
+    const result = materializeProfile({ ...GOOD });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return; // narrow
+
+    const expectedDir = join(getDataDir(), "agents", GOOD.agentId);
+    expect(result.dir).toBe(expectedDir);
+    expect(existsSync(join(expectedDir, "persona.md"))).toBe(true);
+    expect(existsSync(join(expectedDir, "playbook.md"))).toBe(true);
+    expect(existsSync(join(expectedDir, "profile.json"))).toBe(true);
+
+    expect(readFileSync(result.personaPath, "utf8")).toBe(GOOD.persona);
+    expect(result.playbookPath).toBeDefined();
+    expect(readFileSync(result.playbookPath!, "utf8")).toBe(GOOD.playbook);
+  });
+
+  it("resolves the artefact dir from getDataDir() — honours $SIL_DATA_DIR (never hardcoded)", () => {
+    // getAgentArtefactDir must sit under the overridden data dir, proving it
+    // reads the accessor and is not a baked-in ~/.local/share path.
+    expect(getAgentArtefactDir("x")).toBe(join(dataDir, "agents", "x"));
+  });
+
+  it("the manifest is typed and points at the materialized artefacts", () => {
+    const result = materializeProfile({ ...GOOD });
+    expect(result.ok).toBe(true);
+
+    const manifest = readManifest(GOOD.agentId);
+    expect(manifest.agentId).toBe(GOOD.agentId);
+    expect(manifest.name).toBe(GOOD.name);
+    expect(manifest.personaPath).toBe(
+      join(getAgentArtefactDir(GOOD.agentId), "persona.md"),
+    );
+    expect(manifest.playbookPath).toBe(
+      join(getAgentArtefactDir(GOOD.agentId), "playbook.md"),
+    );
+    expect(typeof manifest.createdAt).toBe("string");
+    // ISO 8601 — parseable to a real date.
+    expect(Number.isNaN(Date.parse(manifest.createdAt))).toBe(false);
+  });
+
+  it("omits playbook.md AND the manifest playbookPath when no playbook is supplied", () => {
+    const { playbook: _omit, ...noPlaybook } = GOOD;
+    const result = materializeProfile({ ...noPlaybook });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(existsSync(join(result.dir, "persona.md"))).toBe(true);
+    expect(existsSync(join(result.dir, "playbook.md"))).toBe(false);
+    expect(result.playbookPath).toBeUndefined();
+
+    const manifest = readManifest(GOOD.agentId);
+    expect(manifest.playbookPath).toBeUndefined();
+  });
+
+  it("writes artefacts owner-only (0600) inside a 0700 dir", () => {
+    const result = materializeProfile({ ...GOOD });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    // mask to the permission bits.
+    expect(statSync(result.dir).mode & 0o777).toBe(0o700);
+    expect(statSync(result.personaPath).mode & 0o777).toBe(0o600);
+    expect(statSync(result.profilePath).mode & 0o777).toBe(0o600);
+  });
+
+  it("does NOT read or write any token (no identity coupling)", () => {
+    // The tokens path must not appear as a side effect of materializing.
+    materializeProfile({ ...GOOD });
+    expect(existsSync(getTokensPath())).toBe(false);
+  });
+
+  it("leaves NO .tmp sibling behind after the atomic write (tmp → rename → chmod)", () => {
+    // The store writes via a tmp sibling then renames over the target. A
+    // surviving `.tmp` means the rename never ran — the atomic-write contract
+    // broken (a reader could observe a half-written artefact).
+    const result = materializeProfile({ ...GOOD });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const leftovers = walkFiles(result.dir).filter((f) => f.includes(".tmp"));
+    expect(leftovers).toEqual([]);
+  });
+});
+
+describe("materializeProfile — validate-first: a bad spec writes NOTHING (invalid_request)", () => {
+  const dirExists = () => existsSync(getAgentArtefactDir(GOOD.agentId));
+
+  it("missing agentId → invalid_request(field=agentId), nothing written", () => {
+    const result = materializeProfile({ ...GOOD, agentId: "" });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.kind).toBe("invalid_request");
+    if (result.kind !== "invalid_request") return;
+    expect(result.field).toBe("agentId");
+    expect(dirExists()).toBe(false);
+  });
+
+  it('reserved "main" agentId → invalid_request(field=agentId), nothing written', () => {
+    const result = materializeProfile({ ...GOOD, agentId: "main" });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.kind).toBe("invalid_request");
+    if (result.kind !== "invalid_request") return;
+    expect(result.field).toBe("agentId");
+    expect(existsSync(join(getDataDir(), "agents", "main"))).toBe(false);
+  });
+
+  it("non-kebab agentId → invalid_request(field=agentId), nothing written", () => {
+    const result = materializeProfile({ ...GOOD, agentId: "Gift Buyer!" });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.kind).toBe("invalid_request");
+    if (result.kind !== "invalid_request") return;
+    expect(result.field).toBe("agentId");
+  });
+
+  it("rejects a path-traversing / separator-bearing agentId (it is a dir-path segment)", () => {
+    // Security-relevant: agentId becomes a directory path segment under
+    // $SIL_DATA_DIR/agents/. A `..` or `/` would let an artefact escape the
+    // sandbox. The lower-kebab gate must reject every such shape — and write
+    // nothing for any of them.
+    for (const bad of ["../escape", "gift/buyer", "..", ".", "a/../b", "Gift-Buyer"]) {
+      const result = materializeProfile({ ...GOOD, agentId: bad });
+      expect(result.ok, `expected reject for ${JSON.stringify(bad)}`).toBe(false);
+      if (result.ok) return;
+      expect(result.kind).toBe("invalid_request");
+      if (result.kind !== "invalid_request") return;
+      expect(result.field).toBe("agentId");
+    }
+    // Nothing escaped the agents subtree (no stray file anywhere under it).
+    expect(walkFiles(join(getDataDir(), "agents"))).toEqual([]);
+  });
+
+  it("blank name → invalid_request(field=name), nothing written", () => {
+    const result = materializeProfile({ ...GOOD, name: "   " });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.kind).toBe("invalid_request");
+    if (result.kind !== "invalid_request") return;
+    expect(result.field).toBe("name");
+    expect(dirExists()).toBe(false);
+  });
+
+  it("blank persona → invalid_request(field=persona), nothing written", () => {
+    const result = materializeProfile({ ...GOOD, persona: "" });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.kind).toBe("invalid_request");
+    if (result.kind !== "invalid_request") return;
+    expect(result.field).toBe("persona");
+    expect(dirExists()).toBe(false);
+  });
+
+  it("present-but-blank playbook → invalid_request(field=playbook), nothing written", () => {
+    const result = materializeProfile({ ...GOOD, playbook: "   " });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.kind).toBe("invalid_request");
+    if (result.kind !== "invalid_request") return;
+    expect(result.field).toBe("playbook");
+    expect(dirExists()).toBe(false);
+  });
+});
+
+describe("materializeProfile — atomic on write failure (persistence_failed, nothing partial)", () => {
+  it("when the artefact path is blocked by a file, returns persistence_failed with <dir>: <cause> and leaves nothing partial", () => {
+    // Force a write failure: pre-create `agents/<id>` as a FILE, so mkdir of the
+    // dir (recursive over an existing non-dir leaf) throws ENOTDIR/EEXIST.
+    const agentsDir = join(getDataDir(), "agents");
+    mkdirSync(agentsDir, { recursive: true });
+    // Place a regular file exactly where the agent DIR must go.
+    writeFileSync(join(agentsDir, GOOD.agentId), "i am a file, not a dir");
+
+    const result = materializeProfile({ ...GOOD });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.kind).toBe("persistence_failed");
+    if (result.kind !== "persistence_failed") return;
+    // The path + cause are both present (actionable recovery).
+    expect(result.error).toContain(getAgentArtefactDir(GOOD.agentId));
+    // The blocking file is untouched; no partial artefacts were written under it.
+    expect(statSync(join(agentsDir, GOOD.agentId)).isFile()).toBe(true);
+  });
+
+  // chmod 0500 can't block writes for root — skip there rather than false-fail.
+  // The file-blocks-path case above covers the failure envelope for ALL uids;
+  // this one additionally drives the catch-block rmSync CLEANUP (a dir that was
+  // created, then a write into it failed) so no half-populated dir survives.
+  const asRoot = typeof process.getuid === "function" && process.getuid() === 0;
+  it.skipIf(asRoot)(
+    "CLEANS UP a partially-created artefact dir when a mid-write fails (no half-set survives)",
+    () => {
+      // Pre-create the agent dir READ-ONLY (0500): mkdir(recursive) is a no-op,
+      // then the tmp-file write inside it fails EACCES, driving the cleanup.
+      const agentDir = getAgentArtefactDir(GOOD.agentId);
+      mkdirSync(agentDir, { recursive: true });
+      chmodSync(agentDir, 0o500);
+
+      const result = materializeProfile({ ...GOOD });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.kind).toBe("persistence_failed");
+
+      // No artefact file may survive a failed write. Restore perms first so we
+      // can inspect + afterEach can clean up.
+      if (existsSync(agentDir)) {
+        chmodSync(agentDir, 0o700);
+        expect(walkFiles(agentDir)).toEqual([]);
+      }
+    },
+  );
+});

--- a/src/__tests__/manifest-contract.integration.test.ts
+++ b/src/__tests__/manifest-contract.integration.test.ts
@@ -29,8 +29,8 @@
  *     `contracts.tools` string array;
  *   - the real tool groups register exactly the tools named there (and
  *     the manifest names exactly the tools they register) — the set on
- *     both sides equals { sil_product_get, sil_register, sil_search,
- *     sil_whoami }.
+ *     both sides equals { sil_product_get, sil_profile_materialize,
+ *     sil_register, sil_search, sil_whoami }.
  */
 
 import { describe, it, expect } from "vitest";
@@ -39,6 +39,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { registerIdentityTools } from "../tools/identity.js";
 import { registerCatalogTools } from "../tools/catalog.js";
+import { registerProfileTools } from "../tools/profile.js";
 import {
   createMockPluginApi,
   registeredToolNames,
@@ -80,6 +81,7 @@ function codeRegisteredNames(): Set<string> {
   const api = createMockPluginApi();
   registerIdentityTools(api);
   registerCatalogTools(api);
+  registerProfileTools(api);
   return registeredToolNames(api);
 }
 
@@ -125,6 +127,7 @@ describe("manifest ↔ code drift guard (set-equality, BOTH directions)", () => 
     // not just the symmetric drift check above.
     const expected = [
       "sil_product_get",
+      "sil_profile_materialize",
       "sil_register",
       "sil_search",
       "sil_whoami",
@@ -160,6 +163,16 @@ describe("manifest ↔ code drift guard (set-equality, BOTH directions)", () => 
     // openclaw.plugin.json#contracts.tools.
     expect(codeRegisteredNames().has("sil_product_get")).toBe(true);
     expect(manifestToolNames().has("sil_product_get")).toBe(true);
+  });
+
+  it("sil_profile_materialize is BOTH registered by register() and declared in contracts.tools", () => {
+    // The agent-creation engine's behaviour-artefact tool (card:
+    // create-a-valid-sil-wired-openclaw-agent-profile). registerProfileTools is
+    // wired into codeRegisteredNames (and into src/index.ts#register()), so the
+    // new tool must appear on BOTH sides of the equal set: registered by
+    // registerProfileTools AND listed in openclaw.plugin.json#contracts.tools.
+    expect(codeRegisteredNames().has("sil_profile_materialize")).toBe(true);
+    expect(manifestToolNames().has("sil_profile_materialize")).toBe(true);
   });
 });
 

--- a/src/__tests__/skill-content.test.ts
+++ b/src/__tests__/skill-content.test.ts
@@ -133,3 +133,325 @@ describe("skill/SKILL.md — body is a source of truth for the tool surface", ()
     expect(body).not.toContain("sil_echo");
   });
 });
+
+/* ===========================================================================
+ * AGENT-CREATION ENGINE — the procedure-as-source-of-truth seam
+ * (card: create-a-valid-sil-wired-openclaw-agent-profile)
+ *
+ * tier: integration. These read the REAL skill/SKILL.md from disk and pin
+ * the agent-creation procedure as a source of truth — the engine is the
+ * skill prose driving the host CLI (no plugin-tool code per the architect's
+ * verdict), so the skill body IS the spec the host agent follows. Pinning it
+ * is exactly how `skill-content.test.ts` already pins the tool surface.
+ *
+ * These are adversarial: they do not merely check a keyword is present, they
+ * check the load-bearing invariants of the engine are spelled out —
+ *   - the host-native CLI surface is named (not invented JSON authoring);
+ *   - the four outcome statuses form the engine's status taxonomy;
+ *   - validate-FIRST ordering (nothing written on a bad spec);
+ *   - collision is non-destructive (list-check before add, never clobber);
+ *   - host-own validation gates "success" (config validate before created);
+ *   - the behaviour artefacts are materialized into $SIL_DATA_DIR (founder
+ *     steer) — the persona/instructions + the domain sub-skill that power
+ *     the created agent, kept OUT of the thin host `agents` wiring entry.
+ *
+ * No host, no network, no Docker: this is a content seam over the skill file.
+ * The real host round (create → validate → shop, SC3) is `live-verification`'s
+ * job, NOT a test-tier assertion — these never fake a running host.
+ * ========================================================================= */
+
+/** Lower-cased skill body — substring checks are intent ("the procedure names
+ * X"), so case folding avoids a brittle fail on an incidental capitalization
+ * while keeping the exact-token literals (CLI names, status words) honest. */
+function skillBodyLower(): string {
+  return skillBody(readFileSync(SKILL_PATH, "utf8")).toLowerCase();
+}
+
+/** The four outcome statuses the architect fixed as the engine's taxonomy
+ * (mirrors identity.ts/catalog.ts structured-error vocabulary). Pinned as a
+ * named set so a missing one is reported by NAME, not as an opaque false. */
+const ENGINE_STATUSES = [
+  "created",
+  "invalid_request",
+  "collision",
+  "persistence_failed",
+] as const;
+
+describe("skill/SKILL.md — agent-creation procedure is a pinned source of truth (AC1)", () => {
+  it("names the host-native agent-creation CLI `openclaw agents add`", () => {
+    // The persistence path is host-CLI-driven (the plugin may NOT write host
+    // config — noChildProcess + filesystemScope). The procedure must name the
+    // host's OWN creation command, not a plugin tool or hand-authored JSON.
+    expect(skillBodyLower()).toContain("openclaw agents add");
+  });
+
+  it("names the host `agents` config surface the profile lands in", () => {
+    // Product invariant 1/6: a real host `agents` entry in the user's local
+    // OpenClaw config — not a bespoke sil data file. The body must name the
+    // surface so the agent knows WHERE the profile lives.
+    expect(skillBodyLower()).toContain("agents");
+  });
+
+  it("names ALL FOUR engine outcome statuses (created/invalid_request/collision/persistence_failed)", () => {
+    const body = skillBodyLower();
+    const missing = ENGINE_STATUSES.filter((s) => !body.includes(s));
+    // Report by name: a partial taxonomy is the failure this pins. An engine
+    // that names `created` but never `collision` would silently clobber.
+    expect(missing).toEqual([]);
+  });
+
+  it("frames the procedure as agent-creation, not just tool-driving (a distinct shopping-expert intent)", () => {
+    // Adversarial: the pre-existing skill already drove the four sil_* tools.
+    // This card adds a NEW capability — creating a sil-wired agent. The body
+    // must mention creating an agent/expert/profile, so the new procedure is
+    // a real addition, not a re-read of the old tool table.
+    const body = skillBodyLower();
+    const namesCreation =
+      body.includes("create") || body.includes("creation");
+    const namesSubject =
+      body.includes("expert") ||
+      body.includes("agent profile") ||
+      body.includes("shopping expert");
+    expect(namesCreation && namesSubject).toBe(true);
+  });
+});
+
+describe("skill/SKILL.md — validate-first: a bad spec writes NOTHING (AC2)", () => {
+  it("names the `invalid_request` outcome for an invalid/incomplete spec", () => {
+    expect(skillBodyLower()).toContain("invalid_request");
+  });
+
+  it("specifies validating the spec BEFORE invoking `openclaw agents add` (validate-first ordering)", () => {
+    // Product invariant 7 (atomic outcome) + AC2: on a bad spec the engine
+    // stops at validation and `openclaw agents add` is never reached. The
+    // procedure must put a spec-validation step textually AHEAD of the add
+    // step, so an agent following top-to-bottom validates first. Order in the
+    // prose IS the spec — a procedure that adds-then-validates clobbers on a
+    // bad spec.
+    //
+    // Adversarial precision: key the "before" anchor on the `validate` VERB,
+    // NOT on `invalid_request`. The pre-existing status taxonomy already
+    // contains `invalid_request` ABOVE where the new procedure lands, so an
+    // `/validate|invalid_request/` anchor would pass FALSELY the moment the
+    // developer adds `openclaw agents add` after that old mention — even with
+    // NO real validate-first step. The old body has no `validate` verb at all,
+    // so requiring `validate` before `add` only goes green on a genuine
+    // spec-validation step preceding the creation call.
+    const body = skillBodyLower();
+    const firstValidateIdx = body.indexOf("validate");
+    const addIdx = body.indexOf("openclaw agents add");
+    expect(firstValidateIdx).toBeGreaterThanOrEqual(0);
+    expect(addIdx).toBeGreaterThanOrEqual(0);
+    expect(firstValidateIdx).toBeLessThan(addIdx);
+  });
+
+  it("requires the spec's mandatory fields — name AND persona/instructions — to be present", () => {
+    // AC2 enumerates the invalid shapes: missing name, empty persona, no sil
+    // skill attached. The procedure must name persona/instructions and the
+    // unique name as required, so the validation has a concrete checklist —
+    // not a vague "if the spec is bad".
+    const body = skillBodyLower();
+    expect(body).toContain("persona");
+    // The name must be required AND unique (the collision precondition).
+    expect(body).toMatch(/name/);
+  });
+
+  it("states that nothing is written / no profile is created on an invalid spec", () => {
+    // The atomic-outcome invariant, in prose: on `invalid_request` the engine
+    // writes NOTHING. The body must say so, so the agent does not half-create.
+    const body = skillBodyLower();
+    const saysNothingWritten =
+      body.includes("write nothing") ||
+      body.includes("writes nothing") ||
+      body.includes("nothing is written") ||
+      body.includes("write no") ||
+      body.includes("does not write") ||
+      body.includes("no profile") ||
+      body.includes("nothing partial") ||
+      body.includes("no partial");
+    expect(saysNothingWritten).toBe(true);
+  });
+});
+
+describe("skill/SKILL.md — collision is non-destructive (AC3)", () => {
+  it("names the collision check via `openclaw agents list` (read before write)", () => {
+    // AC3: the engine checks existing agents with the host's OWN list command
+    // before adding, so a same-name agent is detected, not overwritten.
+    expect(skillBodyLower()).toContain("openclaw agents list");
+  });
+
+  it("names the `collision` outcome and that it does NOT clobber an existing agent", () => {
+    const body = skillBodyLower();
+    expect(body).toContain("collision");
+    // Product invariant 8 / UX principle 4: never silently overwrite. The body
+    // must say so explicitly — "do not overwrite" / "never clobber" / "no
+    // overwrite" — so the agent surfaces the collision instead of replacing.
+    const saysNonDestructive =
+      body.includes("overwrite") ||
+      body.includes("clobber") ||
+      body.includes("never overwrite") ||
+      body.includes("not overwrite") ||
+      body.includes("non-destructive") ||
+      body.includes("do not clobber");
+    expect(saysNonDestructive).toBe(true);
+  });
+
+  it("orders the collision check BEFORE the add (list precedes add in the procedure)", () => {
+    // Adversarial ordering: `openclaw agents list` must come before `openclaw
+    // agents add` in the prose, or an agent following the steps top-to-bottom
+    // would add first and discover the collision too late (after clobbering).
+    const body = skillBodyLower();
+    const listIdx = body.indexOf("openclaw agents list");
+    const addIdx = body.indexOf("openclaw agents add");
+    expect(listIdx).toBeGreaterThanOrEqual(0);
+    expect(addIdx).toBeGreaterThanOrEqual(0);
+    expect(listIdx).toBeLessThan(addIdx);
+  });
+});
+
+describe("skill/SKILL.md — valid spec persists a host-loadable, sil-wired agent (AC4)", () => {
+  it("invokes `openclaw agents add` non-interactively with JSON output", () => {
+    // AC4: `openclaw agents add … --non-interactive --json` — the exact
+    // machine-drivable form (an interactive prompt cannot be agent-driven).
+    const body = skillBodyLower();
+    expect(body).toContain("--non-interactive");
+    expect(body).toContain("--json");
+  });
+
+  it("gates 'created' on the host's OWN validation via `openclaw config validate`", () => {
+    // Product invariant 1 + AC4: "valid" means the HOST says yes, verified the
+    // way the host validates — `openclaw config validate` (or load probe). The
+    // body must name it, so success ≠ "the plugin thinks it's fine".
+    expect(skillBodyLower()).toContain("openclaw config validate");
+  });
+
+  it("orders config-validate AFTER add (validate the written profile, then declare created)", () => {
+    // The defect this card exists to prevent: emitting a profile the host then
+    // rejects. The procedure must validate AFTER the add and only then report
+    // `created` — so the validate step sits between `add` and `created`.
+    const body = skillBodyLower();
+    const addIdx = body.indexOf("openclaw agents add");
+    const validateIdx = body.indexOf("openclaw config validate");
+    expect(addIdx).toBeGreaterThanOrEqual(0);
+    expect(validateIdx).toBeGreaterThan(addIdx);
+  });
+
+  it("wires the sil PLUGIN enabled into the created agent (the four tools come for free)", () => {
+    // Product invariant 2 + the spec→flag mapping: the created agent has the
+    // sil plugin enabled, which is what makes sil_register/sil_whoami/
+    // sil_search/sil_product_get available to it. The body must say the
+    // profile enables the `sil` plugin.
+    const body = skillBodyLower();
+    const wiresPlugin =
+      body.includes("plugin") &&
+      (body.includes("enable") || body.includes("enabled"));
+    expect(wiresPlugin).toBe(true);
+  });
+
+  it("wires the sil SKILL attached into the created agent (it knows HOW to drive the tools)", () => {
+    // Product invariant 3: the created agent attaches the sil skill (+ any
+    // generated sub-skill). The body must say the profile attaches the skill,
+    // not just enable the plugin — plugin without skill knows the tools exist
+    // but not how to drive them.
+    const body = skillBodyLower();
+    const wiresSkill =
+      body.includes("skill") &&
+      (body.includes("attach") || body.includes("attached"));
+    expect(wiresSkill).toBe(true);
+  });
+
+  it("names `persistence_failed` (with path + cause) for a write/validate failure", () => {
+    // AC4 failure half / Product invariant 7: on a CLI or validate failure the
+    // engine reports `persistence_failed` with the path + cause and leaves
+    // nothing partial. The body must name the outcome AND that it carries the
+    // failing path/cause, so the agent's recovery is actionable.
+    const body = skillBodyLower();
+    expect(body).toContain("persistence_failed");
+    const namesPathCause =
+      body.includes("path") && body.includes("cause");
+    expect(namesPathCause).toBe(true);
+  });
+});
+
+describe("skill/SKILL.md — the created agent shops with no further setup (AC5 / SC3)", () => {
+  it("states the created agent can call sil_search / sil_product_get with no further setup", () => {
+    // AC5 / SC3 (the goal's primary correctness bar): after creation the agent
+    // shops immediately. The body must name the catalog tools the created
+    // expert calls AND the "no further setup" guarantee — the zero-setup
+    // promise is the whole product (UX principle 1). The HOST round is
+    // live-verified; here we pin that the skill PROMISES it.
+    const body = skillBodyLower();
+    expect(body).toContain("sil_search");
+    expect(body).toContain("sil_product_get");
+    const noFurtherSetup =
+      body.includes("no further setup") ||
+      body.includes("without further setup") ||
+      body.includes("zero further setup") ||
+      body.includes("no additional setup") ||
+      body.includes("zero-setup");
+    expect(noFurtherSetup).toBe(true);
+  });
+
+  it("does NOT couple creation to identity (no register/token as a precondition to CREATE)", () => {
+    // Product out-of-scope: creating an expert neither requires nor performs
+    // sil registration. The procedure must keep creation local + offline — it
+    // must NOT state that registration / a token is a precondition of creating
+    // the profile (the expert registers the user LATER, on first shop).
+    // The skill DOES mention sil_register elsewhere (the tool table), so we
+    // can't assert its absence globally — instead assert the creation procedure
+    // does not present registration as a prerequisite *for creation*.
+    const body = skillBodyLower();
+    const couplesIdentity =
+      /register[^.]*before[^.]*creat/.test(body) ||
+      /creat[^.]*requires[^.]*register/.test(body) ||
+      /must.*register.*to.*creat/.test(body);
+    expect(couplesIdentity).toBe(false);
+  });
+});
+
+describe("skill/SKILL.md — behaviour artefacts materialized into $SIL_DATA_DIR (founder steer)", () => {
+  it("names $SIL_DATA_DIR as where the behaviour artefacts are materialized", () => {
+    // Founder steer 2026-06-22: the engine materializes FIXED behaviour
+    // artefacts into the sil data directory ($SIL_DATA_DIR — the plugin's
+    // disclosed filesystemScope) at creation time. The body must name the
+    // data dir as the artefact store, distinct from the host `agents` wiring.
+    const body = skillBodyLower();
+    const namesDataDir =
+      body.includes("$sil_data_dir") ||
+      body.includes("sil_data_dir") ||
+      body.includes("sil data directory") ||
+      body.includes("sil data dir");
+    expect(namesDataDir).toBe(true);
+  });
+
+  it("names the persona/instructions behaviour artefact", () => {
+    // The artefacts that POWER the created agent's behaviour: the persona/
+    // instructions. The body must name it as a materialized artefact (read by
+    // the sil skill at runtime), keeping the host `agents` entry thin.
+    expect(skillBodyLower()).toContain("persona");
+  });
+
+  it("names the generated domain sub-skill as a behaviour artefact", () => {
+    // The second artefact the card names: a generated domain sub-skill (e.g. a
+    // gift-shopping playbook). The body must name the sub-skill as part of the
+    // materialized behaviour layer.
+    const body = skillBodyLower();
+    expect(body).toContain("sub-skill");
+  });
+
+  it("keeps the store boundary clean: host config = wiring, $SIL_DATA_DIR = behaviour", () => {
+    // Founder steer: store boundary stays clean — host `agents` config holds
+    // the WIRING (plugin enabled + skill attached), $SIL_DATA_DIR holds the
+    // BEHAVIOUR artefacts. The host config write stays host-CLI-driven; the
+    // artefact write is the in-scope sil-owned write. The body must reflect
+    // both surfaces — wiring via the CLI, behaviour via the data dir — so the
+    // two-store boundary is explicit in the prose.
+    const body = skillBodyLower();
+    const namesDataDir =
+      body.includes("sil_data_dir") || body.includes("sil data dir");
+    const namesHostConfig =
+      body.includes("openclaw agents add") ||
+      body.includes("openclaw config validate");
+    expect(namesDataDir && namesHostConfig).toBe(true);
+  });
+});

--- a/src/__tests__/tools/profile-materialize.test.ts
+++ b/src/__tests__/tools/profile-materialize.test.ts
@@ -1,0 +1,170 @@
+/**
+ * UNIT — sil_profile_materialize tool: registration shape + the structured
+ * envelope it maps each store outcome to (tier: unit, mock api + temp data dir,
+ * no network, no host).
+ *
+ * Card: create-a-valid-sil-wired-openclaw-agent-profile (founder steer). The
+ * pure artefact-writer invariants live in `lib/profile-store.test.ts`; here we
+ * pin the TOOL boundary:
+ *   - the tool registers as `sil_profile_materialize` with a TypeBox object
+ *     schema carrying agentId / name / persona (required) + playbook (optional);
+ *   - a valid spec returns the `ok` envelope with the artefact paths and the
+ *     artefacts actually land under $SIL_DATA_DIR/agents/<agentId>/;
+ *   - an invalid field returns the `invalid_request` envelope naming the field
+ *     and writes nothing;
+ *   - the tool makes NO host-config write and reads NO token (no coupling) —
+ *     it is the behaviour-artefact half only.
+ *
+ * Hermetic via the SIL_DATA_DIR temp-dir override.
+ *
+ * Contract this file pins for the implementation (expert-developer):
+ *   - src/tools/profile.ts#registerProfileTools(api) registers a
+ *     `sil_profile_materialize` tool (Type.Object{agentId,name,persona,playbook?});
+ *   - execute() returns a jsonResult mapping the store result to
+ *     {status:"ok",…paths} / {status:"invalid_request",field,message} /
+ *     {status:"persistence_failed",error,message,recovery}.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { registerProfileTools } from "../../tools/profile.js";
+import { getDataDir, getTokensPath } from "../../lib/credentials.js";
+import {
+  createMockPluginApi,
+  getTool,
+  type MockPluginAPI,
+} from "../helpers/mock-plugin-api.js";
+
+const TOOL = "sil_profile_materialize";
+
+let dataDir: string;
+let priorSilDataDir: string | undefined;
+let api: MockPluginAPI;
+
+function payloadOf(result: { content: { text?: string }[] }): Record<string, unknown> {
+  const text = result.content[0]?.text;
+  if (typeof text !== "string") {
+    throw new Error(`tool result has no text payload: ${String(text)}`);
+  }
+  return JSON.parse(text) as Record<string, unknown>;
+}
+
+const GOOD_PARAMS = {
+  agentId: "gift-buyer",
+  name: "Gift Buyer",
+  persona: "You specialise in gifts under €50.",
+  playbook: "Use sil_search to browse, sil_product_get to re-check stock.",
+};
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), "sil-profile-tool-"));
+  priorSilDataDir = process.env["SIL_DATA_DIR"];
+  process.env["SIL_DATA_DIR"] = dataDir;
+  api = createMockPluginApi();
+  registerProfileTools(api);
+});
+
+afterEach(() => {
+  if (priorSilDataDir === undefined) delete process.env["SIL_DATA_DIR"];
+  else process.env["SIL_DATA_DIR"] = priorSilDataDir;
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe("sil_profile_materialize — registration shape", () => {
+  it("registers a sil_profile_materialize tool with a TypeBox object schema", () => {
+    const tool = getTool(api, TOOL);
+    expect(tool.name).toBe(TOOL);
+    const schema = tool.parameters as unknown as {
+      type?: string;
+      properties?: Record<string, unknown>;
+      required?: string[];
+    };
+    expect(schema.type).toBe("object");
+    expect(Object.keys(schema.properties ?? {})).toEqual(
+      expect.arrayContaining(["agentId", "name", "persona", "playbook"]),
+    );
+    // agentId, name, persona are required; playbook is optional.
+    expect(schema.required).toEqual(
+      expect.arrayContaining(["agentId", "name", "persona"]),
+    );
+    expect(schema.required ?? []).not.toContain("playbook");
+  });
+});
+
+describe("sil_profile_materialize — valid spec materializes the artefacts (ok envelope)", () => {
+  it("returns status ok with the artefact paths, and the artefacts land under $SIL_DATA_DIR/agents/<id>/", async () => {
+    const tool = getTool(api, TOOL);
+    const payload = payloadOf(await tool.execute("call-1", { ...GOOD_PARAMS }));
+
+    expect(payload["status"]).toBe("ok");
+    expect(payload["agentId"]).toBe(GOOD_PARAMS.agentId);
+
+    const expectedDir = join(getDataDir(), "agents", GOOD_PARAMS.agentId);
+    expect(payload["dir"]).toBe(expectedDir);
+    expect(payload["personaPath"]).toBe(join(expectedDir, "persona.md"));
+    expect(payload["playbookPath"]).toBe(join(expectedDir, "playbook.md"));
+    expect(payload["profilePath"]).toBe(join(expectedDir, "profile.json"));
+
+    expect(existsSync(join(expectedDir, "persona.md"))).toBe(true);
+    expect(existsSync(join(expectedDir, "playbook.md"))).toBe(true);
+    expect(existsSync(join(expectedDir, "profile.json"))).toBe(true);
+  });
+
+  it("omits playbookPath when no playbook is supplied", async () => {
+    const tool = getTool(api, TOOL);
+    const { playbook: _omit, ...noPlaybook } = GOOD_PARAMS;
+    const payload = payloadOf(await tool.execute("call-2", { ...noPlaybook }));
+
+    expect(payload["status"]).toBe("ok");
+    expect(payload["playbookPath"]).toBeUndefined();
+    const expectedDir = join(getDataDir(), "agents", GOOD_PARAMS.agentId);
+    expect(existsSync(join(expectedDir, "playbook.md"))).toBe(false);
+  });
+
+  it("makes no host-config write and reads no token (behaviour-artefact half only)", async () => {
+    const tool = getTool(api, TOOL);
+    await tool.execute("call-3", { ...GOOD_PARAMS });
+    // No token side effect — creation is identity-decoupled.
+    expect(existsSync(getTokensPath())).toBe(false);
+  });
+});
+
+describe("sil_profile_materialize — invalid spec returns invalid_request, writes nothing", () => {
+  it("blank persona → invalid_request naming the field, no artefact dir", async () => {
+    const tool = getTool(api, TOOL);
+    const payload = payloadOf(
+      await tool.execute("call-4", { ...GOOD_PARAMS, persona: "" }),
+    );
+    expect(payload["status"]).toBe("invalid_request");
+    expect(payload["field"]).toBe("persona");
+    expect(typeof payload["message"]).toBe("string");
+    expect(existsSync(join(getDataDir(), "agents", GOOD_PARAMS.agentId))).toBe(false);
+  });
+
+  it("missing agentId → invalid_request(field=agentId), no write", async () => {
+    const tool = getTool(api, TOOL);
+    const { agentId: _drop, ...noId } = GOOD_PARAMS;
+    const payload = payloadOf(await tool.execute("call-5", { ...noId }));
+    expect(payload["status"]).toBe("invalid_request");
+    expect(payload["field"]).toBe("agentId");
+  });
+
+  it('reserved "main" agentId → invalid_request(field=agentId), no write', async () => {
+    const tool = getTool(api, TOOL);
+    const payload = payloadOf(
+      await tool.execute("call-6", { ...GOOD_PARAMS, agentId: "main" }),
+    );
+    expect(payload["status"]).toBe("invalid_request");
+    expect(payload["field"]).toBe("agentId");
+    expect(existsSync(join(getDataDir(), "agents", "main"))).toBe(false);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ import {
 } from "./lib/config.js";
 import { registerCatalogTools } from "./tools/catalog.js";
 import { registerIdentityTools } from "./tools/identity.js";
+import { registerProfileTools } from "./tools/profile.js";
 
 export default definePluginEntry({
   id: "sil",
@@ -46,6 +47,7 @@ export default definePluginEntry({
 
     registerIdentityTools(api);
     registerCatalogTools(api);
+    registerProfileTools(api);
 
     api.logger.info("sil_plugin_loaded", {
       message: "sil plugin registered.",

--- a/src/lib/profile-store.ts
+++ b/src/lib/profile-store.ts
@@ -120,7 +120,17 @@ export type MaterializeResult =
 const AGENT_ID_RE = /^[a-z0-9][a-z0-9-]*$/;
 
 /** Resolve the per-agent artefact directory under the plugin's data dir. Never
- * hardcoded — `getDataDir()` honors `$SIL_DATA_DIR`/`$XDG_DATA_HOME`. */
+ * hardcoded — `getDataDir()` honors `$SIL_DATA_DIR`/`$XDG_DATA_HOME`.
+ *
+ * SAFETY: this resolver does NOT guard `agentId` — it joins it as a path segment
+ * verbatim. The path-traversal guard lives at the only caller, `materializeProfile`,
+ * which validates `agentId` against `AGENT_ID_RE` (lower-kebab, not `main`) BEFORE
+ * the join, so `../escape`, `a/../b`, `.`, etc. never reach here. The guard is
+ * placed at the caller (not here) because validation must precede ALL writes for
+ * the validate-first / write-nothing-on-bad-input invariant to hold; a guard
+ * duplicated here would be redundant for that path. A FUTURE DIRECT CALLER of this
+ * exported resolver would bypass the guard — re-run `AGENT_ID_RE` (or route through
+ * `materializeProfile`) before trusting the returned path with any filesystem op. */
 export function getAgentArtefactDir(agentId: string): string {
   return join(getDataDir(), AGENTS_SUBDIR, agentId);
 }

--- a/src/lib/profile-store.ts
+++ b/src/lib/profile-store.ts
@@ -1,0 +1,238 @@
+/**
+ * sil shopping-expert behaviour-artefact store.
+ *
+ * The agent-creation engine (the bundled `skill/SKILL.md` procedure driving
+ * the OpenClaw host CLI) registers the *wiring* of a new sil-wired agent into
+ * the host's own config — the `agents.list[]` entry, the enabled `sil` plugin,
+ * the attached `sil` skill. That host-config write is the host agent driving
+ * its own `openclaw …` CLI; the plugin never touches `~/.openclaw`.
+ *
+ * What the plugin DOES own is the agent's *behaviour* layer, materialized into
+ * its own disclosed `filesystemScope` — `$SIL_DATA_DIR` (the same directory
+ * `lib/credentials.ts` uses for tokens/identity). Per the founder steer
+ * (2026-06-22) the engine writes a fixed, minimal set of artefacts there that
+ * power the created expert's behaviour, read by the sil skill at runtime:
+ *
+ *   $SIL_DATA_DIR/agents/<agentId>/
+ *     ├─ persona.md     the shopping persona/instructions (host-natural —
+ *     │                 same shape as a workspace SOUL.md; the skill copies it
+ *     │                 into the agent workspace SOUL.md and re-reads it at
+ *     │                 session start)
+ *     ├─ playbook.md    the generated domain sub-skill (host-natural — same
+ *     │                 shape as a SKILL.md body; loaded by the sil skill at
+ *     │                 session start). OPTIONAL — written only when supplied.
+ *     └─ profile.json   the strictly-typed manifest the sil skill resolves the
+ *                       artefacts from (no filesystem guessing)
+ *
+ * Store boundary: host config = wiring; `$SIL_DATA_DIR` = behaviour artefacts.
+ * Identity/tokens already live in `$SIL_DATA_DIR` but stay logically separate
+ * (no identity coupling — creating an expert reads/writes no token).
+ *
+ * Writes are atomic and all-or-nothing (Product invariant 7): a bad spec
+ * writes NOTHING (validate first), and a mid-write failure leaves no partial
+ * artefact directory behind. The atomic write mirrors `credentials.ts` —
+ * tmp file → write → rename over target → chmod 0600, dir 0700.
+ */
+
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { randomBytes } from "node:crypto";
+
+import { getDataDir } from "./credentials.js";
+
+/** Owner-only file/dir modes — the artefacts are user-scoped, like tokens. */
+const FILE_MODE = 0o600;
+const DIR_MODE = 0o700;
+
+/** The sub-tree under `$SIL_DATA_DIR` that holds per-agent behaviour artefacts. */
+const AGENTS_SUBDIR = "agents";
+
+/** Artefact filenames (stable — the sil skill resolves them from profile.json,
+ * but the names are also documented so a human can find them). */
+const PERSONA_FILE = "persona.md";
+const PLAYBOOK_FILE = "playbook.md";
+const PROFILE_FILE = "profile.json";
+
+/**
+ * The validated spec the engine hands the store. `agentId` is the host agent
+ * id (the `agents.list[].id` the host CLI created); the artefact directory is
+ * keyed by it so the sil skill can resolve "this agent's behaviour" at runtime.
+ */
+export interface ProfileSpec {
+  /** Host agent id — the directory key. Lower-kebab, not `main` (host-reserved). */
+  agentId: string;
+  /** Human-readable expert name (recorded in the manifest). */
+  name: string;
+  /** The shopping persona/instructions — non-empty. */
+  persona: string;
+  /** The generated domain sub-skill playbook — optional, non-blank when present. */
+  playbook?: string;
+}
+
+/** The strictly-typed manifest persisted as `profile.json`. The sil skill reads
+ * this to locate + load the behaviour artefacts for the active agent. */
+export interface ProfileManifest {
+  agentId: string;
+  name: string;
+  /** Absolute path to the persona artefact. */
+  personaPath: string;
+  /** Absolute path to the playbook artefact, when one was materialized. */
+  playbookPath?: string;
+  /** ISO 8601 creation timestamp. */
+  createdAt: string;
+}
+
+/** The discriminated result the store returns — never throws across the
+ * boundary; the tool maps each variant to the structured envelope. */
+export type MaterializeResult =
+  | {
+      ok: true;
+      agentId: string;
+      /** The artefact directory ($SIL_DATA_DIR/agents/<agentId>). */
+      dir: string;
+      personaPath: string;
+      playbookPath?: string;
+      profilePath: string;
+    }
+  | {
+      ok: false;
+      kind: "invalid_request";
+      /** The offending spec field. */
+      field: string;
+      message: string;
+    }
+  | {
+      ok: false;
+      kind: "persistence_failed";
+      /** "<dir>: <cause>" so recovery is actionable. */
+      error: string;
+      message: string;
+    };
+
+/** A host-agent id must be lower-kebab and is never `main` (host-reserved). */
+const AGENT_ID_RE = /^[a-z0-9][a-z0-9-]*$/;
+
+/** Resolve the per-agent artefact directory under the plugin's data dir. Never
+ * hardcoded — `getDataDir()` honors `$SIL_DATA_DIR`/`$XDG_DATA_HOME`. */
+export function getAgentArtefactDir(agentId: string): string {
+  return join(getDataDir(), AGENTS_SUBDIR, agentId);
+}
+
+/** True when `s` is a present, non-blank string. */
+function nonBlank(s: unknown): s is string {
+  return typeof s === "string" && s.trim().length > 0;
+}
+
+function invalid(field: string, message: string): MaterializeResult {
+  return { ok: false, kind: "invalid_request", field, message };
+}
+
+/**
+ * Materialize the behaviour artefacts for a created sil-wired agent.
+ *
+ * Validate-first: any invalid field returns `invalid_request` and writes
+ * NOTHING. On a write failure, the partial directory is removed and
+ * `persistence_failed` is returned with `<dir>: <cause>` — no partial artefact
+ * set ever survives (Product invariant 7, atomic outcome).
+ */
+export function materializeProfile(spec: ProfileSpec): MaterializeResult {
+  // --- validate-first (nothing is written until every field is good) ---
+  if (!nonBlank(spec.agentId)) {
+    return invalid("agentId", "agentId is required and must be non-empty.");
+  }
+  if (spec.agentId === "main") {
+    return invalid("agentId", '"main" is host-reserved and cannot be a sil expert id.');
+  }
+  if (!AGENT_ID_RE.test(spec.agentId)) {
+    return invalid(
+      "agentId",
+      "agentId must be lower-kebab (a-z, 0-9, hyphen) — got: " + JSON.stringify(spec.agentId),
+    );
+  }
+  if (!nonBlank(spec.name)) {
+    return invalid("name", "name is required and must be non-empty.");
+  }
+  if (!nonBlank(spec.persona)) {
+    return invalid("persona", "persona is required and must be non-empty.");
+  }
+  // playbook is optional, but if present it must be non-blank (an empty string
+  // would materialize a useless artefact — reject it loudly rather than write it).
+  if (spec.playbook !== undefined && !nonBlank(spec.playbook)) {
+    return invalid("playbook", "playbook, when provided, must be non-empty.");
+  }
+
+  const dir = getAgentArtefactDir(spec.agentId);
+  const personaPath = join(dir, PERSONA_FILE);
+  const playbookPath = spec.playbook !== undefined ? join(dir, PLAYBOOK_FILE) : undefined;
+  const profilePath = join(dir, PROFILE_FILE);
+
+  const manifest: ProfileManifest = {
+    agentId: spec.agentId,
+    name: spec.name,
+    personaPath,
+    ...(playbookPath ? { playbookPath } : {}),
+    createdAt: new Date().toISOString(),
+  };
+
+  // Whether the artefact directory already existed before this call. If it did,
+  // it is not ours to delete on failure (it may hold a prior expert's artefacts,
+  // or — if the path is occupied by a non-directory — a user's file). We only
+  // remove what THIS call created (Product invariant 7: nothing partial, without
+  // destroying anything pre-existing).
+  const dirPreexisted = existsSync(dir);
+
+  try {
+    mkdirSync(dir, { recursive: true, mode: DIR_MODE });
+    atomicWrite(personaPath, spec.persona);
+    if (playbookPath && spec.playbook !== undefined) {
+      atomicWrite(playbookPath, spec.playbook);
+    }
+    atomicWrite(profilePath, JSON.stringify(manifest, null, 2) + "\n");
+  } catch (err) {
+    // Leave nothing partial behind — but only tear down the dir if WE created it.
+    if (!dirPreexisted) {
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // Cleanup is best-effort; the original cause is what the caller needs.
+      }
+    }
+    const cause = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      kind: "persistence_failed",
+      error: dir + ": " + cause,
+      message:
+        "The shopping-expert behaviour artefacts could NOT be written to the sil"
+        + " data directory, so the profile did not stick. Fix the data directory"
+        + " (it must be writable — check permissions / free space / that"
+        + " $SIL_DATA_DIR is a directory), then create the expert again.",
+    };
+  }
+
+  return {
+    ok: true,
+    agentId: spec.agentId,
+    dir,
+    personaPath,
+    ...(playbookPath ? { playbookPath } : {}),
+    profilePath,
+  };
+}
+
+/** Atomic single-file write: tmp sibling → write → rename over target → chmod.
+ * Mirrors the token/identity write in `credentials.ts` so a half-written
+ * artefact never appears (a reader sees the old file or the new one). */
+function atomicWrite(path: string, contents: string): void {
+  const tmp = path + "." + randomBytes(6).toString("hex") + ".tmp";
+  writeFileSync(tmp, contents, { mode: FILE_MODE });
+  renameSync(tmp, path);
+  chmodSync(path, FILE_MODE);
+}

--- a/src/tools/profile.ts
+++ b/src/tools/profile.ts
@@ -1,0 +1,123 @@
+/**
+ * sil shopping-expert profile tools.
+ *
+ * `sil_profile_materialize` is the plugin's half of the agent-creation engine:
+ * it writes the created expert's *behaviour* artefacts (persona + optional
+ * domain sub-skill playbook + a typed manifest) into the plugin's own data
+ * directory (`$SIL_DATA_DIR`, the disclosed `filesystemScope`). The *wiring*
+ * half — the host `agents.list[]` entry, the enabled `sil` plugin, the attached
+ * `sil` skill — is the host agent driving its own `openclaw …` CLI under the
+ * bundled `skill/SKILL.md` procedure; the plugin never writes `~/.openclaw`
+ * (`security.noChildProcess: true`, host config is outside `filesystemScope`).
+ *
+ * Why a tool (not skill-driven `write`-tool prose): the host agent's only way
+ * to invoke plugin code is a registered tool, and a plugin write buys
+ * host-validated typed inputs, the structured-error envelope, and ATOMIC
+ * all-or-nothing writes — all of which serve the goal's primary correctness
+ * bar (a created expert that actually shops). The artefact write lives here;
+ * the host-config write stays host-CLI.
+ *
+ * This follows `identity.ts` (the reference group): a `registerXTools(api)`
+ * function, a `Type.Object` schema the host validates inputs against, the
+ * `jsonResult` success/structured-error envelope, and ALL I/O inside
+ * `execute()` (register() opens nothing).
+ */
+
+import type { PluginAPI } from "openclaw/plugin-sdk";
+import { Type } from "typebox";
+
+import { materializeProfile, type ProfileSpec } from "../lib/profile-store.js";
+import { jsonResult } from "../lib/tool-result.js";
+
+export function registerProfileTools(api: PluginAPI): void {
+  registerMaterialize(api);
+}
+
+function registerMaterialize(api: PluginAPI): void {
+  api.registerTool({
+    name: "sil_profile_materialize",
+    label: "Materialize a sil shopping-expert's behaviour artefacts",
+    description:
+      "Write a created sil shopping expert's behaviour artefacts into the sil"
+      + " data directory: the persona/instructions, an optional generated domain"
+      + " sub-skill (playbook), and a typed manifest the sil skill reads at"
+      + " runtime to load them. Call this AFTER the host agent has been created"
+      + " (openclaw agents add) and BEFORE openclaw config validate. It does NOT"
+      + " touch the host OpenClaw config — the plugin enable + skill attach are"
+      + " driven by the host CLI, not this tool. Writes are atomic: an invalid"
+      + " spec writes nothing, and a write failure leaves nothing partial.",
+    parameters: Type.Object({
+      agentId: Type.String({
+        description:
+          "The host agent id the expert was created under (agents.list[].id),"
+          + " lower-kebab; not \"main\" (host-reserved). Keys the artefact dir.",
+      }),
+      name: Type.String({
+        description: "The human-readable expert name (recorded in the manifest).",
+      }),
+      persona: Type.String({
+        description:
+          "The shopping persona/instructions — the expert's expertise, tone, and"
+          + " standing rules. Non-empty. Materialized as persona.md and copied"
+          + " into the agent workspace SOUL.md by the skill.",
+      }),
+      playbook: Type.Optional(
+        Type.String({
+          description:
+            "The generated domain sub-skill: how this expert shops on sil (which"
+            + " sil_* tool for which intent, refinement rules). Materialized as"
+            + " playbook.md and loaded by the sil skill at session start. Omit"
+            + " when the expert needs no domain playbook.",
+        }),
+      ),
+    }),
+    async execute(_callId, params) {
+      // The host validates `params` against the schema above before we run, but
+      // narrow at the read site (the SDK types params as Record<string,unknown>)
+      // and let the store do the real, structured-error validation.
+      const spec: ProfileSpec = {
+        agentId: typeof params["agentId"] === "string" ? params["agentId"] : "",
+        name: typeof params["name"] === "string" ? params["name"] : "",
+        persona: typeof params["persona"] === "string" ? params["persona"] : "",
+        ...(typeof params["playbook"] === "string"
+          ? { playbook: params["playbook"] }
+          : {}),
+      };
+
+      const result = materializeProfile(spec);
+
+      if (result.ok) {
+        api.logger.info("sil_profile_materialized", {
+          agent_id: result.agentId,
+          has_playbook: result.playbookPath !== undefined,
+        });
+        return jsonResult({
+          status: "ok",
+          agentId: result.agentId,
+          dir: result.dir,
+          personaPath: result.personaPath,
+          ...(result.playbookPath ? { playbookPath: result.playbookPath } : {}),
+          profilePath: result.profilePath,
+        });
+      }
+
+      if (result.kind === "invalid_request") {
+        api.logger.warn("sil_profile_invalid_request", { field: result.field });
+        return jsonResult({
+          status: "invalid_request",
+          field: result.field,
+          message: result.message,
+        });
+      }
+
+      // persistence_failed — the path + cause are in `error` (never a token/PII).
+      api.logger.error("sil_profile_persistence_failed", { error: result.error });
+      return jsonResult({
+        status: "persistence_failed",
+        error: result.error,
+        message: result.message,
+        recovery: "fix_data_dir",
+      });
+    },
+  });
+}


### PR DESCRIPTION
## Card
`cards/create-a-valid-sil-wired-openclaw-agent-profile.md` (lives in the `card/create-a-valid-sil-wired-openclaw-agent-profile` branch as a local-only worktree doc — gitignored-mode repo; see its body for the full intent + handoffs).

## Summary
Delivers the creation-and-persistence engine for a sil-wired shopping expert, plus the founder-steered behaviour-artefact layer.

- **`skill/SKILL.md`** — the agent-creation engine as an ordered procedure the host agent follows: validate-first → `openclaw agents list` collision check → `openclaw agents add … --non-interactive --json` → `sil_profile_materialize` → copy persona into the workspace `SOUL.md` → `openclaw config set` (attach `sil` skill + enable `sil` plugin) → `openclaw config validate` → `created`. Status taxonomy `created`/`invalid_request`/`collision`/`persistence_failed`. The host-config write is the host agent driving its own CLI — **the plugin never writes `~/.openclaw`** (`noChildProcess`, `filesystemScope`).
- **`src/lib/profile-store.ts`** + **`src/tools/profile.ts`** — `sil_profile_materialize`: a typed, atomic plugin tool that writes the expert's behaviour artefacts (`persona.md`, optional `playbook.md`, typed `profile.json`) into `$SIL_DATA_DIR/agents/<agentId>/` (the plugin's own disclosed scope). Validate-first (writes nothing on a bad spec); atomic (nothing partial on failure); `agentId` validated against path-traversal.
- **`openclaw.plugin.json`** — `contracts.tools` gains `sil_profile_materialize`; `filesystemScope`/`packagingNote` disclose the artefact write.

**Host CLI contract** pinned against docs.openclaw.ai (`/cli/agents`, `/cli/config`, `/gateway/config-agents`, `/tools/skills-config`). Open-question-#1 contingency was **not** hit: the host CLI does the full non-interactive wiring via `config set`, so no plugin-side host-config edit tool was needed.

## Test plan
- [x] `tsc --noEmit` (typecheck) — PASS
- [x] `tsc -p tsconfig.build.json` (build gate) — PASS (`dist/index.js`, `dist/tools/profile.js`, `dist/lib/profile-store.js`)
- [x] `vitest run` — 644 pass (unit + integration), incl. new `profile-store` (16) + `profile-materialize` (7) + the skill-content agent-creation block; all locked drift-guard tests reconciled for the 5th tool and green
- [x] live-verification (behaviour-artefact half) — drove the **compiled** `dist/tools/profile.js` end-to-end on a real `$SIL_DATA_DIR`: artefacts at `0600`, typed manifest, invalid spec writes nothing
- [ ] **SC3 host round (create → validate → shop) — requires a real OpenClaw host, NOT runnable in CI here.** Manual steps documented in the card body; the CLI contract is doc-pinned and the round is **not** faked.

> Note: `repo-scaffold.integration.test.ts` fails in the worktree only because `CLAUDE.md`/`docs/**` are gitignored and absent from the worktree (pre-existing, untouched by this card); it passes in the tracked repo.

## Distillation target
Knowledge capture happens **after Review PASS** in the `distilling` stage — `solutions-architect` runs in this same worktree, commits to this branch, and pushes here so the PR ends up containing implementation + tests + distillation in one mergeable unit. Candidates: the host CLI agent-wiring contract (decisions/), the host-config-vs-`$SIL_DATA_DIR` store boundary + atomic-write idiom (knowledge/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)