### PR TITLE
bug: guarantee the sil data directory exists at plugin registration

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -32,6 +32,17 @@
  */
 
 import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  existsSync,
+  statSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { PluginAPI } from "openclaw/plugin-sdk";
 
 interface CapturedEntry {
@@ -64,6 +75,7 @@ import {
   setWebUrl,
 } from "../lib/config.js";
 import { jsonResult } from "../lib/tool-result.js";
+import { getDataDir, writeTokens } from "../lib/credentials.js";
 import { createMockPluginApi } from "./helpers/mock-plugin-api.js";
 
 beforeAll(async () => {
@@ -71,11 +83,29 @@ beforeAll(async () => {
   await import("../index.js");
 });
 
+// File-scoped hermetic data dir. After register() starts creating the data
+// dir (this card's change), every register() call in this file would touch
+// the real $SIL_DATA_DIR / ~/.local/share/sil. Point all of them at a
+// throwaway temp dir so no test pollutes the real filesystem. The dedicated
+// "data dir is guaranteed at registration time" describe sets its OWN
+// $SIL_DATA_DIR in its nested beforeEach (which runs after this one).
+let fileTempDataDir: string;
+let filePriorSilDataDir: string | undefined;
+
 beforeEach(() => {
   vi.clearAllMocks();
   // Reset module-level config state so each test starts at "default".
   setWebUrl("");
   delete process.env["SIL_WEB_URL"];
+  fileTempDataDir = mkdtempSync(join(tmpdir(), "sil-index-file-"));
+  filePriorSilDataDir = process.env["SIL_DATA_DIR"];
+  process.env["SIL_DATA_DIR"] = fileTempDataDir;
+});
+
+afterEach(() => {
+  if (filePriorSilDataDir === undefined) delete process.env["SIL_DATA_DIR"];
+  else process.env["SIL_DATA_DIR"] = filePriorSilDataDir;
+  rmSync(fileTempDataDir, { recursive: true, force: true });
 });
 
 describe("plugin entry — registration contract", () => {
@@ -190,6 +220,112 @@ describe("plugin entry — opens no long-lived resource (install-hang guard)", (
     } finally {
       fetchSpy.mockRestore();
     }
+  });
+});
+
+describe("plugin entry — data dir is guaranteed at registration time", () => {
+  // The card's product rule: from the instant register() returns, the
+  // resolved sil data dir exists as a 0700 directory — unconditionally,
+  // BEFORE any tool has executed. Hermetic per-test $SIL_DATA_DIR (real
+  // temp dir, no fs mocking — the established credentials.test.ts pattern).
+  // These tests share the captured register fn with the suite above; they
+  // own their own data-dir env so they never leak into the config tests.
+  let parentDir: string;
+  let priorSilDataDir: string | undefined;
+  let priorXdg: string | undefined;
+
+  /** The low 9 permission bits (owner/group/other rwx) of a path. */
+  function modeBits(path: string): number {
+    // eslint-disable-next-line no-bitwise
+    return statSync(path).mode & 0o777;
+  }
+
+  beforeEach(() => {
+    // A brand-new, EMPTY parent per test. The data dir we point at is a
+    // not-yet-existing CHILD of it, so "register creates it" is a real
+    // creation, never a pre-existing no-op — except where a test seeds it.
+    parentDir = mkdtempSync(join(tmpdir(), "sil-regdir-test-"));
+    priorSilDataDir = process.env["SIL_DATA_DIR"];
+    priorXdg = process.env["XDG_DATA_HOME"];
+    process.env["SIL_DATA_DIR"] = join(parentDir, "data");
+  });
+
+  afterEach(() => {
+    if (priorSilDataDir === undefined) delete process.env["SIL_DATA_DIR"];
+    else process.env["SIL_DATA_DIR"] = priorSilDataDir;
+    if (priorXdg === undefined) delete process.env["XDG_DATA_HOME"];
+    else process.env["XDG_DATA_HOME"] = priorXdg;
+    rmSync(parentDir, { recursive: true, force: true });
+  });
+
+  it("AC1 — the data dir exists the moment register() returns (before any tool ran)", () => {
+    const target = getDataDir();
+    // Precondition: the resolved dir does NOT exist before register().
+    // If this fails the test is not proving creation — it would false-green.
+    expect(existsSync(target)).toBe(false);
+
+    const api = createMockPluginApi();
+    capturedRegisterFn!(api);
+
+    // The dir is a directory on disk, AND no tool executed to make it so:
+    // register() only registered tool definitions; none of their execute()
+    // bodies ran. The mock records registrations, not invocations.
+    expect(existsSync(target)).toBe(true);
+    expect(statSync(target).isDirectory()).toBe(true);
+  });
+
+  it("AC2 — the freshly-created dir has mode 0o700 (owner-only)", () => {
+    const target = getDataDir();
+    const api = createMockPluginApi();
+    capturedRegisterFn!(api);
+    // 0700 = owner rwx, group/other none. A group/world-accessible data
+    // home leaks the credential store's container perms.
+    expect(modeBits(target)).toBe(0o700);
+  });
+
+  it("AC4 — a pre-existing dir (with contents) is a clean no-op; nothing is destroyed", () => {
+    const target = getDataDir();
+    // Pre-create the dir and seed a token-like file with known bytes +
+    // owner-only perms, simulating an already-registered user re-loading
+    // the plugin.
+    mkdirSync(target, { recursive: true, mode: 0o700 });
+    const seeded = join(target, "tokens.json");
+    writeFileSync(seeded, '{"access_token":"keep-me"}', { mode: 0o600 });
+
+    const api = createMockPluginApi();
+    // Re-loading the plugin must never throw and never clobber state.
+    expect(() => capturedRegisterFn!(api)).not.toThrow();
+
+    // The seeded file's BYTES are intact (not truncated/overwritten)...
+    expect(readFileSync(seeded, "utf8")).toBe('{"access_token":"keep-me"}');
+    // ...and its 0600 perms were not disturbed by a re-permission pass.
+    expect(modeBits(seeded)).toBe(0o600);
+    expect(modeBits(target)).toBe(0o700);
+  });
+
+  it("AC7 — the home is re-ensured at point-of-need after a mid-session delete", async () => {
+    const target = getDataDir();
+    const api = createMockPluginApi();
+    capturedRegisterFn!(api);
+    expect(existsSync(target)).toBe(true);
+
+    // Simulate the dir being deleted out from under a running session
+    // AFTER registration (the founder's "deleted out from under us" case).
+    rmSync(target, { recursive: true, force: true });
+    expect(existsSync(target)).toBe(false);
+
+    // The next write path must re-ensure the home (same path, same 0700)
+    // BEFORE the write — so a read/write after a mid-session delete is not
+    // wedged. writeTokens is the canonical write site.
+    await writeTokens({ access_token: "at-recover", refresh_token: "rt-recover" });
+
+    expect(existsSync(target)).toBe(true);
+    expect(modeBits(target)).toBe(0o700);
+    // And the write actually landed under the re-ensured home.
+    const tok = JSON.parse(
+      readFileSync(join(target, "tokens.json"), "utf8"),
+    ) as { access_token: string };
+    expect(tok.access_token).toBe("at-recover");
   });
 });
 

--- a/src/__tests__/lib/ensure-data-dir.test.ts
+++ b/src/__tests__/lib/ensure-data-dir.test.ts
@@ -1,0 +1,218 @@
+/**
+ * UNIT — ensureDataDir(), the SOLE data-dir creator (tier: unit, real
+ * temp dir, no fs mocking).
+ *
+ * The card "Create the sil data directory at registration" promotes the
+ * data home from lazily-created-on-first-write to guaranteed-at-load. The
+ * architect's handoff (§2) sites the creator as a single exported helper
+ * beside `getDataDir()`:
+ *
+ *   export function ensureDataDir(): string  — creates getDataDir() with
+ *   mode 0o700 if absent, idempotent (recursive mkdir is a no-op when it
+ *   already exists), returns the resolved path. It is the SOLE creator —
+ *   register() calls it at load; the write paths call it before write
+ *   (which doubles as the mid-session-delete guard).
+ *
+ * These tests pin that helper's contract at the unit tier, against a
+ * hermetic per-test $SIL_DATA_DIR (a real temp dir — NO mocked fs, NO
+ * AUTH_DEV_BYPASS; the repo's established credentials.test.ts pattern).
+ * They are the canonical home for:
+ *   - AC2  the dir is created with mode 0o700 (owner-only);
+ *   - AC3  creation honors the SAME $SIL_DATA_DIR → $XDG_DATA_HOME/sil →
+ *          ~/.local/share/sil precedence getDataDir() resolves, at the
+ *          resolved path and NOWHERE else, and that path is the one every
+ *          later read/write resolves;
+ *   - AC4  a pre-existing dir (with contents) is a clean idempotent no-op —
+ *          nothing overwritten, nothing re-permissioned;
+ *   - AC7  the write path re-ensures the home after a mid-session delete.
+ *
+ * Contract this file pins for the implementation (expert-developer):
+ *   src/lib/credentials.ts exports `ensureDataDir(): string` — see above.
+ *   getDataDir() stays a PURE resolver (no side effects); creation is
+ *   ensureDataDir()'s job only.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  statSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  getDataDir,
+  ensureDataDir,
+  writeTokens,
+  readTokens,
+} from "../../lib/credentials.js";
+
+let parentDir: string;
+let priorSilDataDir: string | undefined;
+let priorXdg: string | undefined;
+
+beforeEach(() => {
+  // A fresh EMPTY parent per test. The data dir under test is a
+  // not-yet-existing CHILD of it, so "ensureDataDir creates it" is a real
+  // creation, never a pre-existing no-op (except where a test seeds it).
+  parentDir = mkdtempSync(join(tmpdir(), "sil-ensuredir-test-"));
+  priorSilDataDir = process.env["SIL_DATA_DIR"];
+  priorXdg = process.env["XDG_DATA_HOME"];
+  process.env["SIL_DATA_DIR"] = join(parentDir, "data");
+});
+
+afterEach(() => {
+  if (priorSilDataDir === undefined) delete process.env["SIL_DATA_DIR"];
+  else process.env["SIL_DATA_DIR"] = priorSilDataDir;
+  if (priorXdg === undefined) delete process.env["XDG_DATA_HOME"];
+  else process.env["XDG_DATA_HOME"] = priorXdg;
+  rmSync(parentDir, { recursive: true, force: true });
+});
+
+/** The low 9 permission bits (owner/group/other rwx) of a path. */
+function modeBits(path: string): number {
+  // eslint-disable-next-line no-bitwise
+  return statSync(path).mode & 0o777;
+}
+
+describe("ensureDataDir — creates the resolved dir (AC2: 0o700)", () => {
+  it("creates a 0o700 directory at the resolved path when absent", () => {
+    const target = getDataDir();
+    expect(existsSync(target)).toBe(false); // precondition: not yet there
+
+    const returned = ensureDataDir();
+
+    expect(existsSync(target)).toBe(true);
+    expect(statSync(target).isDirectory()).toBe(true);
+    // 0o700 = owner rwx, group/other none — byte-identical to the mode the
+    // token/profile write paths already apply (DIR_MODE). A group/world
+    // accessible data home leaks the credential store's container perms.
+    expect(modeBits(target)).toBe(0o700);
+    // Returns the path it ensured, for the caller (register()) to log.
+    expect(returned).toBe(target);
+  });
+
+  it("creates intermediate parents recursively (clean machine, deep path)", () => {
+    const deep = join(parentDir, "a", "b", "c", "sil");
+    process.env["SIL_DATA_DIR"] = deep;
+    expect(existsSync(deep)).toBe(false);
+    ensureDataDir();
+    expect(statSync(deep).isDirectory()).toBe(true);
+    expect(modeBits(deep)).toBe(0o700);
+  });
+});
+
+describe("ensureDataDir — path-resolution precedence at creation (AC3)", () => {
+  it("creates at $SIL_DATA_DIR and nowhere else (highest precedence)", () => {
+    const target = join(parentDir, "via-sil-data-dir");
+    process.env["SIL_DATA_DIR"] = target;
+    // XDG is ALSO set — to prove SIL_DATA_DIR wins and XDG is not touched.
+    const xdg = mkdtempSync(join(tmpdir(), "sil-xdg-prec-"));
+    process.env["XDG_DATA_HOME"] = xdg;
+    try {
+      const created = ensureDataDir();
+      expect(created).toBe(target);
+      expect(existsSync(target)).toBe(true);
+      // The XDG path must NOT have been created — precedence honored.
+      expect(existsSync(join(xdg, "sil"))).toBe(false);
+    } finally {
+      rmSync(xdg, { recursive: true, force: true });
+    }
+  });
+
+  it("creates at $XDG_DATA_HOME/sil when SIL_DATA_DIR is unset", () => {
+    delete process.env["SIL_DATA_DIR"];
+    const xdg = mkdtempSync(join(tmpdir(), "sil-xdg-create-"));
+    process.env["XDG_DATA_HOME"] = xdg;
+    try {
+      const created = ensureDataDir();
+      expect(created).toBe(join(xdg, "sil"));
+      expect(statSync(join(xdg, "sil")).isDirectory()).toBe(true);
+      expect(modeBits(join(xdg, "sil"))).toBe(0o700);
+    } finally {
+      rmSync(xdg, { recursive: true, force: true });
+    }
+  });
+
+  it("targets ~/.local/share/sil when neither env is set (suffix-pinned)", () => {
+    delete process.env["SIL_DATA_DIR"];
+    delete process.env["XDG_DATA_HOME"];
+    // Do NOT actually create under the real home; only assert the resolver
+    // the creator would use points at the XDG-default suffix. getDataDir()
+    // is the creator's target, so pinning it pins where creation lands.
+    expect(getDataDir().endsWith(join(".local", "share", "sil"))).toBe(true);
+  });
+
+  it("the dir ensured at creation is the SAME path getDataDir() resolves later", async () => {
+    const target = join(parentDir, "consistent-home");
+    process.env["SIL_DATA_DIR"] = target;
+    const ensured = ensureDataDir();
+    // Identity: no half-initialized second home — the dir created at load
+    // is exactly the path every subsequent read/write resolves.
+    expect(ensured).toBe(getDataDir());
+    await writeTokens({ access_token: "at", refresh_token: "rt" });
+    expect(existsSync(join(target, "tokens.json"))).toBe(true);
+    expect(readTokens()!.access_token).toBe("at");
+  });
+});
+
+describe("ensureDataDir — pre-existing dir is a clean no-op (AC4: idempotent)", () => {
+  it("does not throw, truncate, or re-permission existing contents", () => {
+    const target = getDataDir();
+    // Pre-create the dir and seed a 0600 file with known bytes — an
+    // already-registered user re-loading the plugin.
+    mkdirSync(target, { recursive: true, mode: 0o700 });
+    const seeded = join(target, "tokens.json");
+    writeFileSync(seeded, '{"access_token":"keep-me"}', { mode: 0o600 });
+
+    expect(() => ensureDataDir()).not.toThrow();
+
+    // Contents intact (not truncated/overwritten) and perms undisturbed.
+    expect(readFileSync(seeded, "utf8")).toBe('{"access_token":"keep-me"}');
+    expect(modeBits(seeded)).toBe(0o600);
+    expect(modeBits(target)).toBe(0o700);
+  });
+
+  it("a second ensureDataDir() in a row is a no-op (truly idempotent)", () => {
+    const first = ensureDataDir();
+    const second = ensureDataDir();
+    expect(second).toBe(first);
+    expect(statSync(first).isDirectory()).toBe(true);
+    expect(modeBits(first)).toBe(0o700);
+  });
+});
+
+describe("ensureDataDir — write path re-ensures after a mid-session delete (AC7)", () => {
+  it("the next writeTokens recreates the deleted home (same path, 0700)", async () => {
+    const target = getDataDir();
+    ensureDataDir();
+    expect(existsSync(target)).toBe(true);
+
+    // Deleted out from under a running session AFTER registration.
+    rmSync(target, { recursive: true, force: true });
+    expect(existsSync(target)).toBe(false);
+
+    // The write path must re-ensure the home BEFORE writing — not wedge.
+    await writeTokens({ access_token: "recovered", refresh_token: "rt" });
+
+    expect(existsSync(target)).toBe(true);
+    expect(modeBits(target)).toBe(0o700);
+    expect(readTokens()!.access_token).toBe("recovered");
+  });
+
+  it("a bare ensureDataDir() call also self-heals a mid-session delete", () => {
+    const target = getDataDir();
+    ensureDataDir();
+    rmSync(target, { recursive: true, force: true });
+    expect(existsSync(target)).toBe(false);
+    // The point-of-need guard: calling the helper again re-creates it.
+    ensureDataDir();
+    expect(existsSync(target)).toBe(true);
+    expect(modeBits(target)).toBe(0o700);
+  });
+});

--- a/src/__tests__/plugin-load.integration.test.ts
+++ b/src/__tests__/plugin-load.integration.test.ts
@@ -27,11 +27,19 @@
  *   throwing and logs `sil_plugin_loaded` exactly once.
  */
 
-import { describe, it, expect, vi, beforeAll } from "vitest";
-import { existsSync } from "node:fs";
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vitest";
+import {
+  existsSync,
+  mkdtempSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { PluginAPI } from "openclaw/plugin-sdk";
+import { getDataDir } from "../lib/credentials.js";
 import { createMockPluginApi } from "./helpers/mock-plugin-api.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -60,6 +68,27 @@ beforeAll(async () => {
     loadedFrom = "src";
     await import("../index.js");
   }
+});
+
+// File-scoped hermetic data dir. Once register() creates the data dir
+// (this card's change), EVERY register() call in this file would otherwise
+// touch the real $SIL_DATA_DIR / ~/.local/share/sil. Point all of them at a
+// throwaway temp dir so no test pollutes the real filesystem. The
+// specialized describe blocks below set their OWN $SIL_DATA_DIR in their own
+// beforeEach (which runs after this one), so they still control their target.
+let fileTempDataDir: string;
+let filePriorSilDataDir: string | undefined;
+
+beforeEach(() => {
+  fileTempDataDir = mkdtempSync(join(tmpdir(), "sil-load-file-"));
+  filePriorSilDataDir = process.env["SIL_DATA_DIR"];
+  process.env["SIL_DATA_DIR"] = fileTempDataDir;
+});
+
+afterEach(() => {
+  if (filePriorSilDataDir === undefined) delete process.env["SIL_DATA_DIR"];
+  else process.env["SIL_DATA_DIR"] = filePriorSilDataDir;
+  rmSync(fileTempDataDir, { recursive: true, force: true });
 });
 
 describe("plugin load (no-Docker downgrade of the e2e host-load criterion)", () => {
@@ -92,5 +121,178 @@ describe("plugin load (no-Docker downgrade of the e2e host-load criterion)", () 
     // Not an assertion on behavior — a visible breadcrumb so the test
     // log says whether the COMPILED entry or the source was exercised.
     expect(["dist", "src"]).toContain(loadedFrom);
+  });
+});
+
+describe("plugin load — data dir is created by the FULL real register() (card integration)", () => {
+  // The integration the product ACs imply (architect handoff §6, final
+  // bullet): the ENTIRE real register() path, under a fresh temp
+  // $SIL_DATA_DIR, creates the data dir, still fires `sil_plugin_loaded`
+  // exactly once, and leaves the tool set unchanged — proving the creation
+  // rides alongside the existing load contract, not in place of it.
+  // Real temp dir, no fs mocking.
+  let parentDir: string;
+  let target: string;
+  let priorSilDataDir: string | undefined;
+  let priorXdg: string | undefined;
+
+  beforeEach(() => {
+    parentDir = mkdtempSync(join(tmpdir(), "sil-load-datadir-"));
+    target = join(parentDir, "data");
+    priorSilDataDir = process.env["SIL_DATA_DIR"];
+    priorXdg = process.env["XDG_DATA_HOME"];
+    process.env["SIL_DATA_DIR"] = target;
+  });
+
+  afterEach(() => {
+    if (priorSilDataDir === undefined) delete process.env["SIL_DATA_DIR"];
+    else process.env["SIL_DATA_DIR"] = priorSilDataDir;
+    if (priorXdg === undefined) delete process.env["XDG_DATA_HOME"];
+    else process.env["XDG_DATA_HOME"] = priorXdg;
+    rmSync(parentDir, { recursive: true, force: true });
+  });
+
+  it("creates the resolved data dir (0700) as a side effect of registering", () => {
+    expect(existsSync(target)).toBe(false); // precondition: clean machine
+    const api = createMockPluginApi();
+    capturedRegisterFn!(api);
+    expect(existsSync(target)).toBe(true);
+    expect(statSync(target).isDirectory()).toBe(true);
+    // eslint-disable-next-line no-bitwise
+    expect(statSync(target).mode & 0o777).toBe(0o700);
+  });
+
+  it("still fires `sil_plugin_loaded` exactly once AND leaves the tool set unchanged", () => {
+    const api = createMockPluginApi();
+    capturedRegisterFn!(api);
+    const markerCalls = vi
+      .mocked(api.logger.info)
+      .mock.calls.filter(([marker]) => marker === "sil_plugin_loaded");
+    expect(markerCalls).toHaveLength(1);
+    // The full real tool set — creation does not add/drop a tool.
+    expect([...api._tools.keys()].sort()).toEqual([
+      "sil_product_get",
+      "sil_profile_get",
+      "sil_profile_list",
+      "sil_profile_materialize",
+      "sil_profile_remove",
+      "sil_register",
+      "sil_search",
+      "sil_whoami",
+    ]);
+  });
+
+  it("surfaces WHERE the guaranteed home is via a `data_dir` field on the load marker", () => {
+    // Product §3: the dir-ensured fact rides the existing `sil_plugin_loaded`
+    // info line as a single `data_dir` field (the resolved path) — NOT a new
+    // `sil_data_dir_ensured` event. So an installer can see the home at load.
+    const api = createMockPluginApi();
+    capturedRegisterFn!(api);
+    expect(api.logger.info).toHaveBeenCalledWith(
+      "sil_plugin_loaded",
+      expect.objectContaining({ data_dir: target }),
+    );
+    // No separate success event for the guaranteed-success path (log noise).
+    const ensuredEvents = vi
+      .mocked(api.logger.info)
+      .mock.calls.filter(([marker]) => marker === "sil_data_dir_ensured");
+    expect(ensuredEvents).toHaveLength(0);
+  });
+});
+
+describe("plugin load — an uncreatable data dir is a LOUD, fail-closed terminal (AC5)", () => {
+  // AC5 (integration tier): when the resolved data dir cannot be created,
+  // register() must FAIL CLOSED — throw out of register() (the host rejects
+  // the plugin) AND emit a structured `sil_plugin_data_dir_failed` error log
+  // naming the path + OS cause (no token/PII). The failure must NOT be
+  // swallowed, and no partial dir may be left behind.
+  //
+  // The failure is induced production-faithfully (the register-claim FIX-C
+  // repro): a regular FILE sits where the data dir's parent should be, so the
+  // recursive mkdir throws ENOTDIR — a real, un-fakeable filesystem failure
+  // carrying the path + cause. NO fs mocking, NO logic stubbing.
+  let parentDir: string;
+  let blockerFile: string;
+  let unwritableDataDir: string;
+  let priorSilDataDir: string | undefined;
+  let priorXdg: string | undefined;
+
+  beforeEach(() => {
+    parentDir = mkdtempSync(join(tmpdir(), "sil-datadir-fail-"));
+    blockerFile = join(parentDir, "blocker");
+    writeFileSync(blockerFile, "i am a file, not a directory");
+    // A child of a regular file → mkdirSync(recursive) throws ENOTDIR.
+    unwritableDataDir = join(blockerFile, "sil-data");
+    priorSilDataDir = process.env["SIL_DATA_DIR"];
+    priorXdg = process.env["XDG_DATA_HOME"];
+    process.env["SIL_DATA_DIR"] = unwritableDataDir;
+  });
+
+  afterEach(() => {
+    if (priorSilDataDir === undefined) delete process.env["SIL_DATA_DIR"];
+    else process.env["SIL_DATA_DIR"] = priorSilDataDir;
+    if (priorXdg === undefined) delete process.env["XDG_DATA_HOME"];
+    else process.env["XDG_DATA_HOME"] = priorXdg;
+    rmSync(parentDir, { recursive: true, force: true });
+  });
+
+  it("register() THROWS (fail-closed) on an uncreatable data dir", () => {
+    // Sanity: the resolver points where we expect, and that path is uncreatable.
+    expect(getDataDir()).toBe(unwritableDataDir);
+    const api = createMockPluginApi();
+    // A guaranteed home that silently isn't there is the exact failure this
+    // card exists to kill — register() must refuse to load, not continue.
+    expect(() => capturedRegisterFn!(api)).toThrow();
+  });
+
+  it("logs a structured `sil_plugin_data_dir_failed` error naming the path + OS cause", () => {
+    const api = createMockPluginApi();
+    try {
+      capturedRegisterFn!(api);
+    } catch {
+      // Expected — we assert on the log emitted BEFORE the rethrow.
+    }
+    const failCalls = vi
+      .mocked(api.logger.error)
+      .mock.calls.filter(([marker]) => marker === "sil_plugin_data_dir_failed");
+    // The failure is observable at error level, NOT swallowed.
+    expect(failCalls).toHaveLength(1);
+    const [, payload] = failCalls[0]!;
+    const detail = JSON.stringify(payload);
+    // Names the failing path...
+    expect(detail).toContain(unwritableDataDir);
+    // ...and the OS cause (ENOTDIR), so the operator can act (fix_data_dir).
+    expect(detail).toContain("ENOTDIR");
+    // No token/PII vocabulary on this registration-time log.
+    expect(detail).not.toContain("access_token");
+    expect(detail).not.toContain("refresh_token");
+  });
+
+  it("does NOT swallow the failure into a `sil_plugin_loaded` success marker", () => {
+    const api = createMockPluginApi();
+    try {
+      capturedRegisterFn!(api);
+    } catch {
+      /* expected */
+    }
+    // Fail-closed means the load marker for SUCCESS must not fire when the
+    // home could not be guaranteed — the throw precedes it.
+    const loaded = vi
+      .mocked(api.logger.info)
+      .mock.calls.filter(([marker]) => marker === "sil_plugin_loaded");
+    expect(loaded).toHaveLength(0);
+  });
+
+  it("leaves NO partial data dir behind (the blocker is still a file)", () => {
+    const api = createMockPluginApi();
+    try {
+      capturedRegisterFn!(api);
+    } catch {
+      /* expected */
+    }
+    // The blocker path stays a regular file — nothing half-created it into
+    // a dir, and the (impossible) data dir does not exist.
+    expect(statSync(blockerFile).isFile()).toBe(true);
+    expect(existsSync(unwritableDataDir)).toBe(false);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,12 +8,14 @@
  * time — `register()` is strictly synchronous and opens nothing.
  *
  * `register()` MUST stay synchronous and side-effect-free beyond
- * registering tools and logging. The reference adapter
- * (`klodi-plugin/adapters/openclaw`) carries a smoke gate precisely
- * because an eager connection opened in `register()` once held the host's
- * install subprocess event loop open and blocked gateway startup. Keep it
- * that way: all I/O lives inside a tool's `execute()` — no timers, no
- * sockets, no unawaited promises here.
+ * registering tools, ensuring the data dir, and logging. The reference
+ * adapter (`klodi-plugin/adapters/openclaw`) carries a smoke gate
+ * precisely because an eager connection opened in `register()` once held
+ * the host's install subprocess event loop open and blocked gateway
+ * startup. Keep it that way: all I/O lives inside a tool's `execute()` —
+ * no timers, no sockets, no unawaited promises here. The one synchronous
+ * `mkdirSync` (via `ensureDataDir()`) is exempt: it returns immediately
+ * and holds no resource open.
  *
  * To add a tool, see `src/tools/identity.ts` (the reference group — it
  * sets the `jsonResult` success shape and structured-error envelope every
@@ -30,6 +32,7 @@ import {
   getApiUrlSource,
   type SilPluginConfig,
 } from "./lib/config.js";
+import { ensureDataDir, getDataDir } from "./lib/credentials.js";
 import { registerCatalogTools } from "./tools/catalog.js";
 import { registerIdentityTools } from "./tools/identity.js";
 import { registerProfileTools } from "./tools/profile.js";
@@ -45,12 +48,42 @@ export default definePluginEntry({
       api.pluginConfig as SilPluginConfig | undefined,
     );
 
+    // Guarantee the data home exists from the instant register() returns — not
+    // lazily on first write — so tokens, config, and SDS profile artefacts have
+    // one consistent home from load. One-shot synchronous mkdir (recursive,
+    // 0700): it returns immediately and holds no resource open, so the
+    // register()-stays-synchronous / opens-nothing invariant is preserved.
+    //
+    // Fail-closed: an uncreatable home (parent unwritable, path occupied by a
+    // file → ENOTDIR, no space) is logged LOUDLY and DISTINCTLY (the path + OS
+    // cause, no token/PII) then RETHROWN — the host rejects a plugin whose
+    // register() throws, which is the correct outcome for an unusable data home.
+    // A guaranteed home that silently isn't there is the exact failure this
+    // guard exists to kill; we do NOT swallow it or fall back to another dir.
+    let dataDir: string;
+    try {
+      dataDir = ensureDataDir();
+    } catch (err) {
+      const cause = err instanceof Error ? err.message : String(err);
+      api.logger.error("sil_plugin_data_dir_failed", {
+        message:
+          "sil could NOT create its data directory at registration, so tokens,"
+          + " config, and profiles have no home. Fix the data directory (it must"
+          + " be writable — check permissions / free space / that $SIL_DATA_DIR"
+          + " is a directory), then reload the plugin.",
+        data_dir: getDataDir(),
+        cause,
+      });
+      throw err;
+    }
+
     registerIdentityTools(api);
     registerCatalogTools(api);
     registerProfileTools(api);
 
     api.logger.info("sil_plugin_loaded", {
       message: "sil plugin registered.",
+      data_dir: dataDir,
       api_url: getWebUrl(),
       api_url_source: getWebUrlSource(),
       sil_api_url: getApiUrl(),

--- a/src/lib/credentials.ts
+++ b/src/lib/credentials.ts
@@ -35,13 +35,16 @@ import {
   writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 import { randomBytes } from "node:crypto";
 
 /** Owner read/write only. The bearer pair must never be group/world-readable. */
 const FILE_MODE = 0o600;
-/** Owner read/write/execute only on the data dir itself. */
-const DIR_MODE = 0o700;
+/** Owner read/write/execute only on the data dir itself. Exported so the one
+ * other writer of a `$SIL_DATA_DIR` sub-tree (`profile-store.ts`, the SDS
+ * artefact store) shares this single source of truth for the data-home mode
+ * rather than duplicating the literal. */
+export const DIR_MODE = 0o700;
 
 const TOKENS_FILE = "tokens.json";
 const CONFIG_FILE = "config.json";
@@ -75,6 +78,24 @@ export function getDataDir(): string {
   if (xdg !== undefined && xdg !== "") return join(xdg, "sil");
 
   return join(homedir(), ".local", "share", "sil");
+}
+
+/**
+ * Create the resolved data dir (`0700`) if absent and return its path. The SOLE
+ * creator of the data dir — `register()` calls it at load (so the home exists
+ * from the moment the plugin registers, not lazily on first write), and the
+ * write paths call it before every write, which doubles as the guard against the
+ * dir being deleted out from under a running session.
+ *
+ * Idempotent: `mkdirSync(..., { recursive: true })` is a clean no-op when the dir
+ * already exists, never re-permissioning or disturbing existing contents. Throws
+ * the raw fs error (ENOTDIR/EACCES/ENOSPC…) on a genuinely uncreatable path —
+ * callers surface it (fail-closed), never swallow it.
+ */
+export function ensureDataDir(): string {
+  const dir = getDataDir();
+  mkdirSync(dir, { recursive: true, mode: DIR_MODE });
+  return dir;
 }
 
 export function getTokensPath(): string {
@@ -150,13 +171,16 @@ export function clearTokens(): void {
  * The temp file is created `0600` and the final file is re-`chmod`'d to `0600`
  * in case the rename inherited a different mode on some filesystems.
  *
- * Creating the dir first (recursive, `0700`) makes first-run on a clean machine
- * a non-error. The temp name carries random bytes so two concurrent writers (a
- * pathological double-register sharing a data dir) don't collide on the temp.
+ * Ensuring the data dir first (recursive, `0700`, via `ensureDataDir()`) makes
+ * first-run on a clean machine a non-error AND re-heals the home if it was
+ * deleted out from under a running session before this write. The token/config
+ * paths are always direct children of `getDataDir()`, so the dir ensured here is
+ * exactly the one the write lands in. The temp name carries random bytes so two
+ * concurrent writers (a pathological double-register sharing a data dir) don't
+ * collide on the temp.
  */
 function writeJsonAtomic(path: string, data: unknown): void {
-  const dir = dirname(path);
-  mkdirSync(dir, { recursive: true, mode: DIR_MODE });
+  ensureDataDir();
 
   const tmp = `${path}.${process.pid}.${randomBytes(6).toString("hex")}.tmp`;
   writeFileSync(tmp, JSON.stringify(data, null, 2), {

--- a/src/lib/profile-store.ts
+++ b/src/lib/profile-store.ts
@@ -79,11 +79,12 @@ import {
 import { dirname, join } from "node:path";
 import { randomBytes } from "node:crypto";
 
-import { getDataDir } from "./credentials.js";
+import { DIR_MODE, ensureDataDir, getDataDir } from "./credentials.js";
 
-/** Owner-only file/dir modes — the artefacts are user-scoped, like tokens. */
+/** Owner-only file mode — the artefacts are user-scoped, like tokens. The dir
+ * mode (`DIR_MODE`, `0o700`) is owned by `credentials.ts` (the data-dir owner)
+ * and imported, so the data-home permission lives in exactly one place. */
 const FILE_MODE = 0o600;
-const DIR_MODE = 0o700;
 
 /** The sub-tree under `$SIL_DATA_DIR` that holds per-agent behaviour artefacts. */
 const AGENTS_SUBDIR = "agents";
@@ -278,6 +279,11 @@ export function materializeProfile(spec: ProfileSpec): MaterializeResult {
   const dirPreexisted = existsSync(dir);
 
   try {
+    // Ensure the data home (`$SIL_DATA_DIR`, 0700) exists first — its creation
+    // and mode are owned by credentials.ts (the data-dir owner), and this also
+    // re-heals it if it was deleted mid-session. Then create the per-agent leaf
+    // (`agents/<id>`), which is profile-store's own concern.
+    ensureDataDir();
     mkdirSync(dir, { recursive: true, mode: DIR_MODE });
     atomicWrite(domainSpecPath, spec.domainSpec);
     atomicWrite(intentSpecPath, spec.intentSpec);


### PR DESCRIPTION
## Card
`cards/create-the-sil-data-directory-at-registration-time.md` (lives in the `card/create-the-sil-data-directory-at-registration-time` branch's worktree — gitignored, not committed; see the card body for the full intent + Discovery + handoffs).

## Summary
The sil data dir was created only lazily on first token/profile *write*, so a session that *reads* before it writes (`sil_whoami`, the skill probing for an expert) had no consistent home. This promotes the home from lazily-created-on-first-write to **guaranteed-at-registration**.

- Add `export function ensureDataDir(): string` to `src/lib/credentials.ts` (beside `getDataDir`) — the SOLE creator of the data dir: `mkdirSync(getDataDir(), { recursive: true, mode: 0o700 })`, idempotent, returns the path. `getDataDir()` stays a pure resolver.
- Call `ensureDataDir()` FIRST in `register()` (`src/index.ts`). Fail-closed: an uncreatable home logs a structured `sil_plugin_data_dir_failed` error (path + OS cause, no token/PII) then **rethrows** — the host rejects the plugin (Q1: throw out of `register()`). No fallback dir, no silent continue.
- Route the write paths through the helper (Q2: adopt the per-call guard → mid-session-delete resilience, AC7): `writeJsonAtomic` (credentials) and `materializeProfile`'s base-dir creation (profile-store).
- Export `DIR_MODE` from credentials and **delete** the duplicated constant in `profile-store.ts` (consolidate-on-touch).
- Add a `data_dir` field to the existing `sil_plugin_loaded` info log — no new success event.
- `register()` stays synchronous and opens nothing (the install-hang guard stays green — a `mkdirSync` arms no timer/socket).

## Test plan
- [x] `pnpm typecheck` clean
- [x] AC1/2/4/7 — `src/__tests__/index.test.ts` (register creates the dir before any tool ran; 0700; pre-existing no-op; mid-session re-heal via writeTokens)
- [x] AC2/3/4/7 — `src/__tests__/lib/ensure-data-dir.test.ts` (the helper's contract: 0700, precedence-at-creation, idempotent, self-heal)
- [x] AC5 + load-marker — `src/__tests__/plugin-load.integration.test.ts` (full real `register()` creates the dir; fail-closed throw + `sil_plugin_data_dir_failed` with path + ENOTDIR cause, no PII, no success marker, no partial dir; `data_dir` on the marker)
- [x] AC6 — existing install-hang guard (`index.test.ts`) stays green untouched
- [x] Full suite: 924 pass / 934 (only `repo-scaffold.integration.test.ts` red — the known worktree-only flake: gitignored `CLAUDE.md`/`docs/` not checked out, untouched by this card)
- [x] Live verification PASS — built `dist/index.js` driven against a real ESM SDK shim: success path (dir 0700, `data_dir` on marker, 8 tools) + fail-closed path (throw, structured error, no PII, no partial dir)

## Distillation target
Knowledge capture happens **after Review PASS** in the `distilling` stage — `solutions-architect` runs in this same worktree, commits to this same branch, and pushes so the PR ends up containing implementation + tests + distillation in one mergeable unit. Candidate: `ensureDataDir()` is the single data-dir creator (register + write paths), data home guaranteed at load, `DIR_MODE` owned by credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)