### PR TITLE
feature: install-time helper to allow-list sil in OpenClaw config

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,12 @@
     "node": ">=22"
   },
   "main": "./dist/index.js",
+  "bin": {
+    "sil-openclaw-allowlist": "./scripts/allowlist-openclaw.mjs"
+  },
   "files": [
     "dist",
+    "scripts",
     "skill",
     "openclaw.plugin.json",
     "README.md",
@@ -79,6 +83,7 @@
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
     "sync-version": "node scripts/sync-version.mjs",
+    "openclaw:allowlist": "node scripts/allowlist-openclaw.mjs",
     "preversion": "pnpm typecheck && pnpm test",
     "version": "pnpm sync-version && node scripts/changelog.mjs cut && git add openclaw.plugin.json CHANGELOG.md",
     "postversion": "git push --follow-tags",

--- a/scripts/allowlist-openclaw.mjs
+++ b/scripts/allowlist-openclaw.mjs
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+/**
+ * Install-time helper: trust `sil` in the host OpenClaw config.
+ *
+ * Operator-invoked (NEVER an npm lifecycle hook — `openclaw.plugin.json#
+ * security.noInstallScripts: true` is a shipped guarantee that the package
+ * runs nothing automatically; an operator explicitly running this is the
+ * opposite of an install hook and honours it). This is a standalone script in
+ * the same class as `scripts/release.mjs` — it is NOT the plugin process, so
+ * the plugin's `~/.openclaw`-write boundary does not apply to it.
+ *
+ * What it does: resolve the host `openclaw.json`, read sil's facts from the
+ * shipped manifest (single source of truth), call the pure `mergeSilAllowlist`
+ * core, and — only when something changed — write a `.bak` then atomically
+ * (tmp → rename) write the merged config back, preserving the file's existing
+ * mode (host config is operator-readable, NOT a 0600 credential). When the
+ * `openclaw` binary is on PATH it runs `openclaw config validate --json` as a
+ * best-effort post-write guard and reverts from `.bak` if the merged config is
+ * rejected — so a bad result fails closed and never leaves the host half-merged.
+ *
+ * Config-path precedence (first existing wins):
+ *   1. $OPENCLAW_CONFIG_PATH
+ *   2. $OPENCLAW_STATE_DIR/openclaw.json
+ *   3. ~/.openclaw/openclaw.json
+ * None resolves → fail closed (structured error + non-zero exit), create no
+ * parent dir (that would mask a misconfiguration; the operator must start the
+ * gateway once so it writes its own base config).
+ *
+ * Three distinct structured outcomes, in sil's `snake_case_marker` log style
+ * (here as plain NDJSON on stdout/stderr — the script runs outside the
+ * gateway, so there is no `api.logger`). No PII, no secrets:
+ *   - sil_allowlist_merged     (info,  stdout) — a fresh merge was written
+ *   - sil_allowlist_unchanged  (info,  stdout) — idempotent no-op, nothing written
+ *   - sil_allowlist_merge_failed (error, stderr) — fail-closed, nothing left half-done
+ *
+ * All real merge logic lives in the typed lib (`src/lib/openclaw-allowlist.ts`,
+ * compiled to `dist/lib/openclaw-allowlist.js`). This shell is thin I/O only.
+ */
+
+import { execFileSync } from "node:child_process";
+import {
+  copyFileSync,
+  existsSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { randomBytes } from "node:crypto";
+import { fileURLToPath } from "node:url";
+
+import { mergeSilAllowlist, AllowlistShapeError } from "../dist/lib/openclaw-allowlist.js";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const MANIFEST_PATH = resolve(ROOT, "openclaw.plugin.json");
+
+/** Emit one structured NDJSON line in sil's marker style: `{event, level, ...}`. */
+function logMarker(stream, level, event, fields) {
+  const line = JSON.stringify({ event, level, ...fields });
+  stream.write(line + "\n");
+}
+
+const logInfo = (event, fields) => logMarker(process.stdout, "info", event, fields ?? {});
+const logError = (event, fields) => logMarker(process.stderr, "error", event, fields ?? {});
+
+/** Resolve the host config path by precedence; first existing file wins.
+ * Returns the resolved path, or null if none exists (caller fails closed). */
+function resolveConfigPath() {
+  const candidates = [];
+  if (process.env["OPENCLAW_CONFIG_PATH"]) {
+    candidates.push(process.env["OPENCLAW_CONFIG_PATH"]);
+  }
+  if (process.env["OPENCLAW_STATE_DIR"]) {
+    candidates.push(join(process.env["OPENCLAW_STATE_DIR"], "openclaw.json"));
+  }
+  candidates.push(join(homedir(), ".openclaw", "openclaw.json"));
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+/** Read sil's facts from the shipped manifest — the single source of truth.
+ * id / tools / skill are never re-hardcoded in this script. */
+function readSilFacts() {
+  const manifest = JSON.parse(readFileSync(MANIFEST_PATH, "utf8"));
+  const id = manifest.id;
+  const tools = Array.isArray(manifest.contracts?.tools) ? manifest.contracts.tools : [];
+  const skill = Array.isArray(manifest.skills) ? (manifest.skills[0] ?? "") : "";
+  if (typeof id !== "string" || id.length === 0) {
+    throw new Error(`manifest ${MANIFEST_PATH} has no usable "id"`);
+  }
+  return { id, tools, skill };
+}
+
+/** Atomic single-file write: tmp sibling → write → rename over target,
+ * PRESERVING the source file's existing mode (host config is operator-readable,
+ * NOT a 0600 credential — mirrors `src/lib/profile-store.ts:321-327` minus the
+ * hardcoded mode). A reader sees either the old file or the new one, never a
+ * half-written one; a crash before rename leaves the original untouched. */
+function atomicWrite(path, contents, mode) {
+  const tmp = path + "." + randomBytes(6).toString("hex") + ".tmp";
+  writeFileSync(tmp, contents, { mode });
+  renameSync(tmp, path);
+}
+
+/** Best-effort `openclaw config validate --json` guard. Returns:
+ *   { ran: false }                 — binary absent / not invokable (skip, keep write)
+ *   { ran: true, valid: boolean, cause?: string }
+ * Never throws across the boundary — a non-zero exit from the binary is read
+ * from its stdout `.valid`, and an un-parseable response is treated as invalid. */
+function validateConfig(path) {
+  let raw;
+  try {
+    raw = execFileSync("openclaw", ["config", "validate", "--json"], {
+      env: { ...process.env, OPENCLAW_CONFIG_PATH: path },
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (err) {
+    // ENOENT → binary not on PATH: skip validation (the script must run
+    // pre-gateway-boot). Any other spawn failure also means we can't validate;
+    // the atomic write + .bak revert remains the real safety net, so we treat a
+    // failed *spawn* as "not run" (keep the write) rather than "invalid".
+    if (err && err.code === "ENOENT") return { ran: false };
+    // The binary ran but exited non-zero — capture its stdout if any so we can
+    // read a structured verdict; otherwise treat as invalid (fail closed).
+    const stdout = typeof err?.stdout === "string" ? err.stdout : "";
+    if (stdout) {
+      raw = stdout;
+    } else {
+      return { ran: true, valid: false, cause: "openclaw config validate exited non-zero" };
+    }
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && parsed.valid === true) return { ran: true, valid: true };
+    const cause =
+      (parsed && (parsed.error || parsed.message))
+      || "openclaw config validate reported valid !== true";
+    return { ran: true, valid: false, cause: String(cause) };
+  } catch {
+    return { ran: true, valid: false, cause: "openclaw config validate returned non-JSON" };
+  }
+}
+
+function main() {
+  const configPath = resolveConfigPath();
+  if (configPath === null) {
+    logError("sil_allowlist_merge_failed", {
+      path: null,
+      cause:
+        "no OpenClaw config found at OPENCLAW_CONFIG_PATH, "
+        + "$OPENCLAW_STATE_DIR/openclaw.json, or ~/.openclaw/openclaw.json — "
+        + "start the OpenClaw gateway once so it writes its base config, then re-run",
+    });
+    process.exit(1);
+  }
+
+  const sil = readSilFacts();
+
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(configPath, "utf8"));
+  } catch (err) {
+    logError("sil_allowlist_merge_failed", {
+      path: configPath,
+      cause: "config is not valid JSON: " + (err?.message ?? String(err)),
+    });
+    process.exit(1);
+  }
+
+  let result;
+  try {
+    result = mergeSilAllowlist(parsed, sil);
+  } catch (err) {
+    const cause =
+      err instanceof AllowlistShapeError
+        ? err.message
+        : "merge failed: " + (err?.message ?? String(err));
+    logError("sil_allowlist_merge_failed", { path: configPath, cause });
+    process.exit(1);
+  }
+
+  if (!result.changed) {
+    logInfo("sil_allowlist_unchanged", { plugin: sil.id });
+    process.exit(0);
+  }
+
+  // Something changed → back up, atomically write, then best-effort validate.
+  const mode = statSync(configPath).mode & 0o777;
+  const bakPath = configPath + ".bak";
+  copyFileSync(configPath, bakPath);
+
+  const serialized = JSON.stringify(result.config, null, 2) + "\n";
+  atomicWrite(configPath, serialized, mode);
+
+  const validation = validateConfig(configPath);
+  if (validation.ran && !validation.valid) {
+    // Revert to the exact pre-run bytes; leave the host in its pre-run state.
+    copyFileSync(bakPath, configPath);
+    logError("sil_allowlist_merge_failed", {
+      path: configPath,
+      cause: validation.cause ?? "openclaw config validate rejected the merged config",
+    });
+    process.exit(1);
+  }
+
+  const allowSize = Array.isArray(result.config.plugins?.allow)
+    ? result.config.plugins.allow.length
+    : 0;
+  logInfo("sil_allowlist_merged", {
+    plugin: sil.id,
+    tools_added: sil.tools.length,
+    skill_added: sil.skill.length > 0,
+    plugins_allow_size: allowSize,
+    validated: validation.ran,
+    path: configPath,
+  });
+  process.exit(0);
+}
+
+main();

--- a/src/__tests__/lib/openclaw-allowlist.test.ts
+++ b/src/__tests__/lib/openclaw-allowlist.test.ts
@@ -1,0 +1,473 @@
+/**
+ * UNIT — mergeSilAllowlist() merge core (tier: unit, pure, in-memory, no I/O,
+ * no network, no host).
+ *
+ * Card: install-time-helper-to-allow-list-sil-in-openclaw. The merge core is
+ * the pure, typed heart of the operator-run helper that additively + idempotently
+ * trusts `sil` in the host OpenClaw config. The architect grounded the design in
+ * the REAL `alpine/openclaw:2026.6.9` config schema (Discovery §"schema reality"):
+ * there are exactly THREE allow surfaces and NO per-tool-name / global-skill key:
+ *
+ *   - `plugins.allow`   : string[] of plugin IDs (emptiness fires the auto-load warning)
+ *   - `tools.alsoAllow` : string[] of plugin IDs (admits a plugin's tools by id)
+ *   - `plugins.entries.<id>` : { enabled, config } (makes the plugin loadable)
+ *
+ * The skill is admitted WITH the plugin (per-agent `agents.list[i].skills` attach
+ * is the host-wiring path's job, NOT this helper's — so the core does NOT touch
+ * `agents`). `sil.tools` / `sil.skill` ride in the facts type for the operator
+ * log fields; the 2026.6.9 mechanism is plugin-id admission, so the core never
+ * enumerates tool names into config.
+ *
+ * The TWO invariants this suite exists to defend (product-owner): AC4 (additive)
+ * and AC6 (idempotent). Every other case is a guard around those two.
+ *
+ * Contract pinned for the implementation (expert-developer):
+ *   export function mergeSilAllowlist(
+ *     config: unknown,
+ *     sil: SilAllowlistFacts,            // { id: string; tools: string[]; skill: string }
+ *   ): { config: OpenClawConfig; changed: boolean }
+ *
+ * Merge logic (in order, all in-memory on the parsed object):
+ *   1. narrow `config` to an object — HARD THROW if not (caller → `failed` outcome);
+ *   2. ensure `plugins` / `tools` containers exist (create empty if absent);
+ *   3. `plugins.allow`: if absent/empty, SEED with `sil.id` + every key of
+ *      `plugins.entries` (the OQ3 rule — never silently un-trust an
+ *      auto-loading plugin); then append `sil.id` if absent. If already
+ *      non-empty, append `sil.id` if absent. THROW if present-but-not-array.
+ *   4. `tools.alsoAllow`: append `sil.id` if absent (create array if absent).
+ *   5. `plugins.entries[sil.id]`: set `{ enabled: true, config: {} }` ONLY if the
+ *      key is absent; NEVER touch an existing entry.
+ *   6. `changed` = OR of the three mutations actually applied.
+ *
+ * These assertions ARE the spec. Do NOT weaken them to match an implementation.
+ * Hermetic: every test builds its own in-memory fixture; no shared state.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  mergeSilAllowlist,
+  type SilAllowlistFacts,
+} from "../../lib/openclaw-allowlist.js";
+
+// sil's real facts (single source of truth in prod is openclaw.plugin.json; the
+// unit core takes them as an argument so the test pins behaviour, not wiring).
+const SIL: SilAllowlistFacts = {
+  id: "sil",
+  tools: [
+    "sil_product_get",
+    "sil_profile_get",
+    "sil_profile_list",
+    "sil_profile_materialize",
+    "sil_profile_remove",
+    "sil_register",
+    "sil_search",
+    "sil_whoami",
+  ],
+  skill: "./skill",
+};
+
+/** A different plugin's facts — used to prove the core is sil-agnostic in the
+ *  ways that matter (it appends whatever id it's given; clobber tests use sil). */
+function clone<T>(v: T): T {
+  return JSON.parse(JSON.stringify(v)) as T;
+}
+
+// ---------------------------------------------------------------------------
+// AC2 — plugins.allow is non-empty and explicit, includes "sil"
+// ---------------------------------------------------------------------------
+describe("AC2 — plugins.allow becomes non-empty and explicitly includes sil", () => {
+  it("seeds sil into an ABSENT plugins.allow (no plugins block at all)", () => {
+    const { config, changed } = mergeSilAllowlist({}, SIL);
+    const allow = (config as { plugins: { allow: unknown } }).plugins.allow;
+    expect(Array.isArray(allow)).toBe(true);
+    expect(allow as string[]).toContain("sil");
+    expect((allow as string[]).length).toBeGreaterThan(0);
+    expect(changed).toBe(true);
+  });
+
+  it("seeds sil into an EMPTY plugins.allow array", () => {
+    const input = { plugins: { allow: [] as string[] } };
+    const { config, changed } = mergeSilAllowlist(input, SIL);
+    const allow = (config as { plugins: { allow: string[] } }).plugins.allow;
+    expect(allow).toContain("sil");
+    expect(allow.length).toBeGreaterThan(0);
+    expect(changed).toBe(true);
+  });
+
+  it("the restriction is now ENABLED — plugins.allow is an explicit id array, not left open", () => {
+    const { config } = mergeSilAllowlist({}, SIL);
+    const allow = (config as { plugins: { allow: string[] } }).plugins.allow;
+    // explicit ids only — every element a non-empty string
+    for (const id of allow) {
+      expect(typeof id).toBe("string");
+      expect(id.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC1 (core slice) — sil trusted at all three real surfaces after a fresh merge.
+// (The full end-to-end AC1 against a file is the integration tier; here we pin
+//  the in-memory result the integration test then reads back from disk.)
+// ---------------------------------------------------------------------------
+describe("AC1 (core) — fresh merge trusts sil at all three real surfaces", () => {
+  it("adds sil to plugins.allow, tools.alsoAllow, and creates plugins.entries.sil", () => {
+    const { config, changed } = mergeSilAllowlist({}, SIL);
+    const c = config as {
+      plugins: { allow: string[]; entries: Record<string, unknown> };
+      tools: { alsoAllow: string[] };
+    };
+    expect(c.plugins.allow).toContain("sil");
+    expect(c.tools.alsoAllow).toContain("sil");
+    expect(c.plugins.entries["sil"]).toEqual({ enabled: true, config: {} });
+    expect(changed).toBe(true);
+  });
+
+  it("does NOT enumerate the 8 tool NAMES into config — admission is by plugin id only", () => {
+    const { config } = mergeSilAllowlist({}, SIL);
+    const serialized = JSON.stringify(config);
+    // The mechanism is plugin-id admission; tool names must never leak into the
+    // written config (no invented `tools.allow` of names — see schema reality).
+    for (const toolName of SIL.tools) {
+      expect(serialized).not.toContain(toolName);
+    }
+    const c = config as { tools: { alsoAllow: string[] } };
+    expect(c.tools.alsoAllow).toEqual(["sil"]);
+  });
+
+  it("does NOT touch agents (skill attach is the host-wiring path's job, not this core)", () => {
+    const input = { agents: { list: [{ id: "shopper", skills: ["other"] }] } };
+    const { config } = mergeSilAllowlist(clone(input), SIL);
+    const c = config as { agents: { list: Array<{ skills: string[] }> } };
+    expect(c.agents.list[0]?.skills).toEqual(["other"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC4 — additive: pre-existing trust survives untouched (THE invariant).
+// ---------------------------------------------------------------------------
+describe("AC4 — additive: every pre-existing entry survives byte-for-byte", () => {
+  it("preserves klodi in plugins.allow / tools.alsoAllow and its plugins.entries config", () => {
+    const input = {
+      plugins: {
+        allow: ["klodi"],
+        entries: {
+          klodi: { enabled: true, config: { apiKey: "operator-set", region: "eu" } },
+        },
+      },
+      tools: { profile: "coding", alsoAllow: ["klodi"] },
+    };
+    const { config } = mergeSilAllowlist(clone(input), SIL);
+    const c = config as {
+      plugins: { allow: string[]; entries: Record<string, unknown> };
+      tools: { profile: string; alsoAllow: string[] };
+    };
+    // klodi preserved at every surface, with sil appended (never inserted ahead).
+    expect(c.plugins.allow).toEqual(["klodi", "sil"]);
+    expect(c.tools.alsoAllow).toEqual(["klodi", "sil"]);
+    // klodi's operator config is byte-identical (never touched).
+    expect(c.plugins.entries["klodi"]).toEqual({
+      enabled: true,
+      config: { apiKey: "operator-set", region: "eu" },
+    });
+    // unrelated keys (tools.profile) preserved.
+    expect(c.tools.profile).toBe("coding");
+  });
+
+  it("never reorders an existing allow-list — appends only, at the tail", () => {
+    const input = { plugins: { allow: ["alpha", "beta", "gamma"] } };
+    const { config } = mergeSilAllowlist(clone(input), SIL);
+    const allow = (config as { plugins: { allow: string[] } }).plugins.allow;
+    expect(allow).toEqual(["alpha", "beta", "gamma", "sil"]);
+  });
+
+  it("leaves an existing plugins.entries.sil entry's operator config UNTOUCHED (no overwrite)", () => {
+    const input = {
+      plugins: {
+        allow: ["sil"],
+        entries: {
+          sil: { enabled: false, config: { sil_api_url: "https://staging.example" } },
+        },
+      },
+      tools: { alsoAllow: ["sil"] },
+    };
+    const { config, changed } = mergeSilAllowlist(clone(input), SIL);
+    const entry = (config as { plugins: { entries: Record<string, unknown> } })
+      .plugins.entries["sil"];
+    // The operator's enabled:false + custom config MUST survive — never clobbered
+    // to {enabled:true, config:{}}.
+    expect(entry).toEqual({
+      enabled: false,
+      config: { sil_api_url: "https://staging.example" },
+    });
+    // fully pre-trusted + entry present → nothing to change.
+    expect(changed).toBe(false);
+  });
+
+  it("preserves an unrelated top-level block (gateway) verbatim", () => {
+    const input = {
+      gateway: { mode: "local", port: 18789, auth: { mode: "token", token: "t" } },
+    };
+    const { config } = mergeSilAllowlist(clone(input), SIL);
+    const c = config as { gateway: unknown };
+    expect(c.gateway).toEqual({
+      mode: "local",
+      port: 18789,
+      auth: { mode: "token", token: "t" },
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC5 — additive into a populated plugins.allow.
+// ---------------------------------------------------------------------------
+describe("AC5 — additive into a populated plugins.allow", () => {
+  it("['klodi'] becomes ['klodi','sil'] — klodi preserved, sil appended, nothing dropped", () => {
+    const input = { plugins: { allow: ["klodi"] } };
+    const { config, changed } = mergeSilAllowlist(clone(input), SIL);
+    const allow = (config as { plugins: { allow: string[] } }).plugins.allow;
+    expect(allow).toEqual(["klodi", "sil"]);
+    expect(changed).toBe(true);
+  });
+
+  it("does NOT re-seed from plugins.entries when plugins.allow is already non-empty", () => {
+    // allow is non-empty (['klodi']) but entries has OTHER ids — the seed rule
+    // only applies to an empty/absent allow. A non-empty allow is appended-to,
+    // not re-seeded, so memory-core is NOT pulled in here (the operator already
+    // chose their explicit list).
+    const input = {
+      plugins: {
+        allow: ["klodi"],
+        entries: { klodi: {}, "memory-core": {}, codex: {} },
+      },
+    };
+    const { config } = mergeSilAllowlist(clone(input), SIL);
+    const allow = (config as { plugins: { allow: string[] } }).plugins.allow;
+    expect(allow).toEqual(["klodi", "sil"]);
+    expect(allow).not.toContain("memory-core");
+    expect(allow).not.toContain("codex");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC6 (core slice) — idempotent: a fully-merged input yields changed:false and
+// no mutation. (The "no second .bak / byte-identical file" half is integration.)
+// ---------------------------------------------------------------------------
+describe("AC6 (core) — idempotent: second merge of an already-merged config is a no-op", () => {
+  it("reports changed:false and produces an equal config when sil is already trusted everywhere", () => {
+    const merged = mergeSilAllowlist({}, SIL).config;
+    const second = mergeSilAllowlist(clone(merged), SIL);
+    expect(second.changed).toBe(false);
+    expect(second.config).toEqual(merged);
+  });
+
+  it("never duplicates sil in plugins.allow or tools.alsoAllow on a re-run", () => {
+    const merged = mergeSilAllowlist({}, SIL).config;
+    const { config } = mergeSilAllowlist(clone(merged), SIL);
+    const c = config as {
+      plugins: { allow: string[] };
+      tools: { alsoAllow: string[] };
+    };
+    expect(c.plugins.allow.filter((x) => x === "sil")).toHaveLength(1);
+    expect(c.tools.alsoAllow.filter((x) => x === "sil")).toHaveLength(1);
+  });
+
+  it("running the merge a THIRD time still changes nothing (stable fixpoint)", () => {
+    let cfg = mergeSilAllowlist({}, SIL).config;
+    cfg = mergeSilAllowlist(clone(cfg), SIL).config;
+    const third = mergeSilAllowlist(clone(cfg), SIL);
+    expect(third.changed).toBe(false);
+    expect(third.config).toEqual(cfg);
+  });
+
+  it("changed:true when sil is in plugins.allow but MISSING from tools.alsoAllow (partial prior state)", () => {
+    // Defends against a half-applied prior run: any one missing surface → changed.
+    const input = {
+      plugins: { allow: ["sil"], entries: { sil: { enabled: true, config: {} } } },
+      tools: { alsoAllow: [] as string[] },
+    };
+    const { config, changed } = mergeSilAllowlist(clone(input), SIL);
+    expect(changed).toBe(true);
+    expect((config as { tools: { alsoAllow: string[] } }).tools.alsoAllow).toContain("sil");
+  });
+
+  it("changed:true when sil is trusted but its plugins.entries entry is MISSING", () => {
+    const input = {
+      plugins: { allow: ["sil"], entries: {} as Record<string, unknown> },
+      tools: { alsoAllow: ["sil"] },
+    };
+    const { config, changed } = mergeSilAllowlist(clone(input), SIL);
+    expect(changed).toBe(true);
+    expect((config as { plugins: { entries: Record<string, unknown> } }).plugins.entries["sil"])
+      .toEqual({ enabled: true, config: {} });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC9 (OQ3) — enabling the restriction never un-trusts an auto-loading plugin.
+// ---------------------------------------------------------------------------
+describe("AC9 / OQ3 — seeding from plugins.entries never silently excludes a previously-auto-loading plugin", () => {
+  it("empty allow + other entries → allow seeded with sil AND every plugins.entries id", () => {
+    const input = {
+      plugins: {
+        allow: [] as string[],
+        entries: {
+          codex: { enabled: true },
+          "memory-core": { enabled: true, config: {} },
+        },
+      },
+    };
+    const { config, changed } = mergeSilAllowlist(clone(input), SIL);
+    const allow = (config as { plugins: { allow: string[] } }).plugins.allow;
+    // Flipping empty (permissive) → non-empty (explicit) must carry the
+    // previously-auto-loading plugins with it.
+    expect(allow).toContain("sil");
+    expect(allow).toContain("codex");
+    expect(allow).toContain("memory-core");
+    expect(changed).toBe(true);
+  });
+
+  it("ABSENT allow + other entries → same OQ3 seeding (codex + memory-core + sil)", () => {
+    const input = {
+      plugins: {
+        entries: { codex: { enabled: true }, "memory-core": { enabled: true } },
+      },
+    };
+    const { config } = mergeSilAllowlist(clone(input), SIL);
+    const allow = (config as { plugins: { allow: string[] } }).plugins.allow;
+    expect(new Set(allow)).toEqual(new Set(["codex", "memory-core", "sil"]));
+  });
+
+  it("reads the pre-existing ids FROM THE CONFIG, never a hardcoded list", () => {
+    // A bespoke set of entry ids the helper could not possibly hardcode.
+    const input = {
+      plugins: {
+        allow: [] as string[],
+        entries: {
+          "acme-widgets": { enabled: true },
+          "zeta-9": { enabled: true },
+        },
+      },
+    };
+    const { config } = mergeSilAllowlist(clone(input), SIL);
+    const allow = (config as { plugins: { allow: string[] } }).plugins.allow;
+    expect(allow).toContain("acme-widgets");
+    expect(allow).toContain("zeta-9");
+    expect(allow).toContain("sil");
+  });
+
+  it("does NOT duplicate an id that is already both an entry AND already in allow", () => {
+    // Defends the seed against double-counting an id present in both places.
+    const input = {
+      plugins: {
+        allow: ["codex"],
+        entries: { codex: { enabled: true } },
+      },
+    };
+    // allow non-empty → append-only path (no re-seed). codex stays single; sil appended.
+    const { config } = mergeSilAllowlist(clone(input), SIL);
+    const allow = (config as { plugins: { allow: string[] } }).plugins.allow;
+    expect(allow.filter((x) => x === "codex")).toHaveLength(1);
+    expect(allow).toEqual(["codex", "sil"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Untrusted-shape config — the file is operator-editable. The core narrows
+// defensively and FAILS CLOSED (hard throw) on the shapes it must not coerce.
+// (Risk: "Untrusted-shape config" + "non-array plugins.allow is a hard error".)
+// ---------------------------------------------------------------------------
+describe("untrusted-shape config — narrow defensively, fail closed on un-coercible shapes", () => {
+  it("THROWS when config is not an object (string)", () => {
+    expect(() => mergeSilAllowlist("not-a-config", SIL)).toThrow();
+  });
+
+  it("THROWS when config is null", () => {
+    expect(() => mergeSilAllowlist(null, SIL)).toThrow();
+  });
+
+  it("THROWS when config is an array (JSON arrays are objects but not a config object)", () => {
+    expect(() => mergeSilAllowlist([], SIL)).toThrow();
+  });
+
+  it("THROWS when config is a number", () => {
+    expect(() => mergeSilAllowlist(42, SIL)).toThrow();
+  });
+
+  it("THROWS when plugins.allow is present but NOT an array (do not coerce → clobber risk)", () => {
+    expect(() =>
+      mergeSilAllowlist({ plugins: { allow: "sil" } }, SIL),
+    ).toThrow();
+  });
+
+  it("THROWS when plugins.allow is an object, not an array", () => {
+    expect(() =>
+      mergeSilAllowlist({ plugins: { allow: { sil: true } } }, SIL),
+    ).toThrow();
+  });
+
+  it("THROWS when tools.alsoAllow is present but NOT an array", () => {
+    expect(() =>
+      mergeSilAllowlist({ tools: { alsoAllow: "sil" } }, SIL),
+    ).toThrow();
+  });
+
+  it("returns NOTHING usable on a bad-shape throw — the caller cannot act on a half-merge", () => {
+    // The card's no-half-write guarantee lives at the FILE boundary (the shell
+    // parses fresh + writes via tmp→rename), so the core is free to mutate its
+    // argument; what MUST hold here is that an un-coercible shape produces a
+    // throw, not a silently-returned partially-merged object the shell would
+    // then write. We assert the throw is total — no value escapes.
+    let returned: unknown = "sentinel";
+    expect(() => {
+      returned = mergeSilAllowlist({ plugins: { allow: "sil" } }, SIL);
+    }).toThrow();
+    expect(returned).toBe("sentinel");
+  });
+
+  it("creates an absent plugins container (does not throw on a bare {})", () => {
+    const { config } = mergeSilAllowlist({}, SIL);
+    const c = config as { plugins: { allow: string[]; entries: Record<string, unknown> } };
+    expect(c.plugins).toBeDefined();
+    expect(Array.isArray(c.plugins.allow)).toBe(true);
+  });
+
+  it("creates an absent tools container with alsoAllow", () => {
+    const { config } = mergeSilAllowlist({}, SIL);
+    const c = config as { tools: { alsoAllow: string[] } };
+    expect(c.tools).toBeDefined();
+    expect(Array.isArray(c.tools.alsoAllow)).toBe(true);
+    expect(c.tools.alsoAllow).toContain("sil");
+  });
+
+  it("creates plugins.entries when absent, preserving an existing plugins block's other keys", () => {
+    const input = { plugins: { allow: ["klodi"] } }; // no entries
+    const { config } = mergeSilAllowlist(clone(input), SIL);
+    const c = config as { plugins: { entries: Record<string, unknown> } };
+    expect(c.plugins.entries["sil"]).toEqual({ enabled: true, config: {} });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Purity — the core does no I/O and does not mutate its input by reference in a
+// way that surprises the caller's snapshot. (We assert it returns a config; the
+// caller clones via JSON round-trip in the script. We DO require: on a no-op,
+// the returned config still deep-equals the input.)
+// ---------------------------------------------------------------------------
+describe("purity / determinism", () => {
+  it("is deterministic — same input twice yields deep-equal output", () => {
+    const input = { plugins: { allow: ["klodi"], entries: { klodi: {} } } };
+    const a = mergeSilAllowlist(clone(input), SIL);
+    const b = mergeSilAllowlist(clone(input), SIL);
+    expect(a.config).toEqual(b.config);
+    expect(a.changed).toBe(b.changed);
+  });
+
+  it("on a no-op (fully merged) returns a config deep-equal to the input", () => {
+    const merged = mergeSilAllowlist({}, SIL).config;
+    const result = mergeSilAllowlist(clone(merged), SIL);
+    expect(result.config).toEqual(merged);
+    expect(result.changed).toBe(false);
+  });
+});

--- a/src/__tests__/openclaw-allowlist.integration.test.ts
+++ b/src/__tests__/openclaw-allowlist.integration.test.ts
@@ -1,0 +1,492 @@
+/**
+ * INTEGRATION — the allowlist helper SCRIPT, end-to-end against a real temp
+ * `openclaw.json` (tier: integration — spawns `scripts/allowlist-openclaw.mjs`
+ * as a child process, real fs reads/writes, real exit codes; no mocked fs, no
+ * stubs of sil's own logic).
+ *
+ * Card: install-time-helper-to-allow-list-sil-in-openclaw. The script is the
+ * thin I/O shell around the pure `mergeSilAllowlist` core (unit-tested in
+ * `lib/openclaw-allowlist.test.ts`). This suite pins the BLACK-BOX, file-level
+ * behaviours the architect tagged `[integration]` — verifiable purely by
+ * inspecting the host config + the helper's stdout/stderr markers + exit code:
+ *
+ *   AC1 — sil trusted at all three real surfaces in the WRITTEN file.
+ *   AC3 — the result satisfies the host's no-warning precondition
+ *         (non-empty plugins.allow that contains "sil").
+ *   AC6 — idempotent: a second run is byte-identical + creates NO new .bak +
+ *         emits the `unchanged` marker + exit 0.
+ *   AC7 — bad result fails closed: an `openclaw config validate` that rejects
+ *         the merge reverts the file from .bak to the exact pre-run bytes,
+ *         emits a `failed` marker naming the cause, exits non-zero.
+ *   AC8 — config-path precedence (OPENCLAW_CONFIG_PATH wins) + missing-config
+ *         fail-closed (no write, no parent dir created, structured error, exit 1).
+ *
+ * The script imports the COMPILED lib (`dist/lib/openclaw-allowlist.js`), so the
+ * suite builds the lib once in beforeAll FROM THE CURRENT SOURCE — never relying
+ * on a possibly-stale dist (a stale dist would silently test old logic). The
+ * build is the same `tsc -p tsconfig.build.json` the script's `dist` import needs.
+ *
+ * The two invariants this suite defends (product-owner): AC6 (idempotent) and the
+ * additive half of AC1 (klodi survives). Every other case guards those two.
+ *
+ * These assertions ARE the spec. Do NOT weaken them to match the script.
+ * Hermetic: each test gets its own mkdtemp dir + its own config fixture; full
+ * teardown in afterEach. NO shared state, NO order dependence.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import { execFileSync } from "node:child_process";
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  chmodSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+/** Repo root of the checkout under test (…/src/__tests__ → root). */
+const REPO_ROOT = join(HERE, "..", "..");
+const SCRIPT = join(REPO_ROOT, "scripts", "allowlist-openclaw.mjs");
+
+// sil's real facts (asserted against, sourced from the manifest the script reads).
+const SIL_ID = "sil";
+const SIL_TOOLS = [
+  "sil_product_get",
+  "sil_profile_get",
+  "sil_profile_list",
+  "sil_profile_materialize",
+  "sil_profile_remove",
+  "sil_register",
+  "sil_search",
+  "sil_whoami",
+] as const;
+
+interface RunResult {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+/** Spawn the helper script with an explicit env (no inheritance of the test
+ * runner's OPENCLAW_* / HOME unless we set it). Captures status + streams. */
+function runHelper(env: Record<string, string>): RunResult {
+  try {
+    const stdout = execFileSync("node", [SCRIPT], {
+      env: { ...baseEnv(), ...env },
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { status: 0, stdout, stderr: "" };
+  } catch (err: unknown) {
+    const e = err as { status?: number; stdout?: Buffer | string; stderr?: Buffer | string };
+    return {
+      status: e.status ?? 1,
+      stdout: (e.stdout ?? "").toString(),
+      stderr: (e.stderr ?? "").toString(),
+    };
+  }
+}
+
+/** A minimal, hermetic base env: PATH for `node`, and HOME pointed at a
+ * guaranteed-empty dir so the ~/.openclaw fallback never resolves a real file
+ * on the developer's machine. OPENCLAW_* are deliberately UNSET here — each
+ * test sets exactly the precedence knob it exercises. */
+let emptyHome: string;
+function baseEnv(): Record<string, string> {
+  return {
+    PATH: process.env["PATH"] ?? "/usr/bin:/bin",
+    HOME: emptyHome,
+  };
+}
+
+/** Parse the single NDJSON marker the script emits on the given stream text. */
+function parseMarker(streamText: string): Record<string, unknown> {
+  const line = streamText.trim().split("\n").filter(Boolean).at(-1) ?? "";
+  return JSON.parse(line) as Record<string, unknown>;
+}
+
+/** A fresh config where sil is discovered but trusted nowhere. */
+function freshConfig(): unknown {
+  return {
+    gateway: { mode: "local", port: 18789 },
+    tools: { profile: "coding", alsoAllow: [] as string[] },
+    plugins: { allow: [] as string[], entries: {} as Record<string, unknown> },
+    meta: { lastTouchedVersion: "2026.6.9" },
+  };
+}
+
+let workdir: string;
+let configPath: string;
+
+beforeAll(() => {
+  // The script imports dist/lib/openclaw-allowlist.js — build the lib from the
+  // CURRENT source so the integration tier exercises what the dev actually
+  // wrote, never a stale dist. Fails loud if the build breaks. We invoke the
+  // TypeScript compiler's real JS entry (node_modules/.bin/tsc is a shell
+  // wrapper that `node` cannot run directly).
+  execFileSync("node", ["node_modules/typescript/bin/tsc", "-p", "tsconfig.build.json"], {
+    cwd: REPO_ROOT,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (!existsSync(join(REPO_ROOT, "dist", "lib", "openclaw-allowlist.js"))) {
+    throw new Error("build did not emit dist/lib/openclaw-allowlist.js — script import would 404");
+  }
+}, 60_000);
+
+beforeEach(() => {
+  workdir = mkdtempSync(join(tmpdir(), "sil-allowlist-it-"));
+  emptyHome = mkdtempSync(join(tmpdir(), "sil-allowlist-home-"));
+  configPath = join(workdir, "openclaw.json");
+});
+
+afterEach(() => {
+  for (const d of [workdir, emptyHome]) {
+    try {
+      chmodSync(d, 0o700);
+    } catch {
+      /* best effort */
+    }
+    rmSync(d, { recursive: true, force: true });
+  }
+});
+
+function writeConfig(value: unknown): void {
+  writeFileSync(configPath, JSON.stringify(value, null, 2) + "\n");
+}
+
+function readConfig(): {
+  plugins: { allow: string[]; entries: Record<string, unknown> };
+  tools: { alsoAllow: string[]; profile?: string };
+  [k: string]: unknown;
+} {
+  return JSON.parse(readFileSync(configPath, "utf8"));
+}
+
+// ---------------------------------------------------------------------------
+// AC1 / AC3 — fresh merge trusts sil at all three surfaces; result satisfies
+// the host's no-warning precondition.
+// ---------------------------------------------------------------------------
+describe("AC1 / AC3 — fresh merge writes sil into all three surfaces (no-warning precondition met)", () => {
+  it("writes sil into plugins.allow, tools.alsoAllow, and plugins.entries.sil", () => {
+    writeConfig(freshConfig());
+    const r = runHelper({ OPENCLAW_CONFIG_PATH: configPath });
+    expect(r.status).toBe(0);
+
+    const c = readConfig();
+    expect(c.plugins.allow).toContain(SIL_ID);
+    expect(c.tools.alsoAllow).toContain(SIL_ID);
+    expect(c.plugins.entries[SIL_ID]).toEqual({ enabled: true, config: {} });
+  });
+
+  it("AC3 — written plugins.allow is non-empty AND contains sil (host suppresses the warning)", () => {
+    writeConfig(freshConfig());
+    runHelper({ OPENCLAW_CONFIG_PATH: configPath });
+    const c = readConfig();
+    expect(c.plugins.allow.length).toBeGreaterThan(0);
+    expect(c.plugins.allow).toContain(SIL_ID);
+  });
+
+  it("emits the `sil_allowlist_merged` info marker on stdout with the operator fields", () => {
+    writeConfig(freshConfig());
+    const r = runHelper({ OPENCLAW_CONFIG_PATH: configPath });
+    const m = parseMarker(r.stdout);
+    expect(m["event"]).toBe("sil_allowlist_merged");
+    expect(m["level"]).toBe("info");
+    expect(m["plugin"]).toBe(SIL_ID);
+    expect(m["tools_added"]).toBe(SIL_TOOLS.length);
+    expect(m["skill_added"]).toBe(true);
+    expect(typeof m["plugins_allow_size"]).toBe("number");
+    expect(m["plugins_allow_size"] as number).toBeGreaterThan(0);
+  });
+
+  it("does NOT enumerate the 8 tool NAMES into the written config (plugin-id admission only)", () => {
+    writeConfig(freshConfig());
+    runHelper({ OPENCLAW_CONFIG_PATH: configPath });
+    const raw = readFileSync(configPath, "utf8");
+    for (const t of SIL_TOOLS) {
+      expect(raw).not.toContain(t);
+    }
+    expect(readConfig().tools.alsoAllow).toEqual([SIL_ID]);
+  });
+
+  it("creates a single `.bak` (single-slot) on the first changed write", () => {
+    writeConfig(freshConfig());
+    const before = readFileSync(configPath, "utf8");
+    runHelper({ OPENCLAW_CONFIG_PATH: configPath });
+    expect(existsSync(configPath + ".bak")).toBe(true);
+    // The .bak holds the exact pre-run bytes.
+    expect(readFileSync(configPath + ".bak", "utf8")).toBe(before);
+    // No .bak.1 rotation slot is created (single overwrite slot only).
+    expect(existsSync(configPath + ".bak.1")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC1 additive (file level) — pre-existing klodi survives a real write.
+// ---------------------------------------------------------------------------
+describe("AC1 additive — pre-existing trust survives a real file write", () => {
+  it("preserves klodi at every surface and appends sil after it", () => {
+    writeConfig({
+      tools: { profile: "coding", alsoAllow: ["klodi"] },
+      plugins: {
+        allow: ["klodi"],
+        entries: { klodi: { enabled: true, config: { apiKey: "operator-set" } } },
+      },
+    });
+    const r = runHelper({ OPENCLAW_CONFIG_PATH: configPath });
+    expect(r.status).toBe(0);
+    const c = readConfig();
+    expect(c.plugins.allow).toEqual(["klodi", "sil"]);
+    expect(c.tools.alsoAllow).toEqual(["klodi", "sil"]);
+    expect(c.plugins.entries["klodi"]).toEqual({
+      enabled: true,
+      config: { apiKey: "operator-set" },
+    });
+    expect(c.tools.profile).toBe("coding");
+  });
+
+  it("OQ3 — empty allow + other entries: written allow carries sil AND the prior plugins (codex, memory-core)", () => {
+    writeConfig({
+      tools: { alsoAllow: [] as string[] },
+      plugins: {
+        allow: [] as string[],
+        entries: { codex: { enabled: true }, "memory-core": { enabled: true } },
+      },
+    });
+    runHelper({ OPENCLAW_CONFIG_PATH: configPath });
+    const allow = readConfig().plugins.allow;
+    expect(allow).toContain("sil");
+    expect(allow).toContain("codex");
+    expect(allow).toContain("memory-core");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC6 — idempotent: second run byte-identical, no new .bak, `unchanged` marker.
+// ---------------------------------------------------------------------------
+describe("AC6 — idempotent: a second run changes nothing and rewrites nothing", () => {
+  it("second run leaves the file BYTE-IDENTICAL, creates NO new .bak, emits `unchanged`, exits 0", () => {
+    writeConfig(freshConfig());
+
+    // First run: merges + writes + creates .bak.
+    const r1 = runHelper({ OPENCLAW_CONFIG_PATH: configPath });
+    expect(r1.status).toBe(0);
+    const afterFirst = readFileSync(configPath, "utf8");
+    // Remove the first .bak so we can detect whether the SECOND run writes one.
+    rmSync(configPath + ".bak", { force: true });
+
+    // Second run: no-op.
+    const r2 = runHelper({ OPENCLAW_CONFIG_PATH: configPath });
+    expect(r2.status).toBe(0);
+
+    // File untouched (byte-identical) — no shape change, no reorder, no dup.
+    expect(readFileSync(configPath, "utf8")).toBe(afterFirst);
+    // No new .bak created on the idempotent run.
+    expect(existsSync(configPath + ".bak")).toBe(false);
+    // Distinct `unchanged` marker, exit 0.
+    const m = parseMarker(r2.stdout);
+    expect(m["event"]).toBe("sil_allowlist_unchanged");
+    expect(m["level"]).toBe("info");
+    expect(m["plugin"]).toBe(SIL_ID);
+  });
+
+  it("a third run is still a no-op (stable fixpoint)", () => {
+    writeConfig(freshConfig());
+    runHelper({ OPENCLAW_CONFIG_PATH: configPath });
+    const settled = readFileSync(configPath, "utf8");
+    runHelper({ OPENCLAW_CONFIG_PATH: configPath });
+    const r3 = runHelper({ OPENCLAW_CONFIG_PATH: configPath });
+    expect(r3.status).toBe(0);
+    expect(parseMarker(r3.stdout)["event"]).toBe("sil_allowlist_unchanged");
+    expect(readFileSync(configPath, "utf8")).toBe(settled);
+  });
+
+  it("never duplicates sil across runs (single sil in each allow surface)", () => {
+    writeConfig(freshConfig());
+    runHelper({ OPENCLAW_CONFIG_PATH: configPath });
+    runHelper({ OPENCLAW_CONFIG_PATH: configPath });
+    const c = readConfig();
+    expect(c.plugins.allow.filter((x) => x === SIL_ID)).toHaveLength(1);
+    expect(c.tools.alsoAllow.filter((x) => x === SIL_ID)).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC7 — bad result fails closed and reverts from .bak.
+//
+// We put a FAKE `openclaw` binary on PATH (a shim) that reports {valid:false}.
+// This is a test double of the EXTERNAL binary boundary (permitted — it is not
+// stubbing sil's own logic), letting us drive the validate-reject path
+// deterministically without the real gateway image.
+// ---------------------------------------------------------------------------
+describe("AC7 — validate-reject reverts from .bak and fails closed", () => {
+  /** Create a PATH dir containing an `openclaw` shim with the given behaviour. */
+  function shimDir(script: string): string {
+    const bin = mkdtempSync(join(tmpdir(), "sil-allowlist-bin-"));
+    const exe = join(bin, "openclaw");
+    writeFileSync(exe, script, { mode: 0o755 });
+    return bin;
+  }
+
+  it("reverts to the EXACT pre-run bytes, emits `failed` with the cause, exits non-zero", () => {
+    const original = freshConfig();
+    writeConfig(original);
+    const preRun = readFileSync(configPath, "utf8");
+
+    // Shim: always reports the merged config invalid.
+    const bin = shimDir(
+      "#!/usr/bin/env bash\n"
+        + 'echo \'{"valid":false,"error":"shim: config rejected for test"}\'\n'
+        + "exit 0\n",
+    );
+
+    const r = runHelper({
+      OPENCLAW_CONFIG_PATH: configPath,
+      PATH: `${bin}:${process.env["PATH"] ?? "/usr/bin:/bin"}`,
+    });
+
+    rmSync(bin, { recursive: true, force: true });
+
+    // Fail closed: non-zero exit.
+    expect(r.status).not.toBe(0);
+    // File reverted to the EXACT pre-run bytes — never left half-merged.
+    expect(readFileSync(configPath, "utf8")).toBe(preRun);
+    // Structured `failed` marker on stderr naming the cause.
+    const m = parseMarker(r.stderr);
+    expect(m["event"]).toBe("sil_allowlist_merge_failed");
+    expect(m["level"]).toBe("error");
+    expect(typeof m["cause"]).toBe("string");
+    expect(String(m["cause"]).length).toBeGreaterThan(0);
+  });
+
+  it("when the openclaw binary VALIDATES the config, the merge is kept (write survives)", () => {
+    writeConfig(freshConfig());
+    const bin = shimDir(
+      "#!/usr/bin/env bash\n" + 'echo \'{"valid":true}\'\n' + "exit 0\n",
+    );
+    const r = runHelper({
+      OPENCLAW_CONFIG_PATH: configPath,
+      PATH: `${bin}:${process.env["PATH"] ?? "/usr/bin:/bin"}`,
+    });
+    rmSync(bin, { recursive: true, force: true });
+
+    expect(r.status).toBe(0);
+    expect(parseMarker(r.stdout)["event"]).toBe("sil_allowlist_merged");
+    expect(readConfig().plugins.allow).toContain(SIL_ID);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC8 — config-path precedence + missing-config fail-closed.
+// ---------------------------------------------------------------------------
+describe("AC8 — path precedence and missing-config fail-closed", () => {
+  it("OPENCLAW_CONFIG_PATH takes precedence over the ~/.openclaw default", () => {
+    // Write a fresh config at the EXPLICIT path.
+    writeConfig(freshConfig());
+
+    // Also place a decoy config at the HOME default — it must NOT be touched.
+    const homeOpenclaw = join(emptyHome, ".openclaw");
+    mkdirSync(homeOpenclaw, { recursive: true });
+    const decoyPath = join(homeOpenclaw, "openclaw.json");
+    const decoy = JSON.stringify({ plugins: { allow: ["DECOY"] } }, null, 2) + "\n";
+    writeFileSync(decoyPath, decoy);
+
+    const r = runHelper({ OPENCLAW_CONFIG_PATH: configPath });
+    expect(r.status).toBe(0);
+
+    // The explicit path got sil; the decoy is byte-unchanged.
+    expect(readConfig().plugins.allow).toContain(SIL_ID);
+    expect(readFileSync(decoyPath, "utf8")).toBe(decoy);
+  });
+
+  it("OPENCLAW_CONFIG_PATH takes precedence over OPENCLAW_STATE_DIR", () => {
+    writeConfig(freshConfig());
+
+    const stateDir = join(workdir, "state");
+    mkdirSync(stateDir, { recursive: true });
+    const statePath = join(stateDir, "openclaw.json");
+    const stateCfg = JSON.stringify({ plugins: { allow: ["STATE-DECOY"] } }, null, 2) + "\n";
+    writeFileSync(statePath, stateCfg);
+
+    const r = runHelper({
+      OPENCLAW_CONFIG_PATH: configPath,
+      OPENCLAW_STATE_DIR: stateDir,
+    });
+    expect(r.status).toBe(0);
+    expect(readConfig().plugins.allow).toContain(SIL_ID);
+    // The state-dir candidate was lower precedence → untouched.
+    expect(readFileSync(statePath, "utf8")).toBe(stateCfg);
+  });
+
+  it("falls back to OPENCLAW_STATE_DIR/openclaw.json when OPENCLAW_CONFIG_PATH is unset", () => {
+    const stateDir = join(workdir, "state");
+    mkdirSync(stateDir, { recursive: true });
+    const statePath = join(stateDir, "openclaw.json");
+    writeFileSync(statePath, JSON.stringify(freshConfig(), null, 2) + "\n");
+
+    const r = runHelper({ OPENCLAW_STATE_DIR: stateDir });
+    expect(r.status).toBe(0);
+    const c = JSON.parse(readFileSync(statePath, "utf8")) as {
+      plugins: { allow: string[] };
+    };
+    expect(c.plugins.allow).toContain(SIL_ID);
+  });
+
+  it("missing config at every resolvable path → fail closed (exit 1, structured error, NO write, NO parent dir)", () => {
+    const missingPath = join(workdir, "nonexistent", "openclaw.json");
+    const missingState = join(workdir, "no-state");
+
+    const r = runHelper({
+      OPENCLAW_CONFIG_PATH: missingPath,
+      OPENCLAW_STATE_DIR: missingState,
+      // HOME is the guaranteed-empty dir → no ~/.openclaw/openclaw.json either.
+    });
+
+    expect(r.status).not.toBe(0);
+    const m = parseMarker(r.stderr);
+    expect(m["event"]).toBe("sil_allowlist_merge_failed");
+    expect(m["level"]).toBe("error");
+    // The error must point the operator at starting the gateway once.
+    expect(String(m["cause"]).toLowerCase()).toContain("gateway");
+    // No file fabricated at the missing path, and NO parent dir tree created
+    // (creating one would mask the misconfiguration).
+    expect(existsSync(missingPath)).toBe(false);
+    expect(existsSync(join(workdir, "nonexistent"))).toBe(false);
+    expect(existsSync(missingState)).toBe(false);
+  });
+
+  it("config that is not valid JSON → fail closed (exit 1, structured error, file untouched)", () => {
+    writeFileSync(configPath, "{ this is : not json,, }\n");
+    const before = readFileSync(configPath, "utf8");
+    const r = runHelper({ OPENCLAW_CONFIG_PATH: configPath });
+    expect(r.status).not.toBe(0);
+    expect(parseMarker(r.stderr)["event"]).toBe("sil_allowlist_merge_failed");
+    // The malformed file is left exactly as-is (no partial write, no .bak churn).
+    expect(readFileSync(configPath, "utf8")).toBe(before);
+    expect(existsSync(configPath + ".bak")).toBe(false);
+  });
+
+  it("a present-but-non-array plugins.allow → fail closed (no coercion, exit 1, file untouched)", () => {
+    // The merge core throws AllowlistShapeError; the shell maps it to `failed`.
+    writeConfig({ plugins: { allow: "sil" } });
+    const before = readFileSync(configPath, "utf8");
+    const r = runHelper({ OPENCLAW_CONFIG_PATH: configPath });
+    expect(r.status).not.toBe(0);
+    expect(parseMarker(r.stderr)["event"]).toBe("sil_allowlist_merge_failed");
+    expect(readFileSync(configPath, "utf8")).toBe(before);
+    expect(existsSync(configPath + ".bak")).toBe(false);
+  });
+});

--- a/src/lib/openclaw-allowlist.ts
+++ b/src/lib/openclaw-allowlist.ts
@@ -1,0 +1,210 @@
+/**
+ * Pure, typed merge core for trusting `sil` in a host OpenClaw config.
+ *
+ * On install OpenClaw discovers `sil` as a non-bundled plugin, but with an
+ * empty `plugins.allow` it warns that discovered plugins may auto-load
+ * unrestricted. This module computes the additive, idempotent edit that
+ * closes that warning by trusting `sil` at the THREE real allow surfaces of
+ * the `alpine/openclaw:2026.6.9` config schema:
+ *
+ *   - `plugins.allow`     string[] of plugin IDs   — emptiness fires the warning
+ *   - `tools.alsoAllow`   string[] of plugin IDs   — admits a plugin's tools by
+ *                                                    ID (NO per-tool-name key
+ *                                                    exists; this is how all of
+ *                                                    sil's tools become un-filtered)
+ *   - `plugins.entries.sil`  { enabled, config }    — makes sil loadable/exposing
+ *
+ * There is no global skill allow-list — a skill attaches per-agent via
+ * `agents.list[i].skills`, which is the host-wiring path's job, NOT this
+ * helper's. `sil.tools` / `sil.skill` are carried in the facts type only for
+ * the operator log fields; the merge never enumerates tool names into config,
+ * because on 2026.6.9 the mechanism is plugin-ID admission.
+ *
+ * This module is pure (no I/O). The config arrives as `unknown` because the
+ * file is operator-editable and may be any shape; every read narrows with
+ * `typeof` / `Array.isArray` before use. A present-but-wrong-typed allow array
+ * is a hard error (we never coerce — that risks clobbering operator state).
+ *
+ * Invariants (the two the suite exists to defend):
+ *   - ADDITIVE: a pre-existing entry is never removed, reordered, or
+ *     overwritten — sil's IDs are only ever appended; an existing
+ *     `plugins.entries.sil` is left untouched.
+ *   - IDEMPOTENT: `changed` is computed from set membership, so a second run
+ *     finds nothing missing and reports `changed: false` (the I/O shell then
+ *     writes nothing).
+ *
+ * OQ3 — enabling the restriction must never silently un-trust a plugin the
+ * permissive empty-list default was auto-loading. So when `plugins.allow` is
+ * empty/absent, we seed it with every ID already recorded under
+ * `plugins.entries` (the host's own record of installed plugins) before
+ * appending `sil`. The seed IDs are read from the live config, never hardcoded.
+ */
+
+/** sil's own facts, read by the I/O shell from the shipped manifest — never
+ * re-hardcoded. `tools` and `skill` feed the operator log; the merge itself
+ * only uses `id` (plugin-ID admission on 2026.6.9). */
+export interface SilAllowlistFacts {
+  /** The plugin ID — `"sil"`. The single value admitted at all three surfaces. */
+  readonly id: string;
+  /** The plugin's tool names, for the operator log's `tools_added` count. */
+  readonly tools: readonly string[];
+  /** The plugin's skill ref (e.g. `"./skill"`), for the operator log. */
+  readonly skill: string;
+}
+
+/** A plugin enable entry under `plugins.entries.<id>`. */
+export interface PluginEntry {
+  enabled: boolean;
+  config: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+/** The slice of the OpenClaw config this helper reads and writes. Other keys
+ * (`gateway`, `agents`, `meta`, …) are preserved verbatim via the index
+ * signature — we only ever touch the three allow surfaces. */
+export interface OpenClawConfig {
+  plugins?: {
+    allow?: string[];
+    entries?: Record<string, PluginEntry | unknown>;
+    [key: string]: unknown;
+  };
+  tools?: {
+    alsoAllow?: string[];
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+/** Thrown when the operator-editable config has a shape we refuse to coerce
+ * (a non-object root, or a present-but-non-array allow surface). The I/O shell
+ * maps this to the `sil_allowlist_merge_failed` outcome — fail closed, never
+ * silently overwrite operator state. */
+export class AllowlistShapeError extends Error {
+  override readonly name = "AllowlistShapeError";
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Append `id` to `arr` if absent. Returns true iff a mutation occurred —
+ * append-only, so order is preserved and pre-existing entries are byte-stable. */
+function appendIfAbsent(arr: string[], id: string): boolean {
+  if (arr.includes(id)) return false;
+  arr.push(id);
+  return true;
+}
+
+/**
+ * Compute the additive, idempotent merge that trusts `sil` in the given config.
+ *
+ * Mutates a copy is NOT what we do — we mutate the passed object in place (the
+ * I/O shell parses fresh per run, so there is no aliasing hazard) and return it
+ * for ergonomics. All three merges happen in-memory before the shell does its
+ * single atomic write, so a crash mid-merge can never half-write the file.
+ *
+ * @throws AllowlistShapeError if `config` is not an object, or if any of
+ *   `plugins.allow`, `tools.alsoAllow`, `plugins.entries` is present but the
+ *   wrong type (non-array / non-object) — we refuse to coerce.
+ */
+export function mergeSilAllowlist(
+  config: unknown,
+  sil: SilAllowlistFacts,
+): { config: OpenClawConfig; changed: boolean } {
+  if (!isPlainObject(config)) {
+    throw new AllowlistShapeError(
+      "OpenClaw config root must be a JSON object, got: "
+        + (config === null ? "null" : Array.isArray(config) ? "array" : typeof config),
+    );
+  }
+
+  // --- Narrow / create the `plugins` container -------------------------------
+  if (config["plugins"] !== undefined && !isPlainObject(config["plugins"])) {
+    throw new AllowlistShapeError(
+      "config.plugins must be an object when present, got: " + typeof config["plugins"],
+    );
+  }
+  if (config["plugins"] === undefined) config["plugins"] = {};
+  const plugins = config["plugins"] as Record<string, unknown>;
+
+  // --- Narrow / create the `tools` container ---------------------------------
+  if (config["tools"] !== undefined && !isPlainObject(config["tools"])) {
+    throw new AllowlistShapeError(
+      "config.tools must be an object when present, got: " + typeof config["tools"],
+    );
+  }
+  if (config["tools"] === undefined) config["tools"] = {};
+  const tools = config["tools"] as Record<string, unknown>;
+
+  // --- Narrow `plugins.entries` (read-only for the OQ3 seed) -----------------
+  if (plugins["entries"] !== undefined && !isPlainObject(plugins["entries"])) {
+    throw new AllowlistShapeError(
+      "config.plugins.entries must be an object when present, got: "
+        + typeof plugins["entries"],
+    );
+  }
+  const entries = isPlainObject(plugins["entries"])
+    ? (plugins["entries"] as Record<string, unknown>)
+    : undefined;
+
+  // --- 1. plugins.allow ------------------------------------------------------
+  // A present-but-non-array allow is a hard error: coercing it would silently
+  // discard whatever the operator put there.
+  if (plugins["allow"] !== undefined && !Array.isArray(plugins["allow"])) {
+    throw new AllowlistShapeError(
+      "config.plugins.allow must be an array when present, got: " + typeof plugins["allow"],
+    );
+  }
+  // Every element must be a string — a mixed array is operator corruption we
+  // refuse to silently propagate.
+  const existingAllow = plugins["allow"] as unknown[] | undefined;
+  if (existingAllow && existingAllow.some((x) => typeof x !== "string")) {
+    throw new AllowlistShapeError("config.plugins.allow must contain only strings");
+  }
+  let allowChanged = false;
+  if (!existingAllow || existingAllow.length === 0) {
+    // Empty/absent → flipping from permissive (auto-loads everything) to
+    // explicit (allow-list enforced) would un-trust every other installed
+    // plugin. Seed with sil + every ID the host already records under
+    // `plugins.entries`, so enabling the restriction never silently excludes a
+    // previously auto-loading plugin (OQ3). Seed IDs come from the live config.
+    const seed = [sil.id, ...(entries ? Object.keys(entries) : [])];
+    const deduped: string[] = [];
+    for (const id of seed) appendIfAbsent(deduped, id);
+    plugins["allow"] = deduped;
+    allowChanged = true;
+  } else {
+    // Non-empty → append sil only; the other trusted IDs stay, in order (AC5).
+    allowChanged = appendIfAbsent(existingAllow as string[], sil.id);
+  }
+
+  // --- 2. tools.alsoAllow ----------------------------------------------------
+  if (tools["alsoAllow"] !== undefined && !Array.isArray(tools["alsoAllow"])) {
+    throw new AllowlistShapeError(
+      "config.tools.alsoAllow must be an array when present, got: "
+        + typeof tools["alsoAllow"],
+    );
+  }
+  const existingAlsoAllow = tools["alsoAllow"] as unknown[] | undefined;
+  if (existingAlsoAllow && existingAlsoAllow.some((x) => typeof x !== "string")) {
+    throw new AllowlistShapeError("config.tools.alsoAllow must contain only strings");
+  }
+  if (existingAlsoAllow === undefined) tools["alsoAllow"] = [];
+  const alsoAllowChanged = appendIfAbsent(tools["alsoAllow"] as string[], sil.id);
+
+  // --- 3. plugins.entries.<id> -----------------------------------------------
+  // Set the enable entry ONLY when absent — never overwrite an operator's
+  // existing `enabled`/`config` (AC4). Create the entries container if needed.
+  if (plugins["entries"] === undefined) plugins["entries"] = {};
+  const entriesObj = plugins["entries"] as Record<string, unknown>;
+  let entryChanged = false;
+  if (!(sil.id in entriesObj)) {
+    entriesObj[sil.id] = { enabled: true, config: {} } satisfies PluginEntry;
+    entryChanged = true;
+  }
+
+  return {
+    config: config as OpenClawConfig,
+    changed: allowChanged || alsoAllowChanged || entryChanged,
+  };
+}


### PR DESCRIPTION
## Card
`cards/install-time-helper-to-allow-list-sil-in-openclaw.md` (lives in the `card/install-time-helper-to-allow-list-sil-in-openclaw` branch — gitignored, see its body for the full intent + handoffs).

## Summary
An operator-run install-time helper that additively + idempotently trusts `sil` in the host OpenClaw config, closing the empty-`plugins.allow` auto-load warning. Grounded in the REAL `alpine/openclaw:2026.6.9` schema — three allow surfaces, no invented shapes.

- **`src/lib/openclaw-allowlist.ts`** — pure, typed `mergeSilAllowlist(config: unknown, sil) → { config, changed }`. Append-if-absent on `plugins.allow` (plugin-id list), `tools.alsoAllow` (plugin-id list — un-filters all 8 sil tools by id, no per-tool-name key exists), and `plugins.entries.sil` (`{enabled,config}` set only when absent). Narrows `unknown` defensively; throws `AllowlistShapeError` on un-coercible shapes (fail closed, no clobber).
- **OQ3 seed**: when `plugins.allow` is empty/absent, seeds it with `sil` + every existing `plugins.entries` id before appending — so enabling the restriction never silently un-trusts a previously auto-loading plugin (e.g. klodi/codex). Ids read from the live config, never hardcoded.
- **`scripts/allowlist-openclaw.mjs`** + `package.json` `bin` (`sil-openclaw-allowlist`) + `openclaw:allowlist` script + `scripts` added to published `files`. Resolves config by precedence (`OPENCLAW_CONFIG_PATH` → `$OPENCLAW_STATE_DIR/openclaw.json` → `~/.openclaw/openclaw.json`), fails closed if none. Reads sil facts from the shipped manifest (single source of truth). On change: `.bak` then atomic `tmp → rename` preserving the file's existing mode; best-effort `openclaw config validate --json` guard reverts from `.bak` on rejection. Three distinct structured NDJSON markers: `sil_allowlist_merged` / `sil_allowlist_unchanged` / `sil_allowlist_merge_failed`.
- NOT a plugin tool, NOT a postinstall hook (honours `security.noInstallScripts: true`), NOT a `openclaw config set` driver.

## Test plan
- [x] Unit (`src/__tests__/lib/openclaw-allowlist.test.ts`) — 34 tests: AC1/2/4/5/6/9 + untrusted-shape fail-closed
- [x] Integration (`src/__tests__/openclaw-allowlist.integration.test.ts`) — 18 tests: script end-to-end vs real temp configs (AC1/3/6/7/8), `openclaw` binary shimmed as a test double of the external boundary
- [x] `pnpm typecheck` clean; full suite 955 passed (only the known `repo-scaffold` worktree-only failure remains — gitignored docs/CLAUDE.md)
- [x] Live verification — build gate + all 6 script outcomes exercised end-to-end

## Distillation target
Knowledge capture happens **after Review PASS** in the `distilling` stage — `solutions-architect` runs in this same worktree, commits to this same branch, and pushes here so the PR ends up containing implementation + tests + distillation in one mergeable unit. Candidate: the `plugins.allow` / `tools.alsoAllow` / `plugins.entries` allow-list surface (constrains any future host-config-touching card).

🤖 Generated with [Claude Code](https://claude.com/claude-code)