### PR TITLE
feature: refine an expert from observed sessions (self-reinforcement) (SC6)

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -34,10 +34,13 @@ Confirm the `sil_*` tools are exposed. If they are missing from the available to
 | "what experts do I have?" / "list my experts" | `sil_profile_list` | [`references/manage_experts.md`](references/manage_experts.md) |
 | "show me / tell me about &lt;expert&gt;" | `sil_profile_get` | [`references/manage_experts.md`](references/manage_experts.md) |
 | "remove / delete &lt;expert&gt;" | `sil_profile_remove` (host-CLI-first — see the reference) | [`references/manage_experts.md`](references/manage_experts.md) |
+| "refine / sharpen / improve &lt;expert&gt;" / "the gift buyer keeps surfacing the wrong stuff — fix it" | (load → propose → confirm → persist — see the reference) | [`references/refine_expert.md`](references/refine_expert.md) |
 
 [`references/catalog_tools_reference.md`](references/catalog_tools_reference.md) holds the per-tool behaviour for the four core tools and the shared status taxonomy. Basic shopping needs only that one reference.
 
 [`references/manage_experts.md`](references/manage_experts.md) holds the list / view / remove flow for the experts the user has created — including the host-CLI-first remove ordering and the confirm-before-remove gate. Load it the moment the user wants to see or remove an existing expert.
+
+[`references/refine_expert.md`](references/refine_expert.md) holds the refinement loop for an *existing* expert — sharpening it from observed sessions, with a confirm-before-persist gate (nothing changes silently). Load it when the user wants to refine, sharpen, or amend an expert they already have.
 
 ### Creating a shopping expert — the endorsement-gated two-step
 

--- a/skill/references/agent_creation_engine.md
+++ b/skill/references/agent_creation_engine.md
@@ -62,4 +62,4 @@ The **sil plugin** and the **sil skill** are always attached (that is what makes
 
 ## Runtime — how a created expert loads its behaviour
 
-When you (the sil skill) start a session inside a created expert, read `$SIL_DATA_DIR/agents/<agentId>/profile.json`, then load the `persona.md` (reaffirm the standing instructions) and `playbook.md` sub-skill (the domain shopping playbook) it points at. That is what lets the expert shop on its niche with no further setup.
+When you (the sil skill) start a session inside a created expert, read `$SIL_DATA_DIR/agents/<agentId>/profile.json`, then load the `persona.md` (reaffirm the standing instructions) and `playbook.md` sub-skill (the domain shopping playbook) it points at. That is what lets the expert shop on its niche with no further setup. To sharpen a created expert from what it observed in real sessions, see [`refine_expert.md`](refine_expert.md).

--- a/skill/references/refine_expert.md
+++ b/skill/references/refine_expert.md
@@ -1,0 +1,41 @@
+# Refine an existing expert from observed sessions — the refinement loop
+
+When the user wants to **sharpen an expert they already have** — "refine my road-cycling buyer", "the gift buyer keeps surfacing the wrong stuff, let's fix it", "amend this expert" — do **not** re-brainstorm it from scratch and do **not** quietly mutate it. Run this **targeted-amend** loop: load the existing expert, propose concrete refinements drawn from what the agent actually **observed** in real shopping sessions under it, let the user **confirm a subset**, and persist **only** the confirmed subset by re-running the existing persist step. Nothing changes silently; nothing persists without the user's explicit confirmation.
+
+This is a distinct capability from creating an expert ([`agent_creation_engine.md`](agent_creation_engine.md), which CREATES) and from the shop-time loop (which SHOPS). Refining **sharpens an existing expert** — the named one — from observed evidence. The default is a **targeted amend**, not a full cold re-brainstorm; a wholesale re-shape via the full interview remains available only on explicit request.
+
+Run these steps **in order, top to bottom** — the order is the spec.
+
+## The refinement loop (run in this exact order)
+
+1. **Trigger + load the named expert.** The user names the expert to refine (or an end-of-session signal invites a refinement). Load that one expert's current artefacts with **`sil_profile_get { agentId }`** — the manifest plus the `persona` and `playbook` bodies. This is the working expert you are about to sharpen; everything you propose is grounded in what it already is.
+
+2. **Propose, session-grounded — concretely, never a generic template.** Propose a small set of **concrete refinements drawn from the observed session** — what the agent actually saw in the just-completed (or in-progress) shopping session under this expert. Each proposal must name **two things**:
+   - **which artefact element it changes** — a `persona` standing rule, a `playbook` answer→param **mapping** entry, or a recommendation **rubric** weight; and
+   - **the concrete observed evidence behind it** — a `sil_search` param mapping that returned **relevant** vs **irrelevant** items, a question that turned out to matter (or was noise), a candidate the user **accepted** or **rejected**, or a taste/constraint the user **volunteered but the playbook never captured** (e.g. "you said 'nothing over 8kg' three times", "you rejected every leather option").
+
+   Every proposal cites the observed evidence — it is **grounded**, not guesswork. This is **not a generic template** and **not** a plausible-sounding ungrounded "improvement"; a proposal not tied to anything the session showed is forbidden. (When the observed session is unavailable, do not invent one — see the fallback at the foot of this reference.)
+
+3. **Confirm — the gate, before anything persists.** Present the proposals and let the user **confirm a subset** — all, some, or none (per-proposal accept/reject; the user chooses **which to keep**). Confirmation is an **explicit affirmative act** on specific proposals. It is **never inferred from silence**, and **never** from the user answering an **off-topic** / unrelated question. This is the strongest invariant of the loop, re-applying the create engine's endorsement discipline at refine time — *see [`brainstorm_interview.md`](brainstorm_interview.md) for the endorsement-gate discipline; do not restate it here.* Until the user confirms, the proposals live **only in the conversation**.
+
+4. **Persist ONLY the confirmed subset.** Fold **only the confirmed** proposals into the expert's **full** spec (persona drift → the `persona` body; mapping / rubric / elicitation drift → the `playbook` body), then re-run the engine's persist step — **`sil_profile_materialize { agentId, name, persona, playbook? }`** — over that one `agentId`. The unconfirmed proposals are **discarded** with the conversation; nothing else persists, no more than what the user agreed to. If the user confirms nothing, nothing changes.
+
+   The re-materialize is an **atomic in-place re-write** of that one expert's artefacts — `persona.md` and `playbook.md` are overwritten and the manifest refreshed, all-or-nothing per file (the store's existing idiom; do **not** hand-roll a write under the sil data directory). **On a persist failure the prior artefacts are left intact** — the expert is never served half-refined, and you tell the user the refinement **did not stick** (the failure leaves the prior state unchanged, so there is nothing to undo). *Truthful failure-safety note: the re-write is per-file atomic and dir-preserving — a failed re-write never tears the expert down and never serves a coherent half-refined expert (a broken manifest reads back as not-found, fail-closed). It is **not** a cross-file transaction; the safety property is "fails closed, prior expert intact / never half-served", not "all three files roll back together".*
+
+   When a confirmed refinement changes the **persona** (the expert's system framing), also refresh the agent's workspace `SOUL.md` via the host CLI — the wiring half, mirroring the engine's persona-as-system-framing step. Behaviour artefacts go to the sil data directory via the plugin tool; the `SOUL.md` refresh is host-CLI; identity is untouched.
+
+5. **Close the loop — the refined expert reflects the kept changes on re-run.** A later session opened inside the refined expert loads the **updated** artefacts (the same Runtime hook the engine documents) and behaves accordingly — the sharper mapping, the new hard-no, the re-weighted rubric. The improvement is durable: refinement is **iterative, never one-shot** — a change that did not land well is itself refinable next time.
+
+6. **Isolation + the no-signal fallback.** A refinement touches exactly the named expert's `agents/<agentId>/` directory — keyed off the single validated `agentId`. **Other experts are untouched** (no sibling expert's artefacts mutate), and the **generic, profile-less shopping path is untouched** (a plain sil session still shops exactly as today). One expert's sharpening never leaks into another or into generic shopping.
+
+## Privacy + scope — per-user and local
+
+The improvement is **per-user and local**: it is written only to this user's sil data directory (`$SIL_DATA_DIR/agents/<agentId>/`), on this machine. There is **no server-side aggregation, no shared store, no shared expert, and no cross-user signal** — the refine path calls **no server endpoint** and performs **no identity round-trip**. The expert gets sharper for this user alone; nothing is pooled or shared.
+
+## Refining the answer→`sil_search`-param mapping
+
+A refinement to the mapping (e.g. a taste the user volunteered but the playbook never captured) maps **only onto real `sil_search` params** — and a volunteered taste with **no matching param** folds into the `query` text or the recommendation **rubric**, **never an invented filter**. The `ship_to` rule is unchanged at refine time too: leave it empty (the server resolves the registered default) — no identity round-trip to populate it. **Do not restate the param table here** — point at [`search_param_mapping.md`](search_param_mapping.md) (the table, the worked params, and the `ship_to`-empty rule); refining the mapping uses exactly those rules.
+
+## When there is no observed-session signal
+
+If the user asks to refine but **no observed session** is available — a fresh session, or the prior session is out of context — do **not fabricate** session observations to propose against. Fall back to a **guided amend**: ask the user what they want to change (and apply the same confirm-before-persist gate to whatever they describe), or **invite them to shop a session first** so the next refinement has real evidence to ground proposals in. Never invent observations.

--- a/src/__tests__/lib/refine-rewrite.test.ts
+++ b/src/__tests__/lib/refine-rewrite.test.ts
@@ -1,0 +1,287 @@
+/**
+ * INTEGRATION — the refine loop's PERSIST + ROUND-TRIP composition over a real
+ * temp $SIL_DATA_DIR (tier: integration — real filesystem artefact interaction,
+ * no mock of the store, no network, no host).
+ *
+ * Card: refine-an-expert-from-observed-sessions-self-reinf (SC6). The architect's
+ * verdict is that SC6 adds NO `src/` code — the refine loop COMPOSES the existing
+ * `sil_profile_get` (load) + `sil_profile_materialize` (atomic in-place re-write)
+ * store paths. So these tests do NOT test new code; they pin the EXISTING
+ * profile-store paths the refine loop RELIES ON, in the specific composed shapes
+ * the loop exercises that the create-time `profile-store.test.ts` does not cover:
+ *
+ *   (a) re-running materializeProfile over a PRE-EXISTING agents/<id>/ dir
+ *       overwrites the artefact bodies IN PLACE (the refinement persists);
+ *   (b) an injected write failure on a PRE-EXISTING dir leaves the PRIOR
+ *       artefacts INTACT — the `dirPreexisted` guard (profile-store.ts:202-219)
+ *       never tears down a dir it did not create, so a failed re-write never
+ *       half-refines an expert;
+ *   (c) materialize → re-materialize-with-an-updated-spec → readAgentProfile
+ *       returns the UPDATED persona/playbook bodies — the load-then-refine-then-
+ *       reload loop closes (the self-reinforcement round-trip).
+ *
+ * These are GREEN on arrival (green characterization of the foundation the loop
+ * composes), NOT RED — they assert the store already does what SC6 needs. They
+ * are deliberately NOT a duplicate of profile-store.test.ts: that file pins the
+ * FRESH-dir create (write artefacts, validate-first, atomic-on-failure cleaning
+ * up a dir IT created); this file pins the PRE-EXISTING-dir re-write semantics
+ * (overwrite-in-place + prior-survives-on-failure + the read round-trip) — the
+ * three behaviours the refine path is built on.
+ *
+ * Hermetic via the SIL_DATA_DIR temp-dir override (the repo's standard knob),
+ * mirroring profile-store.test.ts's beforeEach/afterEach.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  writeFileSync,
+  mkdirSync,
+  chmodSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  materializeProfile,
+  readAgentProfile,
+  getAgentArtefactDir,
+} from "../../lib/profile-store.js";
+
+let dataDir: string;
+let priorSilDataDir: string | undefined;
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), "sil-refine-rewrite-"));
+  priorSilDataDir = process.env["SIL_DATA_DIR"];
+  process.env["SIL_DATA_DIR"] = dataDir;
+});
+
+afterEach(() => {
+  if (priorSilDataDir === undefined) delete process.env["SIL_DATA_DIR"];
+  else process.env["SIL_DATA_DIR"] = priorSilDataDir;
+  // Restore perms so rmSync can clean a dir a failure-injection test chmod'd RO.
+  try {
+    chmodSync(dataDir, 0o700);
+  } catch {
+    /* best-effort */
+  }
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+/** The expert as first created (the working expert the refine loop sharpens). */
+const CREATED = {
+  agentId: "road-cycling-buyer",
+  name: "Road Cycling Buyer",
+  persona: "You are a road-cycling buyer. Prefer endurance geometry; flag anything over 8kg.",
+  playbook: "Map budget to price_min/price_max. Rank by ride comfort, then weight.",
+} as const;
+
+/** The refined spec — the SAME agentId, UPDATED persona + playbook bodies (the
+ * confirmed-subset-folded-into-the-full-spec the refine loop re-materializes). */
+const REFINED = {
+  agentId: "road-cycling-buyer",
+  name: "Road Cycling Buyer",
+  persona:
+    "You are a road-cycling buyer. Prefer endurance geometry; flag anything over 8kg. "
+    + "HARD-NO on carbon rim brakes (the user rejected every one).",
+  playbook:
+    "Map budget to price_min/price_max. Rank by ride comfort, then weight. "
+    + "Down-weight anything the user called 'too racy'.",
+} as const;
+
+/** Every file under `dir`, recursively (relative paths) — to assert no `.tmp`
+ * sibling survives a re-write, and that a failed re-write left only the priors. */
+function walkFiles(dir: string, base = dir): string[] {
+  if (!existsSync(dir)) return [];
+  const out: string[] = [];
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) out.push(...walkFiles(full, base));
+    else out.push(full.slice(base.length + 1));
+  }
+  return out;
+}
+
+describe("refine persist — re-materialize over a PRE-EXISTING dir overwrites the bodies in place", () => {
+  it("a second materialize with an updated spec overwrites persona.md + playbook.md (the refinement sticks)", () => {
+    // Create the working expert, then refine it: re-run materialize with the
+    // UPDATED spec for the SAME agentId. The artefact bodies must be overwritten
+    // in place — the persisted files now hold the refined content, not the
+    // original. This is the persist half of the refine loop.
+    const first = materializeProfile({ ...CREATED });
+    expect(first.ok).toBe(true);
+    if (!first.ok) return;
+    // sanity: the original content is what landed.
+    expect(readFileSync(first.personaPath, "utf8")).toBe(CREATED.persona);
+
+    const dir = getAgentArtefactDir(CREATED.agentId);
+    expect(existsSync(dir)).toBe(true); // the dir pre-exists the re-write
+
+    const second = materializeProfile({ ...REFINED });
+    expect(second.ok).toBe(true);
+    if (!second.ok) return;
+
+    // The SAME files, now holding the REFINED bodies — overwritten in place.
+    expect(second.dir).toBe(dir);
+    expect(readFileSync(second.personaPath, "utf8")).toBe(REFINED.persona);
+    expect(second.playbookPath).toBeDefined();
+    expect(readFileSync(second.playbookPath!, "utf8")).toBe(REFINED.playbook);
+    // The manifest is refreshed and still points at the same artefacts.
+    const manifest = JSON.parse(
+      readFileSync(join(dir, "profile.json"), "utf8"),
+    ) as { agentId: string; name: string };
+    expect(manifest.agentId).toBe(REFINED.agentId);
+    // No `.tmp` sibling survives the atomic re-write (tmp → rename ran).
+    expect(walkFiles(dir).filter((f) => f.includes(".tmp"))).toEqual([]);
+  });
+
+  it("re-materialize does NOT create a sibling dir or leak outside agents/<agentId>/ (single-id scope)", () => {
+    // The refine persist keys off the one validated agentId; a re-write must not
+    // spawn a second agent dir. After create + refine, exactly ONE expert dir
+    // exists under agents/.
+    materializeProfile({ ...CREATED });
+    materializeProfile({ ...REFINED });
+    const agentsRoot = join(dataDir, "agents");
+    const entries = readdirSync(agentsRoot, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name);
+    expect(entries).toEqual([CREATED.agentId]);
+  });
+});
+
+describe("refine persist — a write failure on a PRE-EXISTING dir leaves the PRIOR artefacts intact (dirPreexisted guard)", () => {
+  // chmod 0500 cannot block writes for root — skip there rather than false-fail.
+  const asRoot = typeof process.getuid === "function" && process.getuid() === 0;
+
+  it.skipIf(asRoot)(
+    "when the re-write fails (dir made read-only), the original artefacts survive — never a half-refined expert",
+    () => {
+      // Create the working expert with its ORIGINAL artefacts.
+      const first = materializeProfile({ ...CREATED });
+      expect(first.ok).toBe(true);
+      if (!first.ok) return;
+      const dir = getAgentArtefactDir(CREATED.agentId);
+
+      // Make the PRE-EXISTING dir read-only so the refine re-write's tmp-file
+      // write fails EACCES. The `dirPreexisted` guard (profile-store.ts:202-219)
+      // must NOT tear the dir down — it did not create it.
+      chmodSync(dir, 0o500);
+
+      const second = materializeProfile({ ...REFINED });
+      expect(second.ok).toBe(false);
+      if (second.ok) return;
+      expect(second.kind).toBe("persistence_failed");
+
+      // Restore perms to inspect + let afterEach clean up.
+      chmodSync(dir, 0o700);
+
+      // The PRIOR artefacts survive untouched — the original content, not the
+      // refined content, and not a partial mix. This is the "a persist failure
+      // leaves the prior expert intact, never half-refined" semantics SC6 needs.
+      expect(existsSync(join(dir, "persona.md"))).toBe(true);
+      expect(readFileSync(join(dir, "persona.md"), "utf8")).toBe(CREATED.persona);
+      expect(readFileSync(join(dir, "playbook.md"), "utf8")).toBe(CREATED.playbook);
+      expect(existsSync(join(dir, "profile.json"))).toBe(true);
+      // No tmp leftover from the failed re-write.
+      expect(walkFiles(dir).filter((f) => f.includes(".tmp"))).toEqual([]);
+    },
+  );
+
+  it("a re-write blocked at the manifest stage degrades to not_found on read — never serves a coherent HALF-refined expert (the store's per-file, NOT cross-file, atomicity)", () => {
+    // ADVERSARIAL FINDING the developer must know: materializeProfile is per-FILE
+    // atomic (tmp → rename, each file is all-or-nothing) but NOT transactional
+    // ACROSS its three files. It writes persona.md → playbook.md → profile.json
+    // in order (profile-store.ts:206-210). A failure at the MANIFEST stage —
+    // AFTER persona+playbook have already been overwritten — does NOT roll the
+    // bodies back. So the "a failed re-write leaves the PRIOR artefacts intact"
+    // guarantee holds STRICTLY for a failure at the FIRST write (the read-only-dir
+    // case above); a mid-sequence failure leaves the bodies updated but the
+    // manifest stale/broken.
+    //
+    // What the store DOES still guarantee, and what protects the user, is two
+    // things, both asserted here: (1) the `dirPreexisted` guard never tears the
+    // expert dir down (the expert is not deleted), and (2) readAgentProfile
+    // composes manifest + bodies and degrades to `not_found` when the manifest is
+    // unreadable — so the loop NEVER serves a coherent-looking half-refined expert
+    // off a broken manifest; the read fails closed and the skill lists the healthy
+    // experts. THAT is the meaningful safety property at this seam.
+    const first = materializeProfile({ ...CREATED });
+    expect(first.ok).toBe(true);
+    if (!first.ok) return;
+    const dir = getAgentArtefactDir(CREATED.agentId);
+
+    // Occupy the manifest path with a directory — rename(tmp → profile.json) over
+    // a directory target fails (EISDIR/ENOTEMPTY), failing the manifest write.
+    const profilePath = join(dir, "profile.json");
+    rmSync(profilePath, { force: true });
+    mkdirSync(profilePath);
+    writeFileSync(join(profilePath, "occupied"), "blocks the rename");
+
+    const second = materializeProfile({ ...REFINED });
+    expect(second.ok).toBe(false);
+    if (second.ok) return;
+    expect(second.kind).toBe("persistence_failed");
+
+    // (1) The expert dir was NOT torn down (dirPreexisted guard) — the expert
+    // still exists on disk; the failure did not destroy it.
+    expect(existsSync(dir)).toBe(true);
+    expect(existsSync(join(dir, "persona.md"))).toBe(true);
+    expect(statSync(profilePath).isDirectory()).toBe(true); // blocker untouched
+
+    // (2) The read fails closed: with the manifest unreadable, readAgentProfile
+    // returns not_found rather than serving an expert off a half-written state.
+    // The loop never loads a coherent half-refined expert from a broken manifest.
+    const read = readAgentProfile(CREATED.agentId);
+    expect(read.ok).toBe(false);
+    if (read.ok) return;
+    expect(read.kind).toBe("not_found");
+  });
+});
+
+describe("refine round-trip — materialize → re-materialize(updated) → readAgentProfile returns the UPDATED bodies", () => {
+  it("a later read inside the refined expert loads the kept refinements (the self-reinforcement loop closes)", () => {
+    // The full loop: create the expert, refine it (re-materialize the updated
+    // spec), then LOAD it back via the same get path a later session uses. The
+    // read must return the UPDATED persona/playbook — proving a later session
+    // reflects the kept refinements, not the original spec.
+    expect(materializeProfile({ ...CREATED }).ok).toBe(true);
+    expect(materializeProfile({ ...REFINED }).ok).toBe(true);
+
+    const read = readAgentProfile(CREATED.agentId);
+    expect(read.ok).toBe(true);
+    if (!read.ok) return;
+
+    expect(read.agentId).toBe(REFINED.agentId);
+    expect(read.name).toBe(REFINED.name);
+    // The kept refinements are what a later session loads — the UPDATED bodies.
+    expect(read.persona).toBe(REFINED.persona);
+    expect(read.playbook).toBe(REFINED.playbook);
+    // And it is NOT the stale original (guards against a read that missed the
+    // overwrite).
+    expect(read.persona).not.toBe(CREATED.persona);
+    expect(read.playbook).not.toBe(CREATED.playbook);
+  });
+
+  it("the read after refine carries the refreshed manifest fields (the load path sees the new spec)", () => {
+    // The manifest is re-written on each materialize; the read composes manifest
+    // + bodies. After refine, the read's createdAt is a parseable ISO timestamp
+    // from the re-write and the profilePath still resolves under the one agent
+    // dir — the loop loads a coherent, refreshed expert.
+    materializeProfile({ ...CREATED });
+    materializeProfile({ ...REFINED });
+
+    const read = readAgentProfile(CREATED.agentId);
+    expect(read.ok).toBe(true);
+    if (!read.ok) return;
+    expect(read.profilePath).toBe(
+      join(getAgentArtefactDir(CREATED.agentId), "profile.json"),
+    );
+    expect(Number.isNaN(Date.parse(read.createdAt))).toBe(false);
+  });
+});

--- a/src/__tests__/skill-content.test.ts
+++ b/src/__tests__/skill-content.test.ts
@@ -69,6 +69,9 @@ const BRAINSTORM_PATH = join(SKILL_DIR, "references", "brainstorm_interview.md")
 const ENGINE_PATH = join(SKILL_DIR, "references", "agent_creation_engine.md");
 const MAPPING_PATH = join(SKILL_DIR, "references", "search_param_mapping.md");
 const MANAGE_PATH = join(SKILL_DIR, "references", "manage_experts.md");
+// SC6 — the refine-an-existing-expert loop (this card). NEW reference file; the
+// content-seam block at the foot of this file pins its load-bearing invariants.
+const REFINE_PATH = join(SKILL_DIR, "references", "refine_expert.md");
 const EXAMPLE_PATH = join(
   SKILL_DIR,
   "examples",
@@ -1486,5 +1489,502 @@ describe("examples/ — a worked end-to-end example exists and demonstrates the 
     expect(endorseIdx).toBeGreaterThanOrEqual(0);
     expect(addIdx).toBeGreaterThanOrEqual(0);
     expect(endorseIdx).toBeLessThan(addIdx);
+  });
+});
+
+/* ===========================================================================
+ * REFINE AN EXISTING EXPERT — the self-reinforcement loop seam
+ * (card: refine-an-expert-from-observed-sessions-self-reinf — SC6)
+ *
+ * tier: unit (the *nature* of each assertion is a single-artefact prose check
+ * over the real reference body — the umbrella file declares itself integration
+ * because it reads real skill files, but these mirror how the sibling SC4 card
+ * tagged its identical reference-content criteria). Same content-seam pattern as
+ * the engine/brainstorm blocks above: read the REAL
+ * skill/references/refine_expert.md from disk, lowercase, and pin the loop's
+ * load-bearing invariants via OR-grouped intent-token substrings + indexOf
+ * step-VERB ordering anchors — NEVER `§N` numbers, NEVER exact sentences, so the
+ * prose stays editable.
+ *
+ * The architect's verdict: SC6 is skill-guidance-only — no `src/` change, no new
+ * plugin tool. The refine loop COMPOSES the existing `sil_profile_get` (load) +
+ * `sil_profile_materialize` (atomic in-place re-write) tools; the reference body
+ * IS the spec the host agent follows, exactly as it is for the engine. These
+ * never fake a host: "a real refinement genuinely sharpens the expert" is
+ * `live-verification`'s job (this repo has NO host-load gate per CLAUDE.md), and
+ * the artefact-interaction half (the in-place re-write preserving prior artefacts
+ * on failure; the materialize→re-materialize→read round-trip) is pinned by the
+ * integration test in src/__tests__/lib/refine-rewrite.test.ts.
+ *
+ * The 7 unit invariants pinned here come straight from the card's 7 `unit`
+ * acceptance criteria / the In-Dev handoff "Where to start (qa-developer)" list.
+ * RED on arrival: refine_expert.md does not exist yet (expert-developer authors
+ * it in GREEN) — every read + assert below fails until it does.
+ * ========================================================================= */
+
+/** Lower-cased refine reference body — the file that OWNS the refine loop. */
+function refineBodyLower(): string {
+  return readBody(REFINE_PATH).toLowerCase();
+}
+
+/** The refine reference + the search-param mapping it DELEGATES the param table
+ * to, read as one corpus — for the never-invent-a-filter / ship_to-empty checks
+ * where the worked param detail legitimately lives in the mapping reference the
+ * refine loop POINTS AT (rather than re-carrying). */
+function refineCorpusLower(): string {
+  return (readBody(REFINE_PATH) + "\n" + readBody(MAPPING_PATH)).toLowerCase();
+}
+
+describe("references/refine_expert.md — exists + names the load/persist tools it composes (AC1/AC4)", () => {
+  it("exists on disk", () => {
+    // RED until expert-developer authors the reference. A refine loop with no
+    // reference is a broken capability — the router would point at a missing file.
+    expect(existsSync(REFINE_PATH)).toBe(true);
+  });
+
+  it("names the load step `sil_profile_get` (load the expert it sharpens)", () => {
+    // Step 1 (trigger + load): the loop loads the named expert's current
+    // artefacts via the existing get tool — manifest + persona + playbook. The
+    // reference must name the real load tool so the path is loadable.
+    expect(refineBodyLower()).toContain("sil_profile_get");
+  });
+
+  it("names the persist step `sil_profile_materialize` (the atomic in-place re-write)", () => {
+    // Step 4 (persist): the confirmed subset persists by re-running the engine's
+    // persist step — `sil_profile_materialize` with the UPDATED spec. The
+    // reference must name the real persist tool (NOT a hand-rolled write under
+    // $SIL_DATA_DIR — that would diverge from the store's atomic-write idiom and
+    // re-open the half-refined surface).
+    expect(refineBodyLower()).toContain("sil_profile_materialize");
+  });
+});
+
+describe("references/refine_expert.md — propose from the OBSERVED session, tied to evidence, not a generic template (AC1)", () => {
+  it("frames a distinct REFINE capability (load→propose→confirm→persist), not the create engine or a shop loop", () => {
+    // Adversarial: the engine already CREATES experts and SC4 owns the SHOP loop.
+    // This card adds REFINE — sharpening an EXISTING expert. The body must name
+    // refining/sharpening an existing expert, so it is a real distinct capability,
+    // not a re-read of the create prose or a duplicate of the shop loop.
+    const body = refineBodyLower();
+    const namesRefine =
+      body.includes("refine") ||
+      body.includes("sharpen") ||
+      body.includes("amend");
+    const namesExistingExpert =
+      body.includes("existing expert") ||
+      body.includes("an existing") ||
+      (body.includes("existing") && body.includes("expert")) ||
+      body.includes("the named expert");
+    expect(namesRefine).toBe(true);
+    expect(namesExistingExpert).toBe(true);
+  });
+
+  it("proposes refinements drawn from the OBSERVED session (not invented out of nothing)", () => {
+    // Step 2 (propose, session-grounded): proposals are drawn from what the agent
+    // actually OBSERVED in the just-completed/in-progress shopping session under
+    // this expert. The body must name the observed session as the source.
+    const body = refineBodyLower();
+    const namesObserved =
+      body.includes("observed session") ||
+      body.includes("observed shopping") ||
+      body.includes("what it observed") ||
+      body.includes("what the agent observed") ||
+      (body.includes("observed") && body.includes("session"));
+    expect(namesObserved).toBe(true);
+  });
+
+  it("ties each proposal to CONCRETE observed evidence (a query that returned junk, what was rejected, a taste volunteered-but-uncaptured)", () => {
+    // Business rule / AC1: every proposal CITES the observed evidence behind it —
+    // a `sil_search` param mapping that returned (ir)relevant items, what the user
+    // accepted/rejected, a taste volunteered but never captured. The body must
+    // name the evidence categories so a proposal is grounded, not guesswork.
+    const body = refineBodyLower();
+    // The evidence is tied to what was returned / accepted / rejected / volunteered.
+    const namesEvidence =
+      body.includes("evidence") ||
+      body.includes("grounded") ||
+      body.includes("returned relevant") ||
+      body.includes("returned irrelevant") ||
+      body.includes("relevant or irrelevant") ||
+      body.includes("relevant vs irrelevant") ||
+      body.includes("accepted") ||
+      body.includes("rejected") ||
+      body.includes("volunteered");
+    expect(namesEvidence).toBe(true);
+    // And it names WHICH artefact element each proposal changes — a persona
+    // standing rule, a mapping entry, a rubric weight — so a proposal is concrete.
+    const namesArtefactTarget =
+      body.includes("persona") &&
+      (body.includes("mapping") || body.includes("rubric"));
+    expect(namesArtefactTarget).toBe(true);
+  });
+
+  it("disavows a generic, ungrounded improvement template (no plausible-sounding guesswork)", () => {
+    // AC1 / risk: a proposal NOT tied to anything the session showed is guesswork
+    // dressed as expertise. The body must disavow the generic-template shape —
+    // "not a generic template", "never a generic improvement", "do not fabricate".
+    const body = refineBodyLower();
+    const disavowsGeneric =
+      body.includes("not a generic template") ||
+      body.includes("not a generic") ||
+      body.includes("never a generic") ||
+      body.includes("not a template") ||
+      body.includes("not generic") ||
+      body.includes("ungrounded") ||
+      (body.includes("generic") && body.includes("not")) ||
+      (body.includes("template") && body.includes("not"));
+    expect(disavowsGeneric).toBe(true);
+  });
+});
+
+describe("references/refine_expert.md — per-proposal SUBSET confirmation; only the confirmed subset folds in (AC2)", () => {
+  it("names per-proposal subset confirmation (all / some / none — not all-or-nothing)", () => {
+    // AC2: the user confirms a SUBSET (per-proposal accept/reject), not just a
+    // single yes/no over the whole batch. The body must name subset confirmation.
+    const body = refineBodyLower();
+    const namesSubset =
+      body.includes("subset") ||
+      body.includes("all, some, or none") ||
+      body.includes("all/some/none") ||
+      body.includes("all, some or none") ||
+      body.includes("per-proposal") ||
+      body.includes("per proposal") ||
+      body.includes("which to keep") ||
+      body.includes("which refinements to keep");
+    expect(namesSubset).toBe(true);
+  });
+
+  it("states ONLY the confirmed subset is folded into the spec + persisted (the rest discarded with the conversation)", () => {
+    // AC2: only the confirmed subset persists; the unconfirmed proposals are
+    // discarded with the conversation. The body must say only the confirmed
+    // changes are folded in / persisted — no over-persist.
+    const body = refineBodyLower();
+    const onlyConfirmed =
+      body.includes("only the confirmed") ||
+      body.includes("only confirmed") ||
+      body.includes("confirmed subset") ||
+      (body.includes("confirmed") && body.includes("folded")) ||
+      (body.includes("only") && body.includes("confirm") && body.includes("persist"));
+    expect(onlyConfirmed).toBe(true);
+    const discardsRest =
+      body.includes("discard") ||
+      body.includes("discarded") ||
+      body.includes("dies with the conversation") ||
+      body.includes("live only in the conversation") ||
+      body.includes("lives only in the conversation") ||
+      body.includes("only in the conversation") ||
+      body.includes("nothing else persists") ||
+      body.includes("no more");
+    expect(discardsRest).toBe(true);
+  });
+});
+
+describe("references/refine_expert.md — confirm-before-persist GATE; never inferred from silence/off-topic (AC3)", () => {
+  it("names the confirm-before-persist gate (an explicit affirmative act)", () => {
+    // AC3 (the strongest invariant): nothing persists without the user's explicit
+    // confirmation. The body must name confirmation as an explicit affirmative act
+    // gating the persist.
+    const body = refineBodyLower();
+    const namesConfirmGate =
+      body.includes("confirm") ||
+      body.includes("confirmation") ||
+      body.includes("explicit") ||
+      body.includes("affirmative");
+    expect(namesConfirmGate).toBe(true);
+  });
+
+  it("states confirmation is NEVER inferred from silence or an off-topic / unrelated reply", () => {
+    // AC3 headline trust contract: "confirm" is never inferred from silence or
+    // from the user answering an unrelated question. The body must disavow both.
+    const body = refineBodyLower();
+    const disavowsSilence =
+      body.includes("never inferred from silence") ||
+      body.includes("not inferred from silence") ||
+      body.includes("never from silence") ||
+      (body.includes("silence") && body.includes("never")) ||
+      (body.includes("silence") && body.includes("not"));
+    const disavowsOffTopic =
+      body.includes("off-topic") ||
+      body.includes("off topic") ||
+      body.includes("unrelated question") ||
+      body.includes("unrelated reply") ||
+      body.includes("answering an unrelated") ||
+      body.includes("answering something unrelated") ||
+      body.includes("an unrelated");
+    expect(disavowsSilence).toBe(true);
+    expect(disavowsOffTopic).toBe(true);
+  });
+
+  it("orders the CONFIRM verb strictly BEFORE the persist/materialize verb (the gate precedes the write)", () => {
+    // AC3 ordering anchor (mirrors the engine's validate-before-add): the confirm
+    // step must come textually BEFORE the `sil_profile_materialize`/persist step,
+    // so an agent following top-to-bottom confirms first and can never persist a
+    // proposal the user has not confirmed. Order in the prose IS the spec.
+    //
+    // Adversarial precision: anchor the persist side on the materialize TOOL
+    // token (the write surface), and the confirm side on the `confirm` verb. If
+    // the reference legitimately names the materialize tool earlier (e.g. naming
+    // the persist step it routes to), the LAST confirm before the materialize
+    // CALL still proves the gate; here we require the FIRST confirm to precede the
+    // materialize mention — a procedure that materializes before any confirm is
+    // exactly the trust violation this pins.
+    const body = refineBodyLower();
+    const confirmIdx = body.indexOf("confirm");
+    const materializeIdx = body.indexOf("sil_profile_materialize");
+    expect(confirmIdx).toBeGreaterThanOrEqual(0);
+    expect(materializeIdx).toBeGreaterThanOrEqual(0);
+    expect(confirmIdx).toBeLessThan(materializeIdx);
+  });
+});
+
+describe("references/refine_expert.md — persist is atomic; a failure leaves the PRIOR artefacts intact (AC4)", () => {
+  it("frames the persist as an atomic in-place re-write of THAT ONE agentId's artefacts", () => {
+    // AC4: persona drift → persona.md; mapping/rubric/elicitation drift →
+    // playbook.md; the re-materialize is an ATOMIC in-place re-write of that one
+    // expert's artefacts (full-spec, never a partial/field-level write). The body
+    // must name the atomic/all-or-nothing re-write and the artefact files.
+    const body = refineBodyLower();
+    const namesAtomic =
+      body.includes("atomic") ||
+      body.includes("all-or-nothing") ||
+      body.includes("all or nothing") ||
+      body.includes("in-place re-write") ||
+      body.includes("in-place rewrite") ||
+      body.includes("re-write") ||
+      body.includes("rewrite") ||
+      body.includes("overwrite");
+    expect(namesAtomic).toBe(true);
+    // The artefact files the re-write targets.
+    expect(body).toContain("persona.md");
+    expect(body).toContain("playbook.md");
+  });
+
+  it("states a persist FAILURE leaves the PRIOR artefacts intact (never a half-refined expert) and tells the user it did not stick", () => {
+    // AC4 failure half: a failed re-write leaves the PRIOR artefacts intact (the
+    // store's `dirPreexisted` guard never tears down a pre-existing dir), and the
+    // user is told the refinement did not stick. The body must name BOTH — prior
+    // artefacts survive, and never a half-refined expert.
+    const body = refineBodyLower();
+    const priorSurvives =
+      body.includes("prior artefacts") ||
+      body.includes("prior artifacts") ||
+      body.includes("prior expert") ||
+      body.includes("leaves the prior") ||
+      body.includes("leave the prior") ||
+      body.includes("prior state") ||
+      body.includes("left intact") ||
+      body.includes("leaves intact") ||
+      (body.includes("intact") && body.includes("prior")) ||
+      (body.includes("unchanged") && body.includes("fail"));
+    const neverHalfRefined =
+      body.includes("half-refined") ||
+      body.includes("half refined") ||
+      body.includes("never half") ||
+      body.includes("nothing partial") ||
+      body.includes("no partial") ||
+      body.includes("did not stick") ||
+      body.includes("didn't stick") ||
+      body.includes("does not stick");
+    expect(priorSurvives).toBe(true);
+    expect(neverHalfRefined).toBe(true);
+  });
+});
+
+describe("references/refine_expert.md — per-user/local under $SIL_DATA_DIR; NO server endpoint on the refine path (AC6)", () => {
+  it("frames refinement as per-user + local under $SIL_DATA_DIR (no shared store, no cross-user signal)", () => {
+    // AC6: the improvement is per-user and local — written only to this user's
+    // $SIL_DATA_DIR/agents/<agentId>/, no server-side aggregation, no shared
+    // store. The body must name per-user/local AND the data dir.
+    const body = refineBodyLower();
+    const namesPerUserLocal =
+      body.includes("per-user") ||
+      body.includes("per user") ||
+      body.includes("local") ||
+      body.includes("on this machine") ||
+      body.includes("your own");
+    const namesDataDir =
+      body.includes("$sil_data_dir") ||
+      body.includes("sil_data_dir") ||
+      body.includes("sil data directory") ||
+      body.includes("sil data dir");
+    expect(namesPerUserLocal).toBe(true);
+    expect(namesDataDir).toBe(true);
+    // And it disavows server-side aggregation / a shared store / cross-user signal.
+    const disavowsServer =
+      body.includes("no server-side aggregation") ||
+      body.includes("no server side aggregation") ||
+      body.includes("no shared store") ||
+      body.includes("no shared expert") ||
+      body.includes("no cross-user") ||
+      body.includes("no server endpoint") ||
+      (body.includes("no") && body.includes("aggregation")) ||
+      (body.includes("never") && body.includes("shared"));
+    expect(disavowsServer).toBe(true);
+  });
+
+  it("NEGATIVE: names NO server / sil-api endpoint on the refine path (no register/whoami round-trip, no network call)", () => {
+    // AC6 negative token check: the refine/persist path calls no server endpoint.
+    // The catalog/identity server-call surface must NOT appear as a refine STEP —
+    // the loop reasons over loaded artefacts + observations and persists locally.
+    // sil_register / sil_whoami are the identity round-trips the refine path must
+    // not perform; a `sil-api` / server-endpoint token would mean a network call.
+    const body = refineBodyLower();
+    // No identity round-trip on the refine path (the loop loads + persists, it
+    // does not register or whoami).
+    expect(body).not.toContain("sil_register");
+    expect(body).not.toContain("sil_whoami");
+    // No raw server/api endpoint token on the refine path.
+    expect(body).not.toContain("sil-api");
+    expect(body).not.toContain("api.sil");
+    expect(body).not.toContain("https://");
+  });
+});
+
+describe("references/refine_expert.md — single-agentId isolation; other experts + generic shopping untouched (AC7)", () => {
+  it("scopes the persist to the single named agentId's directory", () => {
+    // AC7: the persist touches exactly `agents/<agentId>/` for the named expert.
+    // The body must name the single-agentId scope (keyed off the one validated id).
+    const body = refineBodyLower();
+    const namesAgentScope =
+      body.includes("agentid") ||
+      body.includes("agent id") ||
+      body.includes("agents/<") ||
+      body.includes("agents/") ||
+      body.includes("the named expert");
+    expect(namesAgentScope).toBe(true);
+  });
+
+  it("states other experts AND the generic profile-less shopping path are UNTOUCHED", () => {
+    // AC7 isolation bar: no sibling expert's artefacts mutate, and a plain sil
+    // session still shops exactly as today. The body must name BOTH — other
+    // experts untouched AND generic/profile-less shopping untouched.
+    const body = refineBodyLower();
+    const othersUntouched =
+      body.includes("other expert") ||
+      body.includes("sibling") ||
+      body.includes("another expert") ||
+      (body.includes("other") && body.includes("untouched"));
+    const genericUntouched =
+      body.includes("generic") ||
+      body.includes("profile-less") ||
+      body.includes("profileless") ||
+      body.includes("plain sil") ||
+      body.includes("plain shopping") ||
+      (body.includes("untouched") && body.includes("shopping"));
+    expect(othersUntouched).toBe(true);
+    expect(genericUntouched).toBe(true);
+  });
+});
+
+describe("references/refine_expert.md — mapping refinements target REAL sil_search params; POINT AT the mapping, don't restate it (AC8)", () => {
+  it("names the never-invent-a-filter rule (a no-matching-param taste folds into query text or the rubric)", () => {
+    // AC8: a refinement to the answer→param mapping maps ONLY onto real
+    // sil_search params; a volunteered taste with no matching param folds into
+    // `query` text or the rubric — NEVER a fabricated filter. The body must name
+    // the never-invent rule AND the fold-into-query/rubric fallback.
+    const body = refineBodyLower();
+    const namesNeverInvent =
+      body.includes("never an invented filter") ||
+      body.includes("never invent a filter") ||
+      body.includes("not invent a filter") ||
+      body.includes("never an invented") ||
+      body.includes("invented filter") ||
+      body.includes("fabricated filter") ||
+      body.includes("real sil_search param") ||
+      body.includes("only real") ||
+      (body.includes("invent") && body.includes("filter"));
+    expect(namesNeverInvent).toBe(true);
+    const foldsIntoQueryOrRubric =
+      body.includes("query text") ||
+      body.includes("into query") ||
+      body.includes("into the query") ||
+      body.includes("the rubric") ||
+      (body.includes("query") && body.includes("rubric"));
+    expect(foldsIntoQueryOrRubric).toBe(true);
+  });
+
+  it("names the ship_to-empty / no-sil_whoami-round-trip rule", () => {
+    // AC8: the mapping leaves ship_to EMPTY (server resolves the registered
+    // default) and never round-trips sil_whoami to populate it. The refine
+    // reference must name this rule (consistent with the established mapping
+    // rules) — read with the mapping reference it points at, since the worked
+    // ship_to detail may legitimately live in the mapping reference.
+    const body = refineCorpusLower();
+    expect(body).toContain("ship_to");
+    const leavesEmpty =
+      body.includes("ship_to empty") ||
+      body.includes("ship_to left empty") ||
+      body.includes("leave ship_to empty") ||
+      body.includes("leaves ship_to empty") ||
+      (body.includes("ship_to") && body.includes("empty"));
+    expect(leavesEmpty).toBe(true);
+    const disavowsWhoamiRoundtrip =
+      /(never|not|no|without|don't|do not)[^.]*sil_whoami/.test(body) ||
+      /sil_whoami[^.]*(never|not)/.test(body);
+    expect(disavowsWhoamiRoundtrip).toBe(true);
+  });
+
+  it("POINTS AT search_param_mapping.md rather than re-carrying the param table (references-not-restates)", () => {
+    // AC8 / the no-duplication invariant (same one the router tests pin): the
+    // refine reference must LINK the mapping reference, NOT restate the param
+    // table. Two checks: (1) it names the mapping reference by relative path;
+    // (2) it does NOT re-carry the worked param TOKENS that belong only to the
+    // mapping reference (a refine reference that lists price_min/price_max/
+    // condition itself has duplicated the table — drift waiting to happen).
+    const body = readBody(REFINE_PATH).toLowerCase();
+    const pointsAtMapping =
+      body.includes("search_param_mapping.md") ||
+      body.includes("references/search_param_mapping.md");
+    expect(pointsAtMapping).toBe(true);
+    // It must NOT re-carry the param table's worked tokens (link, don't restate).
+    expect(body).not.toContain("price_min");
+    expect(body).not.toContain("price_max");
+  });
+});
+
+describe("references/refine_expert.md — no-observed-signal fallback: guided amend, never fabricate (AC9)", () => {
+  it("names the no-observed-signal fallback — guided amend (ask what to change) or invite-to-shop-first", () => {
+    // AC9: when no observed session signal is available (a fresh session, or the
+    // prior session out of context), the agent falls back to a guided amend (ask
+    // the user what to change) or invites them to shop first. The body must name
+    // the no-signal case AND the fallback.
+    const body = refineBodyLower();
+    const namesNoSignal =
+      body.includes("no observed") ||
+      body.includes("no session") ||
+      body.includes("fresh session") ||
+      body.includes("out of context") ||
+      body.includes("no signal") ||
+      body.includes("without an observed") ||
+      body.includes("no shopping session");
+    expect(namesNoSignal).toBe(true);
+    const namesFallback =
+      body.includes("guided amend") ||
+      body.includes("ask the user what to change") ||
+      body.includes("ask what to change") ||
+      body.includes("ask what they") ||
+      body.includes("invite") ||
+      body.includes("shop first") ||
+      body.includes("shop a session first");
+    expect(namesFallback).toBe(true);
+  });
+
+  it("states the agent must NOT fabricate session observations", () => {
+    // AC9 trust bar: the expert must NEVER invent session evidence to propose
+    // against. The body must disavow fabricating observations.
+    const body = refineBodyLower();
+    const disavowsFabrication =
+      body.includes("not fabricate") ||
+      body.includes("never fabricate") ||
+      body.includes("do not fabricate") ||
+      body.includes("don't fabricate") ||
+      body.includes("not invent") ||
+      body.includes("never invent") ||
+      body.includes("without inventing") ||
+      body.includes("rather than inventing") ||
+      body.includes("rather than invent") ||
+      (body.includes("fabricat") && body.includes("not")) ||
+      (body.includes("invent") && body.includes("observation"));
+    expect(disavowsFabrication).toBe(true);
   });
 });


### PR DESCRIPTION
## Card
`cards/refine-an-expert-from-observed-sessions-self-reinf.md` (SC6 of the `shopping-expert-profiles` goal). Card body is gitignored in this repo — it lives in the card branch worktree with the full intent + handoffs.

## Summary
Adds the **self-reinforcement** refinement loop as skill guidance — a user sharpens an *existing* expert from what it observed in real shopping sessions, and changes persist **only on explicit confirmation**.

- **NEW `skill/references/refine_expert.md`** — the refinement loop, step-ordered (the order is the spec, like `agent_creation_engine.md`): load (`sil_profile_get`) → propose session-grounded, evidence-tied refinements (never a generic template) → per-proposal **subset** confirm-before-persist GATE (never inferred from silence / an off-topic reply) → persist ONLY the confirmed subset via `sil_profile_materialize` (atomic in-place re-write of that one `agentId`'s `persona.md`/`playbook.md`) → close the loop → single-`agentId` isolation + the no-observed-signal fallback (guided amend / invite-to-shop-first, never fabricate). Per-user and local (no server endpoint, no aggregation, no shared store).
- **Additive `skill/SKILL.md` router pointer** — one routing row + one pointer line for the "refine / sharpen my expert" intent. Pointer + path only; no inlined steps/taxonomy/param detail.
- **One-line cross-link** from `agent_creation_engine.md`'s Runtime hook onward to `refine_expert.md`.

**Markdown-only; consumes `sil_profile_get` / `sil_profile_materialize` and the 8-tool manifest unchanged.** No `src/` change, no new plugin tool, no `openclaw.plugin.json#contracts.tools` change. Reference links (never restates) `search_param_mapping.md`, `catalog_tools_reference.md`, and `brainstorm_interview.md`. Persist stays on the existing atomic-re-write idiom — no hand-rolled write under `$SIL_DATA_DIR`. No stubs.

## Test plan
- [x] `tsc -p tsconfig.json --noEmit` → 0; `tsc -p tsconfig.build.json` → 0
- [x] `vitest run skill-content.test.ts lib/refine-rewrite.test.ts manifest-contract.integration.test.ts` → 3 files, 119 tests, all pass (23 refine content-seam assertions green; 6 `refine-rewrite` integration tests green; 8-tool manifest contract intact)
- [x] Live-verification: build gate PASS; Run/API/Browser/Integration SKIPPED (markdown-only, no runtime behaviour)

## Distillation target
Knowledge capture happens **after Review PASS** in the `distilling` stage — `solutions-architect` runs in this same worktree, commits to this same branch, and pushes here so the PR ends up containing implementation + tests + distillation in one mergeable unit.