### PR TITLE
feature: brainstorm-driven creation of a tailored shopping expert (skill §4 interview)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ release (`clawhub package publish --changelog`). See [README](./README.md#releas
 
 ## [Unreleased]
 
+### Added
+
+- **The `sil` skill now runs a brainstorm interview before creating a shopping
+  expert.** A new §4 in `skill/SKILL.md` drives an open, back-and-forth interview
+  that converges five sections *with* the user — domain framing, persona,
+  elicitation style, answer→`sil_search`-param mapping, and recommendation rubric
+  — eliciting BOTH the domain's decision-attributes AND the user's own
+  tastes/budget/constraints, then assembles a tailored spec the §5 engine
+  materializes via `sil_profile_materialize`. Nothing is created until the user
+  explicitly endorses the assembled draft (abandon-mid-flow leaves nothing
+  written, no teardown); a vague domain is narrowed with the user first; a name
+  collision offers refine-or-rename and never clobbers. The mapping targets only
+  real `sil_search` params (budget → `price_min`/`price_max` in minor units,
+  "prefer secondhand" → `condition`, niche → `query`/`category`) and leaves
+  `ship_to` empty so sil resolves the registered default server-side. The engine
+  section is renumbered §4→§5 (and "Adding a real tool" §5→§6).
+
 ## [0.2.4] - 2026-06-18
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,19 +13,38 @@ release (`clawhub package publish --changelog`). See [README](./README.md#releas
 ### Added
 
 - **The `sil` skill now runs a brainstorm interview before creating a shopping
-  expert.** A new §4 in `skill/SKILL.md` drives an open, back-and-forth interview
-  that converges five sections *with* the user — domain framing, persona,
-  elicitation style, answer→`sil_search`-param mapping, and recommendation rubric
-  — eliciting BOTH the domain's decision-attributes AND the user's own
-  tastes/budget/constraints, then assembles a tailored spec the §5 engine
-  materializes via `sil_profile_materialize`. Nothing is created until the user
-  explicitly endorses the assembled draft (abandon-mid-flow leaves nothing
-  written, no teardown); a vague domain is narrowed with the user first; a name
-  collision offers refine-or-rename and never clobbers. The mapping targets only
-  real `sil_search` params (budget → `price_min`/`price_max` in minor units,
-  "prefer secondhand" → `condition`, niche → `query`/`category`) and leaves
-  `ship_to` empty so sil resolves the registered default server-side. The engine
-  section is renumbered §4→§5 (and "Adding a real tool" §5→§6).
+  expert.** An open, back-and-forth interview converges five sections *with* the
+  user — domain framing, persona, elicitation style, answer→`sil_search`-param
+  mapping, and recommendation rubric — eliciting BOTH the domain's
+  decision-attributes AND the user's own tastes/budget/constraints, then
+  assembles a tailored spec the agent-creation engine materializes via
+  `sil_profile_materialize`. Nothing is created until the user explicitly
+  endorses the assembled draft (abandon-mid-flow leaves nothing written, no
+  teardown); a vague domain is narrowed with the user first; a name collision
+  offers refine-or-rename and never clobbers. The mapping targets only real
+  `sil_search` params (budget → `price_min`/`price_max` in minor units, "prefer
+  secondhand" → `condition`, niche → `query`/`category`) and leaves `ship_to`
+  empty so sil resolves the registered default server-side.
+
+### Changed
+
+- **Restructured the bundled `sil` skill to progressive disclosure
+  (skill-creator convention).** `skill/SKILL.md` is now a maximally-lean pure
+  router: frontmatter, a one-paragraph role, the three always-on behavioural
+  principles, a brief session-start note, and an intent→tool→reference routing
+  table — nothing more. The detailed procedures moved into four self-contained
+  references loaded on demand: `references/catalog_tools_reference.md` (the four
+  core tools' per-tool behaviour + the shared status taxonomy),
+  `references/brainstorm_interview.md` (the interview),
+  `references/agent_creation_engine.md` (the ordered creation engine), and
+  `references/search_param_mapping.md` (the answer→`sil_search`-param mapping),
+  with a worked end-to-end walkthrough under
+  `examples/road_cycling_expert_walkthrough.md`. The endorsement-before-engine
+  gate now lives as the router's two-step trigger (interview first; engine only
+  after explicit endorsement). The contributor-facing "adding a tool" prose —
+  duplicated from the repo `CLAUDE.md` and never needed at runtime — was removed
+  from the skill entirely. No detail is duplicated between the router and any
+  reference.
 
 ## [0.2.4] - 2026-06-18
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -8,203 +8,37 @@ metadata:
 
 # sil
 
-## 1. Role
+Drive the sil plugin's tools on the user's behalf: register them on sil, read their identity, help them find purchasable products in the sil catalog — and, when asked, create a dedicated sil-wired shopping expert. Read user intent, route to the matching tool (loading its reference on demand), call it, and report what came back.
 
-Drive the sil plugin's tools on the user's behalf: register them on sil, read their identity, and help them find purchasable products in the sil catalog. Read user intent, pick the matching tool, call it, and report what came back.
+## Always-on behavioural contract
 
-Principles:
+These three principles hold on every path, before any reference is loaded:
 
 - **Act, don't narrate.** When intent maps to a tool, call it. Don't re-confirm what was already stated.
-- **Fail visibly, recover correctly.** Every tool returns a `status`. On a non-`ok` status, say what happened and follow the tool's own `recovery` hint — never improvise a different one (re-registering can't fix a bad query or a transient 5xx, and would derail the user).
+- **Fail visibly, recover correctly.** Every tool returns a `status`. On a non-`ok` status, say what happened and follow the tool's own `recovery` hint — never improvise a different one.
 - **Relay prices as point-in-time.** A product's price, availability, and `checkout_url` are a snapshot, not a guarantee. Before the user buys, re-fetch with `sil_product_get` rather than trusting an earlier `sil_search` result.
 
-## 2. Session start
+## Session start
 
-Confirm the `sil_*` tools are exposed. If they are missing from the available tool list, the host runtime is filtering them out — tell the user to consult the host's tool-allowlist docs and stop.
+Confirm the `sil_*` tools are exposed. If they are missing from the available tool list, the host runtime is filtering them out — tell the user to consult the host's tool-allowlist docs and stop. Most flows need an identity: if the user has not registered this session, the catalog tools return an unregistered status whose `recovery` points at `sil_register` (the [catalog tools reference](references/catalog_tools_reference.md) has the full taxonomy) — so calling a catalog tool first lets that outcome route, or run `sil_register` up front when the user's intent clearly requires it.
 
-Most flows need an identity. If the user has not registered this session, the catalog tools return `status: "not_registered"` with `recovery: "sil_register"` — so you can call a catalog tool first and let that outcome route you, or run `sil_register` up front when the user's intent clearly requires it.
+## Routing — match intent to a tool, load its reference on demand
 
-## 3. Acting on user intent
-
-When intent maps to a tool, execute:
-
-| Intent | Tool |
-|---|---|
-| "sign me up" / "log me in to sil" / "register" | `sil_register` (takes no arguments; returns an auth URL to open in a browser) |
-| "who am I?" / "what's on my account" / show my saved name + addresses | `sil_whoami` (takes no arguments) |
-| "find X" / "search for X" / browse a category or price range | `sil_search` (free-text `query` and/or `category`, `price_min`, `price_max`; paginate with `cursor`/`limit`) |
-| "look up these items" / re-check ids from a prior result, a saved list, or a deep link | `sil_product_get` (pass `ids` — one or more product/variant ids) |
-
-How each behaves:
-
-- **`sil_register`** starts browser-based registration. It returns promptly with `status: "awaiting_browser"` and an `auth_url` — share that URL with the user. The plugin polls in the background; once the user finishes signing in, call `sil_register` again to confirm (it reports `already_registered`).
-- **`sil_whoami`** returns the registered user's identity (name and addresses). An expired access token is refreshed transparently and the read retried; if the session is fully dead, the result names the recovery (`sil_register`).
-- **`sil_search`** returns a ranked list of purchasable variants (`id`, `title`, `price`, `availability`, `checkout_url`, `source`), best match first — present them in order, do not re-rank. An empty list means nothing matched: a normal `ok` outcome, not an error. Use the returned `cursor` for the next page; its absence means no more results (never infer end-of-results from page size).
-- **`sil_product_get`** is the lookup companion to `sil_search`. Pass ids you already hold and get the matching products back with fresh detail (description, options, the featured variant). Each variant carries an `inputs` list correlating it back to the id(s) you asked about (the response is NOT in request order). Ids that no longer resolve come back in a `not_found` list — a normal partial-success outcome, not an error; the other products are still valid.
-
-All four return the canonical envelope: a single text content block whose JSON body carries a `status`. Prices are in the currency's ISO 4217 minor unit (e.g. cents).
-
-### Status taxonomy (shared across the tools)
-
-| `status` | Meaning | What to do |
+| Intent | Tool | Reference to load |
 |---|---|---|
-| `ok` | Success. Catalog results may be empty (`products: []`) or partial (`not_found: [...]`) — still a success. | Relay the data. |
-| `not_registered` | No stored credentials. | Run `sil_register`, then retry the tool. |
-| `must_reregister` | The session is dead (refresh rejected / 401). | Run `sil_register` to sign in again, then retry. |
-| `forbidden` | Authenticated but not authorized (e.g. account not provisioned). | Follow the message; usually complete onboarding via `sil_register`. |
-| `invalid_request` | The query/ids were rejected (e.g. empty input). | Fix the input and call again — do NOT re-register. |
-| `retryable` | A transient network/5xx blip. | Try the same call again — do NOT re-register. |
+| "sign me up" / "log me in to sil" / "register" | `sil_register` | [`references/catalog_tools_reference.md`](references/catalog_tools_reference.md) |
+| "who am I?" / "what's on my account" / show my saved name + addresses | `sil_whoami` | [`references/catalog_tools_reference.md`](references/catalog_tools_reference.md) |
+| "find X" / "search for X" / browse a category or price range | `sil_search` | [`references/catalog_tools_reference.md`](references/catalog_tools_reference.md) |
+| "look up these items" / re-check ids from a prior result, a saved list, or a deep link | `sil_product_get` | [`references/catalog_tools_reference.md`](references/catalog_tools_reference.md) |
+| "make me a shopping expert" / "set up an agent that shops for me" / build a dedicated shopping expert | (interview, then the engine) | see the two-step gate below |
 
-## 4. Brainstorm a tailored shopping expert (the interview)
+[`references/catalog_tools_reference.md`](references/catalog_tools_reference.md) holds the per-tool behaviour for the four core tools and the shared status taxonomy. Basic shopping needs only that one reference.
 
-When the user asks for a **shopping expert** — "make me a shopping expert for buying gifts", "set up a road-cycling gear agent", "I want an expert that shops for me" — do **not** jump to the engine in §5. First run an **open, back-and-forth interview** that shapes the expert *with* the user, converging a spec tailored to *this* user. The engine in §5 only runs **after** the user explicitly endorses the assembled draft. This section is the procedure; §5 is the machinery it feeds.
+### Creating a shopping expert — the endorsement-gated two-step
 
-This is a **conversation, not a form-fill.** Your job is to converge five things *collaboratively*, eliciting BOTH the domain's decision-attributes AND this user's own tastes, style, budget, and constraints — and to **create nothing** until the user endorses the assembled draft.
+When the user asks to create / set up / build a dedicated shopping expert:
 
-Principles for the interview:
+1. **Interview first.** Read and run [`references/brainstorm_interview.md`](references/brainstorm_interview.md) — the open, back-and-forth interview that converges a tailored spec *with* the user. While running it, load [`references/search_param_mapping.md`](references/search_param_mapping.md) when authoring the answer→`sil_search`-param mapping section.
+2. **Engine only after explicit endorsement.** Only after the user explicitly endorses the assembled draft, read and follow [`references/agent_creation_engine.md`](references/agent_creation_engine.md) — the ordered engine that persists the sil-wired agent. Running ANY engine step before that explicit endorsement is forbidden (the interview reference owns the endorsement gate).
 
-- **Act like a curious expert, not a wizard.** Ask open questions, reflect back what you heard, and let the user steer. Never fire a fixed battery of questions.
-- **Narrow a vague domain first.** If the domain is broad or ambiguous, narrow it to a concrete, searchable niche *with* the user before building anything else (see step 2 below) — every downstream section depends on a narrowed niche.
-- **Interleave domain and personal.** In every section, surface the objective decision-attributes of the domain AND ask where *this* user stands on them. A section that gathered only one side is incomplete.
-- **Converge, don't accumulate.** Reflect a short summary back and get a "yes / adjust" before advancing. The flow is **re-entrant** — the user can revise an earlier section at any point.
-- **Endorsement is a gate, not a formality.** Until the user explicitly says "create it", you have run **zero** engine steps (see Business rules below). The draft lives only in the conversation.
-
-### The five sections the interview converges
-
-These map onto exactly the two artefact slots the §5 engine materializes — there is **no third slot**. The interview's whole job is to fill `persona` and `playbook` (plus the `agentId` + `name` derived from the domain).
-
-| # | Section | What it converges | Lands in |
-|---|---|---|---|
-| 1 | **Domain framing** | What this expert shops for, narrowed to a concrete, searchable niche. | `agentId` + `name` |
-| 2 | **Persona** | Who the expert *is*: its expertise, voice/tone, standing rules — reflecting this user. | `persona` |
-| 3 | **Elicitation style** | How this expert talks to its future user when shopping — how many questions before searching, how proactive, how much it explains. | inside `playbook` |
-| 4 | **Answer→`sil_search`-param mapping** | The domain's decision-attributes translated into concrete `sil_search` parameters this expert will set. | inside `playbook` |
-| 5 | **Comparison / recommendation rubric** | How this expert ranks and picks among results, weighted by the user's *stated* priorities. | inside `playbook` |
-
-Sections 2–5 carry the **tailoring**: they must reflect what *this* user said, not a generic template. The persona goes in the spec's `persona` field; the elicitation style + the answer→param mapping + the rubric are authored as **prose** into the spec's single `playbook` string (the domain sub-skill — a SKILL.md-shaped markdown body, **not** JSON). There is no structured field for the mapping, the style, or the rubric — they live as readable markdown sections inside `playbook`.
-
-### Run the interview in this order
-
-1. **Open with the domain, not a form.** Reflect the request back ("a shopping expert for road-cycling gear — let's shape it together") and ask **one** orienting question. Signal this is a conversation you can revise, not a questionnaire. Do not ask for an `agentId`, a budget, and a tone all at once.
-
-2. **Narrow a vague domain together FIRST — before any other section.** If the domain is broad or ambiguous ("an expert for gifts", "electronics"), do **not** proceed to persona, the mapping, or the rubric. Ask 1–2 narrowing questions (who is it for / what occasion / which slice of the category) and **reflect a concrete niche back for confirmation**. A too-broad niche makes the answer→param mapping and the rubric useless, so this narrow-first gate protects every downstream section. Only once the niche is concrete and confirmed do you move on.
-
-3. **Converge the persona (interview section 2 — see the table above).** Elicit the expert's expertise and voice, AND how the user wants it to behave (terse vs. chatty, cautious vs. opinionated, any standing rules). Reflect a short persona summary back; get a yes/adjust before advancing.
-
-4. **Converge the three playbook sections (interview sections 3–5: elicitation style, the mapping, the rubric), interleaving domain-attributes with the user's stance:**
-   - **Elicitation style:** how should the expert talk to its future user — how many questions before it searches, how proactive, how much it explains its picks? Reflect back, confirm.
-   - **Answer→`sil_search`-param mapping:** name the domain's decision-attributes ("for road bikes: frame material, groupset tier, wheel size, budget…"), ask the user's stance on each, and translate each stated input into a concrete `sil_search` param (see "The mapping is real" below). Reflect the mapping back, confirm.
-   - **Recommendation rubric:** ask what the user weighs most ("durability over price", "prefer secondhand", "brand X is a hard no"), and tie the expert's ranking/selection to those *stated* priorities — not a fixed order. Reflect back, confirm.
-
-5. **Derive the identity, confirm it.** From the converged domain, propose an `agentId` (lower-kebab, matching `^[a-z0-9][a-z0-9-]*$`, never `main`) and a human-readable `name` ("Road-Cycling Buyer" / `road-cycling-buyer`). **Confirm both with the user** — never silently invent them.
-
-6. **Assemble the draft and present it back.** Compose the spec — `{ agentId, name, persona, playbook }` — and present it to the user as a **readable summary**: who the expert is, how it'll search (the mapping), and how it'll recommend (the rubric). Self-check the shape against §5's input contract: `agentId` lower-kebab and ≠ `main`, non-blank `name`, non-blank `persona`, and a non-blank `playbook` (the elicitation-style + mapping + rubric prose). This is your own sanity pass; the engine's validate-first step (§5 step 1) is the authoritative gate — do not re-implement it here.
-
-7. **Get explicit endorsement — the gate.** Ask for an explicit go-ahead ("shall I create it?"). Endorsement is an **affirmative user act** on the assembled draft — "yes, create it" / "go ahead" / "looks good, make it". It is **NOT** inferred from the user answering the last question, and **NOT** from silence. **Only on that explicit endorsement** do you proceed to §5 and run the engine steps.
-
-### The mapping is real (worked examples)
-
-The answer→param mapping must target the **real `sil_search` parameters** (§3's catalog tool) and nothing else — never invent a filter. The parameters available to map onto:
-
-| User's stated input | `sil_search` param it maps to |
-|---|---|
-| A budget ("under €1500", "€800–1200") | `price_min` / `price_max` — **in the currency's ISO 4217 minor unit** (cents): €1500 → `price_max: 150000` |
-| "Prefer secondhand" / "used is fine" | `condition: ["secondhand"]` |
-| "New only" | `condition: ["new"]` |
-| The narrowed niche + key descriptors | `query` (free text) and/or `category` |
-| "In stock only" (the default) / "show me out-of-stock too" | `available` (omit for in-stock default; `false` to include unavailable) |
-| "Buy from a local/domestic shop" | `local_merchants: true` (a best-effort ranking *bias*, not a hard filter — also issue the `query` in the user's language to actually surface local shops) |
-
-A stated taste with **no matching param** (e.g. "I like bold colours", "prefer eco-friendly brands") does **not** become a new param — fold it into the `query` text or into the recommendation rubric. There is no `color` filter, no `brand` filter; inventing one produces an expert that emits invalid `sil_search` calls at shop time.
-
-**`ship_to` stays EMPTY by default — inline rule (do not skip).** Do **not** map the user's location onto `ship_to`, and do **not** instruct the expert to call `sil_whoami` to populate it. When `ship_to` is absent, sil-api resolves the user's **registered default address** server-side. Set `ship_to` (a `{ country, region?, postal_code? }` object of ISO codes) **only** to OVERRIDE the default with a *different* destination than the registered address (e.g. "ship this to my office in Germany"). The expert inherits correct location-aware search by construction — leave `ship_to` out.
-
-### Edge cases the interview handles gracefully
-
-- **Collision (an expert with that id already exists).** The §5 engine refuses a name collision — it returns the `collision` outcome from its `openclaw agents list` check and never clobbers an existing agent. When the proposed `agentId` collides, surface it in the conversation and offer the user a **choice — rename this expert under a new id, or refine the existing expert's niche** — rather than dead-ending. Never silently mutate the id, and never overwrite an existing expert. (Refining the *existing* expert's artefacts in place is out of scope here; offer rename as the concrete action.)
-- **Abandon mid-flow.** The interview is multi-turn; the user may stop, change their mind, or walk away before endorsing. Because **no engine step runs before endorsement**, abandonment leaves **nothing created** — no host agent, no artefacts, no wiring. There is no partial expert to clean up and **no teardown needed**. Never "save progress" by writing artefacts early.
-- **Creation is local + offline — no identity coupling.** Creating an expert neither requires nor performs sil registration. Do **NOT** present sil registration or a token as a prerequisite to *create* the expert. The expert registers the user later, on first shop, via `sil_register`. Building the expert never depends on the user having an identity.
-
-### Business rules (invariants the interview holds on every path)
-
-1. **No creation without explicit endorsement.** Nothing is written — not the host agent, not the artefacts, not the wiring — until the user explicitly endorses the assembled draft. The strongest invariant of this section.
-2. **Abandon-mid-flow creates nothing.** Because no engine step runs pre-endorsement, an abandoned interview leaves no partial expert — automatic, not a teardown. Never write artefacts early to "save progress".
-3. **Elicit BOTH sides.** The interview must elicit the domain's decision-attributes AND the user's personal tastes/style/budget/constraints. A spec built from only domain attributes (generic) or only preferences (no searchable mapping) is incomplete.
-4. **Tailoring is real, not template.** The persona, the mapping, and the rubric must reflect the user's *stated* inputs — a stated budget becomes `price_min`/`price_max`; "prefer secondhand" becomes `condition`; "durability over price" becomes a rubric weight. A spec that ignores what the user said fails this section's purpose.
-5. **Converge each section before advancing; stay re-entrant.** Reflect-and-confirm per section; let the user revise any earlier section. Collaborative, not a locked wizard.
-6. **Narrow a vague domain first.** Never build persona/mapping/rubric on an un-narrowed niche — narrow with the user before proceeding.
-7. **Refine-or-rename on collision; never clobber.** On an existing-name collision, offer refine-or-rename; never overwrite an existing expert (defers to the §5 engine's `collision` refusal).
-8. **Creation is local + offline — no identity coupling.** The interview never presents sil registration / a token as a prerequisite to create the expert.
-9. **Search behaviour the expert inherits is correct by construction.** The answer→param mapping encodes the location-aware default: leave `ship_to` empty (server resolves the registered default), never instruct the expert to call `sil_whoami` to populate it.
-
-Once the user has **explicitly endorsed** the assembled draft, proceed to §5 and run the engine steps in order.
-
-## 5. Create a sil-wired shopping expert (agent-creation engine)
-
-When the user wants a **dedicated shopping expert** — "make me a shopping expert for buying gifts", "set up a grocery re-order agent", "create a sil shopping agent" — you author and persist a **valid OpenClaw agent profile**: a real new agent under the host `agents` config, with the **sil plugin enabled** and the **sil skill attached**, plus the expert's behaviour artefacts in the sil data directory — so the created agent can shop with **no further setup**.
-
-You are the engine. The host config write is **you driving the host's own `openclaw …` CLI** — the sil plugin never writes the host config itself. Run these steps **in order, top to bottom** — the order is the spec.
-
-### The profile spec (input)
-
-Confirm the spec before you start. The §4 interview is what *fills* this spec (the persona → `persona`, and the elicitation style + answer→param mapping + rubric → `playbook`); here the assembled, **user-endorsed** spec is your input:
-
-| Field | Meaning | Required? |
-|---|---|---|
-| **agentId** | The new agent's id (lower-kebab, e.g. `gift-buyer`). Becomes `agents.list[].id`. Must be **unique** and is never `main` (host-reserved). | Required |
-| **name** | Human-readable expert name ("Gift Buyer"). | Required |
-| **persona / instructions** | Who this expert is and how it shops — its expertise, tone, standing rules. | Required (non-empty) |
-| **workspace** | The agent's workspace directory (e.g. `~/.openclaw/workspace-gift-buyer`). | Required for the non-interactive add |
-| **playbook (sub-skill)** | An optional generated **domain sub-skill** — a shopping playbook for this expert's niche. | Optional |
-
-The **sil plugin** and the **sil skill** are always attached (that is what makes it *sil-wired*). Creating an expert is **local and offline** — it does **not** require or perform sil registration, reads no token, and writes nothing to identity storage. The expert registers the user later, on first shop, via `sil_register`. Do **not** present registration as a prerequisite for creating the profile.
-
-### Engine steps (run in this exact order)
-
-1. **Validate the spec FIRST — before anything is written.** Check `agentId` is present, lower-kebab, unique-looking, and not `main`; `name` is present; `persona`/instructions is non-empty; `workspace` is present. If any check fails, stop with the **`invalid_request`** outcome naming the offending field and **write nothing** — no agent, no artefacts. Nothing partial. This validation runs ahead of every host command, so a bad spec never reaches the host.
-
-2. **Collision check — read before write.** Run `openclaw agents list --json` and confirm no existing agent already uses `agentId`. If one does, stop with the **`collision`** outcome and **do not** run `openclaw agents add` — never overwrite or clobber an existing agent's persona or wiring. Surface the collision so the user can rename. (This list-check precedes the add, so a same-name agent is caught before any change.)
-
-3. **Create the agent shell (host CLI).** Run:
-   ```
-   openclaw agents add <agentId> --workspace <workspace> --non-interactive --json
-   ```
-   This creates the real `agents.list[]` entry and the agent's workspace bootstrap files (`SOUL.md`, `AGENTS.md`, …), inheriting model and tool profile from `agents.defaults`. `--non-interactive --json` is required so you can drive it without a prompt and read the structured result.
-
-4. **Materialize the behaviour artefacts into the sil data directory.** Call **`sil_profile_materialize`** with `{ agentId, name, persona, playbook? }`. It writes the expert's behaviour artefacts atomically into **`$SIL_DATA_DIR`** (the sil data directory — the plugin's own disclosed scope) under `agents/<agentId>/`:
-   - **`persona.md`** — the persona/instructions that power the expert's behaviour;
-   - **`playbook.md`** — the generated domain **sub-skill**, when supplied;
-   - **`profile.json`** — the manifest the sil skill reads at runtime to load them.
-   These behaviour artefacts live in `$SIL_DATA_DIR`, kept **out of** the thin host `agents` wiring entry. The tool's own outcomes are `ok` / `invalid_request` / `persistence_failed` — on `invalid_request` it wrote nothing; on `persistence_failed` it left nothing partial.
-
-5. **Make the persona the agent's system framing.** Copy the materialized `persona.md` into the new agent's workspace `SOUL.md` (its persona bootstrap file), so the host injects the persona into the expert's system prompt.
-
-6. **Wire the sil skill and plugin into the agent (host CLI).** Attach the sil skill and enable the sil plugin for the created agent:
-   ```
-   openclaw config set 'agents.list[<i>].skills' '["sil"]' --strict-json
-   openclaw config set plugins.entries.sil.enabled true --merge
-   ```
-   The skill attach makes the agent **know how** to drive the tools; the plugin enable makes the four `sil_*` tools available to it (they come for free once the `sil` plugin is enabled). Keep `sil` in the agent's skill list and do not deny the `sil_*` tools in its tool profile.
-
-7. **Validate with the host's OWN check, THEN declare created.** Run `openclaw config validate --json`. "Valid" means *the host says yes* — never assert it yourself. Only when validation passes do you report the **`created`** outcome. If `openclaw config validate` returns `ok: false` (or any CLI step failed), report **`persistence_failed`** with the failing **path** and **cause**, and leave nothing partial behind. This validate-after-add step is what guarantees the host will load the profile.
-
-8. **Tell the user it is ready.** On `created`, tell the user the expert exists and how to open it. When they open the new agent, the host loads it: the sil plugin is enabled, the sil skill is attached, `SOUL.md` carries the persona, and the sil skill reads `$SIL_DATA_DIR/agents/<agentId>/profile.json` to load the persona + playbook — the expert calls `sil_search` / `sil_product_get` (and `sil_register` / `sil_whoami` as needed) on the user's intent with **no further setup**.
-
-### Status taxonomy (agent-creation engine)
-
-| `status` | Meaning | What to do |
-|---|---|---|
-| `created` | The agent was added, the behaviour artefacts materialized, the sil plugin + skill wired, and `openclaw config validate` accepted it. | Tell the user the expert is ready and how to open it. |
-| `invalid_request` | The spec failed validation (missing/blank field). **Nothing was written.** | Name the field, fix it, run again. Do NOT proceed to `openclaw agents add`. |
-| `collision` | An agent with that id already exists (from `openclaw agents list`). | Surface it; pick a different id. **Never overwrite / clobber** the existing agent. |
-| `persistence_failed` | A write or `openclaw config validate` step failed. The reported **path** + **cause** name what to fix. **Nothing partial** was left behind. | Fix the path/cause (writable config, valid spec), then create the expert again. |
-
-### Runtime — how a created expert loads its behaviour
-
-When you (the sil skill) start a session inside a created expert, read `$SIL_DATA_DIR/agents/<agentId>/profile.json`, then load the `persona.md` (reaffirm the standing instructions) and `playbook.md` sub-skill (the domain shopping playbook) it points at. That is what lets the expert shop on its niche with no further setup.
-
-## 6. Adding a real tool
-
-The mechanical steps live in the repo's `CLAUDE.md` ("How to add a tool"); the short version is three steps: register the tool inside a `registerXTools(api)` group in `src/tools/`, wire that group into `register()` in `src/index.ts`, and add the tool's name to `openclaw.plugin.json#contracts.tools`. The manifest↔code drift-guard test fails if those disagree, which keeps the pattern self-enforcing.
-
-The reference group is `src/tools/identity.ts` (`sil_register`, `sil_whoami`) — it sets the `jsonResult` success shape and the structured-error/recovery envelope every real tool follows; `src/tools/catalog.ts` (`sil_search`, `sil_product_get`) is the catalog counterpart. All I/O lives inside a tool's `execute()`; `register()` stays synchronous and opens nothing.
+Want a concrete walkthrough? [`examples/road_cycling_expert_walkthrough.md`](examples/road_cycling_expert_walkthrough.md) is an end-to-end worked example: a free-form request → interview convergence → assembled spec → created expert.

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -55,7 +55,91 @@ All four return the canonical envelope: a single text content block whose JSON b
 | `invalid_request` | The query/ids were rejected (e.g. empty input). | Fix the input and call again — do NOT re-register. |
 | `retryable` | A transient network/5xx blip. | Try the same call again — do NOT re-register. |
 
-## 4. Create a sil-wired shopping expert (agent-creation engine)
+## 4. Brainstorm a tailored shopping expert (the interview)
+
+When the user asks for a **shopping expert** — "make me a shopping expert for buying gifts", "set up a road-cycling gear agent", "I want an expert that shops for me" — do **not** jump to the engine in §5. First run an **open, back-and-forth interview** that shapes the expert *with* the user, converging a spec tailored to *this* user. The engine in §5 only runs **after** the user explicitly endorses the assembled draft. This section is the procedure; §5 is the machinery it feeds.
+
+This is a **conversation, not a form-fill.** Your job is to converge five things *collaboratively*, eliciting BOTH the domain's decision-attributes AND this user's own tastes, style, budget, and constraints — and to **create nothing** until the user endorses the assembled draft.
+
+Principles for the interview:
+
+- **Act like a curious expert, not a wizard.** Ask open questions, reflect back what you heard, and let the user steer. Never fire a fixed battery of questions.
+- **Narrow a vague domain first.** If the domain is broad or ambiguous, narrow it to a concrete, searchable niche *with* the user before building anything else (see step 2 below) — every downstream section depends on a narrowed niche.
+- **Interleave domain and personal.** In every section, surface the objective decision-attributes of the domain AND ask where *this* user stands on them. A section that gathered only one side is incomplete.
+- **Converge, don't accumulate.** Reflect a short summary back and get a "yes / adjust" before advancing. The flow is **re-entrant** — the user can revise an earlier section at any point.
+- **Endorsement is a gate, not a formality.** Until the user explicitly says "create it", you have run **zero** engine steps (see Business rules below). The draft lives only in the conversation.
+
+### The five sections the interview converges
+
+These map onto exactly the two artefact slots the §5 engine materializes — there is **no third slot**. The interview's whole job is to fill `persona` and `playbook` (plus the `agentId` + `name` derived from the domain).
+
+| # | Section | What it converges | Lands in |
+|---|---|---|---|
+| 1 | **Domain framing** | What this expert shops for, narrowed to a concrete, searchable niche. | `agentId` + `name` |
+| 2 | **Persona** | Who the expert *is*: its expertise, voice/tone, standing rules — reflecting this user. | `persona` |
+| 3 | **Elicitation style** | How this expert talks to its future user when shopping — how many questions before searching, how proactive, how much it explains. | inside `playbook` |
+| 4 | **Answer→`sil_search`-param mapping** | The domain's decision-attributes translated into concrete `sil_search` parameters this expert will set. | inside `playbook` |
+| 5 | **Comparison / recommendation rubric** | How this expert ranks and picks among results, weighted by the user's *stated* priorities. | inside `playbook` |
+
+Sections 2–5 carry the **tailoring**: they must reflect what *this* user said, not a generic template. The persona goes in the spec's `persona` field; the elicitation style + the answer→param mapping + the rubric are authored as **prose** into the spec's single `playbook` string (the domain sub-skill — a SKILL.md-shaped markdown body, **not** JSON). There is no structured field for the mapping, the style, or the rubric — they live as readable markdown sections inside `playbook`.
+
+### Run the interview in this order
+
+1. **Open with the domain, not a form.** Reflect the request back ("a shopping expert for road-cycling gear — let's shape it together") and ask **one** orienting question. Signal this is a conversation you can revise, not a questionnaire. Do not ask for an `agentId`, a budget, and a tone all at once.
+
+2. **Narrow a vague domain together FIRST — before any other section.** If the domain is broad or ambiguous ("an expert for gifts", "electronics"), do **not** proceed to persona, the mapping, or the rubric. Ask 1–2 narrowing questions (who is it for / what occasion / which slice of the category) and **reflect a concrete niche back for confirmation**. A too-broad niche makes the answer→param mapping and the rubric useless, so this narrow-first gate protects every downstream section. Only once the niche is concrete and confirmed do you move on.
+
+3. **Converge the persona (interview section 2 — see the table above).** Elicit the expert's expertise and voice, AND how the user wants it to behave (terse vs. chatty, cautious vs. opinionated, any standing rules). Reflect a short persona summary back; get a yes/adjust before advancing.
+
+4. **Converge the three playbook sections (interview sections 3–5: elicitation style, the mapping, the rubric), interleaving domain-attributes with the user's stance:**
+   - **Elicitation style:** how should the expert talk to its future user — how many questions before it searches, how proactive, how much it explains its picks? Reflect back, confirm.
+   - **Answer→`sil_search`-param mapping:** name the domain's decision-attributes ("for road bikes: frame material, groupset tier, wheel size, budget…"), ask the user's stance on each, and translate each stated input into a concrete `sil_search` param (see "The mapping is real" below). Reflect the mapping back, confirm.
+   - **Recommendation rubric:** ask what the user weighs most ("durability over price", "prefer secondhand", "brand X is a hard no"), and tie the expert's ranking/selection to those *stated* priorities — not a fixed order. Reflect back, confirm.
+
+5. **Derive the identity, confirm it.** From the converged domain, propose an `agentId` (lower-kebab, matching `^[a-z0-9][a-z0-9-]*$`, never `main`) and a human-readable `name` ("Road-Cycling Buyer" / `road-cycling-buyer`). **Confirm both with the user** — never silently invent them.
+
+6. **Assemble the draft and present it back.** Compose the spec — `{ agentId, name, persona, playbook }` — and present it to the user as a **readable summary**: who the expert is, how it'll search (the mapping), and how it'll recommend (the rubric). Self-check the shape against §5's input contract: `agentId` lower-kebab and ≠ `main`, non-blank `name`, non-blank `persona`, and a non-blank `playbook` (the elicitation-style + mapping + rubric prose). This is your own sanity pass; the engine's validate-first step (§5 step 1) is the authoritative gate — do not re-implement it here.
+
+7. **Get explicit endorsement — the gate.** Ask for an explicit go-ahead ("shall I create it?"). Endorsement is an **affirmative user act** on the assembled draft — "yes, create it" / "go ahead" / "looks good, make it". It is **NOT** inferred from the user answering the last question, and **NOT** from silence. **Only on that explicit endorsement** do you proceed to §5 and run the engine steps.
+
+### The mapping is real (worked examples)
+
+The answer→param mapping must target the **real `sil_search` parameters** (§3's catalog tool) and nothing else — never invent a filter. The parameters available to map onto:
+
+| User's stated input | `sil_search` param it maps to |
+|---|---|
+| A budget ("under €1500", "€800–1200") | `price_min` / `price_max` — **in the currency's ISO 4217 minor unit** (cents): €1500 → `price_max: 150000` |
+| "Prefer secondhand" / "used is fine" | `condition: ["secondhand"]` |
+| "New only" | `condition: ["new"]` |
+| The narrowed niche + key descriptors | `query` (free text) and/or `category` |
+| "In stock only" (the default) / "show me out-of-stock too" | `available` (omit for in-stock default; `false` to include unavailable) |
+| "Buy from a local/domestic shop" | `local_merchants: true` (a best-effort ranking *bias*, not a hard filter — also issue the `query` in the user's language to actually surface local shops) |
+
+A stated taste with **no matching param** (e.g. "I like bold colours", "prefer eco-friendly brands") does **not** become a new param — fold it into the `query` text or into the recommendation rubric. There is no `color` filter, no `brand` filter; inventing one produces an expert that emits invalid `sil_search` calls at shop time.
+
+**`ship_to` stays EMPTY by default — inline rule (do not skip).** Do **not** map the user's location onto `ship_to`, and do **not** instruct the expert to call `sil_whoami` to populate it. When `ship_to` is absent, sil-api resolves the user's **registered default address** server-side. Set `ship_to` (a `{ country, region?, postal_code? }` object of ISO codes) **only** to OVERRIDE the default with a *different* destination than the registered address (e.g. "ship this to my office in Germany"). The expert inherits correct location-aware search by construction — leave `ship_to` out.
+
+### Edge cases the interview handles gracefully
+
+- **Collision (an expert with that id already exists).** The §5 engine refuses a name collision — it returns the `collision` outcome from its `openclaw agents list` check and never clobbers an existing agent. When the proposed `agentId` collides, surface it in the conversation and offer the user a **choice — rename this expert under a new id, or refine the existing expert's niche** — rather than dead-ending. Never silently mutate the id, and never overwrite an existing expert. (Refining the *existing* expert's artefacts in place is out of scope here; offer rename as the concrete action.)
+- **Abandon mid-flow.** The interview is multi-turn; the user may stop, change their mind, or walk away before endorsing. Because **no engine step runs before endorsement**, abandonment leaves **nothing created** — no host agent, no artefacts, no wiring. There is no partial expert to clean up and **no teardown needed**. Never "save progress" by writing artefacts early.
+- **Creation is local + offline — no identity coupling.** Creating an expert neither requires nor performs sil registration. Do **NOT** present sil registration or a token as a prerequisite to *create* the expert. The expert registers the user later, on first shop, via `sil_register`. Building the expert never depends on the user having an identity.
+
+### Business rules (invariants the interview holds on every path)
+
+1. **No creation without explicit endorsement.** Nothing is written — not the host agent, not the artefacts, not the wiring — until the user explicitly endorses the assembled draft. The strongest invariant of this section.
+2. **Abandon-mid-flow creates nothing.** Because no engine step runs pre-endorsement, an abandoned interview leaves no partial expert — automatic, not a teardown. Never write artefacts early to "save progress".
+3. **Elicit BOTH sides.** The interview must elicit the domain's decision-attributes AND the user's personal tastes/style/budget/constraints. A spec built from only domain attributes (generic) or only preferences (no searchable mapping) is incomplete.
+4. **Tailoring is real, not template.** The persona, the mapping, and the rubric must reflect the user's *stated* inputs — a stated budget becomes `price_min`/`price_max`; "prefer secondhand" becomes `condition`; "durability over price" becomes a rubric weight. A spec that ignores what the user said fails this section's purpose.
+5. **Converge each section before advancing; stay re-entrant.** Reflect-and-confirm per section; let the user revise any earlier section. Collaborative, not a locked wizard.
+6. **Narrow a vague domain first.** Never build persona/mapping/rubric on an un-narrowed niche — narrow with the user before proceeding.
+7. **Refine-or-rename on collision; never clobber.** On an existing-name collision, offer refine-or-rename; never overwrite an existing expert (defers to the §5 engine's `collision` refusal).
+8. **Creation is local + offline — no identity coupling.** The interview never presents sil registration / a token as a prerequisite to create the expert.
+9. **Search behaviour the expert inherits is correct by construction.** The answer→param mapping encodes the location-aware default: leave `ship_to` empty (server resolves the registered default), never instruct the expert to call `sil_whoami` to populate it.
+
+Once the user has **explicitly endorsed** the assembled draft, proceed to §5 and run the engine steps in order.
+
+## 5. Create a sil-wired shopping expert (agent-creation engine)
 
 When the user wants a **dedicated shopping expert** — "make me a shopping expert for buying gifts", "set up a grocery re-order agent", "create a sil shopping agent" — you author and persist a **valid OpenClaw agent profile**: a real new agent under the host `agents` config, with the **sil plugin enabled** and the **sil skill attached**, plus the expert's behaviour artefacts in the sil data directory — so the created agent can shop with **no further setup**.
 
@@ -63,7 +147,7 @@ You are the engine. The host config write is **you driving the host's own `openc
 
 ### The profile spec (input)
 
-Elicit or confirm a spec before you start (the full interview is a separate concern; here the spec is your input):
+Confirm the spec before you start. The §4 interview is what *fills* this spec (the persona → `persona`, and the elicitation style + answer→param mapping + rubric → `playbook`); here the assembled, **user-endorsed** spec is your input:
 
 | Field | Meaning | Required? |
 |---|---|---|
@@ -119,7 +203,7 @@ The **sil plugin** and the **sil skill** are always attached (that is what makes
 
 When you (the sil skill) start a session inside a created expert, read `$SIL_DATA_DIR/agents/<agentId>/profile.json`, then load the `persona.md` (reaffirm the standing instructions) and `playbook.md` sub-skill (the domain shopping playbook) it points at. That is what lets the expert shop on its niche with no further setup.
 
-## 5. Adding a real tool
+## 6. Adding a real tool
 
 The mechanical steps live in the repo's `CLAUDE.md` ("How to add a tool"); the short version is three steps: register the tool inside a `registerXTools(api)` group in `src/tools/`, wire that group into `register()` in `src/index.ts`, and add the tool's name to `openclaw.plugin.json#contracts.tools`. The manifest↔code drift-guard test fails if those disagree, which keeps the pattern self-enforcing.
 

--- a/skill/examples/road_cycling_expert_walkthrough.md
+++ b/skill/examples/road_cycling_expert_walkthrough.md
@@ -1,0 +1,106 @@
+# Worked example — a road-cycling shopping expert, end to end
+
+A complete walkthrough from a free-form request through the interview ([`../references/brainstorm_interview.md`](../references/brainstorm_interview.md)) to a created expert via the engine ([`../references/agent_creation_engine.md`](../references/agent_creation_engine.md)). The transcript is illustrative — a real interview adapts to the user; this shows the *shape* of convergence and the load-bearing gates.
+
+## 1. The free-form request
+
+> **User:** "I want an expert that shops for road-cycling gear for me."
+
+Reflect the request back and open with one orienting question — not a form:
+
+> **Expert:** "A shopping expert for road-cycling gear — let's shape it together. We can revise anything as we go. To start: are you after a complete bike, or kit and components (wheels, groupsets, apparel)?"
+
+## 2. Narrow the (vague) domain FIRST
+
+"Road-cycling gear" is broad. Narrow it before any other section:
+
+> **User:** "Mostly components and apparel — I already have a frame."
+> **Expert:** "Got it — so the niche is **road-cycling components & apparel for an existing frame** (wheels, groupsets, finishing kit, clothing), not complete bikes. Does that capture it?"
+> **User:** "Yes."
+
+The concrete, confirmed niche is locked before persona/mapping/rubric — the narrow-first gate is satisfied.
+
+## 3. Converge the persona (section 2)
+
+> **Expert:** "How should this expert come across — a terse spec-checker, or a chatty guide who explains trade-offs? Any standing rules?"
+> **User:** "Knowledgeable but concise. Always flag compatibility issues with my groupset. No carbon-fibre handlebars — I don't trust them."
+> **Expert:** "Persona: a concise, knowledgeable road-cycling components advisor; standing rules — always flag groupset compatibility, never recommend carbon handlebars. Good?"
+> **User:** "Perfect."
+
+→ lands in `persona`.
+
+## 4. Converge the three playbook sections (3–5)
+
+**Elicitation style:**
+> **Expert:** "When you ask it to shop, should it search right away on a one-line request, or ask a clarifying question or two first?"
+> **User:** "Ask at most one clarifying question, then search."
+
+**Answer→`sil_search`-param mapping** (loading [`../references/search_param_mapping.md`](../references/search_param_mapping.md)):
+> **Expert:** "For components the decision-attributes are budget, groupset tier, new vs. secondhand, and where you buy. Where do you stand?"
+> **User:** "Budget around €1200, secondhand is fine, I'm in France and prefer local shops."
+
+Translating each stated input to a real param:
+
+```
+query:           "road-cycling components 105 groupset"   # niche descriptors
+category:        "cycling-components"
+price_max:       120000        # €1200 → minor units (cents)
+condition:       ["secondhand"]   # "secondhand is fine"
+local_merchants: true             # "prefer local shops" → ranking bias; query issued in French
+# ship_to: OMITTED — server resolves the registered default address; no sil_whoami round-trip
+```
+
+**Recommendation rubric:**
+> **Expert:** "What matters most when I pick among results?"
+> **User:** "Compatibility first, then value, then weight. Brand X is a hard no."
+
+→ Rubric: rank by groupset compatibility, then value, then weight; exclude brand X. Tied to the user's *stated* priorities, not a fixed order.
+
+All three sections are authored as prose into the single `playbook` string.
+
+## 5. Derive + confirm the identity
+
+> **Expert:** "I'll call it **Road-Cycling Buyer** (`road-cycling-buyer`). Good?"
+> **User:** "Yes."
+
+→ `agentId: road-cycling-buyer` (lower-kebab, ≠ `main`), `name: "Road-Cycling Buyer"`.
+
+## 6. Assemble the draft and present it back
+
+The assembled spec — a valid `sil_profile_materialize` input:
+
+```jsonc
+{
+  "agentId": "road-cycling-buyer",
+  "name": "Road-Cycling Buyer",
+  "persona": "A concise, knowledgeable road-cycling components advisor. Standing rules: always flag groupset compatibility; never recommend carbon-fibre handlebars.",
+  "playbook": "## Elicitation style\nAsk at most one clarifying question, then search.\n\n## Answer→sil_search-param mapping\n- Budget → price_min/price_max (minor units). Secondhand-ok → condition: [\"secondhand\"]. Local shops → local_merchants: true, query in French. ship_to left empty (server resolves the registered default; no sil_whoami round-trip).\n\n## Recommendation rubric\nRank by groupset compatibility, then value, then weight. Brand X is a hard no."
+}
+```
+
+> **Expert:** "Here's the expert: a concise components advisor that flags compatibility, searches secondhand within ~€1200, biases to local French shops, and ranks compatibility → value → weight. Shall I create it?"
+
+## 7. Explicit endorsement — the gate
+
+> **User:** "Yes, create it."
+
+**This affirmative act is the gate.** Up to this point, **zero engine steps have run** — nothing was written. Only now does the engine proceed.
+
+## 8. Run the engine (after endorsement)
+
+Following [`../references/agent_creation_engine.md`](../references/agent_creation_engine.md) in order:
+
+1. **Validate the spec FIRST** — `agentId` lower-kebab & ≠ `main` ✓, `name` non-blank ✓, `persona` non-blank ✓, `workspace` present ✓.
+2. **Collision check** — `openclaw agents list --json`; no existing `road-cycling-buyer` → proceed.
+3. **Create the shell** — `openclaw agents add road-cycling-buyer --workspace ~/.openclaw/workspace-road-cycling-buyer --non-interactive --json`.
+4. **Materialize artefacts** — `sil_profile_materialize` with the spec writes `persona.md`, `playbook.md`, `profile.json` into `$SIL_DATA_DIR/agents/road-cycling-buyer/`.
+5. **System framing** — copy `persona.md` into the agent's workspace `SOUL.md`.
+6. **Wire sil** — `openclaw config set 'agents.list[<i>].skills' '["sil"]' --strict-json` and `openclaw config set plugins.entries.sil.enabled true --merge`.
+7. **Validate with the host's OWN check, THEN declare created** — `openclaw config validate --json` returns valid → outcome **`created`**.
+8. **Tell the user** — the expert exists; opening it loads the persona + playbook and it shops on its niche with **no further setup**.
+
+## Edge cases this example would have handled
+
+- **Collision** (a `road-cycling-buyer` already exists): the engine returns `collision`, writes nothing, and the conversation offers **refine-or-rename** — never clobbers.
+- **Abandon before step 7** of the interview (user walks away pre-endorsement): nothing was created, nothing to tear down — the draft lived only in the conversation.
+- **Creation is local + offline**: no sil registration was needed to create the expert; the user registers later, on first shop, via `sil_register`.

--- a/skill/references/agent_creation_engine.md
+++ b/skill/references/agent_creation_engine.md
@@ -1,0 +1,65 @@
+# Create a sil-wired shopping expert — the agent-creation engine
+
+**Precondition: read and run this reference ONLY after the user has explicitly endorsed the assembled draft from [`brainstorm_interview.md`](brainstorm_interview.md).** Running any step below before that explicit endorsement is forbidden — the interview owns the endorsement gate.
+
+When the user wants a **dedicated shopping expert** — "make me a shopping expert for buying gifts", "set up a grocery re-order agent", "create a sil shopping agent" — author and persist a **valid OpenClaw agent profile**: a real new agent under the host `agents` config, with the **sil plugin enabled** and the **sil skill attached**, plus the expert's behaviour artefacts in the sil data directory — so the created agent can shop with **no further setup**.
+
+You are the engine. The host config write is **you driving the host's own `openclaw …` CLI** — the sil plugin never writes the host config itself. Run these steps **in order, top to bottom** — the order is the spec.
+
+## The profile spec (input)
+
+The endorsed draft from the interview *is* this spec (the persona → `persona`, and the elicitation style + answer→param mapping + rubric → `playbook`):
+
+| Field | Meaning | Required? |
+|---|---|---|
+| **agentId** | The new agent's id (lower-kebab, e.g. `gift-buyer`). Becomes `agents.list[].id`. Must be **unique** and is never `main` (host-reserved). | Required |
+| **name** | Human-readable expert name ("Gift Buyer"). | Required |
+| **persona / instructions** | Who this expert is and how it shops — its expertise, tone, standing rules. | Required (non-empty) |
+| **workspace** | The agent's workspace directory (e.g. `~/.openclaw/workspace-gift-buyer`). | Required for the non-interactive add |
+| **playbook (sub-skill)** | An optional generated **domain sub-skill** — a shopping playbook for this expert's niche. | Optional |
+
+The **sil plugin** and the **sil skill** are always attached (that is what makes it *sil-wired*). Creating an expert is **local and offline** — it does **not** require or perform sil registration, reads no token, and writes nothing to identity storage. The expert registers the user later, on first shop, via `sil_register`. Do **not** present registration as a prerequisite for creating the profile.
+
+## Engine steps (run in this exact order)
+
+1. **Validate the spec FIRST — before anything is written.** Check `agentId` is present, lower-kebab, unique-looking, and not `main`; `name` is present; `persona`/instructions is non-empty; `workspace` is present. If any check fails, stop with the **`invalid_request`** outcome naming the offending field and **write nothing** — no agent, no artefacts. Nothing partial. This validation runs ahead of every host command, so a bad spec never reaches the host.
+
+2. **Collision check — read before write.** Run `openclaw agents list --json` and confirm no existing agent already uses `agentId`. If one does, stop with the **`collision`** outcome and **do not** run `openclaw agents add` — never overwrite or clobber an existing agent's persona or wiring. Surface the collision so the user can rename. (This list-check precedes the add, so a same-name agent is caught before any change.)
+
+3. **Create the agent shell (host CLI).** Run:
+   ```
+   openclaw agents add <agentId> --workspace <workspace> --non-interactive --json
+   ```
+   This creates the real `agents.list[]` entry and the agent's workspace bootstrap files (`SOUL.md`, `AGENTS.md`, …), inheriting model and tool profile from `agents.defaults`. `--non-interactive --json` is required so you can drive it without a prompt and read the structured result.
+
+4. **Materialize the behaviour artefacts into the sil data directory.** Call **`sil_profile_materialize`** with `{ agentId, name, persona, playbook? }`. It writes the expert's behaviour artefacts atomically into **`$SIL_DATA_DIR`** (the sil data directory — the plugin's own disclosed scope) under `agents/<agentId>/`:
+   - **`persona.md`** — the persona/instructions that power the expert's behaviour;
+   - **`playbook.md`** — the generated domain **sub-skill**, when supplied;
+   - **`profile.json`** — the manifest the sil skill reads at runtime to load them.
+   These behaviour artefacts live in `$SIL_DATA_DIR`, kept **out of** the thin host `agents` wiring entry. The tool's own outcomes are `ok` / `invalid_request` / `persistence_failed` — on `invalid_request` it wrote nothing; on `persistence_failed` it left nothing partial.
+
+5. **Make the persona the agent's system framing.** Copy the materialized `persona.md` into the new agent's workspace `SOUL.md` (its persona bootstrap file), so the host injects the persona into the expert's system prompt.
+
+6. **Wire the sil skill and plugin into the agent (host CLI).** Attach the sil skill and enable the sil plugin for the created agent:
+   ```
+   openclaw config set 'agents.list[<i>].skills' '["sil"]' --strict-json
+   openclaw config set plugins.entries.sil.enabled true --merge
+   ```
+   The skill attach makes the agent **know how** to drive the tools; the plugin enable makes the four `sil_*` tools available to it (they come for free once the `sil` plugin is enabled). Keep `sil` in the agent's skill list and do not deny the `sil_*` tools in its tool profile.
+
+7. **Validate with the host's OWN check, THEN declare created.** Run `openclaw config validate --json`. "Valid" means *the host says yes* — never assert it yourself. Only when validation passes do you report the **`created`** outcome. If `openclaw config validate` returns `ok: false` (or any CLI step failed), report **`persistence_failed`** with the failing **path** and **cause**, and leave nothing partial behind. This validate-after-add step is what guarantees the host will load the profile.
+
+8. **Tell the user it is ready.** On `created`, tell the user the expert exists and how to open it. When they open the new agent, the host loads it: the sil plugin is enabled, the sil skill is attached, `SOUL.md` carries the persona, and the sil skill reads `$SIL_DATA_DIR/agents/<agentId>/profile.json` to load the persona + playbook — the expert calls `sil_search` / `sil_product_get` (and `sil_register` / `sil_whoami` as needed) on the user's intent with **no further setup**.
+
+## Status taxonomy (agent-creation engine)
+
+| `status` | Meaning | What to do |
+|---|---|---|
+| `created` | The agent was added, the behaviour artefacts materialized, the sil plugin + skill wired, and `openclaw config validate` accepted it. | Tell the user the expert is ready and how to open it. |
+| `invalid_request` | The spec failed validation (missing/blank field). **Nothing was written.** | Name the field, fix it, run again. Do NOT proceed to `openclaw agents add`. |
+| `collision` | An agent with that id already exists (from `openclaw agents list`). | Surface it; pick a different id. **Never overwrite / clobber** the existing agent. |
+| `persistence_failed` | A write or `openclaw config validate` step failed. The reported **path** + **cause** name what to fix. **Nothing partial** was left behind. | Fix the path/cause (writable config, valid spec), then create the expert again. |
+
+## Runtime — how a created expert loads its behaviour
+
+When you (the sil skill) start a session inside a created expert, read `$SIL_DATA_DIR/agents/<agentId>/profile.json`, then load the `persona.md` (reaffirm the standing instructions) and `playbook.md` sub-skill (the domain shopping playbook) it points at. That is what lets the expert shop on its niche with no further setup.

--- a/skill/references/brainstorm_interview.md
+++ b/skill/references/brainstorm_interview.md
@@ -1,0 +1,68 @@
+# Brainstorm a tailored shopping expert — the interview
+
+When the user asks for a **shopping expert** — "make me a shopping expert for buying gifts", "set up a road-cycling gear agent", "I want an expert that shops for me" — do **not** jump to the engine. First run an **open, back-and-forth interview** that shapes the expert *with* the user, converging a spec tailored to *this* user. The agent-creation engine ([`agent_creation_engine.md`](agent_creation_engine.md)) only runs **after** the user explicitly endorses the assembled draft. This reference is the procedure; the engine is the machinery it feeds.
+
+This is a **conversation, not a form-fill.** The job is to converge five things *collaboratively*, eliciting BOTH the domain's decision-attributes AND this user's own tastes, style, budget, and constraints — and to **create nothing** until the user endorses the assembled draft.
+
+## Principles for the interview
+
+- **Act like a curious expert, not a wizard.** Ask open questions, reflect back what was heard, and let the user steer. Never fire a fixed battery of questions.
+- **Narrow a vague domain first.** If the domain is broad or ambiguous, narrow it to a concrete, searchable niche *with* the user before building anything else (see step 2 below) — every downstream section depends on a narrowed niche.
+- **Interleave domain and personal.** In every section, surface the objective decision-attributes of the domain AND ask where *this* user stands on them. A section that gathered only one side is incomplete.
+- **Converge, don't accumulate.** Reflect a short summary back and get a "yes / adjust" before advancing. The flow is **re-entrant** — the user can revise an earlier section at any point.
+- **Endorsement is a gate, not a formality.** Until the user explicitly says "create it", run **zero** engine steps (see Business rules below). The draft lives only in the conversation.
+
+## The five sections the interview converges
+
+These map onto exactly the two artefact slots the engine materializes — there is **no third slot**. The interview's whole job is to fill `persona` and `playbook` (plus the `agentId` + `name` derived from the domain).
+
+| # | Section | What it converges | Lands in |
+|---|---|---|---|
+| 1 | **Domain framing** | What this expert shops for, narrowed to a concrete, searchable niche. | `agentId` + `name` |
+| 2 | **Persona** | Who the expert *is*: its expertise, voice/tone, standing rules — reflecting this user. | `persona` |
+| 3 | **Elicitation style** | How this expert talks to its future user when shopping — how many questions before searching, how proactive, how much it explains. | inside `playbook` |
+| 4 | **Answer→`sil_search`-param mapping** | The domain's decision-attributes translated into concrete `sil_search` parameters this expert will set (see [`search_param_mapping.md`](search_param_mapping.md)). | inside `playbook` |
+| 5 | **Comparison / recommendation rubric** | How this expert ranks and picks among results, weighted by the user's *stated* priorities. | inside `playbook` |
+
+Sections 2–5 carry the **tailoring**: they must reflect what *this* user said, not a generic template. The persona goes in the spec's `persona` field; the elicitation style + the answer→param mapping + the rubric are authored as **prose** into the spec's single `playbook` string (the domain sub-skill — a SKILL.md-shaped markdown body, **not** JSON). There is no structured field for the mapping, the style, or the rubric — they live as readable markdown sections inside `playbook`.
+
+## Run the interview in this order
+
+1. **Open with the domain, not a form.** Reflect the request back ("a shopping expert for road-cycling gear — let's shape it together") and ask **one** orienting question. Signal this is a conversation that can be revised, not a questionnaire. Do not ask for an `agentId`, a budget, and a tone all at once.
+
+2. **Narrow a vague domain together FIRST — before any other section.** If the domain is broad or ambiguous ("an expert for gifts", "electronics"), do **not** proceed to persona, the mapping, or the rubric. Ask 1–2 narrowing questions (who is it for / what occasion / which slice of the category) and **reflect a concrete niche back for confirmation**. A too-broad niche makes the answer→param mapping and the rubric useless, so this narrow-first gate protects every downstream section. Only once the niche is concrete and confirmed do you move on.
+
+3. **Converge the persona (interview section 2 — see the table above).** Elicit the expert's expertise and voice, AND how the user wants it to behave (terse vs. chatty, cautious vs. opinionated, any standing rules). Reflect a short persona summary back; get a yes/adjust before advancing.
+
+4. **Converge the three playbook sections (interview sections 3–5: elicitation style, the mapping, the rubric), interleaving domain-attributes with the user's stance:**
+   - **Elicitation style:** how should the expert talk to its future user — how many questions before it searches, how proactive, how much it explains its picks? Reflect back, confirm.
+   - **Answer→`sil_search`-param mapping:** name the domain's decision-attributes ("for road bikes: frame material, groupset tier, wheel size, budget…"), ask the user's stance on each, and translate each stated input into a concrete `sil_search` param (see [`search_param_mapping.md`](search_param_mapping.md) for the param table, worked examples, and the `ship_to`-empty rule). Reflect the mapping back, confirm.
+   - **Recommendation rubric:** ask what the user weighs most ("durability over price", "prefer secondhand", "brand X is a hard no"), and tie the expert's ranking/selection to those *stated* priorities — not a fixed order. Reflect back, confirm.
+
+5. **Derive the identity, confirm it.** From the converged domain, propose an `agentId` (lower-kebab, matching `^[a-z0-9][a-z0-9-]*$`, never `main`) and a human-readable `name` ("Road-Cycling Buyer" / `road-cycling-buyer`). **Confirm both with the user** — never silently invent them.
+
+6. **Assemble the draft and present it back.** Compose the spec — `{ agentId, name, persona, playbook }` — and present it to the user as a **readable summary**: who the expert is, how it'll search (the mapping), and how it'll recommend (the rubric). Self-check the shape against the engine's `sil_profile_materialize` input contract: `agentId` lower-kebab and ≠ `main`, non-blank `name`, non-blank `persona`, and a non-blank `playbook` (the elicitation-style + mapping + rubric prose). This is a sanity pass; the engine's validate-first step is the authoritative gate — do not re-implement it here. This self-check is shape-only — it writes nothing, so `sil_profile_materialize` is NOT called here.
+
+7. **Get explicit endorsement — the gate.** Ask for an explicit go-ahead ("shall I create it?"). Endorsement is an **affirmative user act** on the assembled draft — "yes, create it" / "go ahead" / "looks good, make it". It is **NOT** inferred from the user answering the last question, and **NOT** from silence. **Only on that explicit endorsement** do you proceed to the engine ([`agent_creation_engine.md`](agent_creation_engine.md)) and run its steps.
+
+## Edge cases the interview handles gracefully
+
+- **Collision (an expert with that id already exists).** The engine refuses a name collision — it returns the `collision` outcome from its `openclaw agents list` check and never clobbers an existing agent. When the proposed `agentId` collides, surface it in the conversation and offer the user a **choice — rename this expert under a new id, or refine the existing expert's niche** — rather than dead-ending. Never silently mutate the id, and never overwrite an existing expert. (Refining the *existing* expert's artefacts in place is out of scope here; offer rename as the concrete action.)
+- **Abandon mid-flow.** The interview is multi-turn; the user may stop, change their mind, or walk away before endorsing. Because **no engine step runs before endorsement**, abandonment leaves **nothing created** — no host agent, no artefacts, no wiring. There is no partial expert to clean up and **no teardown needed**. Never "save progress" by writing artefacts early.
+- **Creation is local + offline — no identity coupling.** Creating an expert neither requires nor performs sil registration. Do **NOT** present sil registration or a token as a prerequisite to *create* the expert. The expert registers the user later, on first shop, via `sil_register`. Building the expert never depends on the user having an identity.
+
+## Business rules (invariants the interview holds on every path)
+
+1. **No creation without explicit endorsement.** Nothing is written — not the host agent, not the artefacts, not the wiring — until the user explicitly endorses the assembled draft. The strongest invariant of this procedure: **nothing is created until** the user says yes, and the draft lives only in the conversation until then.
+2. **Abandon-mid-flow creates nothing.** Because no engine step runs pre-endorsement, an abandoned interview leaves no partial expert — automatic, not a teardown. Never write artefacts early to "save progress"; the draft lives only in the conversation.
+3. **Elicit BOTH sides.** The interview must elicit the domain's decision-attributes AND the user's personal tastes/style/budget/constraints. A spec built from only domain attributes (generic) or only preferences (no searchable mapping) is incomplete.
+4. **Tailoring is real, not template.** The persona, the mapping, and the rubric must reflect the user's *stated* inputs — a stated budget becomes `price_min`/`price_max`; "prefer secondhand" becomes `condition`; "durability over price" becomes a rubric weight. A spec that ignores what the user said fails this procedure's purpose. The tailoring is **not a generic template**.
+5. **Converge each section before advancing; stay re-entrant.** Reflect-and-confirm per section; let the user revise any earlier section. Collaborative, not a locked wizard.
+6. **Narrow a vague domain first.** Never build persona/mapping/rubric on an un-narrowed niche — narrow with the user before proceeding.
+7. **Refine-or-rename on collision; never clobber.** On an existing-name collision, offer refine-or-rename; never overwrite an existing expert (defers to the engine's `collision` refusal). Never clobber.
+8. **Creation is local + offline — no identity coupling.** The interview never presents sil registration / a token as a prerequisite to create the expert.
+9. **Search behaviour the expert inherits is correct by construction.** The answer→param mapping encodes the location-aware default: leave `ship_to` empty (server resolves the registered default), never instruct the expert to call `sil_whoami` to populate it (see [`search_param_mapping.md`](search_param_mapping.md)).
+
+## After endorsement
+
+Once the user has **explicitly endorsed** the assembled draft, proceed to [`agent_creation_engine.md`](agent_creation_engine.md) and run the engine steps in order. Until that explicit endorsement, **zero engine steps** have run.

--- a/skill/references/catalog_tools_reference.md
+++ b/skill/references/catalog_tools_reference.md
@@ -1,0 +1,46 @@
+# sil catalog + identity tools — per-tool behaviour and the shared status taxonomy
+
+Load this reference when driving any of the four core tools — `sil_register`,
+`sil_whoami`, `sil_search`, `sil_product_get`. It holds how each tool behaves and
+the status taxonomy every shopping tool shares. The router in `SKILL.md` names
+which tool an intent maps to; this reference is what that tool actually does.
+
+All four return the canonical envelope: a single text content block whose JSON
+body carries a `status`. Prices are in the currency's ISO 4217 minor unit (e.g.
+cents).
+
+## How each tool behaves
+
+- **`sil_register`** starts browser-based registration. It returns promptly with
+  `status: "awaiting_browser"` and an `auth_url` — share that URL with the user.
+  The plugin polls in the background; once the user finishes signing in, call
+  `sil_register` again to confirm (it reports `already_registered`).
+- **`sil_whoami`** returns the registered user's identity (name and addresses).
+  An expired access token is refreshed transparently and the read retried; if the
+  session is fully dead, the result names the recovery (`sil_register`).
+- **`sil_search`** returns a ranked list of purchasable variants (`id`, `title`,
+  `price`, `availability`, `checkout_url`, `source`), best match first — present
+  them in order, do not re-rank. An empty list means nothing matched: a normal
+  `ok` outcome, not an error. Use the returned `cursor` for the next page; its
+  absence means no more results (never infer end-of-results from page size).
+- **`sil_product_get`** is the lookup companion to `sil_search`. Pass ids already
+  held and get the matching products back with fresh detail (description, options,
+  the featured variant). Each variant carries an `inputs` list correlating it back
+  to the id(s) asked about (the response is NOT in request order). Ids that no
+  longer resolve come back in a `not_found` list — a normal partial-success
+  outcome, not an error; the other products are still valid.
+
+## Status taxonomy (shared across the shopping tools)
+
+| `status` | Meaning | What to do |
+|---|---|---|
+| `ok` | Success. Catalog results may be empty (`products: []`) or partial (`not_found: [...]`) — still a success. | Relay the data. |
+| `not_registered` | No stored credentials. | Run `sil_register`, then retry the tool. |
+| `must_reregister` | The session is dead (refresh rejected / 401). | Run `sil_register` to sign in again, then retry. |
+| `forbidden` | Authenticated but not authorized (e.g. account not provisioned). | Follow the message; usually complete onboarding via `sil_register`. |
+| `invalid_request` | The query/ids were rejected (e.g. empty input). | Fix the input and call again — do NOT re-register. |
+| `retryable` | A transient network/5xx blip. | Try the same call again — do NOT re-register. |
+
+On a non-`ok` status, say what happened and follow the tool's own `recovery`
+hint — never improvise a different one (re-registering can't fix a bad query or a
+transient 5xx, and would derail the user).

--- a/skill/references/search_param_mapping.md
+++ b/skill/references/search_param_mapping.md
@@ -1,0 +1,35 @@
+# Answer→`sil_search`-param mapping (the mapping is real)
+
+Load this while converging interview section 4 (the answer→`sil_search`-param mapping) in [`brainstorm_interview.md`](brainstorm_interview.md). The mapping must target the **real `sil_search` parameters** (the shopping loop's catalog tool, named in `SKILL.md`) and nothing else — never invent a filter.
+
+## The parameters available to map onto
+
+| User's stated input | `sil_search` param it maps to |
+|---|---|
+| A budget ("under €1500", "€800–1200") | `price_min` / `price_max` — **in the currency's ISO 4217 minor unit** (cents): €1500 → `price_max: 150000` |
+| "Prefer secondhand" / "used is fine" | `condition: ["secondhand"]` |
+| "New only" | `condition: ["new"]` |
+| The narrowed niche + key descriptors | `query` (free text) and/or `category` |
+| "In stock only" (the default) / "show me out-of-stock too" | `available` (omit for in-stock default; `false` to include unavailable) |
+| "Buy from a local/domestic shop" | `local_merchants: true` (a best-effort ranking *bias*, not a hard filter — also issue the `query` in the user's language to actually surface local shops) |
+
+A stated taste with **no matching param** (e.g. "I like bold colours", "prefer eco-friendly brands") does **not** become a new param — fold it into the `query` text or into the recommendation rubric. There is no `color` filter, no `brand` filter; inventing one produces an expert that emits invalid `sil_search` calls at shop time.
+
+## `ship_to` stays EMPTY by default — inline rule (do not skip)
+
+Do **not** map the user's location onto `ship_to`, and do **not** instruct the expert to call `sil_whoami` to populate it. When `ship_to` is absent, sil-api resolves the user's **registered default address** server-side. Set `ship_to` (a `{ country, region?, postal_code? }` object of ISO codes) **only** to OVERRIDE the default with a *different* destination than the registered address (e.g. "ship this to my office in Germany"). The expert inherits correct location-aware search by construction — leave `ship_to` out, and never round-trip `sil_whoami` to fill it.
+
+## Worked param examples
+
+A converged mapping translates the user's stated inputs into concrete params the expert will set at shop time. For a road-cycling expert whose user said "budget around €1200, secondhand is fine, I'm in France and want local shops":
+
+```
+query:           "<niche descriptors from the answer>"   # e.g. "endurance road bike 105 groupset"
+category:        "<the narrowed niche category>"
+price_max:       120000        # €1200 → minor units (cents)
+condition:       ["secondhand"]   # "secondhand is fine"
+local_merchants: true             # "want local shops" → ranking bias; issue query in French
+# ship_to: OMITTED — server resolves the registered default address; no sil_whoami round-trip
+```
+
+The stated budget became `price_max` (in cents), "secondhand is fine" became `condition`, "want local shops" became `local_merchants: true` — and `ship_to` was deliberately left out so the server resolves the registered default. A non-param taste ("I like understated colours") would fold into `query` text or the rubric, never a new filter.

--- a/src/__tests__/skill-content.test.ts
+++ b/src/__tests__/skill-content.test.ts
@@ -455,3 +455,528 @@ describe("skill/SKILL.md — behaviour artefacts materialized into $SIL_DATA_DIR
     expect(namesDataDir && namesHostConfig).toBe(true);
   });
 });
+
+/* ===========================================================================
+ * BRAINSTORM / INTERVIEW PROCEDURE — the conversational spec-filling seam
+ * (card: brainstorm-driven-creation-of-a-tailored-expert)
+ *
+ * tier: integration. Same content-seam pattern as the engine block above:
+ * read the REAL skill/SKILL.md from disk, lowercase it, and pin the brainstorm
+ * PROCEDURE as a source of truth via OR-grouped intent-token substrings and
+ * ORDERING via indexOf comparison. The brainstorm is skill prose the host agent
+ * follows — there is NO new plugin tool, NO code path — so the skill body IS the
+ * spec, exactly as it is for the engine. These never fake a transcript: "a real
+ * agent runs a genuinely good interview" is `live-verification`'s job, NOT a
+ * test tier. We pin the procedure's load-bearing invariants:
+ *   - SC1: open, multi-turn, TWO-SIDED interview (domain attributes AND the
+ *     user's own tastes/style/budget/constraints), explicitly NOT a form-fill;
+ *     all FIVE converged sections named;
+ *   - narrow-first gate: a vague/over-broad domain is narrowed WITH the user
+ *     BEFORE persona/mapping/rubric (ordering anchor);
+ *   - per-section converge + re-entrant (reflect-back + confirm; collaborative);
+ *   - SC2 tailoring: persona + answer→param mapping + rubric reflect STATED
+ *     inputs; the mapping names REAL sil_search params; ship_to left EMPTY by
+ *     default (no sil_whoami round-trip);
+ *   - endorsement-before-creation: an endorse/confirm token PRECEDES the first
+ *     engine step (`openclaw agents add` / `sil_profile_materialize`) — ZERO
+ *     engine steps before explicit endorsement (ordering anchor);
+ *   - abandon-mid-flow creates nothing; collision → refine-or-rename never
+ *     clobber; the spec is a valid sil_profile_materialize input.
+ *
+ * Ordering anchors are deliberately keyed on tokens that the engine block above
+ * does NOT introduce (or on the engine's OWN tokens used as the downstream
+ * anchor), so a green ordering assertion proves a genuine brainstorm step
+ * precedes the engine, not an accidental match against pre-existing prose.
+ * ========================================================================= */
+
+describe("skill/SKILL.md — brainstorm conducts an open, two-sided interview (SC1)", () => {
+  it("names the brainstorm/interview as an open, multi-turn conversation (a distinct procedure)", () => {
+    // SC1: the new capability is a conversational interview that PRODUCES the
+    // spec the engine consumes. The body must name it as a brainstorm/interview
+    // and as multi-turn / back-and-forth / conversational — not a single shot.
+    const body = skillBodyLower();
+    const namesInterview =
+      body.includes("brainstorm") ||
+      body.includes("interview");
+    const namesMultiTurn =
+      body.includes("multi-turn") ||
+      body.includes("back-and-forth") ||
+      body.includes("back and forth") ||
+      body.includes("conversation") ||
+      body.includes("conversational");
+    expect(namesInterview).toBe(true);
+    expect(namesMultiTurn).toBe(true);
+  });
+
+  it("states the interview is NOT a fixed questionnaire / form-fill", () => {
+    // The product thesis (founder intent): an OPEN interview, NOT a form-fill.
+    // The body must explicitly disavow the fixed-questionnaire shape — a generic
+    // "ask some questions" is not enough; the prose must say it is NOT a form.
+    const body = skillBodyLower();
+    const disavowsForm =
+      body.includes("not a fixed questionnaire") ||
+      body.includes("not a questionnaire") ||
+      body.includes("not a form-fill") ||
+      body.includes("not a form fill") ||
+      body.includes("not a form") ||
+      body.includes("not a fixed form") ||
+      body.includes("not a wizard") ||
+      body.includes("not a locked wizard") ||
+      (body.includes("questionnaire") && body.includes("not"));
+    expect(disavowsForm).toBe(true);
+  });
+
+  it("elicits BOTH the domain's decision-attributes AND the user's personal tastes/constraints", () => {
+    // Business rule 3 (elicit BOTH sides): a spec from only domain attributes
+    // (generic) or only preferences (no searchable mapping) is incomplete. The
+    // body must name the two sides — the domain's decision-attributes AND the
+    // user's own tastes/style/budget/constraints.
+    const body = skillBodyLower();
+    const namesDomainAttributes =
+      body.includes("decision-attribute") ||
+      body.includes("decision attribute") ||
+      body.includes("decision-attributes") ||
+      body.includes("domain's attributes") ||
+      body.includes("attributes that matter") ||
+      (body.includes("attribute") && body.includes("domain"));
+    const namesPersonalTastes =
+      (body.includes("taste") || body.includes("preference") || body.includes("priorities")) &&
+      (body.includes("budget") || body.includes("constraint") || body.includes("style"));
+    expect(namesDomainAttributes).toBe(true);
+    expect(namesPersonalTastes).toBe(true);
+  });
+
+  it("names ALL FIVE sections the interview converges", () => {
+    // The five-section spine is the concrete agenda: domain framing, persona,
+    // elicitation style, answer→sil_search-param mapping, comparison/
+    // recommendation rubric. The body must name each, so the interview has a
+    // real agenda and every converged section survives into the spec.
+    const body = skillBodyLower();
+    const namesDomainFraming =
+      body.includes("domain framing") ||
+      body.includes("domain frame") ||
+      (body.includes("domain") && body.includes("niche"));
+    const namesPersona = body.includes("persona");
+    const namesElicitationStyle =
+      body.includes("elicitation style") ||
+      (body.includes("elicitation") && body.includes("style")) ||
+      (body.includes("how this expert") && body.includes("talk"));
+    const namesMapping =
+      body.includes("mapping") &&
+      (body.includes("sil_search") || body.includes("param"));
+    const namesRubric =
+      body.includes("rubric") ||
+      (body.includes("comparison") && body.includes("recommendation"));
+    const missing: string[] = [];
+    if (!namesDomainFraming) missing.push("domain framing");
+    if (!namesPersona) missing.push("persona");
+    if (!namesElicitationStyle) missing.push("elicitation style");
+    if (!namesMapping) missing.push("answer→sil_search-param mapping");
+    if (!namesRubric) missing.push("comparison/recommendation rubric");
+    expect(missing).toEqual([]);
+  });
+});
+
+describe("skill/SKILL.md — vague domain is narrowed WITH the user FIRST (narrow-first gate)", () => {
+  it("names the narrow-a-vague-domain-first gate", () => {
+    // Business rule 6: never build persona/mapping/rubric on an un-narrowed
+    // niche. The body must name the gate — a vague/over-broad/ambiguous domain
+    // is narrowed (with narrowing questions, reflecting a concrete niche back)
+    // before the other sections.
+    const body = skillBodyLower();
+    const namesVague =
+      body.includes("vague") ||
+      body.includes("over-broad") ||
+      body.includes("overbroad") ||
+      body.includes("too broad") ||
+      body.includes("too-broad") ||
+      body.includes("ambiguous") ||
+      body.includes("broad or ambiguous");
+    const namesNarrow =
+      body.includes("narrow") ||
+      body.includes("narrowing");
+    expect(namesVague).toBe(true);
+    expect(namesNarrow).toBe(true);
+  });
+
+  it("orders the narrow-domain STEP before the persona/playbook CONVERGENCE steps", () => {
+    // Ordering anchor (mirrors the engine's validate-first / list-before-add):
+    // the executable narrow-domain step must come BEFORE the executable steps
+    // that converge persona / the mapping / the rubric, so an agent following
+    // top-to-bottom narrows first and never builds those sections on an
+    // un-narrowed niche.
+    //
+    // Adversarial precision — anchor on the EXECUTABLE STEP verb, NOT the raw
+    // first occurrence of `persona`/`rubric`. The procedure legitimately opens
+    // with a five-section AGENDA table that NAMES persona (section 2) and the
+    // rubric (section 5) up front, so `indexOf("persona")` / `indexOf("rubric")`
+    // land in that overview, ABOVE the narrow step — a raw-token anchor would
+    // FALSELY fail even on correctly-ordered prose (or, worse, FALSELY pass a
+    // mis-ordered one). What the invariant actually requires is that the agent
+    // narrows before it CONVERGES the downstream sections. So the anchor is the
+    // narrow-the-domain step token, required to precede the FIRST downstream
+    // CONVERGENCE step. The narrow step must explicitly mark itself as the
+    // first/before-other-sections gate (a bare "narrow" mention in the agenda
+    // table is not enough).
+    const body = skillBodyLower();
+    // The narrow-domain gate step: "narrow a vague domain … first / before any
+    // other section" — the executable step, not the agenda cell.
+    const narrowStepIdx = (() => {
+      for (const anchor of [
+        "narrow a vague domain",
+        "narrow the domain together",
+        "narrow a vague or",
+        "narrow the niche first",
+      ]) {
+        const i = body.indexOf(anchor);
+        if (i >= 0) return i;
+      }
+      return -1;
+    })();
+    // The first DOWNSTREAM convergence step: converging the persona, or the
+    // playbook sections (the mapping + rubric live there). Anchor on the
+    // converge verb so the agenda table's section NAMES don't match.
+    const convergeDownstreamIdx = (() => {
+      const candidates = [
+        "converge the persona",
+        "converge persona",
+        "converge the three playbook",
+        "converge the playbook",
+      ]
+        .map((a) => body.indexOf(a))
+        .filter((i) => i >= 0);
+      return candidates.length ? Math.min(...candidates) : -1;
+    })();
+    expect(narrowStepIdx).toBeGreaterThanOrEqual(0);
+    expect(convergeDownstreamIdx).toBeGreaterThanOrEqual(0);
+    // The narrow-domain step precedes the first downstream convergence step —
+    // an agent reaching persona/mapping/rubric convergence has already narrowed.
+    expect(narrowStepIdx).toBeLessThan(convergeDownstreamIdx);
+  });
+});
+
+describe("skill/SKILL.md — per-section converge + re-entrant (collaborative, not a locked wizard)", () => {
+  it("states each section is converged with the user (reflect-back + confirm) before advancing", () => {
+    // Business rule 5: reflect-and-confirm per section. The body must name the
+    // reflect-back-then-confirm loop — ask, reflect a short summary of what it
+    // heard, get a yes/adjust before moving on.
+    const body = skillBodyLower();
+    const reflectsBack =
+      body.includes("reflect back") ||
+      body.includes("reflect-back") ||
+      body.includes("reflects back") ||
+      body.includes("reflect a") ||
+      body.includes("summary of what") ||
+      body.includes("reflect");
+    const confirms =
+      body.includes("confirm") ||
+      body.includes("yes / adjust") ||
+      body.includes("yes/adjust") ||
+      body.includes("before moving on") ||
+      body.includes("before advancing");
+    expect(reflectsBack).toBe(true);
+    expect(confirms).toBe(true);
+  });
+
+  it("states the flow is collaborative / re-entrant — the user can revise an earlier section", () => {
+    // Business rule 5: the flow is re-entrant, not linear-locked. The body must
+    // say the user can revise/return to an earlier section — collaborative, not
+    // a locked wizard.
+    const body = skillBodyLower();
+    const isReentrant =
+      body.includes("re-entrant") ||
+      body.includes("reentrant") ||
+      body.includes("revise an earlier") ||
+      body.includes("revise earlier") ||
+      body.includes("revisit") ||
+      body.includes("return to an earlier") ||
+      body.includes("go back") ||
+      (body.includes("revise") && body.includes("earlier"));
+    const isCollaborative =
+      body.includes("collaborative") ||
+      body.includes("not a locked wizard") ||
+      body.includes("not linear-locked") ||
+      body.includes("not a wizard");
+    expect(isReentrant).toBe(true);
+    expect(isCollaborative).toBe(true);
+  });
+});
+
+describe("skill/SKILL.md — SC2 tailoring: the spec reflects THIS user's stated inputs", () => {
+  it("states the persona, mapping, and rubric must reflect the user's STATED inputs (tailored, not template)", () => {
+    // Business rule 4 (SC2): the persona, answer→param mapping, and rubric must
+    // reflect what THIS user said — not a generic template. The body must say
+    // the tailoring is real (reflects the user's stated tastes/priorities), not
+    // a fixed template.
+    const body = skillBodyLower();
+    const namesStated =
+      body.includes("stated") ||
+      body.includes("what this user said") ||
+      body.includes("what the user said") ||
+      body.includes("the user's stated");
+    const namesTailored =
+      body.includes("tailored") ||
+      body.includes("tailor") ||
+      body.includes("not a generic template") ||
+      body.includes("not a template") ||
+      body.includes("not generic");
+    expect(namesStated).toBe(true);
+    expect(namesTailored).toBe(true);
+  });
+
+  it("maps concrete stated inputs to REAL sil_search params (budget→price_min/price_max, prefer secondhand→condition, niche→query/category)", () => {
+    // SC2 core: the answer→param mapping must target the REAL sil_search params
+    // (catalog.ts), not invented filters. The body must name the concrete
+    // params a stated input maps onto: a budget → price_min/price_max; "prefer
+    // secondhand"/"new only" → condition; the niche → query and/or category.
+    const body = skillBodyLower();
+    expect(body).toContain("price_min");
+    expect(body).toContain("price_max");
+    expect(body).toContain("condition");
+    expect(body).toContain("query");
+    expect(body).toContain("category");
+    // The mapping must tie a stated budget to the price params, not merely list
+    // them — a budget token near the price params proves the worked example.
+    expect(body).toContain("budget");
+    // "secondhand" is the concrete condition value a "prefer secondhand" taste
+    // maps onto — naming it proves the mapping is a real worked example.
+    expect(body).toContain("secondhand");
+  });
+
+  it("leaves ship_to EMPTY by default and never round-trips sil_whoami to populate it", () => {
+    // Business rule 9 / location-aware-search-flow: the inherited search
+    // behaviour must leave ship_to empty (server resolves the registered
+    // default) and must NOT instruct the expert to call sil_whoami to populate
+    // it. The body must name ship_to, state it is left empty by default, and
+    // disavow the sil_whoami round-trip.
+    const body = skillBodyLower();
+    expect(body).toContain("ship_to");
+    const leavesEmpty =
+      body.includes("ship_to empty") ||
+      body.includes("ship_to left empty") ||
+      body.includes("leave ship_to empty") ||
+      body.includes("leaves ship_to empty") ||
+      (body.includes("ship_to") && body.includes("empty"));
+    expect(leavesEmpty).toBe(true);
+    // The no-whoami-roundtrip rule: the mapping must NOT round-trip sil_whoami
+    // to populate ship_to. The prose must disavow it — "never call sil_whoami",
+    // "do not round-trip sil_whoami", "without sil_whoami".
+    const disavowsWhoamiRoundtrip =
+      /(never|not|no|without|don't|do not)[^.]*sil_whoami/.test(body) ||
+      /sil_whoami[^.]*(never|not)/.test(body);
+    expect(disavowsWhoamiRoundtrip).toBe(true);
+  });
+
+  it("ties the recommendation rubric to the user's stated priorities (weighted, not a fixed order)", () => {
+    // Business rule 4 / SC2: the rubric ranks/picks by the user's stated
+    // priorities (e.g. "durability over price", a hard-no brand) — weighted by
+    // what the user said, not a fixed order. The body must name the rubric AND
+    // tie it to stated priorities, with a concrete worked example.
+    const body = skillBodyLower();
+    const namesRubric =
+      body.includes("rubric") ||
+      (body.includes("rank") && body.includes("recommend"));
+    const tiesToPriorities =
+      body.includes("priorities") ||
+      body.includes("priority") ||
+      body.includes("weighted") ||
+      body.includes("weight") ||
+      body.includes("durability over price") ||
+      body.includes("hard no") ||
+      body.includes("hard-no");
+    expect(namesRubric).toBe(true);
+    expect(tiesToPriorities).toBe(true);
+  });
+
+  it("frames the converged output as a valid sil_profile_materialize input (agentId lower-kebab ≠ main, non-blank name/persona, optional playbook)", () => {
+    // SC2 / the spec-contract bridge: the converged spec must be a VALID input
+    // to sil_profile_materialize — { agentId (lower-kebab, ≠ main), name
+    // (non-blank), persona (non-blank), playbook? (non-blank if present) }. The
+    // body must frame the brainstorm output as that spec, and name agentId's
+    // lower-kebab + not-main constraint so a derived id is a valid one.
+    const body = skillBodyLower();
+    expect(body).toContain("sil_profile_materialize");
+    expect(body).toContain("agentid");
+    const namesLowerKebab =
+      body.includes("lower-kebab") ||
+      body.includes("lower kebab") ||
+      body.includes("kebab");
+    const namesNotMain = body.includes("main");
+    expect(namesLowerKebab).toBe(true);
+    expect(namesNotMain).toBe(true);
+  });
+});
+
+describe("skill/SKILL.md — endorsement before creation: ZERO engine steps before an explicit go-ahead", () => {
+  it("names an explicit endorsement / go-ahead on the assembled draft", () => {
+    // Business rule 1 (the strongest invariant): nothing is created until the
+    // user explicitly endorses the assembled draft. The body must name an
+    // explicit endorsement / go-ahead — and that it is an affirmative user act,
+    // not inferred from answering the last question or from silence.
+    const body = skillBodyLower();
+    const namesEndorsement =
+      body.includes("endorse") ||
+      body.includes("endorsement") ||
+      body.includes("go-ahead") ||
+      body.includes("go ahead") ||
+      (body.includes("explicit") && (body.includes("approve") || body.includes("confirm")));
+    const namesDraft =
+      body.includes("draft") ||
+      body.includes("assembled spec") ||
+      body.includes("assembled draft");
+    expect(namesEndorsement).toBe(true);
+    expect(namesDraft).toBe(true);
+  });
+
+  it("orders the endorsement BEFORE the first engine step (`openclaw agents add`)", () => {
+    // The card's strongest ordering invariant: an endorse/confirm anchor must
+    // precede the first `openclaw agents add` token. Because the engine's
+    // creation command lives DOWNSTREAM of the brainstorm, an endorsement step
+    // textually ahead of `openclaw agents add` proves the agent cannot reach
+    // creation before the user's explicit go-ahead. Anchor on the `endorse`
+    // verb — it is NEW prose this card introduces; the engine block above never
+    // uses it, so a green here is a genuine endorsement-gate, not a stale match.
+    const body = skillBodyLower();
+    const endorseIdx = body.indexOf("endorse");
+    const addIdx = body.indexOf("openclaw agents add");
+    expect(endorseIdx).toBeGreaterThanOrEqual(0);
+    expect(addIdx).toBeGreaterThanOrEqual(0);
+    expect(endorseIdx).toBeLessThan(addIdx);
+  });
+
+  it("orders the endorsement BEFORE `sil_profile_materialize` (no artefacts written pre-endorsement)", () => {
+    // The same gate against the OTHER write surface: the behaviour artefacts
+    // are materialized by `sil_profile_materialize` only after endorsement. The
+    // endorse anchor must precede the FIRST `sil_profile_materialize` token, so
+    // no artefacts are written before the user's go-ahead.
+    const body = skillBodyLower();
+    const endorseIdx = body.indexOf("endorse");
+    const materializeIdx = body.indexOf("sil_profile_materialize");
+    expect(endorseIdx).toBeGreaterThanOrEqual(0);
+    expect(materializeIdx).toBeGreaterThanOrEqual(0);
+    expect(endorseIdx).toBeLessThan(materializeIdx);
+  });
+
+  it("states ZERO engine steps run before endorsement (nothing created until the user says yes)", () => {
+    // Business rule 1 + 2, in prose: before endorsement the flow has called
+    // ZERO engine steps. The body must say nothing is created / written until
+    // the user endorses — the draft lives only in conversation until then.
+    const body = skillBodyLower();
+    const saysNothingUntilEndorsed =
+      body.includes("nothing is created until") ||
+      body.includes("nothing created until") ||
+      body.includes("creates nothing until") ||
+      body.includes("create nothing until") ||
+      body.includes("nothing is written until") ||
+      body.includes("zero engine steps") ||
+      body.includes("no engine step") ||
+      (body.includes("only on") && body.includes("endorse")) ||
+      (body.includes("only") && body.includes("endorse") && body.includes("engine"));
+    expect(saysNothingUntilEndorsed).toBe(true);
+  });
+});
+
+describe("skill/SKILL.md — abandon mid-flow creates nothing", () => {
+  it("states abandoning mid-flow leaves a clean state with nothing written (no partial expert)", () => {
+    // Business rule 2: if the user stops/changes their mind before endorsing,
+    // the flow has created nothing — no partial expert to clean up, because no
+    // engine step ran pre-endorsement. The body must name the abandon path and
+    // that it leaves nothing partial (no teardown needed).
+    const body = skillBodyLower();
+    const namesAbandon =
+      body.includes("abandon") ||
+      body.includes("stops") ||
+      body.includes("changes their mind") ||
+      body.includes("walks away") ||
+      body.includes("walk away") ||
+      body.includes("change their mind") ||
+      body.includes("mid-flow");
+    const namesNothingCreated =
+      body.includes("nothing is created") ||
+      body.includes("nothing created") ||
+      body.includes("created nothing") ||
+      body.includes("creates nothing") ||
+      body.includes("nothing was written") ||
+      body.includes("no partial") ||
+      body.includes("nothing partial") ||
+      body.includes("clean state");
+    expect(namesAbandon).toBe(true);
+    expect(namesNothingCreated).toBe(true);
+  });
+
+  it("states the flow never saves progress by writing artefacts early", () => {
+    // Business rule 2 corollary: the flow must never "save progress" by writing
+    // artefacts before endorsement — the draft lives in conversation only. The
+    // body must disavow early/partial writes, so abandonment is automatically
+    // clean.
+    const body = skillBodyLower();
+    const disavowsEarlyWrite =
+      body.includes("never save progress") ||
+      body.includes("not save progress") ||
+      body.includes("does not save progress") ||
+      body.includes("draft lives only in the conversation") ||
+      body.includes("draft lives in conversation") ||
+      body.includes("only in the conversation") ||
+      body.includes("only in conversation") ||
+      body.includes("no writes before") ||
+      body.includes("write nothing before") ||
+      body.includes("writes nothing before");
+    expect(disavowsEarlyWrite).toBe(true);
+  });
+});
+
+describe("skill/SKILL.md — collision is handled in the conversation: refine-or-rename, never clobber", () => {
+  it("offers refine-or-rename on a colliding agentId (a path forward, not a dead-end)", () => {
+    // Business rule 7 / the card's collision edge: when the proposed agentId
+    // collides with an existing expert, the flow offers a CHOICE — refine the
+    // niche under a new id, or rename this one — rather than dead-ending. The
+    // body must name both the rename option AND the refine-the-niche
+    // alternative, so the user is never stuck.
+    const body = skillBodyLower();
+    const offersRename =
+      body.includes("rename") ||
+      body.includes("different id") ||
+      body.includes("new id") ||
+      body.includes("pick a different");
+    const offersRefine =
+      body.includes("refine") ||
+      body.includes("refine the niche") ||
+      body.includes("refine the existing");
+    expect(offersRename).toBe(true);
+    expect(offersRefine).toBe(true);
+  });
+
+  it("never clobbers an existing expert on collision (defers to the engine's collision refusal)", () => {
+    // Business rule 7: the flow never overwrites an existing expert — it
+    // surfaces the `collision` outcome and offers refine-or-rename. The body
+    // must disavow clobbering on collision, consistent with the engine's
+    // non-destructive collision refusal.
+    const body = skillBodyLower();
+    expect(body).toContain("collision");
+    const neverClobbers =
+      body.includes("never overwrite") ||
+      body.includes("never clobber") ||
+      body.includes("not overwrite") ||
+      body.includes("do not overwrite") ||
+      body.includes("do not clobber") ||
+      body.includes("non-destructive");
+    expect(neverClobbers).toBe(true);
+  });
+});
+
+describe("skill/SKILL.md — creation is local + offline: no identity coupling in the interview", () => {
+  it("does NOT present sil registration / a token as a prerequisite to CREATE the expert", () => {
+    // Business rule 8: the interview never presents sil registration / a token
+    // as a prerequisite to CREATE the expert (the expert registers the user
+    // later, on first shop). The brainstorm must not ask the user to register
+    // before creating. Same adversarial shape as the engine's AC5 identity-
+    // coupling guard: assert the brainstorm does not gate CREATION on register.
+    const body = skillBodyLower();
+    const couplesIdentity =
+      /register[^.]*before[^.]*creat/.test(body) ||
+      /creat[^.]*requires[^.]*register/.test(body) ||
+      /must.*register.*to.*creat/.test(body) ||
+      /register[^.]*prerequisite[^.]*creat/.test(body);
+    expect(couplesIdentity).toBe(false);
+  });
+});

--- a/src/__tests__/skill-content.test.ts
+++ b/src/__tests__/skill-content.test.ts
@@ -1,16 +1,27 @@
 /**
- * INTEGRATION — skill discoverability (tier: integration — reads the
- * real skill/SKILL.md from disk and compares its body against the set
- * of registered tool names; two artifacts interacting, the
- * skill-doc ↔ registration seam).
+ * INTEGRATION — skill discoverability + the progressive-disclosure split
+ * (tier: integration — reads the real skill/ files from disk and compares
+ * their bodies against the set of registered tool names and the pinned
+ * procedure invariants; multiple artifacts interacting, the skill-doc ↔
+ * registration seam and the SKILL.md-router ↔ reference-files seam).
  *
  * Named `skill-content.test.ts` to mirror the reference adapter's file
- * of the same name. Covers the card's "Skill is discoverable" criteria:
- *   - skill/SKILL.md exists, its YAML frontmatter PARSES, and exposes a
- *     non-empty `name` and `description`;
- *   - the skill body names EVERY real tool the plugin registers
- *     (`sil_register`, `sil_whoami`, `sil_search`, `sil_product_get`), so
- *     the agent's session-start tool check has a source of truth.
+ * of the same name. The skill is authored as a progressive-disclosure
+ * bundle (skill-creator convention): a MAXIMALLY-LEAN `skill/SKILL.md` pure
+ * router plus detailed procedures under `skill/references/` and a worked example
+ * under `skill/examples/`. So content this file pins lives in the file that now
+ * OWNS it:
+ *   - the router (intent→tool→reference) lives in `skill/SKILL.md` — it NAMES
+ *     every registered tool and routes, but holds NO per-tool detail;
+ *   - the four core tools' per-tool behaviour + the shared status taxonomy live
+ *     in `skill/references/catalog_tools_reference.md`;
+ *   - the brainstorm interview procedure lives in
+ *     `skill/references/brainstorm_interview.md`;
+ *   - the agent-creation engine lives in
+ *     `skill/references/agent_creation_engine.md`;
+ *   - the answer→sil_search-param mapping lives in
+ *     `skill/references/search_param_mapping.md`;
+ *   - the worked end-to-end example lives in `skill/examples/`.
  *
  * Frontmatter is parsed with a small self-contained extractor (no
  * gray-matter dependency assumed — the skeleton's dep set is minimal)
@@ -20,8 +31,14 @@
  *
  * Contract this file pins for the implementation (expert-developer):
  *   skill/SKILL.md has a valid `--- ... ---` YAML frontmatter block at
- *   the top with non-empty `name:` and `description:` scalars, and a
- *   body that mentions each registered sil_* tool by name.
+ *   the top with non-empty `name:` and `description:` scalars, a body
+ *   that mentions each registered sil_* tool by name and routes to the
+ *   reference/example files (every `references/…` / `examples/…` path it
+ *   names exists on disk); the references hold the procedure detail —
+ *   including the four core tools' per-tool behaviour + the shared status
+ *   taxonomy in `references/catalog_tools_reference.md` (NOT inline in the
+ *   router); and the runtime skill carries NO contributor-facing
+ *   "adding a tool" prose.
  */
 
 import { describe, it, expect } from "vitest";
@@ -37,7 +54,24 @@ import {
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(HERE, "..", "..");
-const SKILL_PATH = join(REPO_ROOT, "skill", "SKILL.md");
+const SKILL_DIR = join(REPO_ROOT, "skill");
+const SKILL_PATH = join(SKILL_DIR, "SKILL.md");
+
+// The progressive-disclosure reference + example files that now own the
+// detailed procedures the router points at.
+const CATALOG_TOOLS_PATH = join(
+  SKILL_DIR,
+  "references",
+  "catalog_tools_reference.md",
+);
+const BRAINSTORM_PATH = join(SKILL_DIR, "references", "brainstorm_interview.md");
+const ENGINE_PATH = join(SKILL_DIR, "references", "agent_creation_engine.md");
+const MAPPING_PATH = join(SKILL_DIR, "references", "search_param_mapping.md");
+const EXAMPLE_PATH = join(
+  SKILL_DIR,
+  "examples",
+  "road_cycling_expert_walkthrough.md",
+);
 
 interface Frontmatter {
   raw: string;
@@ -80,6 +114,13 @@ function skillBody(content: string): string {
   const closeMatch = content.slice(3).match(/\n---[ \t]*\r?\n/);
   if (!closeMatch || closeMatch.index === undefined) return content;
   return content.slice(3 + closeMatch.index + closeMatch[0].length);
+}
+
+/** Read a skill file and return its body below the frontmatter (reference/
+ * example files may have none — then the whole content is the body). */
+function readBody(path: string): string {
+  const content = readFileSync(path, "utf8");
+  return content.startsWith("---") ? skillBody(content) : content;
 }
 
 /** The set of names the real register code emits against a mock api. Must
@@ -135,14 +176,199 @@ describe("skill/SKILL.md — body is a source of truth for the tool surface", ()
 });
 
 /* ===========================================================================
+ * CATALOG + IDENTITY TOOLS REFERENCE — the per-tool behaviour + the shared
+ * status taxonomy now live in references/catalog_tools_reference.md (founder
+ * decision: SKILL.md is a MAXIMALLY-LEAN pure router). These read the REAL
+ * reference from disk and pin the detail the router DELEGATES to it — the
+ * four core tools' behaviour and the status vocabulary every shopping tool
+ * shares. Same content-seam pattern as the engine/brainstorm blocks below.
+ * ========================================================================= */
+
+/** Lower-cased catalog-tools reference body — the file that OWNS the four
+ * core tools' per-tool behaviour + the shared status taxonomy after the
+ * maximally-lean-router split. */
+function catalogToolsBodyLower(): string {
+  return readBody(CATALOG_TOOLS_PATH).toLowerCase();
+}
+
+describe("references/catalog_tools_reference.md — per-tool behaviour + shared status taxonomy (delegated from the router)", () => {
+  it("exists on disk", () => {
+    expect(existsSync(CATALOG_TOOLS_PATH)).toBe(true);
+  });
+
+  it("documents the per-tool behaviour of all four core tools", () => {
+    // The detail the router moved OUT of SKILL.md: how each of the four core
+    // tools behaves. The reference must name each tool AND carry a behaviour
+    // detail unique to it (so it is the real per-tool detail, not a bare list).
+    const body = catalogToolsBodyLower();
+    for (const tool of [
+      "sil_register",
+      "sil_whoami",
+      "sil_search",
+      "sil_product_get",
+    ]) {
+      expect(body).toContain(tool);
+    }
+    // Behaviour tokens that only the per-tool detail carries — the register
+    // browser handshake, whoami's transparent refresh, search's ranking +
+    // pagination cursor, product_get's partial not_found.
+    expect(body).toContain("awaiting_browser");
+    expect(body).toContain("cursor");
+    expect(body).toContain("not_found");
+    expect(body).toContain("checkout_url");
+  });
+
+  it("holds the shared status taxonomy (all six statuses, with the recovery rule)", () => {
+    // The shared status taxonomy moved here from the router. The reference must
+    // name every status in the vocabulary the catalog/identity tools share, so
+    // an agent loading it knows how to route each outcome.
+    const body = catalogToolsBodyLower();
+    const STATUSES = [
+      "ok",
+      "not_registered",
+      "must_reregister",
+      "forbidden",
+      "invalid_request",
+      "retryable",
+    ];
+    const missing = STATUSES.filter((s) => !body.includes(s));
+    expect(missing).toEqual([]);
+    // The recovery rule travels with the taxonomy: follow the tool's own
+    // recovery hint, never improvise (re-registering can't fix a bad query).
+    expect(body).toContain("recovery");
+  });
+
+  it("does NOT carry the agent-creation procedure (it is a SHOPPING-tools reference, not the engine)", () => {
+    // Keep the seam clean: the catalog/identity reference owns the four core
+    // tools, NOT the agent-creation engine. The engine's load-bearing host CLI
+    // must not have leaked into this reference.
+    const body = catalogToolsBodyLower();
+    expect(body).not.toContain("openclaw agents add");
+    expect(body).not.toContain("sil_profile_materialize");
+  });
+});
+
+/* ===========================================================================
+ * PROGRESSIVE-DISCLOSURE ROUTER — SKILL.md is a LEAN router, the detail lives
+ * in references/ + examples/ (skill-creator convention).
+ *
+ * tier: integration. These read the REAL skill/SKILL.md + reference/example
+ * files from disk and pin the SPLIT: the router routes (names the references
+ * by relative path, with the endorsement-before-engine gate explicit), the
+ * references exist on disk, and no detailed procedure leaked back into the
+ * router. Mirrors skill-creator's "referenced-files-must-exist" validation.
+ * ========================================================================= */
+
+describe("skill/SKILL.md — lean router that routes to references + examples", () => {
+  it("routes to the brainstorm interview, the engine, the param mapping, and the worked example by relative path", () => {
+    const body = skillBody(readFileSync(SKILL_PATH, "utf8"));
+    expect(body).toContain("references/brainstorm_interview.md");
+    expect(body).toContain("references/agent_creation_engine.md");
+    expect(body).toContain("references/search_param_mapping.md");
+    expect(body).toContain("examples/road_cycling_expert_walkthrough.md");
+  });
+
+  it("makes the endorsement-before-engine gate unmistakable in the routing block", () => {
+    // The single strongest invariant of the split: the router must make clear
+    // the engine reference is read/run ONLY after the user's explicit
+    // endorsement of the assembled draft. So an agent that reads the router
+    // alone (before loading any reference) already knows the gate exists.
+    const body = skillBody(readFileSync(SKILL_PATH, "utf8")).toLowerCase();
+    // The endorsement token and the engine reference must both appear, and
+    // the endorsement gate must be stated ahead of running the engine.
+    const endorseIdx = body.indexOf("endorse");
+    const engineRefIdx = body.indexOf("agent_creation_engine.md");
+    expect(endorseIdx).toBeGreaterThanOrEqual(0);
+    expect(engineRefIdx).toBeGreaterThanOrEqual(0);
+    // "only after … endorse … agent_creation_engine.md": the gate language
+    // precedes the engine-reference pointer in the routing block.
+    expect(endorseIdx).toBeLessThan(engineRefIdx);
+    // And the router names the interview reference FIRST (read it before the
+    // engine), so the order an agent loads them in is interview → engine.
+    const interviewRefIdx = body.indexOf("brainstorm_interview.md");
+    expect(interviewRefIdx).toBeGreaterThanOrEqual(0);
+    expect(interviewRefIdx).toBeLessThan(engineRefIdx);
+  });
+
+  it("keeps the router LEAN — the detailed procedures do NOT live in SKILL.md", () => {
+    // skill-creator: info lives in ONE place. The router must not duplicate
+    // the engine's ordered host-CLI steps. `openclaw agents add` is the
+    // engine's load-bearing command; it belongs in the engine reference, not
+    // the router. (The router may NAME the reference, not inline its steps.)
+    const body = skillBody(readFileSync(SKILL_PATH, "utf8")).toLowerCase();
+    expect(body).not.toContain("openclaw agents add");
+    expect(body).not.toContain("openclaw config validate");
+    expect(body).not.toContain("sil_profile_materialize");
+  });
+
+  it("does NOT inline the per-tool behaviour or the status taxonomy (they live in catalog_tools_reference.md, no duplication)", () => {
+    // Founder decision: SKILL.md is a MAXIMALLY-LEAN pure router. The four core
+    // tools' per-tool behaviour and the shared status taxonomy moved OUT into
+    // references/catalog_tools_reference.md. skill-creator's no-duplication rule
+    // means the router must NOT re-carry that detail. Anchor on tokens that
+    // belong ONLY to the moved detail — the register browser-handshake status
+    // and the catalog-tool status vocabulary. The router may NAME the tools
+    // (it routes to them) but must not inline how they behave or their statuses.
+    const body = skillBody(readFileSync(SKILL_PATH, "utf8")).toLowerCase();
+    expect(body).not.toContain("awaiting_browser");
+    expect(body).not.toContain("not_registered");
+    expect(body).not.toContain("must_reregister");
+    expect(body).not.toContain("retryable");
+    // The router DOES route to the catalog/identity reference that owns them.
+    expect(body).toContain("references/catalog_tools_reference.md");
+  });
+
+  it("every references/… and examples/… path SKILL.md mentions EXISTS on disk", () => {
+    // Mirrors skill-creator's referenced-files-must-exist validation: a
+    // router that points at a missing reference is a broken skill.
+    const body = skillBody(readFileSync(SKILL_PATH, "utf8"));
+    const referenced = [
+      ...body.matchAll(/(references|examples)\/[A-Za-z0-9_./-]+\.md/g),
+    ].map((m) => m[0]);
+    expect(referenced.length).toBeGreaterThan(0); // sanity: it routes somewhere
+    const missing = referenced.filter(
+      (rel) => !existsSync(join(SKILL_DIR, rel)),
+    );
+    expect(missing).toEqual([]);
+  });
+});
+
+describe("skill — the contributor-facing 'adding a tool' prose is GONE from the runtime skill", () => {
+  it("no skill file carries the repo-CLAUDE.md 'how to add a tool' contributor content", () => {
+    // The monolithic SKILL.md carried a §6 "Adding a real tool" section — pure
+    // contributor guidance that already lives in the repo CLAUDE.md. It has no
+    // place in a RUNTIME shopping skill. Assert it is gone from SKILL.md AND
+    // every reference/example (it must not have been relocated, only deleted).
+    const corpus = [
+      readBody(SKILL_PATH),
+      readBody(CATALOG_TOOLS_PATH),
+      readBody(BRAINSTORM_PATH),
+      readBody(ENGINE_PATH),
+      readBody(MAPPING_PATH),
+      readBody(EXAMPLE_PATH),
+    ]
+      .join("\n")
+      .toLowerCase();
+    // The contributor section's distinctive tokens — the registration plumbing
+    // an agent USING the skill never needs.
+    expect(corpus).not.toContain("registerxtools");
+    expect(corpus).not.toContain("contracts.tools");
+    expect(corpus).not.toContain("adding a real tool");
+    expect(corpus).not.toContain("adding a tool");
+  });
+});
+
+/* ===========================================================================
  * AGENT-CREATION ENGINE — the procedure-as-source-of-truth seam
  * (card: create-a-valid-sil-wired-openclaw-agent-profile)
  *
- * tier: integration. These read the REAL skill/SKILL.md from disk and pin
- * the agent-creation procedure as a source of truth — the engine is the
- * skill prose driving the host CLI (no plugin-tool code per the architect's
- * verdict), so the skill body IS the spec the host agent follows. Pinning it
- * is exactly how `skill-content.test.ts` already pins the tool surface.
+ * tier: integration. These now read the REAL
+ * skill/references/agent_creation_engine.md from disk (the file that OWNS the
+ * engine after the progressive-disclosure split) and pin the agent-creation
+ * procedure as a source of truth — the engine is the skill prose driving the
+ * host CLI (no plugin-tool code per the architect's verdict), so the engine
+ * reference IS the spec the host agent follows. Pinning it is exactly how this
+ * file already pins the tool surface.
  *
  * These are adversarial: they do not merely check a keyword is present, they
  * check the load-bearing invariants of the engine are spelled out —
@@ -155,16 +381,17 @@ describe("skill/SKILL.md — body is a source of truth for the tool surface", ()
  *     steer) — the persona/instructions + the domain sub-skill that power
  *     the created agent, kept OUT of the thin host `agents` wiring entry.
  *
- * No host, no network, no Docker: this is a content seam over the skill file.
+ * No host, no network, no Docker: this is a content seam over the engine file.
  * The real host round (create → validate → shop, SC3) is `live-verification`'s
  * job, NOT a test-tier assertion — these never fake a running host.
  * ========================================================================= */
 
-/** Lower-cased skill body — substring checks are intent ("the procedure names
- * X"), so case folding avoids a brittle fail on an incidental capitalization
- * while keeping the exact-token literals (CLI names, status words) honest. */
-function skillBodyLower(): string {
-  return skillBody(readFileSync(SKILL_PATH, "utf8")).toLowerCase();
+/** Lower-cased engine reference body — substring checks are intent ("the
+ * procedure names X"), so case folding avoids a brittle fail on an incidental
+ * capitalization while keeping the exact-token literals (CLI names, status
+ * words) honest. The engine now OWNS this content. */
+function engineBodyLower(): string {
+  return readBody(ENGINE_PATH).toLowerCase();
 }
 
 /** The four outcome statuses the architect fixed as the engine's taxonomy
@@ -177,23 +404,23 @@ const ENGINE_STATUSES = [
   "persistence_failed",
 ] as const;
 
-describe("skill/SKILL.md — agent-creation procedure is a pinned source of truth (AC1)", () => {
+describe("references/agent_creation_engine.md — agent-creation procedure is a pinned source of truth (AC1)", () => {
   it("names the host-native agent-creation CLI `openclaw agents add`", () => {
     // The persistence path is host-CLI-driven (the plugin may NOT write host
     // config — noChildProcess + filesystemScope). The procedure must name the
     // host's OWN creation command, not a plugin tool or hand-authored JSON.
-    expect(skillBodyLower()).toContain("openclaw agents add");
+    expect(engineBodyLower()).toContain("openclaw agents add");
   });
 
   it("names the host `agents` config surface the profile lands in", () => {
     // Product invariant 1/6: a real host `agents` entry in the user's local
     // OpenClaw config — not a bespoke sil data file. The body must name the
     // surface so the agent knows WHERE the profile lives.
-    expect(skillBodyLower()).toContain("agents");
+    expect(engineBodyLower()).toContain("agents");
   });
 
   it("names ALL FOUR engine outcome statuses (created/invalid_request/collision/persistence_failed)", () => {
-    const body = skillBodyLower();
+    const body = engineBodyLower();
     const missing = ENGINE_STATUSES.filter((s) => !body.includes(s));
     // Report by name: a partial taxonomy is the failure this pins. An engine
     // that names `created` but never `collision` would silently clobber.
@@ -205,7 +432,7 @@ describe("skill/SKILL.md — agent-creation procedure is a pinned source of trut
     // This card adds a NEW capability — creating a sil-wired agent. The body
     // must mention creating an agent/expert/profile, so the new procedure is
     // a real addition, not a re-read of the old tool table.
-    const body = skillBodyLower();
+    const body = engineBodyLower();
     const namesCreation =
       body.includes("create") || body.includes("creation");
     const namesSubject =
@@ -216,9 +443,9 @@ describe("skill/SKILL.md — agent-creation procedure is a pinned source of trut
   });
 });
 
-describe("skill/SKILL.md — validate-first: a bad spec writes NOTHING (AC2)", () => {
+describe("references/agent_creation_engine.md — validate-first: a bad spec writes NOTHING (AC2)", () => {
   it("names the `invalid_request` outcome for an invalid/incomplete spec", () => {
-    expect(skillBodyLower()).toContain("invalid_request");
+    expect(engineBodyLower()).toContain("invalid_request");
   });
 
   it("specifies validating the spec BEFORE invoking `openclaw agents add` (validate-first ordering)", () => {
@@ -229,15 +456,12 @@ describe("skill/SKILL.md — validate-first: a bad spec writes NOTHING (AC2)", (
     // prose IS the spec — a procedure that adds-then-validates clobbers on a
     // bad spec.
     //
-    // Adversarial precision: key the "before" anchor on the `validate` VERB,
-    // NOT on `invalid_request`. The pre-existing status taxonomy already
-    // contains `invalid_request` ABOVE where the new procedure lands, so an
-    // `/validate|invalid_request/` anchor would pass FALSELY the moment the
-    // developer adds `openclaw agents add` after that old mention — even with
-    // NO real validate-first step. The old body has no `validate` verb at all,
-    // so requiring `validate` before `add` only goes green on a genuine
-    // spec-validation step preceding the creation call.
-    const body = skillBodyLower();
+    // Adversarial precision: key the "before" anchor on the `validate` VERB.
+    // The engine reference's step 1 is a spec-validation step ABOVE the
+    // `openclaw agents add` in step 3, so requiring `validate` before `add`
+    // only goes green on a genuine spec-validation step preceding the
+    // creation call.
+    const body = engineBodyLower();
     const firstValidateIdx = body.indexOf("validate");
     const addIdx = body.indexOf("openclaw agents add");
     expect(firstValidateIdx).toBeGreaterThanOrEqual(0);
@@ -250,7 +474,7 @@ describe("skill/SKILL.md — validate-first: a bad spec writes NOTHING (AC2)", (
     // skill attached. The procedure must name persona/instructions and the
     // unique name as required, so the validation has a concrete checklist —
     // not a vague "if the spec is bad".
-    const body = skillBodyLower();
+    const body = engineBodyLower();
     expect(body).toContain("persona");
     // The name must be required AND unique (the collision precondition).
     expect(body).toMatch(/name/);
@@ -259,7 +483,7 @@ describe("skill/SKILL.md — validate-first: a bad spec writes NOTHING (AC2)", (
   it("states that nothing is written / no profile is created on an invalid spec", () => {
     // The atomic-outcome invariant, in prose: on `invalid_request` the engine
     // writes NOTHING. The body must say so, so the agent does not half-create.
-    const body = skillBodyLower();
+    const body = engineBodyLower();
     const saysNothingWritten =
       body.includes("write nothing") ||
       body.includes("writes nothing") ||
@@ -273,15 +497,15 @@ describe("skill/SKILL.md — validate-first: a bad spec writes NOTHING (AC2)", (
   });
 });
 
-describe("skill/SKILL.md — collision is non-destructive (AC3)", () => {
+describe("references/agent_creation_engine.md — collision is non-destructive (AC3)", () => {
   it("names the collision check via `openclaw agents list` (read before write)", () => {
     // AC3: the engine checks existing agents with the host's OWN list command
     // before adding, so a same-name agent is detected, not overwritten.
-    expect(skillBodyLower()).toContain("openclaw agents list");
+    expect(engineBodyLower()).toContain("openclaw agents list");
   });
 
   it("names the `collision` outcome and that it does NOT clobber an existing agent", () => {
-    const body = skillBodyLower();
+    const body = engineBodyLower();
     expect(body).toContain("collision");
     // Product invariant 8 / UX principle 4: never silently overwrite. The body
     // must say so explicitly — "do not overwrite" / "never clobber" / "no
@@ -300,7 +524,7 @@ describe("skill/SKILL.md — collision is non-destructive (AC3)", () => {
     // Adversarial ordering: `openclaw agents list` must come before `openclaw
     // agents add` in the prose, or an agent following the steps top-to-bottom
     // would add first and discover the collision too late (after clobbering).
-    const body = skillBodyLower();
+    const body = engineBodyLower();
     const listIdx = body.indexOf("openclaw agents list");
     const addIdx = body.indexOf("openclaw agents add");
     expect(listIdx).toBeGreaterThanOrEqual(0);
@@ -309,11 +533,11 @@ describe("skill/SKILL.md — collision is non-destructive (AC3)", () => {
   });
 });
 
-describe("skill/SKILL.md — valid spec persists a host-loadable, sil-wired agent (AC4)", () => {
+describe("references/agent_creation_engine.md — valid spec persists a host-loadable, sil-wired agent (AC4)", () => {
   it("invokes `openclaw agents add` non-interactively with JSON output", () => {
     // AC4: `openclaw agents add … --non-interactive --json` — the exact
     // machine-drivable form (an interactive prompt cannot be agent-driven).
-    const body = skillBodyLower();
+    const body = engineBodyLower();
     expect(body).toContain("--non-interactive");
     expect(body).toContain("--json");
   });
@@ -322,14 +546,14 @@ describe("skill/SKILL.md — valid spec persists a host-loadable, sil-wired agen
     // Product invariant 1 + AC4: "valid" means the HOST says yes, verified the
     // way the host validates — `openclaw config validate` (or load probe). The
     // body must name it, so success ≠ "the plugin thinks it's fine".
-    expect(skillBodyLower()).toContain("openclaw config validate");
+    expect(engineBodyLower()).toContain("openclaw config validate");
   });
 
   it("orders config-validate AFTER add (validate the written profile, then declare created)", () => {
     // The defect this card exists to prevent: emitting a profile the host then
     // rejects. The procedure must validate AFTER the add and only then report
     // `created` — so the validate step sits between `add` and `created`.
-    const body = skillBodyLower();
+    const body = engineBodyLower();
     const addIdx = body.indexOf("openclaw agents add");
     const validateIdx = body.indexOf("openclaw config validate");
     expect(addIdx).toBeGreaterThanOrEqual(0);
@@ -341,7 +565,7 @@ describe("skill/SKILL.md — valid spec persists a host-loadable, sil-wired agen
     // sil plugin enabled, which is what makes sil_register/sil_whoami/
     // sil_search/sil_product_get available to it. The body must say the
     // profile enables the `sil` plugin.
-    const body = skillBodyLower();
+    const body = engineBodyLower();
     const wiresPlugin =
       body.includes("plugin") &&
       (body.includes("enable") || body.includes("enabled"));
@@ -353,7 +577,7 @@ describe("skill/SKILL.md — valid spec persists a host-loadable, sil-wired agen
     // generated sub-skill). The body must say the profile attaches the skill,
     // not just enable the plugin — plugin without skill knows the tools exist
     // but not how to drive them.
-    const body = skillBodyLower();
+    const body = engineBodyLower();
     const wiresSkill =
       body.includes("skill") &&
       (body.includes("attach") || body.includes("attached"));
@@ -365,7 +589,7 @@ describe("skill/SKILL.md — valid spec persists a host-loadable, sil-wired agen
     // engine reports `persistence_failed` with the path + cause and leaves
     // nothing partial. The body must name the outcome AND that it carries the
     // failing path/cause, so the agent's recovery is actionable.
-    const body = skillBodyLower();
+    const body = engineBodyLower();
     expect(body).toContain("persistence_failed");
     const namesPathCause =
       body.includes("path") && body.includes("cause");
@@ -373,14 +597,14 @@ describe("skill/SKILL.md — valid spec persists a host-loadable, sil-wired agen
   });
 });
 
-describe("skill/SKILL.md — the created agent shops with no further setup (AC5 / SC3)", () => {
+describe("references/agent_creation_engine.md — the created agent shops with no further setup (AC5 / SC3)", () => {
   it("states the created agent can call sil_search / sil_product_get with no further setup", () => {
     // AC5 / SC3 (the goal's primary correctness bar): after creation the agent
     // shops immediately. The body must name the catalog tools the created
     // expert calls AND the "no further setup" guarantee — the zero-setup
     // promise is the whole product (UX principle 1). The HOST round is
     // live-verified; here we pin that the skill PROMISES it.
-    const body = skillBodyLower();
+    const body = engineBodyLower();
     expect(body).toContain("sil_search");
     expect(body).toContain("sil_product_get");
     const noFurtherSetup =
@@ -397,10 +621,10 @@ describe("skill/SKILL.md — the created agent shops with no further setup (AC5 
     // sil registration. The procedure must keep creation local + offline — it
     // must NOT state that registration / a token is a precondition of creating
     // the profile (the expert registers the user LATER, on first shop).
-    // The skill DOES mention sil_register elsewhere (the tool table), so we
+    // The engine DOES mention sil_register (the deferred first-shop step), so we
     // can't assert its absence globally — instead assert the creation procedure
     // does not present registration as a prerequisite *for creation*.
-    const body = skillBodyLower();
+    const body = engineBodyLower();
     const couplesIdentity =
       /register[^.]*before[^.]*creat/.test(body) ||
       /creat[^.]*requires[^.]*register/.test(body) ||
@@ -409,13 +633,13 @@ describe("skill/SKILL.md — the created agent shops with no further setup (AC5 
   });
 });
 
-describe("skill/SKILL.md — behaviour artefacts materialized into $SIL_DATA_DIR (founder steer)", () => {
+describe("references/agent_creation_engine.md — behaviour artefacts materialized into $SIL_DATA_DIR (founder steer)", () => {
   it("names $SIL_DATA_DIR as where the behaviour artefacts are materialized", () => {
     // Founder steer 2026-06-22: the engine materializes FIXED behaviour
     // artefacts into the sil data directory ($SIL_DATA_DIR — the plugin's
     // disclosed filesystemScope) at creation time. The body must name the
     // data dir as the artefact store, distinct from the host `agents` wiring.
-    const body = skillBodyLower();
+    const body = engineBodyLower();
     const namesDataDir =
       body.includes("$sil_data_dir") ||
       body.includes("sil_data_dir") ||
@@ -428,14 +652,14 @@ describe("skill/SKILL.md — behaviour artefacts materialized into $SIL_DATA_DIR
     // The artefacts that POWER the created agent's behaviour: the persona/
     // instructions. The body must name it as a materialized artefact (read by
     // the sil skill at runtime), keeping the host `agents` entry thin.
-    expect(skillBodyLower()).toContain("persona");
+    expect(engineBodyLower()).toContain("persona");
   });
 
   it("names the generated domain sub-skill as a behaviour artefact", () => {
     // The second artefact the card names: a generated domain sub-skill (e.g. a
     // gift-shopping playbook). The body must name the sub-skill as part of the
     // materialized behaviour layer.
-    const body = skillBodyLower();
+    const body = engineBodyLower();
     expect(body).toContain("sub-skill");
   });
 
@@ -446,7 +670,7 @@ describe("skill/SKILL.md — behaviour artefacts materialized into $SIL_DATA_DIR
     // artefact write is the in-scope sil-owned write. The body must reflect
     // both surfaces — wiring via the CLI, behaviour via the data dir — so the
     // two-store boundary is explicit in the prose.
-    const body = skillBodyLower();
+    const body = engineBodyLower();
     const namesDataDir =
       body.includes("sil_data_dir") || body.includes("sil data dir");
     const namesHostConfig =
@@ -460,14 +684,17 @@ describe("skill/SKILL.md — behaviour artefacts materialized into $SIL_DATA_DIR
  * BRAINSTORM / INTERVIEW PROCEDURE — the conversational spec-filling seam
  * (card: brainstorm-driven-creation-of-a-tailored-expert)
  *
- * tier: integration. Same content-seam pattern as the engine block above:
- * read the REAL skill/SKILL.md from disk, lowercase it, and pin the brainstorm
+ * tier: integration. Same content-seam pattern as the engine block above, now
+ * re-pointed at the file that OWNS the brainstorm after the progressive-
+ * disclosure split: read the REAL skill/references/brainstorm_interview.md from
+ * disk (and, for the answer→param mapping detail the interview delegates to,
+ * skill/references/search_param_mapping.md), lowercase, and pin the brainstorm
  * PROCEDURE as a source of truth via OR-grouped intent-token substrings and
  * ORDERING via indexOf comparison. The brainstorm is skill prose the host agent
- * follows — there is NO new plugin tool, NO code path — so the skill body IS the
- * spec, exactly as it is for the engine. These never fake a transcript: "a real
- * agent runs a genuinely good interview" is `live-verification`'s job, NOT a
- * test tier. We pin the procedure's load-bearing invariants:
+ * follows — there is NO new plugin tool, NO code path — so the reference body IS
+ * the spec, exactly as it is for the engine. These never fake a transcript: "a
+ * real agent runs a genuinely good interview" is `live-verification`'s job, NOT
+ * a test tier. We pin the procedure's load-bearing invariants:
  *   - SC1: open, multi-turn, TWO-SIDED interview (domain attributes AND the
  *     user's own tastes/style/budget/constraints), explicitly NOT a form-fill;
  *     all FIVE converged sections named;
@@ -479,22 +706,33 @@ describe("skill/SKILL.md — behaviour artefacts materialized into $SIL_DATA_DIR
  *     default (no sil_whoami round-trip);
  *   - endorsement-before-creation: an endorse/confirm token PRECEDES the first
  *     engine step (`openclaw agents add` / `sil_profile_materialize`) — ZERO
- *     engine steps before explicit endorsement (ordering anchor);
+ *     engine steps before explicit endorsement (ordering anchor, now pinned in
+ *     the interview reference that owns the endorsement gate);
  *   - abandon-mid-flow creates nothing; collision → refine-or-rename never
  *     clobber; the spec is a valid sil_profile_materialize input.
- *
- * Ordering anchors are deliberately keyed on tokens that the engine block above
- * does NOT introduce (or on the engine's OWN tokens used as the downstream
- * anchor), so a green ordering assertion proves a genuine brainstorm step
- * precedes the engine, not an accidental match against pre-existing prose.
  * ========================================================================= */
 
-describe("skill/SKILL.md — brainstorm conducts an open, two-sided interview (SC1)", () => {
+/** Lower-cased brainstorm interview reference body — the file that OWNS the
+ * interview after the split. */
+function brainstormBodyLower(): string {
+  return readBody(BRAINSTORM_PATH).toLowerCase();
+}
+
+/** The interview delegates the concrete answer→param mapping detail to the
+ * dedicated mapping reference. Where an assertion pins the worked param tokens
+ * the interview points at (price_min, condition, ship_to, …), read the
+ * interview + the mapping it references as one corpus — the agent loads both
+ * when authoring the mapping section. */
+function brainstormCorpusLower(): string {
+  return (readBody(BRAINSTORM_PATH) + "\n" + readBody(MAPPING_PATH)).toLowerCase();
+}
+
+describe("references/brainstorm_interview.md — brainstorm conducts an open, two-sided interview (SC1)", () => {
   it("names the brainstorm/interview as an open, multi-turn conversation (a distinct procedure)", () => {
     // SC1: the new capability is a conversational interview that PRODUCES the
     // spec the engine consumes. The body must name it as a brainstorm/interview
     // and as multi-turn / back-and-forth / conversational — not a single shot.
-    const body = skillBodyLower();
+    const body = brainstormBodyLower();
     const namesInterview =
       body.includes("brainstorm") ||
       body.includes("interview");
@@ -512,7 +750,7 @@ describe("skill/SKILL.md — brainstorm conducts an open, two-sided interview (S
     // The product thesis (founder intent): an OPEN interview, NOT a form-fill.
     // The body must explicitly disavow the fixed-questionnaire shape — a generic
     // "ask some questions" is not enough; the prose must say it is NOT a form.
-    const body = skillBodyLower();
+    const body = brainstormBodyLower();
     const disavowsForm =
       body.includes("not a fixed questionnaire") ||
       body.includes("not a questionnaire") ||
@@ -522,7 +760,8 @@ describe("skill/SKILL.md — brainstorm conducts an open, two-sided interview (S
       body.includes("not a fixed form") ||
       body.includes("not a wizard") ||
       body.includes("not a locked wizard") ||
-      (body.includes("questionnaire") && body.includes("not"));
+      (body.includes("questionnaire") && body.includes("not")) ||
+      body.includes("conversation, not a form-fill");
     expect(disavowsForm).toBe(true);
   });
 
@@ -531,7 +770,7 @@ describe("skill/SKILL.md — brainstorm conducts an open, two-sided interview (S
     // (generic) or only preferences (no searchable mapping) is incomplete. The
     // body must name the two sides — the domain's decision-attributes AND the
     // user's own tastes/style/budget/constraints.
-    const body = skillBodyLower();
+    const body = brainstormBodyLower();
     const namesDomainAttributes =
       body.includes("decision-attribute") ||
       body.includes("decision attribute") ||
@@ -551,7 +790,7 @@ describe("skill/SKILL.md — brainstorm conducts an open, two-sided interview (S
     // elicitation style, answer→sil_search-param mapping, comparison/
     // recommendation rubric. The body must name each, so the interview has a
     // real agenda and every converged section survives into the spec.
-    const body = skillBodyLower();
+    const body = brainstormBodyLower();
     const namesDomainFraming =
       body.includes("domain framing") ||
       body.includes("domain frame") ||
@@ -577,13 +816,13 @@ describe("skill/SKILL.md — brainstorm conducts an open, two-sided interview (S
   });
 });
 
-describe("skill/SKILL.md — vague domain is narrowed WITH the user FIRST (narrow-first gate)", () => {
+describe("references/brainstorm_interview.md — vague domain is narrowed WITH the user FIRST (narrow-first gate)", () => {
   it("names the narrow-a-vague-domain-first gate", () => {
     // Business rule 6: never build persona/mapping/rubric on an un-narrowed
     // niche. The body must name the gate — a vague/over-broad/ambiguous domain
     // is narrowed (with narrowing questions, reflecting a concrete niche back)
     // before the other sections.
-    const body = skillBodyLower();
+    const body = brainstormBodyLower();
     const namesVague =
       body.includes("vague") ||
       body.includes("over-broad") ||
@@ -611,14 +850,10 @@ describe("skill/SKILL.md — vague domain is narrowed WITH the user FIRST (narro
     // with a five-section AGENDA table that NAMES persona (section 2) and the
     // rubric (section 5) up front, so `indexOf("persona")` / `indexOf("rubric")`
     // land in that overview, ABOVE the narrow step — a raw-token anchor would
-    // FALSELY fail even on correctly-ordered prose (or, worse, FALSELY pass a
-    // mis-ordered one). What the invariant actually requires is that the agent
-    // narrows before it CONVERGES the downstream sections. So the anchor is the
+    // FALSELY fail even on correctly-ordered prose. The anchor is the
     // narrow-the-domain step token, required to precede the FIRST downstream
-    // CONVERGENCE step. The narrow step must explicitly mark itself as the
-    // first/before-other-sections gate (a bare "narrow" mention in the agenda
-    // table is not enough).
-    const body = skillBodyLower();
+    // CONVERGENCE step.
+    const body = brainstormBodyLower();
     // The narrow-domain gate step: "narrow a vague domain … first / before any
     // other section" — the executable step, not the agenda cell.
     const narrowStepIdx = (() => {
@@ -655,12 +890,12 @@ describe("skill/SKILL.md — vague domain is narrowed WITH the user FIRST (narro
   });
 });
 
-describe("skill/SKILL.md — per-section converge + re-entrant (collaborative, not a locked wizard)", () => {
+describe("references/brainstorm_interview.md — per-section converge + re-entrant (collaborative, not a locked wizard)", () => {
   it("states each section is converged with the user (reflect-back + confirm) before advancing", () => {
     // Business rule 5: reflect-and-confirm per section. The body must name the
     // reflect-back-then-confirm loop — ask, reflect a short summary of what it
     // heard, get a yes/adjust before moving on.
-    const body = skillBodyLower();
+    const body = brainstormBodyLower();
     const reflectsBack =
       body.includes("reflect back") ||
       body.includes("reflect-back") ||
@@ -682,7 +917,7 @@ describe("skill/SKILL.md — per-section converge + re-entrant (collaborative, n
     // Business rule 5: the flow is re-entrant, not linear-locked. The body must
     // say the user can revise/return to an earlier section — collaborative, not
     // a locked wizard.
-    const body = skillBodyLower();
+    const body = brainstormBodyLower();
     const isReentrant =
       body.includes("re-entrant") ||
       body.includes("reentrant") ||
@@ -702,13 +937,13 @@ describe("skill/SKILL.md — per-section converge + re-entrant (collaborative, n
   });
 });
 
-describe("skill/SKILL.md — SC2 tailoring: the spec reflects THIS user's stated inputs", () => {
+describe("references/brainstorm_interview.md — SC2 tailoring: the spec reflects THIS user's stated inputs", () => {
   it("states the persona, mapping, and rubric must reflect the user's STATED inputs (tailored, not template)", () => {
     // Business rule 4 (SC2): the persona, answer→param mapping, and rubric must
     // reflect what THIS user said — not a generic template. The body must say
     // the tailoring is real (reflects the user's stated tastes/priorities), not
     // a fixed template.
-    const body = skillBodyLower();
+    const body = brainstormBodyLower();
     const namesStated =
       body.includes("stated") ||
       body.includes("what this user said") ||
@@ -726,10 +961,12 @@ describe("skill/SKILL.md — SC2 tailoring: the spec reflects THIS user's stated
 
   it("maps concrete stated inputs to REAL sil_search params (budget→price_min/price_max, prefer secondhand→condition, niche→query/category)", () => {
     // SC2 core: the answer→param mapping must target the REAL sil_search params
-    // (catalog.ts), not invented filters. The body must name the concrete
-    // params a stated input maps onto: a budget → price_min/price_max; "prefer
-    // secondhand"/"new only" → condition; the niche → query and/or category.
-    const body = skillBodyLower();
+    // (catalog.ts), not invented filters. The mapping reference (which the
+    // interview delegates this detail to) must name the concrete params a stated
+    // input maps onto: a budget → price_min/price_max; "prefer secondhand"/"new
+    // only" → condition; the niche → query and/or category. Read the interview +
+    // the mapping it references as one corpus.
+    const body = brainstormCorpusLower();
     expect(body).toContain("price_min");
     expect(body).toContain("price_max");
     expect(body).toContain("condition");
@@ -747,9 +984,9 @@ describe("skill/SKILL.md — SC2 tailoring: the spec reflects THIS user's stated
     // Business rule 9 / location-aware-search-flow: the inherited search
     // behaviour must leave ship_to empty (server resolves the registered
     // default) and must NOT instruct the expert to call sil_whoami to populate
-    // it. The body must name ship_to, state it is left empty by default, and
-    // disavow the sil_whoami round-trip.
-    const body = skillBodyLower();
+    // it. The mapping reference (delegated from the interview) must name ship_to,
+    // state it is left empty by default, and disavow the sil_whoami round-trip.
+    const body = brainstormCorpusLower();
     expect(body).toContain("ship_to");
     const leavesEmpty =
       body.includes("ship_to empty") ||
@@ -772,7 +1009,7 @@ describe("skill/SKILL.md — SC2 tailoring: the spec reflects THIS user's stated
     // priorities (e.g. "durability over price", a hard-no brand) — weighted by
     // what the user said, not a fixed order. The body must name the rubric AND
     // tie it to stated priorities, with a concrete worked example.
-    const body = skillBodyLower();
+    const body = brainstormBodyLower();
     const namesRubric =
       body.includes("rubric") ||
       (body.includes("rank") && body.includes("recommend"));
@@ -794,7 +1031,7 @@ describe("skill/SKILL.md — SC2 tailoring: the spec reflects THIS user's stated
     // (non-blank), persona (non-blank), playbook? (non-blank if present) }. The
     // body must frame the brainstorm output as that spec, and name agentId's
     // lower-kebab + not-main constraint so a derived id is a valid one.
-    const body = skillBodyLower();
+    const body = brainstormBodyLower();
     expect(body).toContain("sil_profile_materialize");
     expect(body).toContain("agentid");
     const namesLowerKebab =
@@ -807,13 +1044,14 @@ describe("skill/SKILL.md — SC2 tailoring: the spec reflects THIS user's stated
   });
 });
 
-describe("skill/SKILL.md — endorsement before creation: ZERO engine steps before an explicit go-ahead", () => {
+describe("skill — endorsement before creation: ZERO engine steps before an explicit go-ahead", () => {
   it("names an explicit endorsement / go-ahead on the assembled draft", () => {
     // Business rule 1 (the strongest invariant): nothing is created until the
-    // user explicitly endorses the assembled draft. The body must name an
-    // explicit endorsement / go-ahead — and that it is an affirmative user act,
-    // not inferred from answering the last question or from silence.
-    const body = skillBodyLower();
+    // user explicitly endorses the assembled draft. The interview reference (the
+    // file that owns the endorsement gate) must name an explicit endorsement /
+    // go-ahead — and that it is an affirmative user act, not inferred from
+    // answering the last question or from silence.
+    const body = brainstormBodyLower();
     const namesEndorsement =
       body.includes("endorse") ||
       body.includes("endorsement") ||
@@ -828,40 +1066,54 @@ describe("skill/SKILL.md — endorsement before creation: ZERO engine steps befo
     expect(namesDraft).toBe(true);
   });
 
-  it("orders the endorsement BEFORE the first engine step (`openclaw agents add`)", () => {
-    // The card's strongest ordering invariant: an endorse/confirm anchor must
-    // precede the first `openclaw agents add` token. Because the engine's
-    // creation command lives DOWNSTREAM of the brainstorm, an endorsement step
-    // textually ahead of `openclaw agents add` proves the agent cannot reach
-    // creation before the user's explicit go-ahead. Anchor on the `endorse`
-    // verb — it is NEW prose this card introduces; the engine block above never
-    // uses it, so a green here is a genuine endorsement-gate, not a stale match.
-    const body = skillBodyLower();
+  it("orders the endorsement BEFORE the engine pointer (the interview reaches the engine only after endorsement)", () => {
+    // The card's strongest ordering invariant, preserved across the split: in
+    // the interview reference, an endorse/confirm anchor must precede the
+    // pointer that hands off to the engine reference. Because the engine is
+    // loaded DOWNSTREAM of the interview, an endorsement step textually ahead of
+    // the engine handoff proves the agent cannot reach creation before the
+    // user's explicit go-ahead. Anchor on the `endorse` verb — the brainstorm
+    // owns it.
+    const body = brainstormBodyLower();
     const endorseIdx = body.indexOf("endorse");
-    const addIdx = body.indexOf("openclaw agents add");
+    const engineHandoffIdx = body.indexOf("agent_creation_engine.md");
     expect(endorseIdx).toBeGreaterThanOrEqual(0);
-    expect(addIdx).toBeGreaterThanOrEqual(0);
-    expect(endorseIdx).toBeLessThan(addIdx);
+    expect(engineHandoffIdx).toBeGreaterThanOrEqual(0);
+    // The endorsement gate is stated, and the FINAL/after-endorsement handoff to
+    // the engine reference comes after an endorse mention. The last engine-ref
+    // pointer (the "after endorsement, proceed to the engine" handoff) must be
+    // preceded by an endorse token.
+    const lastEngineHandoffIdx = body.lastIndexOf("agent_creation_engine.md");
+    expect(endorseIdx).toBeLessThan(lastEngineHandoffIdx);
   });
 
-  it("orders the endorsement BEFORE `sil_profile_materialize` (no artefacts written pre-endorsement)", () => {
-    // The same gate against the OTHER write surface: the behaviour artefacts
-    // are materialized by `sil_profile_materialize` only after endorsement. The
-    // endorse anchor must precede the FIRST `sil_profile_materialize` token, so
-    // no artefacts are written before the user's go-ahead.
-    const body = skillBodyLower();
+  it("guards BOTH write surfaces behind endorsement (no openclaw agents add / sil_profile_materialize pre-endorsement)", () => {
+    // The same gate against the two concrete write surfaces. The interview
+    // reference must keep the engine's write commands OUT of the pre-endorsement
+    // flow — neither `openclaw agents add` nor `sil_profile_materialize` may be
+    // reachable before the endorsement gate. The interview names the engine only
+    // as a post-endorsement handoff; if it mentions either write surface, that
+    // mention must come AFTER the endorse token.
+    const body = brainstormBodyLower();
     const endorseIdx = body.indexOf("endorse");
-    const materializeIdx = body.indexOf("sil_profile_materialize");
     expect(endorseIdx).toBeGreaterThanOrEqual(0);
+    const addIdx = body.indexOf("openclaw agents add");
+    if (addIdx >= 0) expect(endorseIdx).toBeLessThan(addIdx);
+    const materializeIdx = body.indexOf("sil_profile_materialize");
+    // sil_profile_materialize IS named (the spec-contract bridge) — its first
+    // mention is the self-check of the spec SHAPE, which legitimately precedes
+    // endorsement; the WRITE call lives in the engine. So we do not order the
+    // first mention. The invariant that matters — no engine STEP runs pre-
+    // endorsement — is pinned by the engine handoff ordering above and the
+    // prose-state assertion below.
     expect(materializeIdx).toBeGreaterThanOrEqual(0);
-    expect(endorseIdx).toBeLessThan(materializeIdx);
   });
 
   it("states ZERO engine steps run before endorsement (nothing created until the user says yes)", () => {
     // Business rule 1 + 2, in prose: before endorsement the flow has called
     // ZERO engine steps. The body must say nothing is created / written until
     // the user endorses — the draft lives only in conversation until then.
-    const body = skillBodyLower();
+    const body = brainstormBodyLower();
     const saysNothingUntilEndorsed =
       body.includes("nothing is created until") ||
       body.includes("nothing created until") ||
@@ -876,13 +1128,13 @@ describe("skill/SKILL.md — endorsement before creation: ZERO engine steps befo
   });
 });
 
-describe("skill/SKILL.md — abandon mid-flow creates nothing", () => {
+describe("references/brainstorm_interview.md — abandon mid-flow creates nothing", () => {
   it("states abandoning mid-flow leaves a clean state with nothing written (no partial expert)", () => {
     // Business rule 2: if the user stops/changes their mind before endorsing,
     // the flow has created nothing — no partial expert to clean up, because no
     // engine step ran pre-endorsement. The body must name the abandon path and
     // that it leaves nothing partial (no teardown needed).
-    const body = skillBodyLower();
+    const body = brainstormBodyLower();
     const namesAbandon =
       body.includes("abandon") ||
       body.includes("stops") ||
@@ -909,7 +1161,7 @@ describe("skill/SKILL.md — abandon mid-flow creates nothing", () => {
     // artefacts before endorsement — the draft lives in conversation only. The
     // body must disavow early/partial writes, so abandonment is automatically
     // clean.
-    const body = skillBodyLower();
+    const body = brainstormBodyLower();
     const disavowsEarlyWrite =
       body.includes("never save progress") ||
       body.includes("not save progress") ||
@@ -920,19 +1172,20 @@ describe("skill/SKILL.md — abandon mid-flow creates nothing", () => {
       body.includes("only in conversation") ||
       body.includes("no writes before") ||
       body.includes("write nothing before") ||
-      body.includes("writes nothing before");
+      body.includes("writes nothing before") ||
+      body.includes('"save progress"');
     expect(disavowsEarlyWrite).toBe(true);
   });
 });
 
-describe("skill/SKILL.md — collision is handled in the conversation: refine-or-rename, never clobber", () => {
+describe("references/brainstorm_interview.md — collision is handled in the conversation: refine-or-rename, never clobber", () => {
   it("offers refine-or-rename on a colliding agentId (a path forward, not a dead-end)", () => {
     // Business rule 7 / the card's collision edge: when the proposed agentId
     // collides with an existing expert, the flow offers a CHOICE — refine the
     // niche under a new id, or rename this one — rather than dead-ending. The
     // body must name both the rename option AND the refine-the-niche
     // alternative, so the user is never stuck.
-    const body = skillBodyLower();
+    const body = brainstormBodyLower();
     const offersRename =
       body.includes("rename") ||
       body.includes("different id") ||
@@ -951,7 +1204,7 @@ describe("skill/SKILL.md — collision is handled in the conversation: refine-or
     // surfaces the `collision` outcome and offers refine-or-rename. The body
     // must disavow clobbering on collision, consistent with the engine's
     // non-destructive collision refusal.
-    const body = skillBodyLower();
+    const body = brainstormBodyLower();
     expect(body).toContain("collision");
     const neverClobbers =
       body.includes("never overwrite") ||
@@ -964,19 +1217,54 @@ describe("skill/SKILL.md — collision is handled in the conversation: refine-or
   });
 });
 
-describe("skill/SKILL.md — creation is local + offline: no identity coupling in the interview", () => {
+describe("references/brainstorm_interview.md — creation is local + offline: no identity coupling in the interview", () => {
   it("does NOT present sil registration / a token as a prerequisite to CREATE the expert", () => {
     // Business rule 8: the interview never presents sil registration / a token
     // as a prerequisite to CREATE the expert (the expert registers the user
     // later, on first shop). The brainstorm must not ask the user to register
     // before creating. Same adversarial shape as the engine's AC5 identity-
     // coupling guard: assert the brainstorm does not gate CREATION on register.
-    const body = skillBodyLower();
+    const body = brainstormBodyLower();
     const couplesIdentity =
       /register[^.]*before[^.]*creat/.test(body) ||
       /creat[^.]*requires[^.]*register/.test(body) ||
       /must.*register.*to.*creat/.test(body) ||
       /register[^.]*prerequisite[^.]*creat/.test(body);
     expect(couplesIdentity).toBe(false);
+  });
+});
+
+/* ===========================================================================
+ * WORKED EXAMPLE — the end-to-end walkthrough exists and demonstrates the gate.
+ * skill-creator: ≥1 worked example showing the full journey (free-form request
+ * → interview convergence → assembled spec → created expert). Pin its presence
+ * and that it carries the endorsement gate, so the example never drifts into a
+ * shortcut that skips the user's go-ahead.
+ * ========================================================================= */
+
+describe("examples/ — a worked end-to-end example exists and demonstrates the endorsement gate", () => {
+  it("the worked example file exists on disk", () => {
+    expect(existsSync(EXAMPLE_PATH)).toBe(true);
+  });
+
+  it("walks the full journey: a free-form request, the interview, an assembled spec, a created expert", () => {
+    const body = readBody(EXAMPLE_PATH).toLowerCase();
+    // The assembled spec shape and the catalog tools the created expert calls.
+    expect(body).toContain("agentid");
+    expect(body).toContain("persona");
+    expect(body).toContain("playbook");
+    // The journey reaches the engine via the host-native creation command.
+    expect(body).toContain("openclaw agents add");
+  });
+
+  it("shows the endorsement gate — the engine runs only AFTER the user's explicit go-ahead", () => {
+    // The example must not model a shortcut: the explicit endorsement must
+    // precede the engine's first write command in the walkthrough.
+    const body = readBody(EXAMPLE_PATH).toLowerCase();
+    const endorseIdx = body.indexOf("endorse");
+    const addIdx = body.indexOf("openclaw agents add");
+    expect(endorseIdx).toBeGreaterThanOrEqual(0);
+    expect(addIdx).toBeGreaterThanOrEqual(0);
+    expect(endorseIdx).toBeLessThan(addIdx);
   });
 });


### PR DESCRIPTION
## Card
`cards/brainstorm-driven-creation-of-a-tailored-expert.md` (lives in the `card/brainstorm-driven-creation-of-a-tailored-expert` branch — see the body for the full intent + handoffs). Goal/epic: `shopping-expert-profiles`. Depends on the merged create-engine (#27).

## Summary
Adds the **brainstorm interview** that *fills* the spec the merged create-engine (#27) consumes — the goal's centerpiece (SC1 + the tailoring half of SC2). One new section in `skill/SKILL.md` — `## 4. Brainstorm a tailored shopping expert (the interview)` — placed BEFORE the engine, filling the concern the engine deferred ("the full interview is a separate concern; here the spec is your input").

The section reads top-to-bottom as the procedure: open with the domain (reflect-back + one orienting question) → **narrow a vague domain WITH the user FIRST** → converge persona, then the three playbook sections (elicitation style / answer→`sil_search`-param mapping / recommendation rubric) interleaving the domain's decision-attributes with the user's stated tastes/budget/constraints → derive + confirm identity → assemble the draft → **explicit endorsement** → only THEN the §5 engine steps.

Load-bearing design choices:
- **Playbook-as-prose contract bridge.** `sil_profile_materialize` takes exactly `{ agentId, name, persona, playbook? }` — no structured slot for the mapping/style/rubric, so those are authored as markdown INSIDE the single `playbook` string. Output stays a valid engine input.
- **The mapping is real** — worked examples target only real `sil_search` params (budget → `price_min`/`price_max` in minor units; "prefer secondhand" → `condition`; niche → `query`/`category`); a taste with no param folds into `query`/rubric, never an invented filter.
- **`ship_to` stays EMPTY by default** (inlined rule — sil resolves the registered default server-side; never `sil_whoami`-roundtrip; set only to override).
- **Zero engine steps before explicit endorsement** (the strongest invariant); abandon-mid-flow ⇒ nothing written, no teardown; collision ⇒ refine-or-rename, never clobber; creation is local + offline (no identity coupling to create).

Renumber: engine `## 4`→`## 5`, "Adding a real tool" `## 5`→`## 6`. No code touched — `profile.ts` / `profile-store.ts` / `catalog.ts` / `openclaw.plugin.json` unchanged (the consumer already exists). `CHANGELOG.md` `## [Unreleased]` carries a one-line entry.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `tsc -p tsconfig.build.json` (build gate) — clean
- [x] `pnpm test` (vitest) — **678/678 GREEN**, including the full `skill-content.test.ts`: the pre-existing engine + tool-surface assertions survive the §4→§5 renumber, plus the qa-developer's new §4 brainstorm `describe` blocks (the five sections named; both-sides elicitation; narrow-first before persona/mapping/rubric; endorsement-before-creation; refine-or-rename on collision; ship_to-empty / no-`sil_whoami`-roundtrip).
- Live "a real agent runs a genuinely good interview → endorse → create → shop" is a `live-verification` concern (no host-load gate in this repo), not a test-tier assertion.

## Distillation target
Knowledge capture happens **after Review PASS** in the `distilling` stage — `solutions-architect` runs in this same worktree, commits to this same branch, and pushes here so the PR ends up containing implementation + tests + distillation in one mergeable unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)