### PR TITLE
feature: list, view, and remove local expert agents (lifecycle tools)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ release (`clawhub package publish --changelog`). See [README](./README.md#releas
 
 ## [Unreleased]
 
+### Added
+
+- **Local expert lifecycle — list, view, and remove the shopping experts you
+  create.** Three new tools manage the artefact store the create-engine writes
+  (`$SIL_DATA_DIR/agents/<id>/`): `sil_profile_list` enumerates your experts
+  most-recently-created first (sourced from each `profile.json` manifest — the
+  authoritative "is a sil expert" signal — with one corrupt manifest isolated
+  in `unreadable[]`, never aborting the listing); `sil_profile_get` returns one
+  expert's full detail (name, persona, optional playbook, manifest path,
+  createdAt); and `sil_profile_remove` deletes exactly one validated expert's
+  behaviour-artefact directory. All three make no network call and read no
+  token — generic profile-less shopping is unchanged. Removal is the **artefact
+  half only**: the host-wiring half (`openclaw agents remove`) is host-CLI
+  driven and runs **first** (a failed artefact step then leaves only harmless,
+  list-surfaced disk cruft — never a broken-but-loading expert), and the skill
+  **confirms before removing**. `sil_profile_remove` is fail-closed and scoped:
+  a malformed/traversal/`main` id is rejected (`invalid_request`) and deletes
+  nothing, an absent id is `not_found` (idempotent — safe to re-run), and a
+  genuine filesystem failure is `persistence_failed` with the path + cause —
+  never a thrown error across the tool boundary.
+
 ## [0.2.4] - 2026-06-18
 
 ### Fixed

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -10,7 +10,10 @@
   "contracts": {
     "tools": [
       "sil_product_get",
+      "sil_profile_get",
+      "sil_profile_list",
       "sil_profile_materialize",
+      "sil_profile_remove",
       "sil_register",
       "sil_search",
       "sil_whoami"
@@ -48,7 +51,7 @@
   },
   "security": {
     "shipsRuntimeCode": true,
-    "packagingNote": "Compiled JavaScript ships under ./dist. register() stays synchronous and opens nothing — it only registers tools. ALL I/O happens inside a tool's execute(): sil_register calls sil-web over the network, writes tokens.json + config.json to the plugin data directory (owner-only, 0600), and arms a bounded background poll timer that stops on the first terminal claim outcome or after the session deadline. sil_whoami reads the stored access token and calls sil-api for the user's identity, refreshing transparently via sil-web on a 401 (at most one refresh + one retry per call, no timer); a confirmed-dead session clears tokens.json. sil_search and sil_product_get read the stored access token and call sil-api's catalog endpoints (search / lookup) with it — read-only, no token write, no timer, a single round-trip (a 401 is a terminal re-register hint, no refresh). sil_profile_materialize makes no network call and reads no token: it writes a created shopping expert's behaviour artefacts (persona.md, optional playbook.md, profile.json) atomically into $SIL_DATA_DIR/agents/<agentId>/ (owner-only, 0600) — the agent's host-config wiring is driven separately by the host CLI, never by this plugin. The PKCE verifier is held only in memory and is never written to disk. Tokens and identity PII are never logged.",
+    "packagingNote": "Compiled JavaScript ships under ./dist. register() stays synchronous and opens nothing — it only registers tools. ALL I/O happens inside a tool's execute(): sil_register calls sil-web over the network, writes tokens.json + config.json to the plugin data directory (owner-only, 0600), and arms a bounded background poll timer that stops on the first terminal claim outcome or after the session deadline. sil_whoami reads the stored access token and calls sil-api for the user's identity, refreshing transparently via sil-web on a 401 (at most one refresh + one retry per call, no timer); a confirmed-dead session clears tokens.json. sil_search and sil_product_get read the stored access token and call sil-api's catalog endpoints (search / lookup) with it — read-only, no token write, no timer, a single round-trip (a 401 is a terminal re-register hint, no refresh). sil_profile_materialize makes no network call and reads no token: it writes a created shopping expert's behaviour artefacts (persona.md, optional playbook.md, profile.json) atomically into $SIL_DATA_DIR/agents/<agentId>/ (owner-only, 0600) — the agent's host-config wiring is driven separately by the host CLI, never by this plugin. sil_profile_list / sil_profile_get / sil_profile_remove are the local expert lifecycle over the same artefact store, also making no network call and reading no token: list enumerates $SIL_DATA_DIR/agents/*/profile.json read-only, get reads one expert's manifest + persona/playbook bodies read-only, and remove deletes exactly one validated agents/<agentId>/ leaf directory (fail-closed on a malformed/traversal id — deletes nothing) — the host-wiring half of removal is the host CLI's, not this plugin's. The PKCE verifier is held only in memory and is never written to disk. Tokens and identity PII are never logged.",
     "registersLongLivedService": false,
     "serviceIds": [],
     "runsTimers": true,

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sil
-description: This skill should be used when the user wants to shop on sil — register an identity, see who they are, search the catalog for purchasable products, or look up specific products by id — or when they want to create a dedicated sil-wired shopping expert (a new OpenClaw agent profile). The plugin exposes sil_register, sil_whoami, sil_search, sil_product_get, and sil_profile_materialize.
+description: This skill should be used when the user wants to shop on sil — register an identity, see who they are, search the catalog for purchasable products, or look up specific products by id — or when they want to create a dedicated sil-wired shopping expert (a new OpenClaw agent profile) and then list, view, or remove the experts they have created. The plugin exposes sil_register, sil_whoami, sil_search, sil_product_get, sil_profile_materialize, sil_profile_list, sil_profile_get, and sil_profile_remove.
 metadata:
   openclaw:
     emoji: "\U0001F6D2"
@@ -119,7 +119,46 @@ The **sil plugin** and the **sil skill** are always attached (that is what makes
 
 When you (the sil skill) start a session inside a created expert, read `$SIL_DATA_DIR/agents/<agentId>/profile.json`, then load the `persona.md` (reaffirm the standing instructions) and `playbook.md` sub-skill (the domain shopping playbook) it points at. That is what lets the expert shop on its niche with no further setup.
 
-## 5. Adding a real tool
+## 5. Manage your sil shopping experts (list / view / remove)
+
+Once experts exist, the user manages them by intent — "what experts do I have?", "show me the gift buyer", "delete the grocery agent". These are pure local-lifecycle operations over the two stores the create-engine established — **host config = wiring, `$SIL_DATA_DIR/agents/<id>/` = behaviour artefacts**. No server call, no token read, no identity coupling: a user with zero experts (or who just removed their last) still shops generically exactly as before.
+
+**The source of truth for "what is a sil expert" is the sil artefact store, not the host agent list.** A directory `$SIL_DATA_DIR/agents/<id>/` with a readable `profile.json` IS a sil expert; a bare host `agents.list[]` entry without one is just a host agent and is not ours to list, view, or remove.
+
+| Intent | Tool(s) |
+|---|---|
+| "list my experts" / "what shopping experts do I have?" | `sil_profile_list` (no arguments) |
+| "show me / tell me about <expert>" | `sil_profile_get` (pass the expert's `agentId`) |
+| "remove / delete / get rid of <expert>" | host CLI `openclaw agents remove <agentId>` **FIRST**, then the artefact tool (see the remove flow below) |
+
+The two read intents behave as follows:
+
+- **`sil_profile_list`** enumerates the artefact store and returns the user's experts most-recently-created first (`createdAt` desc), each with its `agentId`, `name`, `hasPlaybook`, and `createdAt`. Present a name + a short domain summary (distilled from the persona; a playbook signals a specialized domain) plus the `agentId` so the user can refer to one unambiguously. An empty `experts: []` is a normal, successful outcome — say plainly "you have no sil shopping experts yet" and point at how to create one ("ask me to make a shopping expert for …"). One degraded expert lands in `unreadable[]` — mention it inline, but never let it hide the healthy ones.
+- **`sil_profile_get`** resolves one expert by `agentId` and returns its `name`, `persona`, optional `playbook`, `profilePath`, and `createdAt`. Render a human summary: the expert's name, its domain/persona, whether it carries a domain playbook (and a summary when present), and a wiring summary — it is a real host agent with the sil plugin enabled and the sil skill attached, ready to shop with no further setup. An unknown expert returns `not_found` — frame it plainly ("no sil expert named '<x>'") and list the experts that DO exist (or say there are none) so the next step is obvious. Never surface a stack trace or a raw filesystem path.
+
+### Remove flow — host-CLI FIRST, then the artefact tool
+
+Removal is **destructive and irreversible** (the persona and playbook the user authored are deleted), so **confirm before removing**: state exactly what will be deleted — this one named expert, both its host wiring and its sil behaviour artefacts — and proceed only on the user's explicit go-ahead. Then run these steps **in this exact order**:
+
+1. **Existence check (read).** Run `openclaw agents list --json` and confirm the `agentId` is a sil-wired agent the user means.
+2. **Remove the host wiring (host CLI) — FIRST.** Run `openclaw agents remove <agentId>`, then `openclaw config validate --json` to confirm the host config is still valid. The plugin cannot write the host config, so this half is always the host CLI's, and it runs ahead of the artefact removal.
+3. **Remove the sil artefacts (plugin tool) — SECOND.** Call `sil_profile_remove { agentId }` to delete the expert's behaviour-artefact directory. It deletes the **artefact half only** — the expert's `$SIL_DATA_DIR/agents/<id>/` directory — scoped to exactly the one validated `agentId`; a malformed/traversal/`main` id returns `invalid_request` and deletes nothing, and an unknown id returns `not_found` (idempotent — safe to re-run).
+
+**Never artefacts-first.** The order is a safety decision, not a style choice: if step 3 fails after step 2, the only survivor is a *residual artefact directory with no host entry* — harmless disk cruft, no broken agent ever loads, and `sil_profile_list` still surfaces it so the user retries `sil_profile_remove` clean. The **reverse** order is unsafe: artefacts removed first, then a failed host step, leaves a *host `agents` entry whose `profile.json` is gone* — the agent still loads but the sil skill ENOENTs on its persona/playbook at runtime, a visible, confusing, broken expert. Both halves are individually idempotent (host `agents remove` and `sil_profile_remove` both no-op on an absent target), so a re-run from any partial state converges to clean. After a successful removal, confirm the expert is gone and that the user's **other experts and generic shopping are untouched**.
+
+Leave `plugins.entries.sil.enabled` alone on removal — it is shared host state (every other expert depends on it; generic shopping is unaffected by it), not per-agent. Even removing the last expert leaves it enabled.
+
+### Status taxonomy (manage: list / view / remove)
+
+| `status` | Meaning | What to do |
+|---|---|---|
+| `ok` | List succeeded (`experts` may be empty — a normal outcome), or a view returned the expert's detail. | Relay the data; on an empty list, say so plainly and point at creation. |
+| `not_found` | No sil expert matches the `agentId` (view or remove). | Frame it plainly and list the experts that DO exist; do NOT re-register. For remove, this also means a re-run is safe (idempotent). |
+| `invalid_request` | The `agentId` was malformed, `main`, or traversal-shaped. **Nothing was read or deleted.** | Fix the id and call again — never a stack trace or a raw path to the user. |
+| `removed` | `sil_profile_remove` deleted the expert's artefact directory. | Confirm it is gone; ensure the host-wiring removal (step 2) ran first. |
+| `persistence_failed` | The artefact directory could not be removed (the **path** + **cause** name what to fix). | Fix the data directory (writable), then remove again; the already-done host-wiring half need not be redone. |
+
+## 6. Adding a real tool
 
 The mechanical steps live in the repo's `CLAUDE.md` ("How to add a tool"); the short version is three steps: register the tool inside a `registerXTools(api)` group in `src/tools/`, wire that group into `register()` in `src/index.ts`, and add the tool's name to `openclaw.plugin.json#contracts.tools`. The manifest↔code drift-guard test fails if those disagree, which keeps the pattern self-enforcing.
 

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -96,15 +96,20 @@ describe("plugin entry — registration contract", () => {
 
   it("wires the real tool groups into register() — registers exactly the real tool set", () => {
     // register() runs the real tool groups (no mock), so it populates the
-    // api with exactly the five real tools and NO example stub. This pins
-    // the wiring AND the card's "absence" goal: sil_ping / sil_echo gone.
+    // api with exactly the real tools and NO example stub. This pins the
+    // wiring AND the card's "absence" goal: sil_ping / sil_echo gone.
     // sil_profile_materialize (agent-creation engine, card:
-    // create-a-valid-sil-wired-openclaw-agent-profile) joins the set.
+    // create-a-valid-sil-wired-openclaw-agent-profile) and the local expert
+    // lifecycle sil_profile_list / sil_profile_get / sil_profile_remove (card:
+    // list-view-and-remove-local-expert-agents) join the set.
     const api = createMockPluginApi();
     capturedRegisterFn!(api);
     expect([...api._tools.keys()].sort()).toEqual([
       "sil_product_get",
+      "sil_profile_get",
+      "sil_profile_list",
       "sil_profile_materialize",
+      "sil_profile_remove",
       "sil_register",
       "sil_search",
       "sil_whoami",

--- a/src/__tests__/lib/profile-store-manage.test.ts
+++ b/src/__tests__/lib/profile-store-manage.test.ts
@@ -1,0 +1,538 @@
+/**
+ * UNIT — list/read/remove store primitives (tier: unit, real temp dir via the
+ * SIL_DATA_DIR override, no network, no host).
+ *
+ * Card: list-view-and-remove-local-expert-agents. The create-engine
+ * (`materializeProfile`) wrote the artefact store; this card adds the three
+ * primitives that MANAGE it:
+ *   - listAgentProfiles()        — enumerate $SIL_DATA_DIR/agents/*\/profile.json
+ *   - readAgentProfile(agentId)  — manifest + persona/playbook bodies for one
+ *   - removeAgentArtefacts(id)   — delete exactly one validated agent's dir
+ *
+ * Each returns a discriminated result that NEVER throws across the boundary
+ * (cloning the `MaterializeResult` shape, profile-store.ts:94-117) — the tool
+ * maps each variant to a structured envelope. The invariants pinned here ARE
+ * the card's correctness bar for the artefact-half of list/view/remove:
+ *
+ *   LIST   (Flow 1, AC List):
+ *     1. empty/absent store → ok with empty experts (a normal outcome).
+ *     2. multiple experts → all present, each from its profile.json manifest
+ *        (no dirname guessing — name/createdAt/hasPlaybook come from the file).
+ *     3. ordered createdAt DESC (most-recently-created first).
+ *     4. one corrupt/unreadable profile.json among healthy ones → that one in
+ *        unreadable[], the rest still listed (the list never aborts/throws).
+ *   READ   (Flow 2, AC View):
+ *     5. ok → manifest + persona body (+ playbook body when present) read from
+ *        the files the manifest points at.
+ *     6. unknown id → not_found (a normal outcome, never a throw).
+ *     7. traversal-shaped id (../x, a/b, .., a/../b, main, Mixed-Case) →
+ *        invalid_request via AGENT_ID_RE, rejected BEFORE any join/read.
+ *   REMOVE (Flow 3, AC Remove — clears the artefact half, scoped):
+ *     8. removed → the target dir is gone.
+ *     9. idempotent not_found on absent — a re-run is safe (converges to clean).
+ *    10. traversal/main/malformed → invalid_request, DELETES NOTHING.
+ *    11. a sibling expert's dir is byte-for-byte untouched (non-destructive).
+ *    12. an rmSync that genuinely fails (non-writable parent) → persistence_failed
+ *        with <dir>: <cause>, never a throw.
+ *   IDENTITY BOUNDARY (Generic shopping unchanged):
+ *    13. none of the three read/write a token (getTokensPath() never appears).
+ *
+ * Hermetic via the SIL_DATA_DIR temp-dir override (the repo's standard knob,
+ * mirrors profile-store.test.ts:64-80).
+ *
+ * Contract this file pins for the implementation (expert-developer),
+ * `src/lib/profile-store.ts`:
+ *   - listAgentProfiles(): ListProfilesResult — discriminated, never throws.
+ *     ok variant: { ok:true, experts: {agentId,name,hasPlaybook,createdAt}[]
+ *     (createdAt DESC), unreadable: {agentId,error}[] }.
+ *   - readAgentProfile(agentId): ReadProfileResult — discriminated, never throws.
+ *     ok: { ok:true, agentId, name, persona, playbook?, profilePath, createdAt };
+ *     not_found: { ok:false, kind:"not_found", agentId, message };
+ *     bad id: { ok:false, kind:"invalid_request", field:"agentId", message }.
+ *   - removeAgentArtefacts(agentId): RemoveProfileResult — discriminated, never
+ *     throws. removed: { ok:true, agentId }; absent: { ok:false,
+ *     kind:"not_found", agentId, message }; bad id: { ok:false,
+ *     kind:"invalid_request", field:"agentId", message } AND deletes nothing;
+ *     rmSync failure: { ok:false, kind:"persistence_failed", error:"<dir>:
+ *     <cause>", message }.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  readdirSync,
+  readFileSync,
+  mkdirSync,
+  statSync,
+  chmodSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  materializeProfile,
+  listAgentProfiles,
+  readAgentProfile,
+  removeAgentArtefacts,
+  getAgentArtefactDir,
+} from "../../lib/profile-store.js";
+import { getDataDir, getTokensPath } from "../../lib/credentials.js";
+
+let dataDir: string;
+let priorSilDataDir: string | undefined;
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), "sil-profile-manage-"));
+  priorSilDataDir = process.env["SIL_DATA_DIR"];
+  process.env["SIL_DATA_DIR"] = dataDir;
+});
+
+afterEach(() => {
+  if (priorSilDataDir === undefined) delete process.env["SIL_DATA_DIR"];
+  else process.env["SIL_DATA_DIR"] = priorSilDataDir;
+  // Restore perms so rmSync can clean a dir a failure test chmod'd read-only.
+  try {
+    chmodSync(dataDir, 0o700);
+    const agents = join(dataDir, "agents");
+    if (existsSync(agents)) {
+      chmodSync(agents, 0o700);
+      for (const e of readdirSync(agents)) {
+        try {
+          chmodSync(join(agents, e), 0o700);
+        } catch {
+          /* best-effort */
+        }
+      }
+    }
+  } catch {
+    /* best-effort */
+  }
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+/** Materialize an expert and (optionally) backdate its manifest createdAt so
+ * ordering is deterministic regardless of wall-clock resolution. The store's
+ * own writer is used (never a hand-rolled fixture) so the test exercises the
+ * real on-disk shape readAgentProfile/listAgentProfiles must parse. */
+function makeExpert(
+  agentId: string,
+  opts: { name?: string; persona?: string; playbook?: string; createdAt?: string } = {},
+): void {
+  const result = materializeProfile({
+    agentId,
+    name: opts.name ?? `Expert ${agentId}`,
+    persona: opts.persona ?? `Persona for ${agentId} — shops carefully.`,
+    ...(opts.playbook !== undefined ? { playbook: opts.playbook } : {}),
+  });
+  if (!result.ok) {
+    throw new Error(`fixture setup failed for ${agentId}: ${JSON.stringify(result)}`);
+  }
+  if (opts.createdAt !== undefined) {
+    // Rewrite profile.json with a fixed createdAt to pin ordering.
+    const manifestPath = join(getAgentArtefactDir(agentId), "profile.json");
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+    manifest["createdAt"] = opts.createdAt;
+    writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + "\n");
+  }
+}
+
+/** Every file under `dir`, recursively (relative paths). Used to prove a
+ * rejected-on-bad-id remove deleted NOTHING anywhere under agents/. */
+function walkFiles(dir: string, base = dir): string[] {
+  if (!existsSync(dir)) return [];
+  const out: string[] = [];
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) out.push(...walkFiles(full, base));
+    else out.push(full.slice(base.length + 1));
+  }
+  return out;
+}
+
+// ===========================================================================
+// listAgentProfiles
+// ===========================================================================
+
+describe("listAgentProfiles — empty/absent store is a normal, successful empty listing", () => {
+  // list has NO failure variant: an absent store is a normal empty listing and
+  // per-entry problems land in unreadable[]. So the result carries experts +
+  // unreadable directly (no `ok` discriminant to gate on) — pin the BEHAVIOUR.
+  it("absent agents/ dir → empty experts, empty unreadable (not an error)", () => {
+    // Fresh temp data dir: no agents/ subtree exists at all.
+    expect(existsSync(join(getDataDir(), "agents"))).toBe(false);
+    const result = listAgentProfiles();
+    expect(result.experts).toEqual([]);
+    expect(result.unreadable).toEqual([]);
+  });
+
+  it("present-but-empty agents/ dir → empty experts", () => {
+    // An agents/ dir with no expert subdirs is still a normal empty listing.
+    mkdirSync(join(getDataDir(), "agents"), { recursive: true });
+    const result = listAgentProfiles();
+    expect(result.experts).toEqual([]);
+  });
+});
+
+describe("listAgentProfiles — multiple experts: all present, sourced from profile.json", () => {
+  it("lists every materialized expert with name + hasPlaybook + agentId from its manifest", () => {
+    makeExpert("gift-buyer", { name: "Gift Buyer", playbook: "Browse with sil_search." });
+    makeExpert("grocery-agent", { name: "Grocery Agent" }); // no playbook
+
+    const result = listAgentProfiles();
+    expect(result.unreadable).toEqual([]);
+
+    const byId = new Map(result.experts.map((e) => [e.agentId, e]));
+    expect(byId.size).toBe(2);
+
+    const gift = byId.get("gift-buyer");
+    expect(gift).toBeDefined();
+    // name comes from the manifest, NOT from the directory name.
+    expect(gift!.name).toBe("Gift Buyer");
+    expect(gift!.hasPlaybook).toBe(true);
+    expect(typeof gift!.createdAt).toBe("string");
+
+    const grocery = byId.get("grocery-agent");
+    expect(grocery).toBeDefined();
+    expect(grocery!.name).toBe("Grocery Agent");
+    // hasPlaybook reflects the manifest's playbookPath presence (none here).
+    expect(grocery!.hasPlaybook).toBe(false);
+  });
+
+  it("reads name from the manifest, not the directory name (no filesystem-name guessing)", () => {
+    // The directory key is the agentId; the human name is a DISTINCT manifest
+    // field. A list that echoed the dir name as the name would pass a naive
+    // test but fail here, where the two deliberately differ.
+    makeExpert("shoe-expert", { name: "Sneaker Specialist" });
+    const result = listAgentProfiles();
+    const entry = result.experts.find((e) => e.agentId === "shoe-expert");
+    expect(entry).toBeDefined();
+    expect(entry!.name).toBe("Sneaker Specialist");
+    expect(entry!.name).not.toBe("shoe-expert");
+  });
+});
+
+describe("listAgentProfiles — ordered most-recently-created first (createdAt DESC)", () => {
+  it("returns experts in descending createdAt order", () => {
+    makeExpert("oldest", { createdAt: "2026-01-01T00:00:00.000Z" });
+    makeExpert("newest", { createdAt: "2026-06-22T00:00:00.000Z" });
+    makeExpert("middle", { createdAt: "2026-03-15T00:00:00.000Z" });
+
+    const result = listAgentProfiles();
+    expect(result.experts.map((e) => e.agentId)).toEqual([
+      "newest",
+      "middle",
+      "oldest",
+    ]);
+  });
+});
+
+describe("listAgentProfiles — one corrupt manifest never blinds the user to the rest", () => {
+  it("a healthy expert + an unparseable profile.json → healthy listed, broken in unreadable[]", () => {
+    makeExpert("healthy", { name: "Healthy Expert", createdAt: "2026-05-01T00:00:00.000Z" });
+    makeExpert("broken", { name: "Broken Expert", createdAt: "2026-05-02T00:00:00.000Z" });
+    // Corrupt the broken one's manifest with non-JSON.
+    const brokenManifest = join(getAgentArtefactDir("broken"), "profile.json");
+    chmodSync(brokenManifest, 0o600);
+    writeFileSync(brokenManifest, "{ this is not valid json ");
+
+    const result = listAgentProfiles();
+    // Must NOT throw — the broken one is isolated into unreadable[].
+
+    // The healthy expert still lists.
+    expect(result.experts.map((e) => e.agentId)).toEqual(["healthy"]);
+    // The broken one is reported by agentId in unreadable[], with an error.
+    expect(result.unreadable.map((u) => u.agentId)).toEqual(["broken"]);
+    expect(typeof result.unreadable[0]!.error).toBe("string");
+    expect(result.unreadable[0]!.error.length).toBeGreaterThan(0);
+  });
+
+  it("an expert subdir whose profile.json is entirely MISSING → reported unreadable, others still list", () => {
+    makeExpert("intact", { name: "Intact" });
+    // Create an agent subdir with NO profile.json (an interrupted create).
+    const orphanDir = getAgentArtefactDir("orphaned");
+    mkdirSync(orphanDir, { recursive: true });
+    writeFileSync(join(orphanDir, "persona.md"), "persona but no manifest");
+
+    const result = listAgentProfiles();
+    expect(result.experts.map((e) => e.agentId)).toEqual(["intact"]);
+    expect(result.unreadable.map((u) => u.agentId)).toContain("orphaned");
+  });
+});
+
+// ===========================================================================
+// readAgentProfile
+// ===========================================================================
+
+describe("readAgentProfile — ok: manifest + artefact bodies for one expert", () => {
+  it("returns name, persona body, playbook body, profilePath, createdAt from the files the manifest points at", () => {
+    makeExpert("gift-buyer", {
+      name: "Gift Buyer",
+      persona: "You specialise in gifts under €50; always check stock first.",
+      playbook: "Use sil_search to browse; sil_product_get to re-check stock.",
+    });
+
+    const result = readAgentProfile("gift-buyer");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.agentId).toBe("gift-buyer");
+    expect(result.name).toBe("Gift Buyer");
+    // The BODIES are read from disk (the files the manifest points at), not the
+    // manifest paths alone — the skill renders detail from these.
+    expect(result.persona).toBe(
+      "You specialise in gifts under €50; always check stock first.",
+    );
+    expect(result.playbook).toBe(
+      "Use sil_search to browse; sil_product_get to re-check stock.",
+    );
+    expect(result.profilePath).toBe(
+      join(getAgentArtefactDir("gift-buyer"), "profile.json"),
+    );
+    expect(typeof result.createdAt).toBe("string");
+    expect(Number.isNaN(Date.parse(result.createdAt))).toBe(false);
+  });
+
+  it("omits the playbook body when the expert has no playbook", () => {
+    makeExpert("grocery-agent", { name: "Grocery Agent" }); // no playbook
+    const result = readAgentProfile("grocery-agent");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.playbook).toBeUndefined();
+    expect(typeof result.persona).toBe("string");
+    expect(result.persona.length).toBeGreaterThan(0);
+  });
+});
+
+describe("readAgentProfile — unknown id fails gracefully (not_found, never a throw)", () => {
+  it("an id with no artefact dir → not_found naming the agentId, no throw", () => {
+    makeExpert("exists", {}); // a healthy neighbour, to prove read is scoped
+    const result = readAgentProfile("does-not-exist");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.kind).toBe("not_found");
+    if (result.kind !== "not_found") return;
+    expect(result.agentId).toBe("does-not-exist");
+    expect(typeof result.message).toBe("string");
+  });
+
+  it("an agent dir whose profile.json is unreadable → not_found (a degraded read, not a throw)", () => {
+    makeExpert("degraded", { name: "Degraded" });
+    const manifestPath = join(getAgentArtefactDir("degraded"), "profile.json");
+    writeFileSync(manifestPath, "}}} not json {{{");
+    const result = readAgentProfile("degraded");
+    // A corrupt manifest must never throw out of read — it degrades to not_found.
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.kind).toBe("not_found");
+  });
+});
+
+describe("readAgentProfile — traversal-shaped id rejected fail-closed BEFORE any read", () => {
+  it.each(["../escape", "gift/buyer", "..", ".", "a/../b", "main", "Gift-Buyer", ""])(
+    "rejects %j with invalid_request(field=agentId) and reads nothing",
+    (bad) => {
+      const result = readAgentProfile(bad);
+      expect(result.ok, `expected reject for ${JSON.stringify(bad)}`).toBe(false);
+      if (result.ok) return;
+      expect(result.kind).toBe("invalid_request");
+      if (result.kind !== "invalid_request") return;
+      expect(result.field).toBe("agentId");
+    },
+  );
+});
+
+// ===========================================================================
+// removeAgentArtefacts
+// ===========================================================================
+
+describe("removeAgentArtefacts — removes exactly the named expert's dir", () => {
+  it("removed → the target artefact dir is gone", () => {
+    makeExpert("gift-buyer", { name: "Gift Buyer" });
+    const dir = getAgentArtefactDir("gift-buyer");
+    expect(existsSync(dir)).toBe(true);
+
+    const result = removeAgentArtefacts("gift-buyer");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.agentId).toBe("gift-buyer");
+    expect(existsSync(dir)).toBe(false);
+  });
+});
+
+describe("removeAgentArtefacts — non-destructive to OTHER experts", () => {
+  it("removing one of several leaves every other expert's dir byte-for-byte untouched", () => {
+    makeExpert("target", { name: "Target", playbook: "to be deleted" });
+    makeExpert("survivor-a", { name: "Survivor A", playbook: "keep me A" });
+    makeExpert("survivor-b", { name: "Survivor B" });
+
+    const survivorAFiles = walkFiles(getAgentArtefactDir("survivor-a")).sort();
+    const survivorASnapshot = survivorAFiles.map((rel) =>
+      readFileSync(join(getAgentArtefactDir("survivor-a"), rel), "utf8"),
+    );
+
+    const result = removeAgentArtefacts("target");
+    expect(result.ok).toBe(true);
+
+    // The target is gone…
+    expect(existsSync(getAgentArtefactDir("target"))).toBe(false);
+    // …and every other expert's dir survives, byte-for-byte.
+    expect(existsSync(getAgentArtefactDir("survivor-a"))).toBe(true);
+    expect(existsSync(getAgentArtefactDir("survivor-b"))).toBe(true);
+    expect(walkFiles(getAgentArtefactDir("survivor-a")).sort()).toEqual(survivorAFiles);
+    survivorAFiles.forEach((rel, i) => {
+      expect(
+        readFileSync(join(getAgentArtefactDir("survivor-a"), rel), "utf8"),
+      ).toBe(survivorASnapshot[i]);
+    });
+  });
+
+  it("never deletes the agents/ PARENT — only the single leaf dir", () => {
+    makeExpert("solo", { name: "Solo" });
+    const agentsParent = join(getDataDir(), "agents");
+    expect(existsSync(agentsParent)).toBe(true);
+    const result = removeAgentArtefacts("solo");
+    expect(result.ok).toBe(true);
+    // The leaf is gone but the agents/ subtree itself remains (a removed-last
+    // expert must not delete the store root — list of an empty store still works).
+    expect(existsSync(getAgentArtefactDir("solo"))).toBe(false);
+    expect(existsSync(agentsParent)).toBe(true);
+  });
+});
+
+describe("removeAgentArtefacts — idempotent not_found on an absent target", () => {
+  it("an id with no dir → not_found, deletes nothing; a second remove is also not_found (re-run safe)", () => {
+    makeExpert("neighbour", { name: "Neighbour" }); // prove scope
+
+    const first = removeAgentArtefacts("never-existed");
+    expect(first.ok).toBe(false);
+    if (first.ok) return;
+    expect(first.kind).toBe("not_found");
+    if (first.kind !== "not_found") return;
+    expect(first.agentId).toBe("never-existed");
+
+    // The neighbour is untouched by the no-op remove.
+    expect(existsSync(getAgentArtefactDir("neighbour"))).toBe(true);
+
+    // Idempotent: a second remove of the same absent id ALSO returns not_found,
+    // never an error — a retry after a partial host-CLI/artefact failure
+    // converges to clean.
+    const second = removeAgentArtefacts("never-existed");
+    expect(second.ok).toBe(false);
+    if (second.ok) return;
+    expect(second.kind).toBe("not_found");
+  });
+
+  it("re-removing an id that WAS just removed returns not_found (full removed→not_found cycle is idempotent)", () => {
+    makeExpert("transient", { name: "Transient" });
+    const removed = removeAgentArtefacts("transient");
+    expect(removed.ok).toBe(true);
+    const again = removeAgentArtefacts("transient");
+    expect(again.ok).toBe(false);
+    if (again.ok) return;
+    expect(again.kind).toBe("not_found");
+  });
+});
+
+describe("removeAgentArtefacts — malformed/traversal/main id is rejected and DELETES NOTHING", () => {
+  it.each(["../escape", "gift/buyer", "..", ".", "a/../b", "main", "Gift-Buyer", ""])(
+    "rejects %j with invalid_request(field=agentId) and removes nothing from the store",
+    (bad) => {
+      // Seed two real experts; a bad id must not reach outside the agents subtree
+      // nor touch either of them.
+      makeExpert("alpha", { name: "Alpha", playbook: "keep" });
+      makeExpert("beta", { name: "Beta" });
+      const before = walkFiles(join(getDataDir(), "agents")).sort();
+
+      const result = removeAgentArtefacts(bad);
+      expect(result.ok, `expected reject for ${JSON.stringify(bad)}`).toBe(false);
+      if (result.ok) return;
+      expect(result.kind).toBe("invalid_request");
+      if (result.kind !== "invalid_request") return;
+      expect(result.field).toBe("agentId");
+
+      // NOTHING under agents/ changed — the bad id deleted nothing.
+      expect(walkFiles(join(getDataDir(), "agents")).sort()).toEqual(before);
+      expect(existsSync(getAgentArtefactDir("alpha"))).toBe(true);
+      expect(existsSync(getAgentArtefactDir("beta"))).toBe(true);
+    },
+  );
+});
+
+describe("removeAgentArtefacts — a genuine rmSync failure returns persistence_failed, never throws", () => {
+  // chmod 0500 can't block deletes for root — skip there rather than false-fail.
+  const asRoot = typeof process.getuid === "function" && process.getuid() === 0;
+  it.skipIf(asRoot)(
+    "a non-writable agents/ parent (rmSync of the leaf fails EACCES) → persistence_failed with <dir>: <cause>",
+    () => {
+      makeExpert("locked", { name: "Locked" });
+      const dir = getAgentArtefactDir("locked");
+      const agentsParent = join(getDataDir(), "agents");
+      // rmSync of the leaf needs WRITE on the PARENT dir (to unlink the entry).
+      // Make the parent read+exec-only so the unlink fails EACCES.
+      chmodSync(agentsParent, 0o500);
+
+      const result = removeAgentArtefacts("locked");
+      // Restore perms immediately so the assertions + afterEach can clean up.
+      chmodSync(agentsParent, 0o700);
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.kind).toBe("persistence_failed");
+      if (result.kind !== "persistence_failed") return;
+      // The path + cause are both present in `error` (actionable recovery),
+      // mirroring the writer's failure envelope: "<dir>: <cause>".
+      expect(result.error).toContain(dir);
+      expect(result.error).toMatch(/.+: .+/);
+      // The recovery hint steers the agent at the data dir (card §108).
+      expect(result.recovery).toBe("fix_data_dir");
+      // The dir was NOT removed (the delete genuinely failed) — but the result
+      // is a structured failure, not a thrown error.
+      expect(existsSync(dir)).toBe(true);
+    },
+  );
+});
+
+// ===========================================================================
+// Identity boundary — none of the three read or write a token
+// ===========================================================================
+
+describe("list/read/remove — no identity coupling (getTokensPath never appears)", () => {
+  it("listAgentProfiles reads/writes no token", () => {
+    makeExpert("a", {});
+    listAgentProfiles();
+    expect(existsSync(getTokensPath())).toBe(false);
+  });
+
+  it("readAgentProfile reads/writes no token", () => {
+    makeExpert("b", {});
+    readAgentProfile("b");
+    expect(existsSync(getTokensPath())).toBe(false);
+  });
+
+  it("removeAgentArtefacts reads/writes no token", () => {
+    makeExpert("c", {});
+    removeAgentArtefacts("c");
+    expect(existsSync(getTokensPath())).toBe(false);
+  });
+
+  it("none of the three create the tokens path even across a full list→read→remove cycle", () => {
+    makeExpert("cycle", { name: "Cycle", playbook: "pb" });
+    listAgentProfiles();
+    readAgentProfile("cycle");
+    removeAgentArtefacts("cycle");
+    expect(existsSync(getTokensPath())).toBe(false);
+    // Sanity: the leaf statSync below proves the temp dir itself is intact.
+    expect(statSync(getDataDir()).isDirectory()).toBe(true);
+  });
+});

--- a/src/__tests__/manifest-contract.integration.test.ts
+++ b/src/__tests__/manifest-contract.integration.test.ts
@@ -29,7 +29,8 @@
  *     `contracts.tools` string array;
  *   - the real tool groups register exactly the tools named there (and
  *     the manifest names exactly the tools they register) — the set on
- *     both sides equals { sil_product_get, sil_profile_materialize,
+ *     both sides equals { sil_product_get, sil_profile_get,
+ *     sil_profile_list, sil_profile_materialize, sil_profile_remove,
  *     sil_register, sil_search, sil_whoami }.
  */
 
@@ -127,7 +128,10 @@ describe("manifest ↔ code drift guard (set-equality, BOTH directions)", () => 
     // not just the symmetric drift check above.
     const expected = [
       "sil_product_get",
+      "sil_profile_get",
+      "sil_profile_list",
       "sil_profile_materialize",
+      "sil_profile_remove",
       "sil_register",
       "sil_search",
       "sil_whoami",
@@ -173,6 +177,29 @@ describe("manifest ↔ code drift guard (set-equality, BOTH directions)", () => 
     // registerProfileTools AND listed in openclaw.plugin.json#contracts.tools.
     expect(codeRegisteredNames().has("sil_profile_materialize")).toBe(true);
     expect(manifestToolNames().has("sil_profile_materialize")).toBe(true);
+  });
+
+  it("sil_profile_list is BOTH registered by register() and declared in contracts.tools", () => {
+    // The list-view-and-remove card's enumerate tool. Added to the existing
+    // registerProfileTools group (already wired into register() + here), so it
+    // must appear on BOTH sides of the equal set — registered AND declared.
+    expect(codeRegisteredNames().has("sil_profile_list")).toBe(true);
+    expect(manifestToolNames().has("sil_profile_list")).toBe(true);
+  });
+
+  it("sil_profile_get is BOTH registered by register() and declared in contracts.tools", () => {
+    // The list-view-and-remove card's view tool. Same group, same self-enforcing
+    // bar: a missing manifest entry (or a stale one) flips the set-equality RED.
+    expect(codeRegisteredNames().has("sil_profile_get")).toBe(true);
+    expect(manifestToolNames().has("sil_profile_get")).toBe(true);
+  });
+
+  it("sil_profile_remove is BOTH registered by register() and declared in contracts.tools", () => {
+    // The list-view-and-remove card's destructive remove tool (artefact half).
+    // Must appear on BOTH sides — registered by registerProfileTools AND listed
+    // in openclaw.plugin.json#contracts.tools.
+    expect(codeRegisteredNames().has("sil_profile_remove")).toBe(true);
+    expect(manifestToolNames().has("sil_profile_remove")).toBe(true);
   });
 });
 

--- a/src/__tests__/skill-content.test.ts
+++ b/src/__tests__/skill-content.test.ts
@@ -30,6 +30,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { registerIdentityTools } from "../tools/identity.js";
 import { registerCatalogTools } from "../tools/catalog.js";
+import { registerProfileTools } from "../tools/profile.js";
 import {
   createMockPluginApi,
   registeredToolNames,
@@ -85,11 +86,15 @@ function skillBody(content: string): string {
 /** The set of names the real register code emits against a mock api. Must
  * call EVERY tool group that src/index.ts#register() wires, so the skill
  * body is checked against the REAL tool surface (`sil_register`,
- * `sil_whoami`, `sil_search`, `sil_product_get`). Mirror register(). */
+ * `sil_whoami`, `sil_search`, `sil_product_get`, and the `sil_profile_*`
+ * family). Mirror register() — registerProfileTools is now wired in too, so
+ * the body-mentions check below covers the profile tools (materialize +
+ * list/get/remove), not just identity + catalog. */
 function registeredNames(): Set<string> {
   const api = createMockPluginApi();
   registerIdentityTools(api);
   registerCatalogTools(api);
+  registerProfileTools(api);
   return registeredToolNames(api);
 }
 
@@ -131,6 +136,116 @@ describe("skill/SKILL.md — body is a source of truth for the tool surface", ()
     const body = skillBody(readFileSync(SKILL_PATH, "utf8"));
     expect(body).not.toContain("sil_ping");
     expect(body).not.toContain("sil_echo");
+  });
+});
+
+/* ===========================================================================
+ * MANAGE LOCAL EXPERTS — list / view / remove
+ * (card: list-view-and-remove-local-expert-agents)
+ *
+ * tier: integration. The three management intents are conversational prose in
+ * skill/SKILL.md driving the three new plugin tools (+ the host CLI for the
+ * wiring half of remove). The skill body IS the source of truth the host agent
+ * follows, so — exactly as the create-engine block above pins its procedure —
+ * we pin that the management section names each new tool and spells out the
+ * load-bearing invariants (host-CLI-FIRST remove ordering, confirm-before-
+ * remove, graceful not_found framing).
+ *
+ * Cross-card note: PR #28 (open, unmerged) also edits this file and renumbers
+ * the engine section. These assertions anchor on tool NAMES and content tokens,
+ * NEVER on `§N` section numbers, so they survive that renumber.
+ * ========================================================================= */
+
+describe("skill/SKILL.md — names the three management tools by name (list/view/remove)", () => {
+  it("names sil_profile_list, sil_profile_get, and sil_profile_remove in the body", () => {
+    const body = skillBody(readFileSync(SKILL_PATH, "utf8"));
+    const missing = [
+      "sil_profile_list",
+      "sil_profile_get",
+      "sil_profile_remove",
+    ].filter((name) => !body.includes(name));
+    // Report by name so a forgotten tool is named, not an opaque false.
+    expect(missing).toEqual([]);
+  });
+});
+
+describe("skill/SKILL.md — manage-experts procedure spells out the load-bearing invariants", () => {
+  it("frames a distinct manage/list/view/remove capability (not just the create engine)", () => {
+    // Adversarial: the create-engine section already names experts. This card
+    // adds MANAGEMENT — the body must name listing/viewing/removing experts, so
+    // the new section is a real addition, not a re-read of the create prose.
+    const body = skillBodyLower();
+    const namesList = body.includes("list");
+    const namesView = body.includes("view") || body.includes("show");
+    const namesRemove = body.includes("remove") || body.includes("delete");
+    expect(namesList && namesView && namesRemove).toBe(true);
+  });
+
+  it("orders the remove flow host-CLI FIRST: `openclaw agents remove` precedes the procedural `sil_profile_remove` call", () => {
+    // The architect's partial-failure decision (card §110/§197): the skill runs
+    // the HOST wiring removal (`openclaw agents remove <id>`) BEFORE the sil
+    // artefact removal (`sil_profile_remove { agentId }`). Order in the prose IS
+    // the spec — artefacts-first then a failed host step leaves a broken-but-
+    // loading expert; host-first leaves only harmless, list-surfaced disk cruft.
+    //
+    // Adversarial precision on the anchor: `sil_profile_remove` is also named
+    // earlier in the intent→tool TABLE and the tool DESCRIPTION (before the
+    // numbered procedure). A naive first-occurrence `indexOf("sil_profile_remove")`
+    // would catch those reference mentions and FALSELY fail even on a correctly
+    // ordered procedure. Anchor the artefact step on its procedural CALL FORM
+    // (`sil_profile_remove { agentId }` — the invocation with its param), which
+    // appears only in the numbered remove procedure, so the ordering check pins
+    // the real step sequence, not an incidental earlier reference.
+    const body = skillBodyLower();
+    const hostRemoveIdx = body.indexOf("openclaw agents remove");
+    // The call-form prefix `sil_profile_remove {` marks the invocation (with its
+    // arg object) — present only in the numbered procedure, not the reference
+    // mentions. Resilient to whitespace inside the braces.
+    const artefactCallIdx = body.indexOf("sil_profile_remove {");
+    expect(hostRemoveIdx).toBeGreaterThanOrEqual(0);
+    expect(artefactCallIdx).toBeGreaterThanOrEqual(0);
+    expect(hostRemoveIdx).toBeLessThan(artefactCallIdx);
+  });
+
+  it("requires confirming with the user BEFORE a destructive remove", () => {
+    // Product rule 7 / UX: remove is destructive + irreversible, so the skill
+    // confirms before acting. The body must say so (confirm/confirmation before
+    // removing/deleting), so the agent does not silently delete.
+    const body = skillBodyLower();
+    const confirms =
+      body.includes("confirm") ||
+      body.includes("confirmation") ||
+      body.includes("explicit go-ahead") ||
+      body.includes("ask before");
+    expect(confirms).toBe(true);
+  });
+
+  it("names `not_found` graceful framing for an unknown expert (view & remove)", () => {
+    // Product rule 4 / UX principle: referencing an unknown expert fails
+    // gracefully — a plain not_found, ideally listing the experts that DO exist,
+    // never a stack trace or raw path. The body must name the not_found outcome.
+    expect(skillBodyLower()).toContain("not_found");
+  });
+
+  it("names `invalid_request` for a malformed/traversal expert id", () => {
+    // The fail-closed id-validation outcome the management tools surface — the
+    // body must name it so the agent recognizes a bad-id rejection (deletes
+    // nothing) versus an unknown expert (not_found).
+    expect(skillBodyLower()).toContain("invalid_request");
+  });
+
+  it("keeps the artefact-store source-of-truth framing (list reads profile.json, not the host list)", () => {
+    // Product rule 5: a sil expert IS a readable agents/<id>/profile.json — list
+    // reads the manifest, not the host agent list. The body must name the
+    // artefact store / profile.json as the listing source, so a bare host agent
+    // is not mistaken for a sil expert.
+    const body = skillBodyLower();
+    const namesArtefactSource =
+      body.includes("profile.json") ||
+      body.includes("artefact store") ||
+      body.includes("sil_data_dir") ||
+      body.includes("sil data dir");
+    expect(namesArtefactSource).toBe(true);
   });
 });
 

--- a/src/__tests__/tools/profile-manage.test.ts
+++ b/src/__tests__/tools/profile-manage.test.ts
@@ -1,0 +1,345 @@
+/**
+ * UNIT — sil_profile_list / sil_profile_get / sil_profile_remove tools:
+ * registration shape + the structured envelope each maps the store outcome to
+ * (tier: unit, mock api + temp data dir, no network, no host).
+ *
+ * Card: list-view-and-remove-local-expert-agents. The pure store-primitive
+ * invariants live in `lib/profile-store-manage.test.ts`; here we pin the TOOL
+ * boundary — the three management tools that wrap list/read/remove:
+ *
+ *   sil_profile_list   (no args)      → { status:"ok", experts[], unreadable[] }
+ *   sil_profile_get    (agentId)      → ok | not_found | invalid_request
+ *   sil_profile_remove (agentId)      → removed | not_found | invalid_request
+ *                                       | persistence_failed
+ *
+ * Adversarial, behaviour-first: the tools must map every store variant to the
+ * agreed envelope, and the destructive one (remove) must clear EXACTLY the named
+ * expert's dir while a sibling expert's dir survives (the scoped-delete +
+ * non-destructiveness criteria at the tool seam). Reads no token (generic
+ * shopping is identity-decoupled).
+ *
+ * Hermetic via the SIL_DATA_DIR temp-dir override (mirrors
+ * profile-materialize.test.ts:68-80).
+ *
+ * Contract this file pins for the implementation (expert-developer),
+ * `src/tools/profile.ts#registerProfileTools(api)`:
+ *   - registers sil_profile_list (Type.Object({})), sil_profile_get and
+ *     sil_profile_remove (Type.Object({agentId})) — agentId required;
+ *   - list  → jsonResult({status:"ok", experts, unreadable}), createdAt DESC;
+ *   - get   → {status:"ok", agentId, name, persona, playbook?, profilePath,
+ *     createdAt} / {status:"not_found", agentId, …recovery} /
+ *     {status:"invalid_request", field, message};
+ *   - remove→ {status:"removed", agentId} / {status:"not_found", agentId} /
+ *     {status:"invalid_request", field} / {status:"persistence_failed", error,
+ *     recovery} — and clears only the named expert's dir.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { registerProfileTools } from "../../tools/profile.js";
+import {
+  materializeProfile,
+  getAgentArtefactDir,
+} from "../../lib/profile-store.js";
+import { getTokensPath } from "../../lib/credentials.js";
+import {
+  createMockPluginApi,
+  getTool,
+  type MockPluginAPI,
+} from "../helpers/mock-plugin-api.js";
+
+const LIST = "sil_profile_list";
+const GET = "sil_profile_get";
+const REMOVE = "sil_profile_remove";
+
+let dataDir: string;
+let priorSilDataDir: string | undefined;
+let api: MockPluginAPI;
+
+function payloadOf(result: { content: { text?: string }[] }): Record<string, unknown> {
+  const text = result.content[0]?.text;
+  if (typeof text !== "string") {
+    throw new Error(`tool result has no text payload: ${String(text)}`);
+  }
+  return JSON.parse(text) as Record<string, unknown>;
+}
+
+/** Materialize an expert via the real store writer (never a hand fixture), so
+ * the tools read the genuine on-disk shape. Optionally pin createdAt. */
+function makeExpert(
+  agentId: string,
+  opts: { name?: string; persona?: string; playbook?: string; createdAt?: string } = {},
+): void {
+  const result = materializeProfile({
+    agentId,
+    name: opts.name ?? `Expert ${agentId}`,
+    persona: opts.persona ?? `Persona for ${agentId}.`,
+    ...(opts.playbook !== undefined ? { playbook: opts.playbook } : {}),
+  });
+  if (!result.ok) throw new Error(`fixture setup failed: ${JSON.stringify(result)}`);
+  if (opts.createdAt !== undefined) {
+    const manifestPath = join(getAgentArtefactDir(agentId), "profile.json");
+    const m = JSON.parse(readFileSync(manifestPath, "utf8")) as Record<string, unknown>;
+    m["createdAt"] = opts.createdAt;
+    writeFileSync(manifestPath, JSON.stringify(m, null, 2) + "\n");
+  }
+}
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), "sil-profile-manage-tool-"));
+  priorSilDataDir = process.env["SIL_DATA_DIR"];
+  process.env["SIL_DATA_DIR"] = dataDir;
+  api = createMockPluginApi();
+  registerProfileTools(api);
+});
+
+afterEach(() => {
+  if (priorSilDataDir === undefined) delete process.env["SIL_DATA_DIR"];
+  else process.env["SIL_DATA_DIR"] = priorSilDataDir;
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+// ===========================================================================
+// Registration shape
+// ===========================================================================
+
+describe("management tools — registration shape", () => {
+  it("registers sil_profile_list with a no-arg TypeBox object schema", () => {
+    const tool = getTool(api, LIST);
+    expect(tool.name).toBe(LIST);
+    const schema = tool.parameters as unknown as {
+      type?: string;
+      properties?: Record<string, unknown>;
+      required?: string[];
+    };
+    expect(schema.type).toBe("object");
+    // No required args — list takes nothing.
+    expect(schema.required ?? []).toEqual([]);
+  });
+
+  it("registers sil_profile_get with a required agentId string param", () => {
+    const tool = getTool(api, GET);
+    expect(tool.name).toBe(GET);
+    const schema = tool.parameters as unknown as {
+      type?: string;
+      properties?: Record<string, { type?: string }>;
+      required?: string[];
+    };
+    expect(schema.type).toBe("object");
+    expect(schema.properties?.["agentId"]?.type).toBe("string");
+    expect(schema.required ?? []).toContain("agentId");
+  });
+
+  it("registers sil_profile_remove with a required agentId string param", () => {
+    const tool = getTool(api, REMOVE);
+    expect(tool.name).toBe(REMOVE);
+    const schema = tool.parameters as unknown as {
+      type?: string;
+      properties?: Record<string, { type?: string }>;
+      required?: string[];
+    };
+    expect(schema.type).toBe("object");
+    expect(schema.properties?.["agentId"]?.type).toBe("string");
+    expect(schema.required ?? []).toContain("agentId");
+  });
+});
+
+// ===========================================================================
+// sil_profile_list
+// ===========================================================================
+
+describe("sil_profile_list — ok envelope", () => {
+  it("empty store → status ok with empty experts (a normal outcome)", async () => {
+    const tool = getTool(api, LIST);
+    const payload = payloadOf(await tool.execute("c-1", {}));
+    expect(payload["status"]).toBe("ok");
+    expect(payload["experts"]).toEqual([]);
+    expect(payload["unreadable"]).toEqual([]);
+  });
+
+  it("lists every expert (name + hasPlaybook + agentId from the manifest), createdAt DESC", async () => {
+    makeExpert("oldest", { name: "Oldest", createdAt: "2026-01-01T00:00:00.000Z" });
+    makeExpert("newest", {
+      name: "Newest",
+      playbook: "pb",
+      createdAt: "2026-06-22T00:00:00.000Z",
+    });
+
+    const tool = getTool(api, LIST);
+    const payload = payloadOf(await tool.execute("c-2", {}));
+    expect(payload["status"]).toBe("ok");
+    const experts = payload["experts"] as Array<Record<string, unknown>>;
+    // Most-recently-created first.
+    expect(experts.map((e) => e["agentId"])).toEqual(["newest", "oldest"]);
+    expect(experts[0]!["name"]).toBe("Newest");
+    expect(experts[0]!["hasPlaybook"]).toBe(true);
+    expect(experts[1]!["hasPlaybook"]).toBe(false);
+  });
+
+  it("one corrupt manifest → healthy experts still list, broken one in unreadable[]", async () => {
+    makeExpert("healthy", { name: "Healthy" });
+    makeExpert("broken", { name: "Broken" });
+    writeFileSync(join(getAgentArtefactDir("broken"), "profile.json"), "not json {{{");
+
+    const tool = getTool(api, LIST);
+    const payload = payloadOf(await tool.execute("c-3", {}));
+    expect(payload["status"]).toBe("ok");
+    const experts = payload["experts"] as Array<Record<string, unknown>>;
+    const unreadable = payload["unreadable"] as Array<Record<string, unknown>>;
+    expect(experts.map((e) => e["agentId"])).toEqual(["healthy"]);
+    expect(unreadable.map((u) => u["agentId"])).toContain("broken");
+  });
+});
+
+// ===========================================================================
+// sil_profile_get
+// ===========================================================================
+
+describe("sil_profile_get — ok envelope (full detail from artefacts)", () => {
+  it("returns status ok with name, persona, playbook, profilePath, createdAt", async () => {
+    makeExpert("gift-buyer", {
+      name: "Gift Buyer",
+      persona: "Gifts under €50; check stock.",
+      playbook: "Use sil_search then sil_product_get.",
+    });
+    const tool = getTool(api, GET);
+    const payload = payloadOf(await tool.execute("c-4", { agentId: "gift-buyer" }));
+    expect(payload["status"]).toBe("ok");
+    expect(payload["agentId"]).toBe("gift-buyer");
+    expect(payload["name"]).toBe("Gift Buyer");
+    expect(payload["persona"]).toBe("Gifts under €50; check stock.");
+    expect(payload["playbook"]).toBe("Use sil_search then sil_product_get.");
+    expect(payload["profilePath"]).toBe(
+      join(getAgentArtefactDir("gift-buyer"), "profile.json"),
+    );
+    expect(typeof payload["createdAt"]).toBe("string");
+  });
+
+  it("omits playbook in the envelope when the expert has none", async () => {
+    makeExpert("grocery", { name: "Grocery" });
+    const tool = getTool(api, GET);
+    const payload = payloadOf(await tool.execute("c-5", { agentId: "grocery" }));
+    expect(payload["status"]).toBe("ok");
+    expect(payload["playbook"]).toBeUndefined();
+    expect(typeof payload["persona"]).toBe("string");
+  });
+});
+
+describe("sil_profile_get — graceful failures", () => {
+  it("unknown id → status not_found naming the agentId, with a list-then-retry recovery hint", async () => {
+    makeExpert("exists", {}); // a neighbour, to prove get is scoped
+    const tool = getTool(api, GET);
+    const payload = payloadOf(await tool.execute("c-6", { agentId: "ghost" }));
+    expect(payload["status"]).toBe("not_found");
+    expect(payload["agentId"]).toBe("ghost");
+    // The recovery hint steers the agent to list, not to re-register.
+    expect(payload["recovery"]).toBe("sil_profile_list");
+    // No stack trace / raw path leaked — the message is a plain string.
+    expect(typeof payload["message"]).toBe("string");
+  });
+
+  it.each(["../escape", "gift/buyer", "..", "main", "Gift-Buyer"])(
+    "traversal/main/malformed id %j → status invalid_request(field=agentId), reads nothing",
+    async (bad) => {
+      const tool = getTool(api, GET);
+      const payload = payloadOf(await tool.execute("c-7", { agentId: bad }));
+      expect(payload["status"]).toBe("invalid_request");
+      expect(payload["field"]).toBe("agentId");
+      expect(typeof payload["message"]).toBe("string");
+    },
+  );
+});
+
+// ===========================================================================
+// sil_profile_remove
+// ===========================================================================
+
+describe("sil_profile_remove — clears the target dir, sibling survives (scoped)", () => {
+  it("removed → status removed and the target dir is gone; a sibling expert's dir survives", async () => {
+    makeExpert("target", { name: "Target", playbook: "doomed" });
+    makeExpert("survivor", { name: "Survivor", playbook: "keep me" });
+    const targetDir = getAgentArtefactDir("target");
+    const survivorDir = getAgentArtefactDir("survivor");
+    expect(existsSync(targetDir)).toBe(true);
+
+    const tool = getTool(api, REMOVE);
+    const payload = payloadOf(await tool.execute("c-8", { agentId: "target" }));
+    expect(payload["status"]).toBe("removed");
+    expect(payload["agentId"]).toBe("target");
+
+    // Scoped: target gone, sibling untouched.
+    expect(existsSync(targetDir)).toBe(false);
+    expect(existsSync(survivorDir)).toBe(true);
+    expect(existsSync(join(survivorDir, "profile.json"))).toBe(true);
+    expect(existsSync(join(survivorDir, "playbook.md"))).toBe(true);
+  });
+});
+
+describe("sil_profile_remove — graceful + fail-closed", () => {
+  it("unknown id → status not_found (idempotent: a re-run is also not_found), deletes nothing", async () => {
+    makeExpert("neighbour", { name: "Neighbour" });
+    const tool = getTool(api, REMOVE);
+
+    const first = payloadOf(await tool.execute("c-9", { agentId: "ghost" }));
+    expect(first["status"]).toBe("not_found");
+    expect(first["agentId"]).toBe("ghost");
+    expect(existsSync(getAgentArtefactDir("neighbour"))).toBe(true);
+
+    // Idempotent re-run.
+    const second = payloadOf(await tool.execute("c-10", { agentId: "ghost" }));
+    expect(second["status"]).toBe("not_found");
+  });
+
+  it.each(["../escape", "gift/buyer", "..", "main", "Gift-Buyer"])(
+    "traversal/main/malformed id %j → status invalid_request(field=agentId), deletes nothing",
+    async (bad) => {
+      makeExpert("alpha", { name: "Alpha", playbook: "keep" });
+      const tool = getTool(api, REMOVE);
+      const payload = payloadOf(await tool.execute("c-11", { agentId: bad }));
+      expect(payload["status"]).toBe("invalid_request");
+      expect(payload["field"]).toBe("agentId");
+      // The real expert is untouched — the bad id deleted nothing.
+      expect(existsSync(getAgentArtefactDir("alpha"))).toBe(true);
+    },
+  );
+
+  it("removed → re-remove of the same id returns not_found (full removed→not_found cycle)", async () => {
+    makeExpert("transient", { name: "Transient" });
+    const tool = getTool(api, REMOVE);
+    expect(payloadOf(await tool.execute("c-12", { agentId: "transient" }))["status"]).toBe(
+      "removed",
+    );
+    expect(payloadOf(await tool.execute("c-13", { agentId: "transient" }))["status"]).toBe(
+      "not_found",
+    );
+  });
+});
+
+// ===========================================================================
+// Identity boundary — no token side effect across any management tool
+// ===========================================================================
+
+describe("management tools — no identity coupling (no token side effect)", () => {
+  it("list, get, and remove read/write no token across a full cycle", async () => {
+    makeExpert("cycle", { name: "Cycle", playbook: "pb" });
+    await getTool(api, LIST).execute("c-14", {});
+    await getTool(api, GET).execute("c-15", { agentId: "cycle" });
+    await getTool(api, REMOVE).execute("c-16", { agentId: "cycle" });
+    expect(existsSync(getTokensPath())).toBe(false);
+  });
+});

--- a/src/lib/profile-store.ts
+++ b/src/lib/profile-store.ts
@@ -38,11 +38,14 @@ import {
   chmodSync,
   existsSync,
   mkdirSync,
+  readFileSync,
+  readdirSync,
   renameSync,
   rmSync,
   writeFileSync,
+  type Dirent,
 } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { randomBytes } from "node:crypto";
 
 import { getDataDir } from "./credentials.js";
@@ -245,4 +248,347 @@ function atomicWrite(path: string, contents: string): void {
   writeFileSync(tmp, contents, { mode: FILE_MODE });
   renameSync(tmp, path);
   chmodSync(path, FILE_MODE);
+}
+
+// ===========================================================================
+// Local expert lifecycle — list / view / remove the artefact half.
+//
+// The manifest (`profile.json`) is the source of truth for "is this a sil
+// expert": a directory under `agents/<id>/` with a readable profile.json IS an
+// expert; a bare host `agents.list[]` entry without one is not ours to manage.
+// The host-config (wiring) half of list/remove is the host agent driving its
+// own `openclaw …` CLI — these primitives only ever touch `$SIL_DATA_DIR`.
+//
+// Each primitive returns a discriminated result and NEVER throws across the
+// boundary (mirroring MaterializeResult), so one corrupt manifest or a single
+// failed delete degrades only its own outcome — never the whole operation.
+// ===========================================================================
+
+/** Resolve the agents subtree root under the plugin's data dir — the parent of
+ * every per-agent artefact directory. The deleter asserts a target is strictly
+ * a child of this (and never this itself), so a delete can never reach the
+ * parent and wipe sibling experts. */
+function getAgentsRoot(): string {
+  return join(getDataDir(), AGENTS_SUBDIR);
+}
+
+/** Re-run the writer's exact `agentId` gate at a DIRECT caller of
+ * `getAgentArtefactDir`. Returns `null` when valid; an `invalid_request`
+ * variant naming the field otherwise. The gate is identical to
+ * `materializeProfile`'s validate-first block (`AGENT_ID_RE` + non-`main`),
+ * applied BEFORE any `join`/`read`/`rm` so a `../`, `/`, `.`, or `main` never
+ * becomes a filesystem path segment. `getAgentArtefactDir`'s SAFETY note
+ * mandates exactly this for every direct caller — list does not (it never
+ * trusts a caller-supplied id; it reads only ids it discovered on disk), but
+ * read and remove DO take a caller id and so call this first. */
+function rejectBadAgentId(
+  agentId: unknown,
+): { ok: false; kind: "invalid_request"; field: "agentId"; message: string } | null {
+  if (!nonBlank(agentId)) {
+    return invalidAgentId("agentId is required and must be non-empty.");
+  }
+  if (agentId === "main") {
+    return invalidAgentId('"main" is host-reserved and is not a sil expert id.');
+  }
+  if (!AGENT_ID_RE.test(agentId)) {
+    return invalidAgentId(
+      "agentId must be lower-kebab (a-z, 0-9, hyphen) — got: " + JSON.stringify(agentId),
+    );
+  }
+  return null;
+}
+
+function invalidAgentId(
+  message: string,
+): { ok: false; kind: "invalid_request"; field: "agentId"; message: string } {
+  return { ok: false, kind: "invalid_request", field: "agentId", message };
+}
+
+/** One listed expert, summarized from its manifest (no body read — list stays
+ * cheap). `hasPlaybook` lets the skill flag a specialized expert at a glance. */
+export interface ListedProfile {
+  agentId: string;
+  name: string;
+  hasPlaybook: boolean;
+  createdAt: string;
+}
+
+/** A `profile.json` that could not be read or parsed — surfaced inline so one
+ * corrupt expert never blinds the user to the healthy ones (Product rule 6). */
+export interface UnreadableProfile {
+  /** The directory name (best-effort id); the manifest may be unreadable. */
+  agentId: string;
+  /** Human-readable cause (no token/PII — a parse error or fs error message). */
+  error: string;
+}
+
+/** `listAgentProfiles()` result — always `ok: true` (an empty/absent store is a
+ * normal, successful empty listing, not an error). The `ok` discriminator keeps
+ * the shape uniform with the read/remove results so callers narrow identically. */
+export interface ListResult {
+  ok: true;
+  experts: ListedProfile[];
+  unreadable: UnreadableProfile[];
+}
+
+/** `readAgentProfile(agentId)` result — discriminated, never throws. */
+export type ReadResult =
+  | {
+      ok: true;
+      agentId: string;
+      name: string;
+      persona: string;
+      playbook?: string;
+      profilePath: string;
+      createdAt: string;
+    }
+  | { ok: false; kind: "not_found"; agentId: string; message: string }
+  | { ok: false; kind: "invalid_request"; field: "agentId"; message: string };
+
+/** `removeAgentArtefacts(agentId)` result — discriminated, never throws. */
+export type RemoveResult =
+  | { ok: true; agentId: string }
+  | { ok: false; kind: "not_found"; agentId: string; message: string }
+  | { ok: false; kind: "invalid_request"; field: "agentId"; message: string }
+  | {
+      ok: false;
+      kind: "persistence_failed";
+      /** "<dir>: <cause>" so recovery is actionable. */
+      error: string;
+      message: string;
+      recovery: "fix_data_dir";
+    };
+
+/** Read + parse one `agents/<id>/profile.json` into a typed manifest, or throw
+ * a descriptive error the caller maps to an `unreadable`/`not_found` outcome.
+ * A manifest whose JSON parses but is missing the required string fields is
+ * treated as corrupt (an interrupted or hand-edited write) — not silently
+ * coerced. */
+function readManifestFile(profilePath: string): ProfileManifest {
+  const raw = readFileSync(profilePath, "utf8");
+  const parsed = JSON.parse(raw) as unknown;
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    typeof (parsed as { agentId?: unknown }).agentId !== "string" ||
+    typeof (parsed as { name?: unknown }).name !== "string" ||
+    typeof (parsed as { personaPath?: unknown }).personaPath !== "string" ||
+    typeof (parsed as { createdAt?: unknown }).createdAt !== "string"
+  ) {
+    throw new Error("profile.json is missing required manifest fields");
+  }
+  return parsed as ProfileManifest;
+}
+
+/**
+ * Enumerate the materialized experts under each `$SIL_DATA_DIR/agents/<id>/`.
+ *
+ * The manifest is the source of truth — each `agents/<id>/profile.json` is read
+ * and parsed (no dirname guessing). Experts are returned `createdAt` DESC (the
+ * just-made expert first, the one the user most likely wants to act on). An
+ * absent/empty store yields a normal empty listing. One unreadable or corrupt
+ * manifest lands in `unreadable[]` and never aborts the listing — the healthy
+ * experts still list. Reads only; never writes, never reads a token.
+ */
+export function listAgentProfiles(): ListResult {
+  const root = getAgentsRoot();
+  if (!existsSync(root)) {
+    return { ok: true, experts: [], unreadable: [] };
+  }
+
+  const experts: ListedProfile[] = [];
+  const unreadable: UnreadableProfile[] = [];
+
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(root, { withFileTypes: true });
+  } catch (err) {
+    // The agents root exists but cannot be enumerated (e.g. EACCES). Surface it
+    // as a single degraded entry rather than throwing across the boundary.
+    unreadable.push({
+      agentId: AGENTS_SUBDIR,
+      error: errCause(err),
+    });
+    return { ok: true, experts, unreadable };
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const agentId = entry.name;
+    const profilePath = join(root, agentId, PROFILE_FILE);
+    if (!existsSync(profilePath)) {
+      // A directory under agents/ with no manifest is not a (loadable) sil
+      // expert — report it degraded so the user sees the residue (e.g. a
+      // remove that cleared the manifest but left a stray file).
+      unreadable.push({ agentId, error: "no profile.json manifest" });
+      continue;
+    }
+    try {
+      const manifest = readManifestFile(profilePath);
+      experts.push({
+        agentId: manifest.agentId,
+        name: manifest.name,
+        hasPlaybook: manifest.playbookPath !== undefined,
+        createdAt: manifest.createdAt,
+      });
+    } catch (err) {
+      unreadable.push({ agentId, error: errCause(err) });
+    }
+  }
+
+  // Most-recently-created first (Product Flow 1). createdAt is ISO 8601, so a
+  // lexical compare is also chronological; fall back to it when Date.parse is
+  // NaN (a corrupt-but-parseable date) so the sort is total and stable-ish.
+  experts.sort((a, b) => createdAtDesc(a.createdAt, b.createdAt));
+
+  return { ok: true, experts, unreadable };
+}
+
+/** Compare two ISO 8601 createdAt strings, most-recent first. */
+function createdAtDesc(a: string, b: string): number {
+  const ta = Date.parse(a);
+  const tb = Date.parse(b);
+  if (Number.isNaN(ta) || Number.isNaN(tb)) {
+    // Lexical fallback keeps the sort total when a timestamp is unparseable.
+    return a < b ? 1 : a > b ? -1 : 0;
+  }
+  return tb - ta;
+}
+
+/**
+ * Read one expert's full detail — the manifest PLUS the persona/playbook bodies
+ * from the files it points at — so the skill can render a complete view.
+ *
+ * Re-runs the writer's `agentId` gate BEFORE any `join`/read (a traversal-shaped
+ * id → `invalid_request`, reading nothing). An unknown id, an absent/unreadable
+ * manifest, or an absent persona body → `not_found` (a degraded expert is, from
+ * the user's view, not viewable). Never throws across the boundary; reads only.
+ */
+export function readAgentProfile(agentId: string): ReadResult {
+  const bad = rejectBadAgentId(agentId);
+  if (bad) return bad;
+
+  const dir = getAgentArtefactDir(agentId);
+  const profilePath = join(dir, PROFILE_FILE);
+  if (!existsSync(profilePath)) {
+    return notFoundRead(agentId);
+  }
+
+  let manifest: ProfileManifest;
+  try {
+    manifest = readManifestFile(profilePath);
+  } catch {
+    // A corrupt/half-written manifest is, to the viewer, an expert that cannot
+    // be loaded — surface not_found (the skill lists the healthy ones), never a
+    // raw parse error across the boundary.
+    return notFoundRead(agentId);
+  }
+
+  let persona: string;
+  try {
+    persona = readFileSync(manifest.personaPath, "utf8");
+  } catch {
+    // Manifest present but its persona body is gone (a partial removal, or a
+    // hand-deleted file) — the expert is not viewable.
+    return notFoundRead(agentId);
+  }
+
+  let playbook: string | undefined;
+  if (manifest.playbookPath !== undefined) {
+    try {
+      playbook = readFileSync(manifest.playbookPath, "utf8");
+    } catch {
+      // The playbook is optional detail; its absence does not make the expert
+      // unviewable. Render the rest without it.
+      playbook = undefined;
+    }
+  }
+
+  return {
+    ok: true,
+    agentId: manifest.agentId,
+    name: manifest.name,
+    persona,
+    ...(playbook !== undefined ? { playbook } : {}),
+    profilePath,
+    createdAt: manifest.createdAt,
+  };
+}
+
+function notFoundRead(agentId: string): ReadResult {
+  return {
+    ok: false,
+    kind: "not_found",
+    agentId,
+    message: 'No sil expert "' + agentId + '" — list your experts to see which exist.',
+  };
+}
+
+/**
+ * Remove one expert's behaviour-artefact directory — the sil-side half of a
+ * clean removal (the host-wiring half is the skill's `openclaw` CLI step; the
+ * plugin cannot write `~/.openclaw`).
+ *
+ * Fail-closed and scoped to exactly the named expert:
+ *   - re-runs the writer's `agentId` gate ITSELF (never trusts the caller) — a
+ *     bad/`main`/traversal-shaped id → `invalid_request`, deletes NOTHING;
+ *   - asserts the resolved target is strictly UNDER `getDataDir()/agents/` and
+ *     is NOT the `agents/` parent, so a delete can never escape the subtree or
+ *     wipe sibling experts;
+ *   - `rmSync(dir, { recursive, force })` the single leaf dir.
+ *
+ * Absent target → `not_found` (idempotent — a re-run after a partial host-CLI
+ * failure is safe). A genuine `rmSync` failure (e.g. EACCES) →
+ * `persistence_failed` with `<dir>: <cause>`. Never throws across the boundary.
+ */
+export function removeAgentArtefacts(agentId: string): RemoveResult {
+  const bad = rejectBadAgentId(agentId);
+  if (bad) return bad;
+
+  const dir = getAgentArtefactDir(agentId);
+
+  // Defence in depth beyond the id gate: assert the resolved path is strictly a
+  // child of the agents root and never the root itself. A `rmSync` of the
+  // parent would wipe every sibling expert — refuse it even if some future
+  // change to the gate let a separator-bearing id through.
+  const root = getAgentsRoot();
+  if (dirname(dir) !== root || dir === root) {
+    return invalidAgentId(
+      "agentId resolves outside the agents subtree — refusing to delete: " +
+        JSON.stringify(agentId),
+    );
+  }
+
+  if (!existsSync(dir)) {
+    return {
+      ok: false,
+      kind: "not_found",
+      agentId,
+      message:
+        'No sil expert "' + agentId + '" to remove (already gone) — list your'
+        + " experts to see which exist. A re-run is safe (idempotent).",
+    };
+  }
+
+  try {
+    rmSync(dir, { recursive: true, force: true });
+  } catch (err) {
+    return {
+      ok: false,
+      kind: "persistence_failed",
+      error: dir + ": " + errCause(err),
+      message:
+        "The expert's behaviour artefacts could NOT be removed from the sil data"
+        + " directory. Fix the data directory (it must be writable — check"
+        + " permissions), then remove the expert again.",
+      recovery: "fix_data_dir",
+    };
+  }
+
+  return { ok: true, agentId };
+}
+
+/** Extract a human-readable cause from an unknown thrown value (never PII). */
+function errCause(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }

--- a/src/tools/profile.ts
+++ b/src/tools/profile.ts
@@ -26,11 +26,20 @@
 import type { PluginAPI } from "openclaw/plugin-sdk";
 import { Type } from "typebox";
 
-import { materializeProfile, type ProfileSpec } from "../lib/profile-store.js";
+import {
+  listAgentProfiles,
+  materializeProfile,
+  readAgentProfile,
+  removeAgentArtefacts,
+  type ProfileSpec,
+} from "../lib/profile-store.js";
 import { jsonResult } from "../lib/tool-result.js";
 
 export function registerProfileTools(api: PluginAPI): void {
   registerMaterialize(api);
+  registerList(api);
+  registerGet(api);
+  registerRemove(api);
 }
 
 function registerMaterialize(api: PluginAPI): void {
@@ -117,6 +126,193 @@ function registerMaterialize(api: PluginAPI): void {
         error: result.error,
         message: result.message,
         recovery: "fix_data_dir",
+      });
+    },
+  });
+}
+
+/**
+ * `sil_profile_list` — enumerate the user's sil shopping experts (read-only).
+ *
+ * The artefact store is the source of truth for "what is a sil expert" (a
+ * readable `agents/<id>/profile.json`), not the host agent list. Returns each
+ * expert summarized from its manifest, most-recently-created first, plus an
+ * `unreadable[]` bucket so one corrupt manifest never blinds the user to the
+ * rest. An empty store is a normal `ok` outcome (like an empty `sil_search`).
+ */
+function registerList(api: PluginAPI): void {
+  api.registerTool({
+    name: "sil_profile_list",
+    label: "List the user's sil shopping experts",
+    description:
+      "List the sil shopping experts the user has created — read-only, no"
+      + " arguments. Sourced from the sil data directory's artefact store (each"
+      + " agents/<id>/profile.json is the authoritative \"is a sil expert\""
+      + " signal — a bare host agent without one is not listed). Returns the"
+      + " experts most-recently-created first, each with its agentId, name,"
+      + " whether it carries a domain playbook, and createdAt. An empty store is"
+      + " a normal, successful empty listing — not an error. One unreadable or"
+      + " corrupt manifest is reported inline in `unreadable` and never aborts"
+      + " the listing. Reads no token and writes nothing.",
+    parameters: Type.Object({}),
+    async execute(_callId, _params) {
+      const { experts, unreadable } = listAgentProfiles();
+      api.logger.info("sil_profile_listed", {
+        expert_count: experts.length,
+        unreadable_count: unreadable.length,
+      });
+      return jsonResult({
+        status: "ok",
+        experts,
+        unreadable,
+      });
+    },
+  });
+}
+
+/**
+ * `sil_profile_get` — view one expert's full detail (read-only).
+ *
+ * Re-runs the writer's `agentId` gate before any read (a traversal-shaped id →
+ * `invalid_request`). Returns the manifest plus the persona/playbook bodies so
+ * the skill can render a complete view. An unknown or unloadable expert →
+ * `not_found` (the skill lists the healthy experts) — never a stack trace or a
+ * raw path. Reads no token and writes nothing.
+ */
+function registerGet(api: PluginAPI): void {
+  api.registerTool({
+    name: "sil_profile_get",
+    label: "View one sil shopping expert's detail",
+    description:
+      "Show one sil shopping expert's full detail — read-only. Pass its"
+      + " `agentId`. Returns the expert's name, its persona/instructions, its"
+      + " domain playbook when one exists, the manifest path, and createdAt,"
+      + " read from the artefact store so the agent can summarize the expert."
+      + " An unknown expert returns `not_found` (list the experts to see which"
+      + " exist) — never a stack trace or a raw path. A malformed/traversal id"
+      + " returns `invalid_request`. Reads no token and writes nothing.",
+    parameters: Type.Object({
+      agentId: Type.String({
+        description:
+          "The expert's host agent id (lower-kebab, e.g. \"gift-buyer\"; not"
+          + " \"main\"). Keys the artefact directory the detail is read from.",
+      }),
+    }),
+    async execute(_callId, params) {
+      const agentId = typeof params["agentId"] === "string" ? params["agentId"] : "";
+      const result = readAgentProfile(agentId);
+
+      if (result.ok) {
+        api.logger.info("sil_profile_viewed", {
+          agent_id: result.agentId,
+          has_playbook: result.playbook !== undefined,
+        });
+        return jsonResult({
+          status: "ok",
+          agentId: result.agentId,
+          name: result.name,
+          persona: result.persona,
+          ...(result.playbook !== undefined ? { playbook: result.playbook } : {}),
+          profilePath: result.profilePath,
+          createdAt: result.createdAt,
+        });
+      }
+
+      if (result.kind === "invalid_request") {
+        api.logger.warn("sil_profile_get_invalid_request", { field: result.field });
+        return jsonResult({
+          status: "invalid_request",
+          field: result.field,
+          message: result.message,
+        });
+      }
+
+      // not_found — a normal outcome; steer the agent to list-then-retry.
+      api.logger.info("sil_profile_get_not_found", { agent_id: result.agentId });
+      return jsonResult({
+        status: "not_found",
+        agentId: result.agentId,
+        message: result.message,
+        recovery: "sil_profile_list",
+      });
+    },
+  });
+}
+
+/**
+ * `sil_profile_remove` — remove one expert's behaviour artefacts (the sil-side
+ * half of a clean removal).
+ *
+ * This is the ARTEFACT half ONLY. The host-wiring half (the `agents.list[]`
+ * entry) is the skill's `openclaw agents remove <agentId>` CLI step, which the
+ * skill runs FIRST — the plugin cannot write `~/.openclaw` (`noChildProcess`).
+ *
+ * Fail-closed: re-runs the `agentId` gate itself, deletes only the single
+ * validated leaf directory under `agents/`, and deletes NOTHING on a bad id.
+ * Absent target → `not_found` (idempotent — safe to re-run after a partial host
+ * failure). A genuine `rmSync` failure → `persistence_failed`. Reads no token.
+ */
+function registerRemove(api: PluginAPI): void {
+  api.registerTool({
+    name: "sil_profile_remove",
+    label: "Remove a sil shopping expert's behaviour artefacts",
+    description:
+      "Remove one sil shopping expert's behaviour artefacts from the sil data"
+      + " directory (its agents/<id>/ directory). This is the SIL-SIDE half of"
+      + " removal only — the host wiring (the agents.list[] entry) is removed"
+      + " separately by the host CLI, which the skill runs FIRST (this plugin"
+      + " cannot write the host config). Pass the `agentId`. Scoped to exactly"
+      + " that one expert: a malformed/traversal/\"main\" id returns"
+      + " `invalid_request` and deletes nothing; an unknown id returns"
+      + " `not_found` (idempotent — safe to re-run after a partial failure); a"
+      + " genuine filesystem failure returns `persistence_failed`. Confirm with"
+      + " the user before removing — it is destructive and irreversible.",
+    parameters: Type.Object({
+      agentId: Type.String({
+        description:
+          "The expert's host agent id (lower-kebab, e.g. \"gift-buyer\"; not"
+          + " \"main\"). Keys the artefact directory to remove. Exactly one"
+          + " expert is affected.",
+      }),
+    }),
+    async execute(_callId, params) {
+      const agentId = typeof params["agentId"] === "string" ? params["agentId"] : "";
+      const result = removeAgentArtefacts(agentId);
+
+      if (result.ok) {
+        api.logger.info("sil_profile_removed", { agent_id: result.agentId });
+        return jsonResult({
+          status: "removed",
+          agentId: result.agentId,
+        });
+      }
+
+      if (result.kind === "invalid_request") {
+        api.logger.warn("sil_profile_remove_invalid_request", { field: result.field });
+        return jsonResult({
+          status: "invalid_request",
+          field: result.field,
+          message: result.message,
+        });
+      }
+
+      if (result.kind === "not_found") {
+        api.logger.info("sil_profile_remove_not_found", { agent_id: result.agentId });
+        return jsonResult({
+          status: "not_found",
+          agentId: result.agentId,
+          message: result.message,
+          recovery: "sil_profile_list",
+        });
+      }
+
+      // persistence_failed — the path + cause are in `error` (never a token/PII).
+      api.logger.error("sil_profile_remove_persistence_failed", { error: result.error });
+      return jsonResult({
+        status: "persistence_failed",
+        error: result.error,
+        message: result.message,
+        recovery: result.recovery,
       });
     },
   });


### PR DESCRIPTION
## Card
`cards/list-view-and-remove-local-expert-agents.md` (lives in the `card/list-view-and-remove-local-expert-agents` branch — see the body for the full intent + handoffs). Goal/epic: `shopping-expert-profiles`.

## Summary
Delivers the local expert lifecycle (the artefact half) over the `$SIL_DATA_DIR/agents/<id>/` store the create-engine (#27) writes — three store primitives + three tools, no server, no identity coupling.

- **`src/lib/profile-store.ts`** — `listAgentProfiles()` (manifest-sourced, `createdAt` DESC, one corrupt manifest isolated in `unreadable[]`), `readAgentProfile(agentId)` (manifest + persona/playbook bodies; unknown/corrupt → `not_found`, traversal → `invalid_request`), `removeAgentArtefacts(agentId)` (artefact half only; fail-closed id gate + a path-segment assertion that the target is strictly a child of `agents/` — never the parent; idempotent `not_found`; `persistence_failed` on a genuine `rmSync` failure). Each returns a discriminated result that never throws across the boundary.
- **`src/tools/profile.ts`** — `sil_profile_list` / `sil_profile_get` / `sil_profile_remove`, extending `registerProfileTools` (no `index.ts` edit needed). `sil_profile_remove` is the artefact half only — the host-wiring half is the skill's `openclaw agents remove` CLI step, run FIRST.
- **`openclaw.plugin.json`** — three names added to `contracts.tools` (the load-bearing drift-guard step) + `security.packagingNote` extended.
- **`skill/SKILL.md`** — peer "Manage your sil shopping experts" section: host-CLI-FIRST remove ordering, confirm-before-remove, graceful `not_found`/`invalid_request` framing, manage status taxonomy.
- **`CHANGELOG.md`** — `[Unreleased]` entry.

Invariants held: clean removal clears both stores (no orphan); every op scoped to one validated `agentId`; generic profile-less shopping + the four core `sil_*` tools untouched (no token read/write); unknown-expert references fail gracefully.

## Test plan
- [x] `pnpm typecheck` green
- [x] Store primitives (unit): `src/__tests__/lib/profile-store-manage.test.ts` (37) — list/read/remove, traversal-reject, idempotency, scoped-delete, no-token
- [x] Tools (unit): `src/__tests__/tools/profile-manage.test.ts` (23) — registration shape + envelope mapping
- [x] Drift guards (integration): `manifest-contract.integration.test.ts` (set-equality both directions) + `skill-content.test.ts` (host-CLI-first ordering anchor)
- [x] Live verification: compiled primitives exercised end-to-end against a real temp `SIL_DATA_DIR`
- Note: `repo-scaffold.integration.test.ts` fails on the known worktree baseline quirk (repo-local `CLAUDE.md`/`docs/` are gitignored, absent on disk in card worktrees) — not a regression. The clears-BOTH-stores + host-CLI-first ordering criterion is `[e2e]`-only and gated on the deferred host harness (the host CLI was not faked to claim it at a lower tier).

## Distillation target
Knowledge capture happens **after Review PASS** in the `distilling` stage — `solutions-architect` runs in this same worktree, commits to this same branch, and pushes here so the PR ends up containing implementation + tests + distillation in one mergeable unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)