### PR TITLE
refactor: single multi-domain sil shopper — Slice 1 (store/tool plumbing)

### DIFF
--- a/src/__tests__/lib/profile-store-manage.test.ts
+++ b/src/__tests__/lib/profile-store-manage.test.ts
@@ -1,62 +1,46 @@
 /**
- * UNIT — list/read/remove store primitives (tier: unit, real temp dir via the
- * SIL_DATA_DIR override, no network, no host).
+ * UNIT — list / read / remove store primitives after the single-multi-domain
+ * shopper reshape (tier: unit, real temp dir via the SIL_DATA_DIR override, no
+ * network, no host).
  *
- * Card: list-view-and-remove-local-expert-agents. The create-engine
- * (`materializeProfile`) wrote the artefact store; this card adds the three
- * primitives that MANAGE it:
- *   - listAgentProfiles()        — enumerate $SIL_DATA_DIR/agents/*\/profile.json
- *   - readAgentProfile(agentId)  — manifest + the SDS spec bodies for one
- *   - removeAgentArtefacts(id)   — delete exactly one validated agent's dir
+ * Card: single-multi-domain-sil-shopper — Slice 1. The lifecycle primitives shift
+ * from "experts" to "DOMAINS" semantics — they now manage the ONE shopper's
+ * domain packs, not separate per-niche experts:
  *
- * Each returns a discriminated result that NEVER throws across the boundary
- * (cloning the `MaterializeResult` shape, profile-store.ts:94-117) — the tool
- * maps each variant to a structured envelope. The invariants pinned here ARE
- * the card's correctness bar for the artefact-half of list/view/remove:
+ *   listAgentProfiles()                  — enumerate the shopper(s) + each one's
+ *                                          domain index from its `domains` map.
+ *   readAgentProfile(agentId, slug?)     — slug ⇒ that domain's 3 bodies + the
+ *                                          SHARED user_spec; no slug ⇒ the shopper
+ *                                          overview (identity + shared user_spec +
+ *                                          the domain index).
+ *   removeAgentArtefacts(agentId, slug)  — remove exactly ONE domain leaf +
+ *                                          de-register domains[slug]; the shopper
+ *                                          and shared user_spec survive. `slug` is
+ *                                          REQUIRED (no omit-deletes-everything).
  *
- *   LIST   (Flow 1, AC List):
- *     1. empty/absent store → ok with empty experts (a normal outcome).
- *     2. multiple experts → all present, each from its profile.json manifest
- *        (no dirname guessing — name/createdAt come from the file).
- *     3. ordered createdAt DESC (most-recently-created first).
- *     4. one corrupt/unreadable profile.json among healthy ones → that one in
- *        unreadable[], the rest still listed (the list never aborts/throws).
- *   READ   (Flow 2, AC View):
- *     5. ok → manifest + ALL FOUR spec bodies (round-2: all present from creation)
- *        read from the files the manifest points at.
- *     6. unknown id → not_found (a normal outcome, never a throw).
- *     7. traversal-shaped id (../x, a/b, .., a/../b, main, Mixed-Case) →
- *        invalid_request via AGENT_ID_RE, rejected BEFORE any join/read.
- *   REMOVE (Flow 3, AC Remove — clears the artefact half, scoped):
- *     8. removed → the target dir is gone.
- *     9. idempotent not_found on absent — a re-run is safe (converges to clean).
- *    10. traversal/main/malformed → invalid_request, DELETES NOTHING.
- *    11. a sibling expert's dir is byte-for-byte untouched (non-destructive).
- *    12. an rmSync that genuinely fails (non-writable parent) → persistence_failed
- *        with <dir>: <cause>, never a throw.
- *   IDENTITY BOUNDARY (Generic shopping unchanged):
- *    13. none of the three read/write a token (getTokensPath() never appears).
+ * The invariants pinned here:
+ *   LIST   1. empty/absent store → ok with empty shoppers (normal).
+ *          2. a shopper with N domains → its identity + N domain summaries
+ *             (slug, name, createdAt, updatedAt) from the `domains` map.
+ *          3. empty `domains` → the shopper still lists, with an empty domain
+ *             list (NOT not_found / NOT unreadable).
+ *          4. one corrupt profile.json → that shopper in unreadable[], the rest
+ *             still list (never aborts/throws).
+ *   READ   5. overview (no slug) → identity + shared user_spec + the domain index.
+ *          6. per-domain (slug) → the 3 domain bodies + the shared user_spec.
+ *          7. unknown agentId → not_found; traversal agentId → invalid_request.
+ *   REMOVE 8. removes exactly one leaf + de-registers it; sibling + shared
+ *             user_spec + the shopper survive.
+ *          9. removing the LAST domain leaves a healthy `domains: {}` shopper
+ *             (never deletes the agent dir / the domains parent / the shopper).
+ *         10. absent slug → not_found (idempotent); a missing/blank slug →
+ *             invalid_request(field=domainSlug), deletes nothing.
+ *         11. traversal/main slug → invalid_request(field=domainSlug), deletes
+ *             nothing; bad agentId → invalid_request(field=agentId).
+ *         12. a genuine rmSync failure → persistence_failed with <dir>: <cause>.
+ *   IDENTITY 13. none of the three read/write a token.
  *
- * Hermetic via the SIL_DATA_DIR temp-dir override (the repo's standard knob,
- * mirrors profile-store.test.ts:64-80).
- *
- * Contract this file pins for the implementation (expert-developer),
- * `src/lib/profile-store.ts`:
- *   - listAgentProfiles(): ListProfilesResult — discriminated, never throws.
- *     ok variant: { ok:true, experts: {agentId,name,…,createdAt}[]
- *     (createdAt DESC), unreadable: {agentId,error}[] }. (round-2: with all four
- *     specs required+present, a per-slot presence flag carries no signal.)
- *   - readAgentProfile(agentId): ReadProfileResult — discriminated, never throws.
- *     ok: { ok:true, agentId, name, domainSpec, intentSpec, userSpec, playbook,
- *     profilePath, createdAt } (NO persona; all four present at creation);
- *     not_found: { ok:false, kind:"not_found", agentId, message };
- *     bad id: { ok:false, kind:"invalid_request", field:"agentId", message }.
- *   - removeAgentArtefacts(agentId): RemoveProfileResult — discriminated, never
- *     throws. removed: { ok:true, agentId }; absent: { ok:false,
- *     kind:"not_found", agentId, message }; bad id: { ok:false,
- *     kind:"invalid_request", field:"agentId", message } AND deletes nothing;
- *     rmSync failure: { ok:false, kind:"persistence_failed", error:"<dir>:
- *     <cause>", message }.
+ * Hermetic via the SIL_DATA_DIR temp-dir override (mirrors profile-store.test.ts).
  */
 
 import {
@@ -86,6 +70,7 @@ import {
   readAgentProfile,
   removeAgentArtefacts,
   getAgentArtefactDir,
+  type ProfileSpec,
 } from "../../lib/profile-store.js";
 import { getDataDir, getTokensPath } from "../../lib/credentials.js";
 
@@ -93,7 +78,7 @@ let dataDir: string;
 let priorSilDataDir: string | undefined;
 
 beforeEach(() => {
-  dataDir = mkdtempSync(join(tmpdir(), "sil-profile-manage-"));
+  dataDir = mkdtempSync(join(tmpdir(), "sil-shopper-manage-"));
   priorSilDataDir = process.env["SIL_DATA_DIR"];
   process.env["SIL_DATA_DIR"] = dataDir;
 });
@@ -101,15 +86,26 @@ beforeEach(() => {
 afterEach(() => {
   if (priorSilDataDir === undefined) delete process.env["SIL_DATA_DIR"];
   else process.env["SIL_DATA_DIR"] = priorSilDataDir;
-  // Restore perms so rmSync can clean a dir a failure test chmod'd read-only.
   try {
     chmodSync(dataDir, 0o700);
     const agents = join(dataDir, "agents");
     if (existsSync(agents)) {
       chmodSync(agents, 0o700);
       for (const e of readdirSync(agents)) {
+        const a = join(agents, e);
         try {
-          chmodSync(join(agents, e), 0o700);
+          chmodSync(a, 0o700);
+          const dom = join(a, "domains");
+          if (existsSync(dom)) {
+            chmodSync(dom, 0o700);
+            for (const d of readdirSync(dom)) {
+              try {
+                chmodSync(join(dom, d), 0o700);
+              } catch {
+                /* best-effort */
+              }
+            }
+          }
         } catch {
           /* best-effort */
         }
@@ -121,50 +117,44 @@ afterEach(() => {
   rmSync(dataDir, { recursive: true, force: true });
 });
 
-/** Materialize an expert and (optionally) backdate its manifest createdAt so
- * ordering is deterministic regardless of wall-clock resolution. The store's
- * own writer is used (never a hand-rolled fixture) so the test exercises the
- * real on-disk shape readAgentProfile/listAgentProfiles must parse.
- *
- * After the SDS reframe the store holds NO persona. Round-2: ALL FOUR specs are
- * REQUIRED and present from creation, so the fixture ALWAYS supplies all four (a
- * real create). Callers may override any of the four via opts. */
-function makeExpert(
+const SHOPPER = "sil-shopper";
+const USER_SPEC =
+  "# User spec (shared)\n- Ships to Berlin 10115.\nHARD-NO: leather (ethics).";
+
+function pack(slug: string, name: string): NonNullable<ProfileSpec["domain"]> {
+  return {
+    slug,
+    name,
+    domainSpec: `# Domain spec — ${name}\nResearched mechanics.`,
+    intentSpec: `# Intent spec — ${name}\nDecomposition dimensions.`,
+    playbook: `# Taste — ${name}\nSeeded preferences.`,
+  };
+}
+
+/** Create the shopper with `agentId`, then mint each (slug → name) domain. */
+function makeShopper(
   agentId: string,
-  opts: {
-    name?: string;
-    domainSpec?: string;
-    intentSpec?: string;
-    userSpec?: string;
-    playbook?: string;
-    createdAt?: string;
-  } = {},
+  domains: ReadonlyArray<readonly [string, string]> = [],
+  userSpec = USER_SPEC,
 ): void {
-  const result = materializeProfile({
-    agentId,
-    name: opts.name ?? `Expert ${agentId}`,
-    domainSpec: opts.domainSpec ?? `# Domain spec for ${agentId}\nResearched dimensions.`,
-    intentSpec: opts.intentSpec ?? `# Intent spec for ${agentId}\nDecomposition dimensions.`,
-    userSpec: opts.userSpec ?? `# User spec for ${agentId}\nFacts + hard constraints.`,
-    playbook: opts.playbook ?? `# Buying taste for ${agentId}\nSeeded preferences.`,
-  });
-  if (!result.ok) {
-    throw new Error(`fixture setup failed for ${agentId}: ${JSON.stringify(result)}`);
-  }
-  if (opts.createdAt !== undefined) {
-    // Rewrite profile.json with a fixed createdAt to pin ordering.
-    const manifestPath = join(getAgentArtefactDir(agentId), "profile.json");
-    const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as Record<
-      string,
-      unknown
-    >;
-    manifest["createdAt"] = opts.createdAt;
-    writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + "\n");
+  const created = materializeProfile({ agentId, name: `Shopper ${agentId}`, userSpec });
+  if (!created.ok) throw new Error(`create failed: ${JSON.stringify(created)}`);
+  for (const [slug, name] of domains) {
+    const r = materializeProfile({ agentId, name: `Shopper ${agentId}`, userSpec, domain: pack(slug, name) });
+    if (!r.ok) throw new Error(`mint ${slug} failed: ${JSON.stringify(r)}`);
   }
 }
 
-/** Every file under `dir`, recursively (relative paths). Used to prove a
- * rejected-on-bad-id remove deleted NOTHING anywhere under agents/. */
+function domainDir(slug: string, agentId = SHOPPER): string {
+  return join(getAgentArtefactDir(agentId), "domains", slug);
+}
+
+function readManifest(agentId = SHOPPER): Record<string, unknown> {
+  return JSON.parse(
+    readFileSync(join(getAgentArtefactDir(agentId), "profile.json"), "utf8"),
+  ) as Record<string, unknown>;
+}
+
 function walkFiles(dir: string, base = dir): string[] {
   if (!existsSync(dir)) return [];
   const out: string[] = [];
@@ -181,192 +171,105 @@ function walkFiles(dir: string, base = dir): string[] {
 // ===========================================================================
 
 describe("listAgentProfiles — empty/absent store is a normal, successful empty listing", () => {
-  // list has NO failure variant: an absent store is a normal empty listing and
-  // per-entry problems land in unreadable[]. So the result carries experts +
-  // unreadable directly (no `ok` discriminant to gate on) — pin the BEHAVIOUR.
-  it("absent agents/ dir → empty experts, empty unreadable (not an error)", () => {
-    // Fresh temp data dir: no agents/ subtree exists at all.
+  it("absent agents/ dir → empty shoppers, empty unreadable (not an error)", () => {
     expect(existsSync(join(getDataDir(), "agents"))).toBe(false);
     const result = listAgentProfiles();
-    expect(result.experts).toEqual([]);
+    expect(result.shoppers).toEqual([]);
     expect(result.unreadable).toEqual([]);
-  });
-
-  it("present-but-empty agents/ dir → empty experts", () => {
-    // An agents/ dir with no expert subdirs is still a normal empty listing.
-    mkdirSync(join(getDataDir(), "agents"), { recursive: true });
-    const result = listAgentProfiles();
-    expect(result.experts).toEqual([]);
   });
 });
 
-describe("listAgentProfiles — multiple experts: all present, sourced from profile.json", () => {
-  it("lists every materialized expert with name + agentId + createdAt from its manifest", () => {
-    // Round-2: with all four specs required+present, a hasPlaybook flag is trivially
-    // true for every created expert and carries no discriminating signal — so we do
-    // NOT assert it. The durable behaviour is: every expert is enumerated, with its
-    // manifest name + createdAt sourced from the file (not the directory name).
-    makeExpert("gift-buyer", { name: "Gift Buyer" });
-    makeExpert("grocery-agent", { name: "Grocery Agent" });
-
-    const result = listAgentProfiles();
-    expect(result.unreadable).toEqual([]);
-
-    const byId = new Map(result.experts.map((e) => [e.agentId, e]));
-    expect(byId.size).toBe(2);
-
-    const gift = byId.get("gift-buyer");
-    expect(gift).toBeDefined();
-    // name comes from the manifest, NOT from the directory name.
-    expect(gift!.name).toBe("Gift Buyer");
-    expect(typeof gift!.createdAt).toBe("string");
-
-    const grocery = byId.get("grocery-agent");
-    expect(grocery).toBeDefined();
-    expect(grocery!.name).toBe("Grocery Agent");
-  });
-
-  it("reads name from the manifest, not the directory name (no filesystem-name guessing)", () => {
-    // The directory key is the agentId; the human name is a DISTINCT manifest
-    // field. A list that echoed the dir name as the name would pass a naive
-    // test but fail here, where the two deliberately differ.
-    makeExpert("shoe-expert", { name: "Sneaker Specialist" });
-    const result = listAgentProfiles();
-    const entry = result.experts.find((e) => e.agentId === "shoe-expert");
-    expect(entry).toBeDefined();
-    expect(entry!.name).toBe("Sneaker Specialist");
-    expect(entry!.name).not.toBe("shoe-expert");
-  });
-});
-
-describe("listAgentProfiles — ordered most-recently-created first (createdAt DESC)", () => {
-  it("returns experts in descending createdAt order", () => {
-    makeExpert("oldest", { createdAt: "2026-01-01T00:00:00.000Z" });
-    makeExpert("newest", { createdAt: "2026-06-22T00:00:00.000Z" });
-    makeExpert("middle", { createdAt: "2026-03-15T00:00:00.000Z" });
-
-    const result = listAgentProfiles();
-    expect(result.experts.map((e) => e.agentId)).toEqual([
-      "newest",
-      "middle",
-      "oldest",
+describe("listAgentProfiles — a shopper with N domains lists its identity + domain index", () => {
+  it("returns the shopper identity + each domain's slug/name/createdAt/updatedAt from the map", () => {
+    makeShopper(SHOPPER, [
+      ["road-cycling", "Road cycling"],
+      ["running-shoes", "Running shoes"],
     ]);
+
+    const result = listAgentProfiles();
+    expect(result.unreadable).toEqual([]);
+    const shopper = result.shoppers.find((s) => s.agentId === SHOPPER);
+    expect(shopper).toBeDefined();
+    expect(shopper!.name).toBe(`Shopper ${SHOPPER}`);
+
+    const byId = new Map(shopper!.domains.map((d) => [d.slug, d]));
+    expect([...byId.keys()].sort()).toEqual(["road-cycling", "running-shoes"]);
+    expect(byId.get("road-cycling")!.name).toBe("Road cycling");
+    expect(typeof byId.get("road-cycling")!.createdAt).toBe("string");
+    expect(typeof byId.get("road-cycling")!.updatedAt).toBe("string");
+  });
+
+  it("an empty-`domains` shopper still lists, with an EMPTY domain list (not not_found, not unreadable)", () => {
+    makeShopper(SHOPPER, []); // created, never shopped
+    const result = listAgentProfiles();
+    expect(result.unreadable).toEqual([]);
+    const shopper = result.shoppers.find((s) => s.agentId === SHOPPER);
+    expect(shopper).toBeDefined();
+    expect(shopper!.domains).toEqual([]);
   });
 });
 
 describe("listAgentProfiles — one corrupt manifest never blinds the user to the rest", () => {
-  it("a healthy expert + an unparseable profile.json → healthy listed, broken in unreadable[]", () => {
-    makeExpert("healthy", { name: "Healthy Expert", createdAt: "2026-05-01T00:00:00.000Z" });
-    makeExpert("broken", { name: "Broken Expert", createdAt: "2026-05-02T00:00:00.000Z" });
-    // Corrupt the broken one's manifest with non-JSON.
+  it("a healthy shopper + a corrupt profile.json → healthy listed, broken in unreadable[]", () => {
+    makeShopper("healthy", [["a-niche", "A niche"]]);
+    makeShopper("broken", []);
     const brokenManifest = join(getAgentArtefactDir("broken"), "profile.json");
     chmodSync(brokenManifest, 0o600);
-    writeFileSync(brokenManifest, "{ this is not valid json ");
+    writeFileSync(brokenManifest, "{ not valid json ");
 
     const result = listAgentProfiles();
-    // Must NOT throw — the broken one is isolated into unreadable[].
-
-    // The healthy expert still lists.
-    expect(result.experts.map((e) => e.agentId)).toEqual(["healthy"]);
-    // The broken one is reported by agentId in unreadable[], with an error.
-    expect(result.unreadable.map((u) => u.agentId)).toEqual(["broken"]);
+    expect(result.shoppers.map((s) => s.agentId)).toEqual(["healthy"]);
+    expect(result.unreadable.map((u) => u.agentId)).toContain("broken");
     expect(typeof result.unreadable[0]!.error).toBe("string");
     expect(result.unreadable[0]!.error.length).toBeGreaterThan(0);
   });
-
-  it("an expert subdir whose profile.json is entirely MISSING → reported unreadable, others still list", () => {
-    makeExpert("intact", { name: "Intact" });
-    // Create an agent subdir with NO profile.json (an interrupted create).
-    const orphanDir = getAgentArtefactDir("orphaned");
-    mkdirSync(orphanDir, { recursive: true });
-    writeFileSync(join(orphanDir, "domain_spec.md"), "a spec but no manifest");
-
-    const result = listAgentProfiles();
-    expect(result.experts.map((e) => e.agentId)).toEqual(["intact"]);
-    expect(result.unreadable.map((u) => u.agentId)).toContain("orphaned");
-  });
 });
 
 // ===========================================================================
-// readAgentProfile
+// readAgentProfile — overview vs per-domain
 // ===========================================================================
 
-describe("readAgentProfile — ok: manifest + artefact bodies for one expert", () => {
-  it("returns name, the required spec bodies, the lazy bodies, profilePath, createdAt — and NO persona", () => {
-    makeExpert("gift-buyer", {
-      name: "Gift Buyer",
-      domainSpec: "# Gift-buying domain spec\nRecipient, occasion, budget, taste dimensions.",
-      intentSpec: "# Intent spec\nrecipient, occasion, budget, timeline.",
-      userSpec: "# User spec\nBuys for partner.\nHARD-NO: nothing over €50.",
-      playbook: "# Buying taste\nValue-conscious.",
-    });
-
-    const result = readAgentProfile("gift-buyer");
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(result.agentId).toBe("gift-buyer");
-    expect(result.name).toBe("Gift Buyer");
-    // The BODIES are read from disk (the files the manifest points at), not the
-    // manifest paths alone — the skill renders detail from these.
-    expect(result.domainSpec).toBe(
-      "# Gift-buying domain spec\nRecipient, occasion, budget, taste dimensions.",
-    );
-    expect(result.intentSpec).toBe("# Intent spec\nrecipient, occasion, budget, timeline.");
-    expect(result.userSpec).toBe("# User spec\nBuys for partner.\nHARD-NO: nothing over €50.");
-    expect(result.playbook).toBe("# Buying taste\nValue-conscious.");
-    // Persona left the store — the read result carries none.
-    expect("persona" in result).toBe(false);
-    expect(result.profilePath).toBe(
-      join(getAgentArtefactDir("gift-buyer"), "profile.json"),
-    );
-    expect(typeof result.createdAt).toBe("string");
-    expect(Number.isNaN(Date.parse(result.createdAt))).toBe(false);
-  });
-
-  it("returns ALL FOUR spec bodies for a created expert (round-2: none is absent at creation)", () => {
-    makeExpert("grocery-agent", { name: "Grocery Agent" }); // all four seeded by default
-    const result = readAgentProfile("grocery-agent");
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    // All four specs are present from creation now.
-    expect(typeof result.domainSpec).toBe("string");
-    expect(result.domainSpec.length).toBeGreaterThan(0);
-    expect(typeof result.intentSpec).toBe("string");
-    expect(result.intentSpec.length).toBeGreaterThan(0);
-    expect(typeof result.userSpec).toBe("string");
-    expect(result.userSpec!.length).toBeGreaterThan(0);
-    expect(typeof result.playbook).toBe("string");
-    expect(result.playbook!.length).toBeGreaterThan(0);
+describe("readAgentProfile — overview (no slug): identity + shared user_spec + domain index", () => {
+  it("returns the shopper identity, the SHARED user_spec body, and the domain index — no bodies", () => {
+    makeShopper(SHOPPER, [["road-cycling", "Road cycling"]], USER_SPEC);
+    const overview = readAgentProfile(SHOPPER);
+    expect(overview.ok).toBe(true);
+    if (!overview.ok) return;
+    expect(overview.agentId).toBe(SHOPPER);
+    expect(overview.userSpec).toBe(USER_SPEC);
+    expect(overview.domains.map((d) => d.slug)).toEqual(["road-cycling"]);
+    expect(overview.profilePath).toBe(join(getAgentArtefactDir(SHOPPER), "profile.json"));
   });
 });
 
-describe("readAgentProfile — unknown id fails gracefully (not_found, never a throw)", () => {
-  it("an id with no artefact dir → not_found naming the agentId, no throw", () => {
-    makeExpert("exists", {}); // a healthy neighbour, to prove read is scoped
-    const result = readAgentProfile("does-not-exist");
+describe("readAgentProfile — per-domain (slug): the 3 domain bodies + the shared user_spec", () => {
+  it("returns domainSpec + intentSpec + playbook (the pack) AND the shared user_spec", () => {
+    makeShopper(SHOPPER, [["road-cycling", "Road cycling"]], USER_SPEC);
+    const read = readAgentProfile(SHOPPER, "road-cycling");
+    expect(read.ok).toBe(true);
+    if (!read.ok) return;
+    expect(read.slug).toBe("road-cycling");
+    expect(read.domainSpec).toBe("# Domain spec — Road cycling\nResearched mechanics.");
+    expect(read.intentSpec).toBe("# Intent spec — Road cycling\nDecomposition dimensions.");
+    expect(read.playbook).toBe("# Taste — Road cycling\nSeeded preferences.");
+    // The user_spec read with a domain is the SHARED, agent-level one.
+    expect(read.userSpec).toBe(USER_SPEC);
+  });
+});
+
+describe("readAgentProfile — graceful failures", () => {
+  it("an unknown agentId → not_found naming it, no throw", () => {
+    makeShopper(SHOPPER, [["road-cycling", "Road cycling"]]);
+    const result = readAgentProfile("no-such-shopper");
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.kind).toBe("not_found");
     if (result.kind !== "not_found") return;
-    expect(result.agentId).toBe("does-not-exist");
-    expect(typeof result.message).toBe("string");
+    expect(result.agentId).toBe("no-such-shopper");
   });
 
-  it("an agent dir whose profile.json is unreadable → not_found (a degraded read, not a throw)", () => {
-    makeExpert("degraded", { name: "Degraded" });
-    const manifestPath = join(getAgentArtefactDir("degraded"), "profile.json");
-    writeFileSync(manifestPath, "}}} not json {{{");
-    const result = readAgentProfile("degraded");
-    // A corrupt manifest must never throw out of read — it degrades to not_found.
-    expect(result.ok).toBe(false);
-    if (result.ok) return;
-    expect(result.kind).toBe("not_found");
-  });
-});
-
-describe("readAgentProfile — traversal-shaped id rejected fail-closed BEFORE any read", () => {
-  it.each(["../escape", "gift/buyer", "..", ".", "a/../b", "main", "Gift-Buyer", ""])(
-    "rejects %j with invalid_request(field=agentId) and reads nothing",
+  it.each(["../escape", "shop/per", "..", ".", "main", "Sil-Shopper", ""])(
+    "a traversal/main/malformed agentId %j → invalid_request(field=agentId), reads nothing",
     (bad) => {
       const result = readAgentProfile(bad);
       expect(result.ok, `expected reject for ${JSON.stringify(bad)}`).toBe(false);
@@ -379,152 +282,131 @@ describe("readAgentProfile — traversal-shaped id rejected fail-closed BEFORE a
 });
 
 // ===========================================================================
-// removeAgentArtefacts
+// removeAgentArtefacts(agentId, slug) — one domain leaf, de-registered, scoped
 // ===========================================================================
 
-describe("removeAgentArtefacts — removes exactly the named expert's dir", () => {
-  it("removed → the target artefact dir is gone", () => {
-    makeExpert("gift-buyer", { name: "Gift Buyer" });
-    const dir = getAgentArtefactDir("gift-buyer");
-    expect(existsSync(dir)).toBe(true);
+describe("removeAgentArtefacts — removes exactly ONE domain leaf + de-registers it", () => {
+  it("the target leaf is gone + de-registered; the sibling domain + shared user_spec + shopper survive", () => {
+    makeShopper(SHOPPER, [
+      ["road-cycling", "Road cycling"],
+      ["running-shoes", "Running shoes"],
+    ]);
+    expect(existsSync(domainDir("road-cycling"))).toBe(true);
 
-    const result = removeAgentArtefacts("gift-buyer");
+    const result = removeAgentArtefacts(SHOPPER, "road-cycling");
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.agentId).toBe("gift-buyer");
-    expect(existsSync(dir)).toBe(false);
-  });
-});
 
-describe("removeAgentArtefacts — non-destructive to OTHER experts", () => {
-  it("removing one of several leaves every other expert's dir byte-for-byte untouched", () => {
-    makeExpert("target", { name: "Target", playbook: "to be deleted" });
-    makeExpert("survivor-a", { name: "Survivor A", playbook: "keep me A" });
-    makeExpert("survivor-b", { name: "Survivor B" });
-
-    const survivorAFiles = walkFiles(getAgentArtefactDir("survivor-a")).sort();
-    const survivorASnapshot = survivorAFiles.map((rel) =>
-      readFileSync(join(getAgentArtefactDir("survivor-a"), rel), "utf8"),
+    // The leaf is gone…
+    expect(existsSync(domainDir("road-cycling"))).toBe(false);
+    // …and de-registered from the manifest, while the sibling stays.
+    const domains = (readManifest()["domains"] ?? {}) as Record<string, unknown>;
+    expect(Object.keys(domains)).toEqual(["running-shoes"]);
+    expect(existsSync(domainDir("running-shoes"))).toBe(true);
+    // The shopper + the SHARED user_spec are untouched (artefact-only, scoped).
+    expect(existsSync(join(getAgentArtefactDir(SHOPPER), "user_spec.md"))).toBe(true);
+    expect(readFileSync(join(getAgentArtefactDir(SHOPPER), "user_spec.md"), "utf8")).toBe(
+      USER_SPEC,
     );
-
-    const result = removeAgentArtefacts("target");
-    expect(result.ok).toBe(true);
-
-    // The target is gone…
-    expect(existsSync(getAgentArtefactDir("target"))).toBe(false);
-    // …and every other expert's dir survives, byte-for-byte.
-    expect(existsSync(getAgentArtefactDir("survivor-a"))).toBe(true);
-    expect(existsSync(getAgentArtefactDir("survivor-b"))).toBe(true);
-    expect(walkFiles(getAgentArtefactDir("survivor-a")).sort()).toEqual(survivorAFiles);
-    survivorAFiles.forEach((rel, i) => {
-      expect(
-        readFileSync(join(getAgentArtefactDir("survivor-a"), rel), "utf8"),
-      ).toBe(survivorASnapshot[i]);
-    });
   });
 
-  it("never deletes the agents/ PARENT — only the single leaf dir", () => {
-    makeExpert("solo", { name: "Solo" });
-    const agentsParent = join(getDataDir(), "agents");
-    expect(existsSync(agentsParent)).toBe(true);
-    const result = removeAgentArtefacts("solo");
+  it("removing the LAST domain leaves a healthy `domains: {}` shopper (never deletes the shopper)", () => {
+    makeShopper(SHOPPER, [["road-cycling", "Road cycling"]]);
+    const result = removeAgentArtefacts(SHOPPER, "road-cycling");
     expect(result.ok).toBe(true);
-    // The leaf is gone but the agents/ subtree itself remains (a removed-last
-    // expert must not delete the store root — list of an empty store still works).
-    expect(existsSync(getAgentArtefactDir("solo"))).toBe(false);
-    expect(existsSync(agentsParent)).toBe(true);
+
+    // The agent dir + shared user_spec + manifest survive; the domains map is now {}.
+    expect(existsSync(getAgentArtefactDir(SHOPPER))).toBe(true);
+    expect(existsSync(join(getAgentArtefactDir(SHOPPER), "user_spec.md"))).toBe(true);
+    expect((readManifest()["domains"] ?? {})).toEqual({});
+    // The shopper still reads back healthy (empty domain index, not not_found).
+    const overview = readAgentProfile(SHOPPER);
+    expect(overview.ok).toBe(true);
+    if (!overview.ok) return;
+    expect(overview.domains).toEqual([]);
   });
 });
 
-describe("removeAgentArtefacts — idempotent not_found on an absent target", () => {
-  it("an id with no dir → not_found, deletes nothing; a second remove is also not_found (re-run safe)", () => {
-    makeExpert("neighbour", { name: "Neighbour" }); // prove scope
-
-    const first = removeAgentArtefacts("never-existed");
+describe("removeAgentArtefacts — required slug, idempotent, fail-closed on a bad slug/id", () => {
+  it("absent slug → not_found (idempotent: a re-run is also not_found), deletes nothing", () => {
+    makeShopper(SHOPPER, [["road-cycling", "Road cycling"]]);
+    const first = removeAgentArtefacts(SHOPPER, "never-minted");
     expect(first.ok).toBe(false);
     if (first.ok) return;
     expect(first.kind).toBe("not_found");
-    if (first.kind !== "not_found") return;
-    expect(first.agentId).toBe("never-existed");
-
-    // The neighbour is untouched by the no-op remove.
-    expect(existsSync(getAgentArtefactDir("neighbour"))).toBe(true);
-
-    // Idempotent: a second remove of the same absent id ALSO returns not_found,
-    // never an error — a retry after a partial host-CLI/artefact failure
-    // converges to clean.
-    const second = removeAgentArtefacts("never-existed");
+    // The real domain is untouched.
+    expect(existsSync(domainDir("road-cycling"))).toBe(true);
+    const second = removeAgentArtefacts(SHOPPER, "never-minted");
     expect(second.ok).toBe(false);
     if (second.ok) return;
     expect(second.kind).toBe("not_found");
   });
 
-  it("re-removing an id that WAS just removed returns not_found (full removed→not_found cycle is idempotent)", () => {
-    makeExpert("transient", { name: "Transient" });
-    const removed = removeAgentArtefacts("transient");
-    expect(removed.ok).toBe(true);
-    const again = removeAgentArtefacts("transient");
-    expect(again.ok).toBe(false);
-    if (again.ok) return;
-    expect(again.kind).toBe("not_found");
+  it("a MISSING/blank domainSlug → invalid_request(field=domainSlug), deletes nothing (no omit-deletes-everything)", () => {
+    makeShopper(SHOPPER, [["road-cycling", "Road cycling"]]);
+    for (const missing of ["", undefined as unknown as string]) {
+      const result = removeAgentArtefacts(SHOPPER, missing);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.kind).toBe("invalid_request");
+      if (result.kind !== "invalid_request") return;
+      expect(result.field).toBe("domainSlug");
+      // The whole shopper + its domain are untouched — an absent slug deletes NOTHING.
+      expect(existsSync(domainDir("road-cycling"))).toBe(true);
+      expect(existsSync(getAgentArtefactDir(SHOPPER))).toBe(true);
+    }
   });
-});
 
-describe("removeAgentArtefacts — malformed/traversal/main id is rejected and DELETES NOTHING", () => {
-  it.each(["../escape", "gift/buyer", "..", ".", "a/../b", "main", "Gift-Buyer", ""])(
-    "rejects %j with invalid_request(field=agentId) and removes nothing from the store",
+  it.each(["../escape", "road/cycling", "..", ".", "a/../b", "main", "Road-Cycling"])(
+    "a traversal/main slug %j → invalid_request(field=domainSlug), deletes nothing",
     (bad) => {
-      // Seed two real experts; a bad id must not reach outside the agents subtree
-      // nor touch either of them.
-      makeExpert("alpha", { name: "Alpha", playbook: "keep" });
-      makeExpert("beta", { name: "Beta" });
-      const before = walkFiles(join(getDataDir(), "agents")).sort();
-
-      const result = removeAgentArtefacts(bad);
+      makeShopper(SHOPPER, [["road-cycling", "Road cycling"]]);
+      const before = walkFiles(getAgentArtefactDir(SHOPPER)).sort();
+      const result = removeAgentArtefacts(SHOPPER, bad);
       expect(result.ok, `expected reject for ${JSON.stringify(bad)}`).toBe(false);
       if (result.ok) return;
       expect(result.kind).toBe("invalid_request");
       if (result.kind !== "invalid_request") return;
-      expect(result.field).toBe("agentId");
-
-      // NOTHING under agents/ changed — the bad id deleted nothing.
-      expect(walkFiles(join(getDataDir(), "agents")).sort()).toEqual(before);
-      expect(existsSync(getAgentArtefactDir("alpha"))).toBe(true);
-      expect(existsSync(getAgentArtefactDir("beta"))).toBe(true);
+      expect(result.field).toBe("domainSlug");
+      expect(walkFiles(getAgentArtefactDir(SHOPPER)).sort()).toEqual(before);
     },
   );
+
+  it("a bad agentId → invalid_request(field=agentId), deletes nothing", () => {
+    makeShopper(SHOPPER, [["road-cycling", "Road cycling"]]);
+    const result = removeAgentArtefacts("../escape", "road-cycling");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.kind).toBe("invalid_request");
+    if (result.kind !== "invalid_request") return;
+    expect(result.field).toBe("agentId");
+    expect(existsSync(domainDir("road-cycling"))).toBe(true);
+  });
 });
 
 describe("removeAgentArtefacts — a genuine rmSync failure returns persistence_failed, never throws", () => {
-  // chmod 0500 can't block deletes for root — skip there rather than false-fail.
   const asRoot = typeof process.getuid === "function" && process.getuid() === 0;
   it.skipIf(asRoot)(
-    "a non-writable agents/ parent (rmSync of the leaf fails EACCES) → persistence_failed with <dir>: <cause>",
+    "a non-writable domains/ parent (rmSync of the leaf fails EACCES) → persistence_failed with <dir>: <cause>",
     () => {
-      makeExpert("locked", { name: "Locked" });
-      const dir = getAgentArtefactDir("locked");
-      const agentsParent = join(getDataDir(), "agents");
-      // rmSync of the leaf needs WRITE on the PARENT dir (to unlink the entry).
-      // Make the parent read+exec-only so the unlink fails EACCES.
-      chmodSync(agentsParent, 0o500);
+      makeShopper(SHOPPER, [["road-cycling", "Road cycling"]]);
+      const leaf = domainDir("road-cycling");
+      const domainsParent = join(getAgentArtefactDir(SHOPPER), "domains");
+      // Unlinking the leaf needs WRITE on its PARENT (domains/). Make it read+exec.
+      chmodSync(domainsParent, 0o500);
 
-      const result = removeAgentArtefacts("locked");
-      // Restore perms immediately so the assertions + afterEach can clean up.
-      chmodSync(agentsParent, 0o700);
+      const result = removeAgentArtefacts(SHOPPER, "road-cycling");
+      chmodSync(domainsParent, 0o700); // restore immediately for assertions + cleanup
 
       expect(result.ok).toBe(false);
       if (result.ok) return;
       expect(result.kind).toBe("persistence_failed");
       if (result.kind !== "persistence_failed") return;
-      // The path + cause are both present in `error` (actionable recovery),
-      // mirroring the writer's failure envelope: "<dir>: <cause>".
-      expect(result.error).toContain(dir);
+      expect(result.error).toContain(leaf);
       expect(result.error).toMatch(/.+: .+/);
-      // The recovery hint steers the agent at the data dir (card §108).
       expect(result.recovery).toBe("fix_data_dir");
-      // The dir was NOT removed (the delete genuinely failed) — but the result
-      // is a structured failure, not a thrown error.
-      expect(existsSync(dir)).toBe(true);
+      // The leaf was NOT removed (the delete genuinely failed) — structured, not thrown.
+      expect(existsSync(leaf)).toBe(true);
     },
   );
 });
@@ -534,31 +416,12 @@ describe("removeAgentArtefacts — a genuine rmSync failure returns persistence_
 // ===========================================================================
 
 describe("list/read/remove — no identity coupling (getTokensPath never appears)", () => {
-  it("listAgentProfiles reads/writes no token", () => {
-    makeExpert("a", {});
+  it("none of the three create the tokens path across a full list→read→remove cycle", () => {
+    makeShopper(SHOPPER, [["road-cycling", "Road cycling"]]);
     listAgentProfiles();
+    readAgentProfile(SHOPPER, "road-cycling");
+    removeAgentArtefacts(SHOPPER, "road-cycling");
     expect(existsSync(getTokensPath())).toBe(false);
-  });
-
-  it("readAgentProfile reads/writes no token", () => {
-    makeExpert("b", {});
-    readAgentProfile("b");
-    expect(existsSync(getTokensPath())).toBe(false);
-  });
-
-  it("removeAgentArtefacts reads/writes no token", () => {
-    makeExpert("c", {});
-    removeAgentArtefacts("c");
-    expect(existsSync(getTokensPath())).toBe(false);
-  });
-
-  it("none of the three create the tokens path even across a full list→read→remove cycle", () => {
-    makeExpert("cycle", { name: "Cycle", playbook: "pb" });
-    listAgentProfiles();
-    readAgentProfile("cycle");
-    removeAgentArtefacts("cycle");
-    expect(existsSync(getTokensPath())).toBe(false);
-    // Sanity: the leaf statSync below proves the temp dir itself is intact.
     expect(statSync(getDataDir()).isDirectory()).toBe(true);
   });
 });

--- a/src/__tests__/lib/profile-store-sds.test.ts
+++ b/src/__tests__/lib/profile-store-sds.test.ts
@@ -1,50 +1,37 @@
 /**
- * UNIT — the SDS artefact store after the five-artefact reframe (tier: unit,
- * real temp dir via the SIL_DATA_DIR override, no network, no host).
+ * UNIT — the single-multi-domain shopper layout, the DEEP store semantics (tier:
+ * unit, real temp dir via the SIL_DATA_DIR override, no network, no host).
  *
- * Card: spec-driven-shopping-sds-for-created-experts — Founder review round 2
- * (PR #33 bounced a SECOND time). SDS is the operating model for EVERY created
- * expert. The sil store holds FOUR behaviour artefacts (the persona left the
- * store — it is the host SOUL.md, written by the engine via the host CLI, never a
- * sil-side file). The ROUND-2 correction: all four sil docs are PRESENT, non-blank,
- * from creation — seeded *partial* (the ≤10-question setup + a quick initial
- * research pass), then lazily AUGMENTED/reinforced on every query. None is
- * "absent-is-fine"; none "starts empty". All four are REQUIRED:
+ * Card: single-multi-domain-sil-shopper — Slice 1. The per-niche flat layout is
+ * DELETED. ONE shopper dir holds a SHARED agent-level user_spec.md + profile.json
+ * (with a slug-keyed `domains` MAP), and niche packs live under
+ * domains/<slug>/{domain_spec,intent_spec,playbook}.md, minted LAZILY on first
+ * shop. `sil_profile_materialize` stays ONE tool with an OPTIONAL `domain`:
+ *   - no domain  ⇒ create the shopper (shared user_spec + `domains: {}`);
+ *   - with domain ⇒ ATOMIC lazy mint of domains/<slug>/* + a shared-user_spec
+ *     full-body rewrite + an upsert into `domains[slug]`.
  *
- *   domain_spec.md  — REQUIRED. The deep, researched niche expertise (how to buy
- *                     well, the full mechanics) — web-refreshed every query.
- *   intent_spec.md  — REQUIRED. The agent-specific decomposition DIMENSIONS
- *                     (PRD-style) a good query must resolve, derived from the
- *                     domain at creation.
- *   user_spec.md    — REQUIRED. The user's domain-relevant facts + hard
- *                     constraints, seeded partial at creation, AUGMENTED per-query.
- *   playbook.md     — REQUIRED. The user's buying TASTE (price sensitivity, brand,
- *                     preferences) — seeded partial at creation, AUGMENTED per-query.
- *
- * The store-layer contract this file pins for the implementation
- * (`src/lib/profile-store.ts`):
- *   1. NO PERSONA in the store. `ProfileSpec` has no `persona`; `materializeProfile`
- *      writes no persona.md; `ProfileManifest` has no personaPath;
- *      `readManifestFile`'s required gate is agentId/name/createdAt + ALL FOUR spec
- *      paths (NOT personaPath); `readAgentProfile` returns no persona.
- *   2. ALL FOUR specs are REQUIRED on materialize (Founder review round 2). A
- *      present-but-blank OR omitted domainSpec / intentSpec / userSpec / playbook →
- *      invalid_request naming the field, and WRITES NOTHING (whole-spec
- *      validate-first — not even the other good files). A min create IS a full
- *      create: there is no two-spec-only valid create any more.
- *   3. The manifest carries ALL FOUR path keys (domainSpecPath + intentSpecPath +
- *      userSpecPath + playbookPath), all REQUIRED in `readManifestFile`'s gate. A
- *      manifest missing ANY of the four path keys is corrupt (not_found).
- *   4. `readAgentProfile` is fail-closed on ANY of the four bodies missing — a
- *      referenced-but-missing domain/intent/user/playbook body → not_found (all
- *      four always exist; there is no degrade-to-undefined path any more).
- *   5. The store carries `intentSpec` (the persisted decomposition-dimension
- *      SCHEMA). The prior @ts-expect-error that blocked an intent store field is
- *      REVERSED — intentSpec is a real, required field. The per-query intent (the
- *      filled dimensions) is STILL never persisted: no intent.md of filled values
- *      is ever written; only the intent_spec.md schema is.
- *   6. Bodies round-trip VERBATIM (so hard-constraint vs soft-preference in the
- *      user spec stays distinguishable); 0600 files in a 0700 dir; no .tmp survivor.
+ * This file pins the layout-specific contract for `src/lib/profile-store.ts`:
+ *   1. SHARED vs PER-DOMAIN placement — user_spec is agent-level (read by every
+ *      domain's loop, so a fact stored in niche A is reused in niche B without
+ *      re-asking); the playbook/domain_spec/intent_spec are per-domain. A domain
+ *      mint NEVER touches a sibling domain's pack.
+ *   2. The `domains` map is the source of truth — slug-keyed, each entry carrying
+ *      { slug, name, domainSpecPath, intentSpecPath, playbookPath, createdAt,
+ *      updatedAt }. `domains: {}` is the HEALTHY freshly-created state.
+ *   3. The slug is a NEW filesystem path segment → it MUST be validated exactly
+ *      like agentId (AGENT_ID_RE + non-"main") BEFORE any join. A traversal /
+ *      "main" / empty / non-kebab slug → invalid_request(field=domain.slug),
+ *      writing NOTHING (validate-first). Every one of the five `domain` fields is
+ *      REQUIRED non-blank.
+ *   4. ATOMICITY one level deeper — write order: domains/<slug>/* → shared
+ *      user_spec → profile.json LAST. A failed FIRST mint of a NEW domain tears
+ *      down ONLY that leaf (the agent dir, shared user_spec, and sibling domains
+ *      survive). A crash before the profile.json write leaves an ORPHANED,
+ *      unreferenced leaf — invisible to readers (manifest-gated, fail-closed).
+ *   5. FAIL-CLOSED reads — readAgentProfile(agentId, slug) returns not_found when
+ *      the shared user_spec OR ANY of the 3 referenced domain bodies is missing
+ *      (never a partial pack).
  *
  * Hermetic via the SIL_DATA_DIR temp-dir override (mirrors profile-store.test.ts).
  */
@@ -65,6 +52,7 @@ import {
   statSync,
   chmodSync,
   writeFileSync,
+  mkdirSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -72,8 +60,8 @@ import { join } from "node:path";
 import {
   materializeProfile,
   readAgentProfile,
+  listAgentProfiles,
   getAgentArtefactDir,
-  type ProfileManifest,
   type ProfileSpec,
 } from "../../lib/profile-store.js";
 import { getDataDir } from "../../lib/credentials.js";
@@ -82,7 +70,7 @@ let dataDir: string;
 let priorSilDataDir: string | undefined;
 
 beforeEach(() => {
-  dataDir = mkdtempSync(join(tmpdir(), "sil-profile-sds-"));
+  dataDir = mkdtempSync(join(tmpdir(), "sil-shopper-sds-"));
   priorSilDataDir = process.env["SIL_DATA_DIR"];
   process.env["SIL_DATA_DIR"] = dataDir;
 });
@@ -90,7 +78,6 @@ beforeEach(() => {
 afterEach(() => {
   if (priorSilDataDir === undefined) delete process.env["SIL_DATA_DIR"];
   else process.env["SIL_DATA_DIR"] = priorSilDataDir;
-  // Restore perms so rmSync can clean a dir a cleanup test chmod'd read-only.
   try {
     chmodSync(dataDir, 0o700);
   } catch {
@@ -99,68 +86,54 @@ afterEach(() => {
   rmSync(dataDir, { recursive: true, force: true });
 });
 
-/** A deep, research-grade domain spec — niche-concrete mechanics a layperson
- * couldn't enumerate (the store never validates THIS; it preserves the body). */
-const DOMAIN_SPEC =
-  "# Road-cycling domain spec (deep)\n"
-  + "Fit mechanics: stack/reach drive torso angle; saddle setback from KOPS;"
-  + " crank length scales with inseam; bar reach + drop set hand position.\n"
-  + "Gearing theory: gear-inches = chainring/cog × wheel diameter; compact vs"
-  + " mid-compact vs 1x trade range for steps. Frame geometry: head-tube angle +"
-  + " trail govern handling; chainstay length governs stiffness vs comfort.\n"
-  + "Trade-offs: deeper rims buy aero but cost crosswind handling; a stiffer frame"
-  + " buys power transfer but costs all-day comfort.";
+const AGENT_ID = "sil-shopper";
 
-/** The persisted decomposition-DIMENSION schema (PRD-style) — the dimensions a
- * good query must resolve, derived from the domain. NOT a filled-in instance. */
-const INTENT_SPEC =
-  "# Intent spec — decomposition dimensions (schema, not a fill)\n"
-  + "A road-cycling purchase query must resolve: use-case (commute/race/endurance),"
-  + " terrain, budget band, timeline, compatibility-with-existing-setup,"
-  + " performance priorities, aesthetics. Each is a dimension the per-query intent"
-  + " fills in — the fill is ephemeral, this schema is persisted.";
+const USER_SPEC_V1 =
+  "# User spec (shared)\n## Standing facts\n- Ships to Berlin 10115.\n"
+  + "## Hard constraints\n- HARD-NO: leather (ethics).";
 
-/** A user spec carrying a SOFT preference AND a HARD constraint — the two must
- * round-trip distinguishably so downstream reasoning treats them differently. */
-const USER_SPEC =
-  "# User spec — road-cycling buyer\n"
-  + "## Domain-relevant facts (soft preferences)\n"
-  + "- Prefers endurance geometry over race geometry.\n"
-  + "- Inseam 81cm, height 178cm.\n"
-  + "## Hard constraints (INVIOLABLE — never recommend a violating item)\n"
-  + "- HARD-NO: rim brakes (disc only).\n"
-  + "- HARD-NO: anything over 9 kg.";
+/** A cross-niche fact added while shopping niche A — must be reusable in niche B. */
+const USER_SPEC_V2 =
+  USER_SPEC_V1 + "\n- Allergic to wool (added while shopping cycling kit).";
 
-/** The user's buying TASTE (the new playbook meaning) — price sensitivity /
- * brand / preference, NOT a seller's method. */
-const PLAYBOOK =
-  "# Buying taste\nBudget comfort zone around €1500; will stretch 10% for the"
-  + " right frame. Brand-agnostic but distrusts house-brand groupsets.";
-
-/** A complete create: ALL FOUR REQUIRED specs (Founder review round 2 — none is
- * lazy/optional; all four are present non-blank from creation). */
-const GOOD = {
-  agentId: "road-cycling-buyer",
-  name: "Road Cycling Buyer",
-  domainSpec: DOMAIN_SPEC,
-  intentSpec: INTENT_SPEC,
-  userSpec: USER_SPEC,
-  playbook: PLAYBOOK,
+const CYCLING = {
+  slug: "road-cycling",
+  name: "Road cycling",
+  domainSpec: "# Road-cycling domain spec\nFit, gearing, geometry.",
+  intentSpec: "# Intent spec — cycling\nuse-case, terrain, budget, timeline.",
+  playbook: "# Taste — cycling\n~€1500; Shimano over SRAM.",
 } as const;
 
-/** The minimum valid create. After Founder review round 2, ALL FOUR sil docs are
- * REQUIRED and present (seeded partial at creation), so the minimum create IS the
- * full four-spec create — there is no two-spec-only valid create any more. Kept as
- * a named alias so the intent ("the smallest thing that creates an expert") stays
- * legible at each call site. */
-const MIN_CREATE = GOOD;
+const RUNNING = {
+  slug: "running-shoes",
+  name: "Running shoes",
+  domainSpec: "# Running-shoe domain spec\nLast shape, stack, drop, foam.",
+  intentSpec: "# Intent spec — running\nsurface, distance, gait, budget.",
+  playbook: "# Taste — running\nUnder €160; neutral foam; no carbon plate.",
+} as const;
 
-function readManifest(agentId: string): ProfileManifest {
-  const path = join(getAgentArtefactDir(agentId), "profile.json");
-  return JSON.parse(readFileSync(path, "utf8")) as ProfileManifest;
+/** Create the shopper (no domain). */
+function createShopper(userSpec = USER_SPEC_V1): void {
+  const r = materializeProfile({ agentId: AGENT_ID, name: "sil shopper", userSpec });
+  if (!r.ok) throw new Error(`createShopper failed: ${JSON.stringify(r)}`);
 }
 
-/** Every file under `dir`, recursively (relative paths). */
+/** Mint a domain pack onto the shopper, carrying a (possibly augmented) shared spec. */
+function mint(domain: ProfileSpec["domain"], userSpec = USER_SPEC_V1): void {
+  const r = materializeProfile({ agentId: AGENT_ID, name: "sil shopper", userSpec, domain });
+  if (!r.ok) throw new Error(`mint failed: ${JSON.stringify(r)}`);
+}
+
+function readManifest(agentId = AGENT_ID): Record<string, unknown> {
+  return JSON.parse(
+    readFileSync(join(getAgentArtefactDir(agentId), "profile.json"), "utf8"),
+  ) as Record<string, unknown>;
+}
+
+function domainDir(slug: string, agentId = AGENT_ID): string {
+  return join(getAgentArtefactDir(agentId), "domains", slug);
+}
+
 function walkFiles(dir: string, base = dir): string[] {
   if (!existsSync(dir)) return [];
   const out: string[] = [];
@@ -172,414 +145,295 @@ function walkFiles(dir: string, base = dir): string[] {
   return out;
 }
 
-describe("materializeProfile — persona is GONE from the store (it is the host SOUL.md)", () => {
-  it("writes NO persona.md and records NO personaPath — persona left the sil store entirely", () => {
-    // Correction 1: the persona is the agent's soul/system framing — the host's
-    // SOUL.md, written by the engine via the host CLI, never a sil-side file. The
-    // store holds only behaviour artefacts (domain/intent/user/playbook).
-    const result = materializeProfile({ ...GOOD });
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
+// ===========================================================================
+// 1 — shared user_spec is agent-level; per-domain packs are isolated
+// ===========================================================================
 
-    expect(existsSync(join(result.dir, "persona.md"))).toBe(false);
-    const manifest = readManifest(GOOD.agentId);
-    expect("personaPath" in manifest).toBe(false);
-    // Only the four behaviour artefacts + manifest exist — never persona.md.
-    const files = walkFiles(result.dir).sort();
-    expect(files).toEqual(
-      ["domain_spec.md", "intent_spec.md", "playbook.md", "profile.json", "user_spec.md"].sort(),
-    );
+describe("layout — the shared user_spec is agent-level; a domain mint never touches a sibling", () => {
+  it("a fact written to the shared user_spec while minting niche A is read back when viewing niche B (no re-ask)", () => {
+    createShopper(USER_SPEC_V1);
+    mint(CYCLING, USER_SPEC_V1);
+    // While shopping running, a NEW standing fact (wool allergy) is captured into
+    // the SHARED user_spec — minted alongside the running pack in one call.
+    mint(RUNNING, USER_SPEC_V2);
+
+    // Viewing niche A (cycling) surfaces the LATEST shared user_spec — the fact
+    // added during niche B is already there. This is the cross-niche signal as a
+    // native property of the agent-level user_spec, not a feature to build.
+    const cycling = readAgentProfile(AGENT_ID, CYCLING.slug);
+    expect(cycling.ok).toBe(true);
+    if (!cycling.ok) return;
+    expect(cycling.userSpec).toBe(USER_SPEC_V2);
+    expect(cycling.userSpec).toContain("Allergic to wool");
+    // There is ONE shared user_spec.md at the agent level — never one per domain.
+    expect(existsSync(join(getAgentArtefactDir(AGENT_ID), "user_spec.md"))).toBe(true);
+    expect(existsSync(join(domainDir(CYCLING.slug), "user_spec.md"))).toBe(false);
+    expect(existsSync(join(domainDir(RUNNING.slug), "user_spec.md"))).toBe(false);
   });
 
-  it("a ProfileSpec carrying a `persona` field is a type error (the store has no persona slot)", () => {
+  it("minting a SECOND domain leaves the FIRST domain's pack byte-for-byte untouched", () => {
+    createShopper();
+    mint(CYCLING);
+    const cyclingBefore = walkFiles(domainDir(CYCLING.slug)).sort().map((rel) =>
+      readFileSync(join(domainDir(CYCLING.slug), rel), "utf8"),
+    );
+
+    mint(RUNNING, USER_SPEC_V2);
+
+    // The cycling pack is identical — a running mint touches only domains/running-shoes/.
+    const cyclingAfter = walkFiles(domainDir(CYCLING.slug)).sort().map((rel) =>
+      readFileSync(join(domainDir(CYCLING.slug), rel), "utf8"),
+    );
+    expect(cyclingAfter).toEqual(cyclingBefore);
+    expect(readFileSync(join(domainDir(CYCLING.slug), "domain_spec.md"), "utf8")).toBe(
+      CYCLING.domainSpec,
+    );
+    // Both domains are registered in the map.
+    const domains = (readManifest()["domains"] ?? {}) as Record<string, unknown>;
+    expect(Object.keys(domains).sort()).toEqual([CYCLING.slug, RUNNING.slug].sort());
+  });
+
+  it("re-minting an EXISTING domain upserts its entry (updatedAt advances) without adding a sibling", () => {
+    createShopper();
+    mint(CYCLING);
+    const first = (readManifest()["domains"] as Record<string, Record<string, unknown>>)[
+      CYCLING.slug
+    ]!;
+
+    // Re-mint the same slug with a refreshed domain_spec (a per-query web refresh).
+    mint({ ...CYCLING, domainSpec: CYCLING.domainSpec + "\n(refreshed this query)" });
+
+    const domains = readManifest()["domains"] as Record<string, Record<string, unknown>>;
+    // Still exactly one domain — an upsert by key, not a duplicate.
+    expect(Object.keys(domains)).toEqual([CYCLING.slug]);
+    // createdAt is preserved; the body is overwritten in place.
+    expect(domains[CYCLING.slug]!["createdAt"]).toBe(first["createdAt"]);
+    expect(readFileSync(join(domainDir(CYCLING.slug), "domain_spec.md"), "utf8")).toContain(
+      "(refreshed this query)",
+    );
+  });
+});
+
+// ===========================================================================
+// 2 — slug is a path segment: guarded exactly like agentId
+// ===========================================================================
+
+describe("mint — the slug is a path segment, validated BEFORE any join (write-nothing on a bad slug)", () => {
+  it.each(["../escape", "road/cycling", "..", ".", "a/../b", "main", "Road-Cycling", ""])(
+    "rejects slug %j with invalid_request(field=domain.slug) and writes NO domain pack",
+    (badSlug) => {
+      createShopper();
+      const before = walkFiles(getAgentArtefactDir(AGENT_ID)).sort();
+      const result = materializeProfile({
+        agentId: AGENT_ID,
+        name: "sil shopper",
+        userSpec: USER_SPEC_V1,
+        domain: { ...CYCLING, slug: badSlug },
+      });
+      expect(result.ok, `expected reject for ${JSON.stringify(badSlug)}`).toBe(false);
+      if (result.ok) return;
+      expect(result.kind).toBe("invalid_request");
+      if (result.kind !== "invalid_request") return;
+      expect(result.field).toBe("domain.slug");
+      // Nothing minted — the shopper's tree is unchanged, no domains/ leaf appeared.
+      expect(walkFiles(getAgentArtefactDir(AGENT_ID)).sort()).toEqual(before);
+      expect(existsSync(join(getAgentArtefactDir(AGENT_ID), "domains"))).toBe(false);
+    },
+  );
+
+  it.each([
+    ["name", { ...CYCLING, name: "   " }, "domain.name"],
+    ["domainSpec", { ...CYCLING, domainSpec: "" }, "domain.domainSpec"],
+    ["intentSpec", { ...CYCLING, intentSpec: "\t\n" }, "domain.intentSpec"],
+    ["playbook", { ...CYCLING, playbook: "  " }, "domain.playbook"],
+  ] as const)(
+    "a blank domain field (%s) → invalid_request naming it, writes NO domain pack",
+    (_label, badDomain, field) => {
+      createShopper();
+      const result = materializeProfile({
+        agentId: AGENT_ID,
+        name: "sil shopper",
+        userSpec: USER_SPEC_V1,
+        domain: badDomain,
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.kind).toBe("invalid_request");
+      if (result.kind !== "invalid_request") return;
+      expect(result.field).toBe(field);
+      expect(existsSync(join(getAgentArtefactDir(AGENT_ID), "domains"))).toBe(false);
+    },
+  );
+});
+
+// ===========================================================================
+// 3 — atomicity one level deeper: fresh-leaf teardown + orphan invisibility
+// ===========================================================================
+
+describe("mint atomicity — a failed FIRST mint of a NEW domain tears down ONLY that leaf", () => {
+  it("the agent dir, shared user_spec, and sibling domains all survive a failed new-domain mint", () => {
+    createShopper(USER_SPEC_V1);
+    mint(CYCLING); // a sibling that must survive
+
+    // Force a failure AFTER the new domain's pack is written but BEFORE the
+    // profile.json upsert: replace the shared user_spec.md with a DIRECTORY, so
+    // the store's atomic rewrite of it fails (rename-over-a-dir → EISDIR). This is
+    // perm-independent (works as root), unlike a chmod-based block.
+    const userSpecPath = join(getAgentArtefactDir(AGENT_ID), "user_spec.md");
+    rmSync(userSpecPath, { force: true });
+    mkdirSync(userSpecPath);
+    writeFileSync(join(userSpecPath, "occupant"), "make it non-empty");
+
     const result = materializeProfile({
-      ...MIN_CREATE,
-      // @ts-expect-error — `persona` is NOT a ProfileSpec field after the reframe;
-      // the persona lives only in the host SOUL.md. The compile error IS part of
-      // the assertion: the store must NOT carry a persona slot.
-      persona: "You are a road-cycling buyer.",
+      agentId: AGENT_ID,
+      name: "sil shopper",
+      userSpec: USER_SPEC_V2,
+      domain: RUNNING, // a NEW domain (not yet in the map)
     });
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    // Even if a caller smuggles it, no persona.md is written.
-    expect(existsSync(join(result.dir, "persona.md"))).toBe(false);
-  });
-});
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.kind).toBe("persistence_failed");
 
-describe("materializeProfile — all four SDS specs are REQUIRED and land at creation (round-2: none lazy)", () => {
-  it("writes domain_spec.md, intent_spec.md, user_spec.md, playbook.md under agents/<id>/ for a create", () => {
-    const result = materializeProfile({ ...GOOD });
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-
-    const dir = join(getDataDir(), "agents", GOOD.agentId);
-    expect(existsSync(join(dir, "domain_spec.md"))).toBe(true);
-    expect(existsSync(join(dir, "intent_spec.md"))).toBe(true);
-    expect(existsSync(join(dir, "user_spec.md"))).toBe(true);
-    expect(existsSync(join(dir, "playbook.md"))).toBe(true);
-
-    // The ok variant surfaces the two required paths…
-    expect(result.domainSpecPath).toBe(join(dir, "domain_spec.md"));
-    expect(result.intentSpecPath).toBe(join(dir, "intent_spec.md"));
-    // …and the two optional ones when supplied.
-    expect(result.userSpecPath).toBe(join(dir, "user_spec.md"));
-    expect(result.playbookPath).toBe(join(dir, "playbook.md"));
-
-    expect(readFileSync(result.domainSpecPath, "utf8")).toBe(DOMAIN_SPEC);
-    expect(readFileSync(result.intentSpecPath, "utf8")).toBe(INTENT_SPEC);
-    expect(readFileSync(result.userSpecPath!, "utf8")).toBe(USER_SPEC);
-    expect(readFileSync(result.playbookPath!, "utf8")).toBe(PLAYBOOK);
-  });
-
-  it("a creation produces ALL FOUR spec files + their manifest paths — none is lazily absent (round-2)", () => {
-    // Founder review round 2: all four sil docs are PRESENT, non-blank, from
-    // creation (seeded partial by the ≤10-question setup + the agent's initial
-    // research). There is no two-spec-only create — the minimum create IS the full
-    // four-spec create.
-    const result = materializeProfile({ ...MIN_CREATE });
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-
-    expect(existsSync(join(result.dir, "domain_spec.md"))).toBe(true);
-    expect(existsSync(join(result.dir, "intent_spec.md"))).toBe(true);
-    expect(existsSync(join(result.dir, "user_spec.md"))).toBe(true);
-    expect(existsSync(join(result.dir, "playbook.md"))).toBe(true);
-
-    expect(result.userSpecPath).toBeDefined();
-    expect(result.playbookPath).toBeDefined();
-    const manifest = readManifest(GOOD.agentId);
-    expect(typeof manifest.userSpecPath).toBe("string");
-    expect(typeof manifest.playbookPath).toBe("string");
-    // All four required artefacts + manifest.
-    expect(walkFiles(result.dir).sort()).toEqual(
-      ["domain_spec.md", "intent_spec.md", "user_spec.md", "playbook.md", "profile.json"].sort(),
+    // The freshly-created NEW-domain leaf is torn down (it was ours, just created).
+    expect(existsSync(domainDir(RUNNING.slug))).toBe(false);
+    // The agent dir survives, and the sibling domain's pack is intact.
+    expect(existsSync(getAgentArtefactDir(AGENT_ID))).toBe(true);
+    expect(readFileSync(join(domainDir(CYCLING.slug), "domain_spec.md"), "utf8")).toBe(
+      CYCLING.domainSpec,
     );
+    // The manifest was NEVER rewritten — the failed new domain is unregistered.
+    const domains = (readManifest()["domains"] ?? {}) as Record<string, unknown>;
+    expect(Object.keys(domains)).toEqual([CYCLING.slug]);
+    expect(domains[RUNNING.slug]).toBeUndefined();
   });
 
-  it("records domainSpecPath + intentSpecPath in the typed manifest, pointing at the artefacts", () => {
-    materializeProfile({ ...GOOD });
-    const manifest = readManifest(GOOD.agentId);
-    const dir = getAgentArtefactDir(GOOD.agentId);
-    expect(manifest.domainSpecPath).toBe(join(dir, "domain_spec.md"));
-    expect(manifest.intentSpecPath).toBe(join(dir, "intent_spec.md"));
-    expect(manifest.userSpecPath).toBe(join(dir, "user_spec.md"));
-    expect(manifest.playbookPath).toBe(join(dir, "playbook.md"));
-  });
+  it("a domains-path blocked by a regular file → persistence_failed, nothing partial, manifest unchanged", () => {
+    createShopper();
+    mint(CYCLING);
+    // Block the domains/ subtree with a regular file where the running leaf's
+    // parent chain expects a dir is impossible here; instead block the specific
+    // new leaf path with a FILE so mkdir(domains/<slug>) throws ENOTDIR.
+    const leaf = domainDir(RUNNING.slug);
+    mkdirSync(join(getAgentArtefactDir(AGENT_ID), "domains"), { recursive: true });
+    writeFileSync(leaf, "i am a file where the running leaf must go");
 
-  it("writes every artefact owner-only (0600) inside the 0700 dir", () => {
-    const result = materializeProfile({ ...GOOD });
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(statSync(result.dir).mode & 0o777).toBe(0o700);
-    expect(statSync(result.domainSpecPath).mode & 0o777).toBe(0o600);
-    expect(statSync(result.intentSpecPath).mode & 0o777).toBe(0o600);
-    expect(statSync(result.userSpecPath!).mode & 0o777).toBe(0o600);
-    expect(statSync(result.playbookPath!).mode & 0o777).toBe(0o600);
-  });
-
-  it("leaves NO .tmp sibling behind after the atomic write", () => {
-    const result = materializeProfile({ ...GOOD });
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(walkFiles(result.dir).filter((f) => f.includes(".tmp"))).toEqual([]);
+    const result = materializeProfile({
+      agentId: AGENT_ID,
+      name: "sil shopper",
+      userSpec: USER_SPEC_V1,
+      domain: RUNNING,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.kind).toBe("persistence_failed");
+    // The blocking file is untouched; the cycling sibling + manifest are intact.
+    expect(statSync(leaf).isFile()).toBe(true);
+    const domains = (readManifest()["domains"] ?? {}) as Record<string, unknown>;
+    expect(Object.keys(domains)).toEqual([CYCLING.slug]);
   });
 });
 
-describe("materializeProfile — validate-first: a missing/blank REQUIRED spec writes NOTHING", () => {
-  const dirExists = () => existsSync(getAgentArtefactDir(GOOD.agentId));
+describe("mint atomicity — an ORPHANED leaf (crash before the profile.json write) is invisible to readers", () => {
+  it("a domains/<slug>/ leaf not referenced by the manifest reads as not_found and never lists", () => {
+    createShopper();
+    mint(CYCLING);
 
-  it("OMITTED domainSpec → invalid_request(field=domainSpec), nothing written", () => {
-    // SDS is the operating model — domain_spec is required, not absent-is-fine.
-    // Cast: omitting a required field is a type error, but the RUNTIME contract is
-    // exactly that the store rejects it fail-closed (validate-first).
-    const { domainSpec: _d, ...noDomain } = GOOD;
-    const result = materializeProfile(noDomain as unknown as ProfileSpec);
-    expect(result.ok).toBe(false);
-    if (result.ok) return;
-    expect(result.kind).toBe("invalid_request");
-    if (result.kind !== "invalid_request") return;
-    expect(result.field).toBe("domainSpec");
-    expect(dirExists()).toBe(false);
-  });
+    // Simulate a crash AFTER the bodies were written but BEFORE the profile.json
+    // upsert: fabricate a fully-populated leaf the manifest does NOT reference.
+    const zombie = domainDir("zombie-niche");
+    mkdirSync(zombie, { recursive: true });
+    writeFileSync(join(zombie, "domain_spec.md"), "# orphan\nnever registered");
+    writeFileSync(join(zombie, "intent_spec.md"), "# orphan");
+    writeFileSync(join(zombie, "playbook.md"), "# orphan");
 
-  it("OMITTED intentSpec → invalid_request(field=intentSpec), nothing written", () => {
-    const { intentSpec: _i, ...noIntent } = GOOD;
-    const result = materializeProfile(noIntent as unknown as ProfileSpec);
-    expect(result.ok).toBe(false);
-    if (result.ok) return;
-    expect(result.kind).toBe("invalid_request");
-    if (result.kind !== "invalid_request") return;
-    expect(result.field).toBe("intentSpec");
-    expect(dirExists()).toBe(false);
-  });
+    // Manifest-gated: an unreferenced leaf is invisible.
+    const read = readAgentProfile(AGENT_ID, "zombie-niche");
+    expect(read.ok).toBe(false);
+    if (read.ok) return;
+    expect(read.kind).toBe("not_found");
 
-  it("OMITTED userSpec → invalid_request(field=userSpec), nothing written (round-2: user_spec is REQUIRED)", () => {
-    // Founder review round 2: user_spec is no longer lazy/optional — it is present
-    // (seeded partial) from creation. Omitting it is a defect the store rejects
-    // fail-closed, exactly like a missing domain/intent spec.
-    const { userSpec: _u, ...noUser } = GOOD;
-    const result = materializeProfile(noUser as unknown as ProfileSpec);
-    expect(result.ok).toBe(false);
-    if (result.ok) return;
-    expect(result.kind).toBe("invalid_request");
-    if (result.kind !== "invalid_request") return;
-    expect(result.field).toBe("userSpec");
-    expect(dirExists()).toBe(false);
-  });
+    // It never appears in the shopper's domain list either (the map is the truth).
+    const list = listAgentProfiles();
+    const shopper = list.shoppers.find((s) => s.agentId === AGENT_ID);
+    expect(shopper).toBeDefined();
+    expect(shopper!.domains.map((d) => d.slug)).toEqual([CYCLING.slug]);
 
-  it("OMITTED playbook → invalid_request(field=playbook), nothing written (round-2: playbook is REQUIRED)", () => {
-    // Founder review round 2: playbook (buying taste) is no longer lazy/optional —
-    // it is present (seeded partial) from creation. Omitting it is rejected.
-    const { playbook: _p, ...noPlaybook } = GOOD;
-    const result = materializeProfile(noPlaybook as unknown as ProfileSpec);
-    expect(result.ok).toBe(false);
-    if (result.ok) return;
-    expect(result.kind).toBe("invalid_request");
-    if (result.kind !== "invalid_request") return;
-    expect(result.field).toBe("playbook");
-    expect(dirExists()).toBe(false);
-  });
-
-  it("present-but-blank domainSpec → invalid_request(field=domainSpec), nothing written", () => {
-    const result = materializeProfile({ ...GOOD, domainSpec: "   " });
-    expect(result.ok).toBe(false);
-    if (result.ok) return;
-    expect(result.kind).toBe("invalid_request");
-    if (result.kind !== "invalid_request") return;
-    expect(result.field).toBe("domainSpec");
-    expect(dirExists()).toBe(false);
-  });
-
-  it("present-but-blank intentSpec → invalid_request(field=intentSpec), nothing written", () => {
-    const result = materializeProfile({ ...GOOD, intentSpec: "" });
-    expect(result.ok).toBe(false);
-    if (result.ok) return;
-    expect(result.kind).toBe("invalid_request");
-    if (result.kind !== "invalid_request") return;
-    expect(result.field).toBe("intentSpec");
-    expect(dirExists()).toBe(false);
-  });
-
-  it("a blank REQUIRED spec does NOT partially write the OTHER good artefacts (whole-spec validate-first)", () => {
-    // The architect's partial-write-brick risk: a blank intentSpec must reject
-    // BEFORE any file is written — domain_spec.md must NOT appear just because it
-    // was the first good field. Validate-first is whole-spec.
-    const result = materializeProfile({ ...GOOD, intentSpec: "\t\n " });
-    expect(result.ok).toBe(false);
-    expect(existsSync(join(getAgentArtefactDir(GOOD.agentId), "domain_spec.md"))).toBe(false);
-    expect(walkFiles(join(getDataDir(), "agents"))).toEqual([]);
+    // …nor in the shopper overview's domain index.
+    const overview = readAgentProfile(AGENT_ID);
+    expect(overview.ok).toBe(true);
+    if (!overview.ok) return;
+    expect(overview.domains.map((d) => d.slug)).toEqual([CYCLING.slug]);
   });
 });
 
-describe("materializeProfile — every spec is required + non-blank; a later query AUGMENTS one in place", () => {
-  it("present-but-blank userSpec → invalid_request(field=userSpec), nothing written", () => {
-    const result = materializeProfile({ ...GOOD, userSpec: "   " });
-    expect(result.ok).toBe(false);
-    if (result.ok) return;
-    expect(result.kind).toBe("invalid_request");
-    if (result.kind !== "invalid_request") return;
-    expect(result.field).toBe("userSpec");
-    expect(existsSync(getAgentArtefactDir(GOOD.agentId))).toBe(false);
+// ===========================================================================
+// 4 — fail-closed reads: a missing required body → not_found (never partial)
+// ===========================================================================
+
+describe("readAgentProfile(agentId, slug) — fail-closed on any missing required body", () => {
+  it("the shared user_spec body is GONE → not_found for the overview AND for a domain read", () => {
+    createShopper();
+    mint(CYCLING);
+    rmSync(join(getAgentArtefactDir(AGENT_ID), "user_spec.md"), { force: true });
+
+    const overview = readAgentProfile(AGENT_ID);
+    expect(overview.ok).toBe(false);
+    if (overview.ok) return;
+    expect(overview.kind).toBe("not_found");
+
+    const domain = readAgentProfile(AGENT_ID, CYCLING.slug);
+    expect(domain.ok).toBe(false);
+    if (domain.ok) return;
+    expect(domain.kind).toBe("not_found");
   });
 
-  it("present-but-blank playbook → invalid_request(field=playbook), nothing written", () => {
-    const result = materializeProfile({ ...GOOD, playbook: "" });
-    expect(result.ok).toBe(false);
-    if (result.ok) return;
-    expect(result.kind).toBe("invalid_request");
-    if (result.kind !== "invalid_request") return;
-    expect(result.field).toBe("playbook");
-    expect(existsSync(getAgentArtefactDir(GOOD.agentId))).toBe(false);
+  it.each(["domain_spec.md", "intent_spec.md", "playbook.md"])(
+    "a domain whose %s body is GONE → not_found (never a half pack)",
+    (file) => {
+      createShopper();
+      mint(CYCLING);
+      rmSync(join(domainDir(CYCLING.slug), file), { force: true });
+      const read = readAgentProfile(AGENT_ID, CYCLING.slug);
+      expect(read.ok).toBe(false);
+      if (read.ok) return;
+      expect(read.kind).toBe("not_found");
+    },
+  );
+
+  it("a slug NOT in the domains map → not_found (manifest-gated), never a filesystem guess", () => {
+    createShopper();
+    mint(CYCLING);
+    const read = readAgentProfile(AGENT_ID, "never-minted");
+    expect(read.ok).toBe(false);
+    if (read.ok) return;
+    expect(read.kind).toBe("not_found");
   });
 
-  it("a later re-materialize AUGMENTS the already-present user_spec in place, without disturbing domain/intent", () => {
-    // Round-2 model: user_spec is PRESENT (seeded partial) from creation, then
-    // lazily AUGMENTED per-query — not "added from absent". After a create, a
-    // second materialize overwrites user_spec.md with the augmented body.
-    const first = materializeProfile({ ...GOOD });
-    expect(first.ok).toBe(true);
-    if (!first.ok) return;
-    expect(readFileSync(first.userSpecPath!, "utf8")).toBe(USER_SPEC);
-
-    const augmented = USER_SPEC + "\n- HARD-NO: anything over 9 kg (reinforced this query).";
-    const second = materializeProfile({ ...GOOD, userSpec: augmented });
-    expect(second.ok).toBe(true);
-    if (!second.ok) return;
-    expect(readFileSync(second.userSpecPath!, "utf8")).toBe(augmented);
-    // Domain + intent untouched by a user-side augmentation.
-    expect(readFileSync(second.domainSpecPath, "utf8")).toBe(DOMAIN_SPEC);
-    expect(readFileSync(second.intentSpecPath, "utf8")).toBe(INTENT_SPEC);
+  it("a malformed/traversal domainSlug → invalid_request(field=domainSlug), reads nothing", () => {
+    createShopper();
+    mint(CYCLING);
+    for (const bad of ["../escape", "road/cycling", "..", "main", "Road-Cycling"]) {
+      const read = readAgentProfile(AGENT_ID, bad);
+      expect(read.ok, `expected reject for ${JSON.stringify(bad)}`).toBe(false);
+      if (read.ok) return;
+      expect(read.kind).toBe("invalid_request");
+      if (read.kind !== "invalid_request") return;
+      expect(read.field).toBe("domainSlug");
+    }
   });
 });
 
-describe("readAgentProfile — round-trips the four bodies; no persona; required specs always present", () => {
-  it("returns domainSpec + intentSpec + userSpec + playbook VERBATIM, and NO persona", () => {
-    materializeProfile({ ...GOOD });
-    const read = readAgentProfile(GOOD.agentId);
-    expect(read.ok).toBe(true);
-    if (!read.ok) return;
-    // The store preserves the bodies byte-for-byte — it does NOT parse them.
-    expect(read.domainSpec).toBe(DOMAIN_SPEC);
-    expect(read.intentSpec).toBe(INTENT_SPEC);
-    expect(read.userSpec).toBe(USER_SPEC);
-    expect(read.playbook).toBe(PLAYBOOK);
-    // Persona left the store — the read result carries no persona field.
-    expect("persona" in read).toBe(false);
-  });
+// ===========================================================================
+// 5 — empty-domains shopper reads as HEALTHY (not_found is the wrong answer)
+// ===========================================================================
 
-  it("HARD-constraint vs SOFT-preference survive distinguishably in the round-tripped user spec", () => {
-    // The store keeps the user_spec.md body intact, so the markers that separate a
-    // bendable soft preference from an inviolable hard constraint survive the
-    // write→read cycle — THIS is what lets downstream reasoning treat a hard
-    // constraint as inviolable (the distinction is in the persisted body, not lost
-    // to a lossy parse).
-    materializeProfile({ ...GOOD });
-    const read = readAgentProfile(GOOD.agentId);
-    expect(read.ok).toBe(true);
-    if (!read.ok) return;
-    const spec = read.userSpec!;
-    expect(spec).toContain("soft preferences");
-    expect(spec).toContain("HARD-NO: rim brakes");
-    expect(spec).toContain("INVIOLABLE");
-    expect(spec).toBe(USER_SPEC);
-  });
-
-  it("a created expert reads back ALL FOUR specs — none is absent at creation (round-2)", () => {
-    materializeProfile({ ...MIN_CREATE });
-    const read = readAgentProfile(GOOD.agentId);
-    expect(read.ok).toBe(true);
-    if (!read.ok) return;
-    expect(read.domainSpec).toBe(DOMAIN_SPEC);
-    expect(read.intentSpec).toBe(INTENT_SPEC);
-    // All four are present from creation — the user side is no longer absent.
-    expect(read.userSpec).toBe(USER_SPEC);
-    expect(read.playbook).toBe(PLAYBOOK);
-  });
-
-  it("a created manifest carries ALL FOUR path keys; the required gate is agentId/name/createdAt + all four spec paths", () => {
-    // Round-2: the manifest's required gate includes userSpecPath + playbookPath.
-    // A created expert's manifest carries all four spec path keys.
-    const result = materializeProfile({ ...MIN_CREATE });
-    expect(result.ok).toBe(true);
-    const manifest = readManifest(GOOD.agentId);
-    expect(typeof manifest.domainSpecPath).toBe("string");
-    expect(typeof manifest.intentSpecPath).toBe("string");
-    expect(typeof manifest.userSpecPath).toBe("string");
-    expect(typeof manifest.playbookPath).toBe("string");
-    expect(readAgentProfile(GOOD.agentId).ok).toBe(true);
-  });
-});
-
-describe("readAgentProfile — a manifest missing a REQUIRED spec key is corrupt (fails closed)", () => {
-  it("a profile.json with NO domainSpecPath → not_found (domain_spec is a required-gate field)", () => {
-    // SDS reframe: domain_spec/intent_spec are required, so their manifest path
-    // keys are part of readManifestFile's required gate. A manifest missing one is
-    // an interrupted/hand-edited write → the expert reads back not_found, never as
-    // a coherent-but-incomplete expert.
-    materializeProfile({ ...GOOD });
-    const manifestPath = join(getAgentArtefactDir(GOOD.agentId), "profile.json");
-    const manifest = readManifest(GOOD.agentId) as unknown as Record<string, unknown>;
-    delete manifest["domainSpecPath"];
-    // Re-write the manifest without the required key, preserving the file's perms.
-    chmodSync(manifestPath, 0o600);
-    writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + "\n");
-    const read = readAgentProfile(GOOD.agentId);
-    expect(read.ok).toBe(false);
-    if (read.ok) return;
-    expect(read.kind).toBe("not_found");
-  });
-
-  it("a profile.json with NO intentSpecPath → not_found (intent_spec is a required-gate field)", () => {
-    materializeProfile({ ...GOOD });
-    const manifestPath = join(getAgentArtefactDir(GOOD.agentId), "profile.json");
-    const manifest = readManifest(GOOD.agentId) as unknown as Record<string, unknown>;
-    delete manifest["intentSpecPath"];
-    chmodSync(manifestPath, 0o600);
-    writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + "\n");
-    const read = readAgentProfile(GOOD.agentId);
-    expect(read.ok).toBe(false);
-    if (read.ok) return;
-    expect(read.kind).toBe("not_found");
-  });
-
-  it("a profile.json with NO userSpecPath → not_found (round-2: user_spec is a required-gate field)", () => {
-    // Founder review round 2: userSpecPath joins the required gate. A manifest
-    // missing it is an interrupted/hand-edited write → not_found, never a
-    // coherent-but-incomplete expert.
-    materializeProfile({ ...GOOD });
-    const manifestPath = join(getAgentArtefactDir(GOOD.agentId), "profile.json");
-    const manifest = readManifest(GOOD.agentId) as unknown as Record<string, unknown>;
-    delete manifest["userSpecPath"];
-    chmodSync(manifestPath, 0o600);
-    writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + "\n");
-    const read = readAgentProfile(GOOD.agentId);
-    expect(read.ok).toBe(false);
-    if (read.ok) return;
-    expect(read.kind).toBe("not_found");
-  });
-
-  it("a profile.json with NO playbookPath → not_found (round-2: playbook is a required-gate field)", () => {
-    materializeProfile({ ...GOOD });
-    const manifestPath = join(getAgentArtefactDir(GOOD.agentId), "profile.json");
-    const manifest = readManifest(GOOD.agentId) as unknown as Record<string, unknown>;
-    delete manifest["playbookPath"];
-    chmodSync(manifestPath, 0o600);
-    writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + "\n");
-    const read = readAgentProfile(GOOD.agentId);
-    expect(read.ok).toBe(false);
-    if (read.ok) return;
-    expect(read.kind).toBe("not_found");
-  });
-
-  it("a manifest pointing at a user_spec.md whose body is GONE fails closed → not_found (round-2: all four are required)", () => {
-    // Per-file atomic, not transactional: a manifest can point at a user_spec.md
-    // that was hand-deleted. After round-2 the user spec is REQUIRED — a
-    // referenced-but-missing body of ANY of the four is fail-closed, exactly the
-    // role persona played pre-SDS. The read must NOT serve a coherent-but-partial
-    // expert off a missing required body.
-    materializeProfile({ ...GOOD });
-    rmSync(join(getAgentArtefactDir(GOOD.agentId), "user_spec.md"), { force: true });
-    const read = readAgentProfile(GOOD.agentId);
-    expect(read.ok).toBe(false);
-    if (read.ok) return;
-    expect(read.kind).toBe("not_found");
-  });
-
-  it("a manifest pointing at a playbook.md whose body is GONE fails closed → not_found (round-2: all four are required)", () => {
-    materializeProfile({ ...GOOD });
-    rmSync(join(getAgentArtefactDir(GOOD.agentId), "playbook.md"), { force: true });
-    const read = readAgentProfile(GOOD.agentId);
-    expect(read.ok).toBe(false);
-    if (read.ok) return;
-    expect(read.kind).toBe("not_found");
-  });
-});
-
-describe("materializeProfile — intentSpec is the PERSISTED schema; the per-query intent is NEVER persisted", () => {
-  it("persists intent_spec.md (the decomposition-dimension schema) — the store now carries intentSpec", () => {
-    // Correction 4: the prior @ts-expect-error blocking an intent store field is
-    // REVERSED. intentSpec is a real, REQUIRED ProfileSpec field — the persisted
-    // dimension schema/template. (No @ts-expect-error here: it must compile.)
-    const result = materializeProfile({ ...GOOD });
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(existsSync(join(result.dir, "intent_spec.md"))).toBe(true);
-    expect(readFileSync(result.intentSpecPath, "utf8")).toBe(INTENT_SPEC);
-  });
-
-  it("NEVER writes an intent.md of filled per-query values — only the intent_spec.md schema", () => {
-    // The per-query intent (the dimensions filled in for one request) is ephemeral,
-    // conversation-only. The store persists the SCHEMA (intent_spec.md), never the
-    // INSTANCE. No intent.md is ever written.
-    const result = materializeProfile({ ...GOOD });
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(existsSync(join(result.dir, "intent.md"))).toBe(false);
-    // Exactly the four behaviour artefacts + manifest — and intent_spec.md, never
-    // a bare intent.md.
-    const files = walkFiles(result.dir).sort();
-    expect(files).toEqual(
-      ["domain_spec.md", "intent_spec.md", "playbook.md", "profile.json", "user_spec.md"].sort(),
-    );
+describe("readAgentProfile — a freshly-created shopper with `domains: {}` is HEALTHY, not not_found", () => {
+  it("the overview returns ok with the shared user_spec + an EMPTY domain index", () => {
+    createShopper(USER_SPEC_V1);
+    const overview = readAgentProfile(AGENT_ID);
+    expect(overview.ok).toBe(true);
+    if (!overview.ok) return;
+    expect(overview.userSpec).toBe(USER_SPEC_V1);
+    expect(overview.domains).toEqual([]);
   });
 });

--- a/src/__tests__/lib/profile-store.test.ts
+++ b/src/__tests__/lib/profile-store.test.ts
@@ -1,34 +1,40 @@
 /**
- * UNIT — materializeProfile() behaviour-artefact writer (tier: unit, real temp
- * dir via the SIL_DATA_DIR override, no network, no host).
+ * UNIT — materializeProfile() writer, after the single-multi-domain shopper
+ * reshape (tier: unit, real temp dir via the SIL_DATA_DIR override, no network,
+ * no host).
  *
- * Card: spec-driven-shopping-sds-for-created-experts — Founder review round 2
- * (PR #33 bounced a SECOND time). After the SDS reframe the sil store holds FOUR
- * behaviour artefacts and NO persona (the persona is the host SOUL.md, written by
- * the engine via the host CLI — not a sil-side file). Round-2: ALL FOUR specs are
- * REQUIRED and present non-blank from creation (seeded partial, then augmented
- * per-query) — none is lazy/optional:
- *   - domain_spec.md  (REQUIRED) — deep researched niche expertise;
- *   - intent_spec.md  (REQUIRED) — the decomposition-dimension schema;
- *   - user_spec.md    (REQUIRED) — the user's domain-relevant facts + constraints;
- *   - playbook.md     (REQUIRED) — the user's buying taste.
+ * Card: single-multi-domain-sil-shopper — Slice 1 (store/tool plumbing). The
+ * per-niche flat layout is DELETED (no backwards compat). One persistent "sil
+ * shopper" now owns ONE agent dir holding a SHARED, agent-level user_spec.md +
+ * profile.json, with niche packs pushed down a level under domains/<slug>/:
  *
- * This file pins the GENERIC store invariants (the agentId gate, atomicity, the
- * 0600/0700 modes, no-token-coupling). The SDS-specific slot semantics
- * (required-vs-lazy, persona-gone, intent-schema-persisted) live in
- * `profile-store-sds.test.ts`.
+ *   $SIL_DATA_DIR/agents/<shopperId>/
+ *     ├─ user_spec.md            SHARED, agent-level (the one person).
+ *     ├─ profile.json            manifest: identity + userSpecPath + a `domains` MAP.
+ *     └─ domains/<slug>/
+ *         ├─ domain_spec.md      per-domain pack (researched niche expertise)
+ *         ├─ intent_spec.md      per-domain pack (decomposition dimensions)
+ *         └─ playbook.md         per-domain pack (niche buying taste)
  *
- * The invariants pinned here ARE the card's correctness bar for the artefact
- * layer:
- *   1. A valid spec materializes the required specs + profile.json (and the lazy
- *      ones when supplied) under $SIL_DATA_DIR/agents/<agentId>/, owner-only
- *      (0600), in a 0700 dir, with a typed manifest pointing at the artefacts.
- *   2. Validate-FIRST: every invalid field returns `invalid_request` naming the
- *      field and writes NOTHING — no agent directory appears (Product
- *      invariant 7, atomic outcome).
- *   3. Atomic on failure: a mid-write failure leaves NOTHING partial behind
- *      (persistence_failed with <dir>: <cause>).
- *   4. Identity boundary: materializing reads/writes no token (no coupling).
+ * `ProfileSpec` is reshaped to agent-level fields + an OPTIONAL `domain` pack:
+ *   { agentId, name, userSpec, domain?: { slug, name, domainSpec, intentSpec, playbook } }
+ *   - NO `domain`  ⇒ CREATE the shopper: write the shared user_spec.md + a
+ *     profile.json with `domains: {}` (the healthy freshly-created state). NO
+ *     domains/ dir exists yet.
+ *   - WITH `domain` ⇒ lazily MINT/refresh that niche: write
+ *     domains/<slug>/{domain_spec,intent_spec,playbook}.md, overwrite the shared
+ *     user_spec.md, and upsert `domains[slug]` — all in one atomic call.
+ *
+ * This file pins the GENERIC writer invariants that survive the reshape — the
+ * agentId gate, the NEW slug path-segment gate, validate-first, atomicity on a
+ * blocked path, the 0600/0700 modes, no-token-coupling, the resolved-from-
+ * getDataDir() dir. The deeper layout / lazy-mint / domains-map semantics live in
+ * `profile-store-sds.test.ts`; list/read/remove in `profile-store-manage.test.ts`.
+ *
+ * The four-flat-spec-per-expert contract is GONE: ProfileSpec no longer carries
+ * top-level domainSpec/intentSpec/playbook; the manifest no longer carries the
+ * four flat *Path keys (it carries userSpecPath + a domains map). No assertion of
+ * the old shape survives.
  *
  * Hermetic via the SIL_DATA_DIR temp-dir override (the repo's standard knob).
  */
@@ -57,7 +63,6 @@ import { join } from "node:path";
 import {
   materializeProfile,
   getAgentArtefactDir,
-  type ProfileManifest,
   type ProfileSpec,
 } from "../../lib/profile-store.js";
 import { getDataDir, getTokensPath } from "../../lib/credentials.js";
@@ -74,7 +79,6 @@ beforeEach(() => {
 afterEach(() => {
   if (priorSilDataDir === undefined) delete process.env["SIL_DATA_DIR"];
   else process.env["SIL_DATA_DIR"] = priorSilDataDir;
-  // Restore perms so rmSync can clean a dir a cleanup test chmod'd read-only.
   try {
     chmodSync(dataDir, 0o700);
   } catch {
@@ -83,31 +87,49 @@ afterEach(() => {
   rmSync(dataDir, { recursive: true, force: true });
 });
 
-/** A full create — ALL FOUR REQUIRED specs (round-2: none is lazy/optional). */
-const GOOD = {
-  agentId: "gift-buyer",
-  name: "Gift Buyer",
+/** The shared, agent-level user spec — the one person, carried across niches. */
+const USER_SPEC =
+  "# User spec — the shopper (shared, agent-level)\n"
+  + "## Standing facts\n- Ships to Berlin 10115.\n- Inseam 81cm, shoe EU 43.\n"
+  + "## Hard constraints (INVIOLABLE across every niche)\n"
+  + "- HARD-NO: leather (ethics).\n- HARD-NO: anything over budget without a flag.";
+
+/** A complete domain pack (the per-niche artefacts, minted lazily on first shop). */
+const DOMAIN = {
+  slug: "road-cycling",
+  name: "Road cycling",
   domainSpec:
-    "# Gift-buying domain spec\nDimensions: recipient relationship, occasion,"
-    + " budget band, taste signals, delivery timeline. Trade-offs noted.",
+    "# Road-cycling domain spec (deep)\nFit mechanics, gearing theory, frame"
+    + " geometry, the full bike-fit process. Trade-offs noted.",
   intentSpec:
-    "# Intent spec — dimensions\nrecipient, occasion, budget, timeline, taste.",
-  userSpec: "# User spec\nFacts: buys for partner + two kids.\nHARD-NO: nothing over €50.",
-  playbook: "# Buying taste\nValue-conscious; prefers experiences over objects.",
+    "# Intent spec — decomposition dimensions\nuse-case, terrain, budget, timeline,"
+    + " compatibility, performance priorities, aesthetics.",
+  playbook:
+    "# Buying taste (road cycling)\nBudget band ~€1500; distrusts house-brand"
+    + " groupsets; Shimano over SRAM.",
 } as const;
 
-/** The minimum valid create. After Founder review round 2, all four sil specs are
- * REQUIRED + present from creation — so the minimum create IS the full four-spec
- * create. Kept as a named alias for call-site legibility. */
-const MIN = GOOD;
+/** Create the shopper (no domain): the one-time agent-level write. */
+const CREATE_SHOPPER = {
+  agentId: "sil-shopper",
+  name: "sil shopper",
+  userSpec: USER_SPEC,
+} as const;
 
-function readManifest(agentId: string): ProfileManifest {
+/** Mint a niche onto the shopper (lazy, shop-time). */
+const MINT = {
+  ...CREATE_SHOPPER,
+  domain: DOMAIN,
+} as const;
+
+/** Raw, untyped manifest read — decoupled from the manifest field shape so a
+ * RED run against the un-reshaped store never throws on a missing key. */
+function readManifest(agentId: string): Record<string, unknown> {
   const path = join(getAgentArtefactDir(agentId), "profile.json");
-  return JSON.parse(readFileSync(path, "utf8")) as ProfileManifest;
+  return JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
 }
 
-/** Every file under `dir`, recursively (relative paths). Used to prove no
- * `.tmp` sibling survives a write and no artefact survives a failed write. */
+/** Every file under `dir`, recursively (relative paths). */
 function walkFiles(dir: string, base = dir): string[] {
   if (!existsSync(dir)) return [];
   const out: string[] = [];
@@ -119,103 +141,133 @@ function walkFiles(dir: string, base = dir): string[] {
   return out;
 }
 
-describe("materializeProfile — valid spec writes the behaviour artefacts", () => {
-  it("writes domain_spec.md, intent_spec.md, the lazy slots, and profile.json under $SIL_DATA_DIR/agents/<agentId>/", () => {
-    const result = materializeProfile({ ...GOOD });
+describe("materializeProfile — create the shopper (no domain): shared user_spec + empty domains map", () => {
+  it("writes ONLY user_spec.md + profile.json at the agent level; NO domains/ dir yet", () => {
+    const result = materializeProfile({ ...CREATE_SHOPPER });
     expect(result.ok).toBe(true);
-    if (!result.ok) return; // narrow
+    if (!result.ok) return;
 
-    const expectedDir = join(getDataDir(), "agents", GOOD.agentId);
-    expect(result.dir).toBe(expectedDir);
-    expect(existsSync(join(expectedDir, "domain_spec.md"))).toBe(true);
-    expect(existsSync(join(expectedDir, "intent_spec.md"))).toBe(true);
-    expect(existsSync(join(expectedDir, "user_spec.md"))).toBe(true);
-    expect(existsSync(join(expectedDir, "playbook.md"))).toBe(true);
-    expect(existsSync(join(expectedDir, "profile.json"))).toBe(true);
-    // The persona is the host SOUL.md — never a sil-side file.
-    expect(existsSync(join(expectedDir, "persona.md"))).toBe(false);
+    const dir = join(getDataDir(), "agents", CREATE_SHOPPER.agentId);
+    expect(result.dir).toBe(dir);
+    expect(existsSync(join(dir, "user_spec.md"))).toBe(true);
+    expect(existsSync(join(dir, "profile.json"))).toBe(true);
+    // The per-niche flat artefacts are GONE from the agent level.
+    expect(existsSync(join(dir, "domain_spec.md"))).toBe(false);
+    expect(existsSync(join(dir, "intent_spec.md"))).toBe(false);
+    expect(existsSync(join(dir, "playbook.md"))).toBe(false);
+    // A freshly-created shopper has shopped nothing — no domains/ subtree.
+    expect(existsSync(join(dir, "domains"))).toBe(false);
 
-    expect(readFileSync(result.domainSpecPath, "utf8")).toBe(GOOD.domainSpec);
-    expect(readFileSync(result.intentSpecPath, "utf8")).toBe(GOOD.intentSpec);
+    // Exactly the two agent-level files.
+    expect(walkFiles(dir).sort()).toEqual(["profile.json", "user_spec.md"].sort());
+    expect(readFileSync(join(dir, "user_spec.md"), "utf8")).toBe(USER_SPEC);
+  });
+
+  it("the ok result surfaces userSpecPath + profilePath (and NO old flat *Path fields)", () => {
+    const result = materializeProfile({ ...CREATE_SHOPPER });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const dir = getAgentArtefactDir(CREATE_SHOPPER.agentId);
+    expect(result.userSpecPath).toBe(join(dir, "user_spec.md"));
+    expect(result.profilePath).toBe(join(dir, "profile.json"));
+    // The four flat spec paths left the result — they are per-domain now.
+    expect("domainSpecPath" in result).toBe(false);
+    expect("intentSpecPath" in result).toBe(false);
+    expect("playbookPath" in result).toBe(false);
+  });
+
+  it("the manifest carries userSpecPath + an EMPTY domains map + identity (no flat *Path keys)", () => {
+    materializeProfile({ ...CREATE_SHOPPER });
+    const manifest = readManifest(CREATE_SHOPPER.agentId);
+    const dir = getAgentArtefactDir(CREATE_SHOPPER.agentId);
+    expect(manifest["agentId"]).toBe(CREATE_SHOPPER.agentId);
+    expect(manifest["name"]).toBe(CREATE_SHOPPER.name);
+    expect(manifest["userSpecPath"]).toBe(join(dir, "user_spec.md"));
+    // domains is the source of truth — present, an object, and EMPTY (healthy).
+    expect(manifest["domains"]).toEqual({});
+    expect(typeof manifest["createdAt"]).toBe("string");
+    expect(Number.isNaN(Date.parse(manifest["createdAt"] as string))).toBe(false);
+    // The four flat spec-path keys are GONE from the manifest.
+    expect("domainSpecPath" in manifest).toBe(false);
+    expect("intentSpecPath" in manifest).toBe(false);
+    expect("playbookPath" in manifest).toBe(false);
   });
 
   it("resolves the artefact dir from getDataDir() — honours $SIL_DATA_DIR (never hardcoded)", () => {
-    // getAgentArtefactDir must sit under the overridden data dir, proving it
-    // reads the accessor and is not a baked-in ~/.local/share path.
     expect(getAgentArtefactDir("x")).toBe(join(dataDir, "agents", "x"));
   });
 
-  it("the manifest is typed and points at the required-spec artefacts (no personaPath)", () => {
-    const result = materializeProfile({ ...GOOD });
-    expect(result.ok).toBe(true);
-
-    const manifest = readManifest(GOOD.agentId);
-    expect(manifest.agentId).toBe(GOOD.agentId);
-    expect(manifest.name).toBe(GOOD.name);
-    expect(manifest.domainSpecPath).toBe(
-      join(getAgentArtefactDir(GOOD.agentId), "domain_spec.md"),
-    );
-    expect(manifest.intentSpecPath).toBe(
-      join(getAgentArtefactDir(GOOD.agentId), "intent_spec.md"),
-    );
-    // Persona left the store — no personaPath key on the manifest.
-    expect("personaPath" in manifest).toBe(false);
-    expect(typeof manifest.createdAt).toBe("string");
-    // ISO 8601 — parseable to a real date.
-    expect(Number.isNaN(Date.parse(manifest.createdAt))).toBe(false);
-  });
-
-  it("writes ALL FOUR spec files AND their manifest paths for a create (round-2: none is lazily absent)", () => {
-    const result = materializeProfile({ ...MIN });
+  it("writes the shared user_spec + manifest owner-only (0600) inside a 0700 dir", () => {
+    const result = materializeProfile({ ...CREATE_SHOPPER });
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-
-    expect(existsSync(join(result.dir, "domain_spec.md"))).toBe(true);
-    expect(existsSync(join(result.dir, "intent_spec.md"))).toBe(true);
-    expect(existsSync(join(result.dir, "user_spec.md"))).toBe(true);
-    expect(existsSync(join(result.dir, "playbook.md"))).toBe(true);
-    expect(result.userSpecPath).toBeDefined();
-    expect(result.playbookPath).toBeDefined();
-
-    const manifest = readManifest(GOOD.agentId);
-    expect(typeof manifest.userSpecPath).toBe("string");
-    expect(typeof manifest.playbookPath).toBe("string");
-  });
-
-  it("writes artefacts owner-only (0600) inside a 0700 dir", () => {
-    const result = materializeProfile({ ...GOOD });
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-
-    // mask to the permission bits.
     expect(statSync(result.dir).mode & 0o777).toBe(0o700);
-    expect(statSync(result.domainSpecPath).mode & 0o777).toBe(0o600);
+    expect(statSync(result.userSpecPath).mode & 0o777).toBe(0o600);
     expect(statSync(result.profilePath).mode & 0o777).toBe(0o600);
   });
 
   it("does NOT read or write any token (no identity coupling)", () => {
-    // The tokens path must not appear as a side effect of materializing.
-    materializeProfile({ ...GOOD });
+    materializeProfile({ ...CREATE_SHOPPER });
     expect(existsSync(getTokensPath())).toBe(false);
   });
 
-  it("leaves NO .tmp sibling behind after the atomic write (tmp → rename → chmod)", () => {
-    // The store writes via a tmp sibling then renames over the target. A
-    // surviving `.tmp` means the rename never ran — the atomic-write contract
-    // broken (a reader could observe a half-written artefact).
-    const result = materializeProfile({ ...GOOD });
+  it("leaves NO .tmp sibling behind after the atomic write", () => {
+    const result = materializeProfile({ ...CREATE_SHOPPER });
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    const leftovers = walkFiles(result.dir).filter((f) => f.includes(".tmp"));
-    expect(leftovers).toEqual([]);
+    expect(walkFiles(result.dir).filter((f) => f.includes(".tmp"))).toEqual([]);
   });
 });
 
-describe("materializeProfile — validate-first: a bad spec writes NOTHING (invalid_request)", () => {
-  const dirExists = () => existsSync(getAgentArtefactDir(GOOD.agentId));
+describe("materializeProfile — mint a niche (with domain): the pack lands under domains/<slug>/", () => {
+  it("writes domains/<slug>/{domain_spec,intent_spec,playbook}.md owner-only, and upserts domains[slug]", () => {
+    // Create the shopper first (the intended flow), then mint the niche.
+    expect(materializeProfile({ ...CREATE_SHOPPER }).ok).toBe(true);
+    const result = materializeProfile({ ...MINT });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const domainDir = join(getAgentArtefactDir(MINT.agentId), "domains", DOMAIN.slug);
+    expect(readFileSync(join(domainDir, "domain_spec.md"), "utf8")).toBe(DOMAIN.domainSpec);
+    expect(readFileSync(join(domainDir, "intent_spec.md"), "utf8")).toBe(DOMAIN.intentSpec);
+    expect(readFileSync(join(domainDir, "playbook.md"), "utf8")).toBe(DOMAIN.playbook);
+    // Per-domain pack files are owner-only.
+    expect(statSync(join(domainDir, "domain_spec.md")).mode & 0o777).toBe(0o600);
+
+    // The manifest's domains map gains the slug, with the three per-domain paths.
+    const domains = (readManifest(MINT.agentId)["domains"] ?? {}) as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(domains[DOMAIN.slug]).toBeDefined();
+    expect(domains[DOMAIN.slug]!["slug"]).toBe(DOMAIN.slug);
+    expect(domains[DOMAIN.slug]!["name"]).toBe(DOMAIN.name);
+    expect(domains[DOMAIN.slug]!["domainSpecPath"]).toBe(join(domainDir, "domain_spec.md"));
+    expect(domains[DOMAIN.slug]!["intentSpecPath"]).toBe(join(domainDir, "intent_spec.md"));
+    expect(domains[DOMAIN.slug]!["playbookPath"]).toBe(join(domainDir, "playbook.md"));
+    expect(typeof domains[DOMAIN.slug]!["createdAt"]).toBe("string");
+    expect(typeof domains[DOMAIN.slug]!["updatedAt"]).toBe("string");
+  });
+
+  it("the ok result echoes the minted domain entry (slug + the three per-domain paths)", () => {
+    expect(materializeProfile({ ...CREATE_SHOPPER }).ok).toBe(true);
+    const result = materializeProfile({ ...MINT });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.domain).toBeDefined();
+    expect(result.domain!.slug).toBe(DOMAIN.slug);
+    const domainDir = join(getAgentArtefactDir(MINT.agentId), "domains", DOMAIN.slug);
+    expect(result.domain!.domainSpecPath).toBe(join(domainDir, "domain_spec.md"));
+    expect(result.domain!.intentSpecPath).toBe(join(domainDir, "intent_spec.md"));
+    expect(result.domain!.playbookPath).toBe(join(domainDir, "playbook.md"));
+  });
+});
+
+describe("materializeProfile — validate-first on the agent-level fields (writes NOTHING)", () => {
+  const dirExists = () => existsSync(getAgentArtefactDir(CREATE_SHOPPER.agentId));
 
   it("missing agentId → invalid_request(field=agentId), nothing written", () => {
-    const result = materializeProfile({ ...GOOD, agentId: "" });
+    const result = materializeProfile({ ...CREATE_SHOPPER, agentId: "" });
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.kind).toBe("invalid_request");
@@ -225,7 +277,7 @@ describe("materializeProfile — validate-first: a bad spec writes NOTHING (inva
   });
 
   it('reserved "main" agentId → invalid_request(field=agentId), nothing written', () => {
-    const result = materializeProfile({ ...GOOD, agentId: "main" });
+    const result = materializeProfile({ ...CREATE_SHOPPER, agentId: "main" });
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.kind).toBe("invalid_request");
@@ -234,34 +286,20 @@ describe("materializeProfile — validate-first: a bad spec writes NOTHING (inva
     expect(existsSync(join(getDataDir(), "agents", "main"))).toBe(false);
   });
 
-  it("non-kebab agentId → invalid_request(field=agentId), nothing written", () => {
-    const result = materializeProfile({ ...GOOD, agentId: "Gift Buyer!" });
-    expect(result.ok).toBe(false);
-    if (result.ok) return;
-    expect(result.kind).toBe("invalid_request");
-    if (result.kind !== "invalid_request") return;
-    expect(result.field).toBe("agentId");
-  });
-
-  it("rejects a path-traversing / separator-bearing agentId (it is a dir-path segment)", () => {
-    // Security-relevant: agentId becomes a directory path segment under
-    // $SIL_DATA_DIR/agents/. A `..` or `/` would let an artefact escape the
-    // sandbox. The lower-kebab gate must reject every such shape — and write
-    // nothing for any of them.
-    for (const bad of ["../escape", "gift/buyer", "..", ".", "a/../b", "Gift-Buyer"]) {
-      const result = materializeProfile({ ...GOOD, agentId: bad });
+  it("path-traversing / separator-bearing agentId → invalid_request(field=agentId), nothing escapes", () => {
+    for (const bad of ["../escape", "shop/per", "..", ".", "a/../b", "Sil-Shopper"]) {
+      const result = materializeProfile({ ...CREATE_SHOPPER, agentId: bad });
       expect(result.ok, `expected reject for ${JSON.stringify(bad)}`).toBe(false);
       if (result.ok) return;
       expect(result.kind).toBe("invalid_request");
       if (result.kind !== "invalid_request") return;
       expect(result.field).toBe("agentId");
     }
-    // Nothing escaped the agents subtree (no stray file anywhere under it).
     expect(walkFiles(join(getDataDir(), "agents"))).toEqual([]);
   });
 
   it("blank name → invalid_request(field=name), nothing written", () => {
-    const result = materializeProfile({ ...GOOD, name: "   " });
+    const result = materializeProfile({ ...CREATE_SHOPPER, name: "   " });
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.kind).toBe("invalid_request");
@@ -270,32 +308,8 @@ describe("materializeProfile — validate-first: a bad spec writes NOTHING (inva
     expect(dirExists()).toBe(false);
   });
 
-  it("missing domainSpec (required) → invalid_request(field=domainSpec), nothing written", () => {
-    // Cast: omitting a required field is a type error; the RUNTIME contract is that
-    // the store rejects it fail-closed (validate-first).
-    const { domainSpec: _d, ...noDomain } = GOOD;
-    const result = materializeProfile(noDomain as unknown as ProfileSpec);
-    expect(result.ok).toBe(false);
-    if (result.ok) return;
-    expect(result.kind).toBe("invalid_request");
-    if (result.kind !== "invalid_request") return;
-    expect(result.field).toBe("domainSpec");
-    expect(dirExists()).toBe(false);
-  });
-
-  it("missing intentSpec (required) → invalid_request(field=intentSpec), nothing written", () => {
-    const { intentSpec: _i, ...noIntent } = GOOD;
-    const result = materializeProfile(noIntent as unknown as ProfileSpec);
-    expect(result.ok).toBe(false);
-    if (result.ok) return;
-    expect(result.kind).toBe("invalid_request");
-    if (result.kind !== "invalid_request") return;
-    expect(result.field).toBe("intentSpec");
-    expect(dirExists()).toBe(false);
-  });
-
-  it("missing userSpec (required, round-2) → invalid_request(field=userSpec), nothing written", () => {
-    const { userSpec: _u, ...noUser } = GOOD;
+  it("missing userSpec → invalid_request(field=userSpec), nothing written (userSpec is REQUIRED on EVERY call)", () => {
+    const { userSpec: _u, ...noUser } = CREATE_SHOPPER;
     const result = materializeProfile(noUser as unknown as ProfileSpec);
     expect(result.ok).toBe(false);
     if (result.ok) return;
@@ -305,73 +319,30 @@ describe("materializeProfile — validate-first: a bad spec writes NOTHING (inva
     expect(dirExists()).toBe(false);
   });
 
-  it("missing playbook (required, round-2) → invalid_request(field=playbook), nothing written", () => {
-    const { playbook: _p, ...noPlaybook } = GOOD;
-    const result = materializeProfile(noPlaybook as unknown as ProfileSpec);
+  it("present-but-blank userSpec → invalid_request(field=userSpec), nothing written", () => {
+    const result = materializeProfile({ ...CREATE_SHOPPER, userSpec: "  \t\n " });
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.kind).toBe("invalid_request");
     if (result.kind !== "invalid_request") return;
-    expect(result.field).toBe("playbook");
-    expect(dirExists()).toBe(false);
-  });
-
-  it("present-but-blank playbook (required) → invalid_request(field=playbook), nothing written", () => {
-    const result = materializeProfile({ ...GOOD, playbook: "   " });
-    expect(result.ok).toBe(false);
-    if (result.ok) return;
-    expect(result.kind).toBe("invalid_request");
-    if (result.kind !== "invalid_request") return;
-    expect(result.field).toBe("playbook");
+    expect(result.field).toBe("userSpec");
     expect(dirExists()).toBe(false);
   });
 });
 
-describe("materializeProfile — atomic on write failure (persistence_failed, nothing partial)", () => {
-  it("when the artefact path is blocked by a file, returns persistence_failed with <dir>: <cause> and leaves nothing partial", () => {
-    // Force a write failure: pre-create `agents/<id>` as a FILE, so mkdir of the
-    // dir (recursive over an existing non-dir leaf) throws ENOTDIR/EEXIST.
+describe("materializeProfile — atomic on a blocked path (persistence_failed, nothing partial)", () => {
+  it("when the agent dir path is blocked by a regular file → persistence_failed, the file untouched", () => {
     const agentsDir = join(getDataDir(), "agents");
     mkdirSync(agentsDir, { recursive: true });
     // Place a regular file exactly where the agent DIR must go.
-    writeFileSync(join(agentsDir, GOOD.agentId), "i am a file, not a dir");
+    writeFileSync(join(agentsDir, CREATE_SHOPPER.agentId), "i am a file, not a dir");
 
-    const result = materializeProfile({ ...GOOD });
+    const result = materializeProfile({ ...CREATE_SHOPPER });
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.kind).toBe("persistence_failed");
     if (result.kind !== "persistence_failed") return;
-    // The path + cause are both present (actionable recovery).
-    expect(result.error).toContain(getAgentArtefactDir(GOOD.agentId));
-    // The blocking file is untouched; no partial artefacts were written under it.
-    expect(statSync(join(agentsDir, GOOD.agentId)).isFile()).toBe(true);
+    expect(result.error).toContain(getAgentArtefactDir(CREATE_SHOPPER.agentId));
+    expect(statSync(join(agentsDir, CREATE_SHOPPER.agentId)).isFile()).toBe(true);
   });
-
-  // chmod 0500 can't block writes for root — skip there rather than false-fail.
-  // The file-blocks-path case above covers the failure envelope for ALL uids;
-  // this one additionally drives the catch-block rmSync CLEANUP (a dir that was
-  // created, then a write into it failed) so no half-populated dir survives.
-  const asRoot = typeof process.getuid === "function" && process.getuid() === 0;
-  it.skipIf(asRoot)(
-    "CLEANS UP a partially-created artefact dir when a mid-write fails (no half-set survives)",
-    () => {
-      // Pre-create the agent dir READ-ONLY (0500): mkdir(recursive) is a no-op,
-      // then the tmp-file write inside it fails EACCES, driving the cleanup.
-      const agentDir = getAgentArtefactDir(GOOD.agentId);
-      mkdirSync(agentDir, { recursive: true });
-      chmodSync(agentDir, 0o500);
-
-      const result = materializeProfile({ ...GOOD });
-      expect(result.ok).toBe(false);
-      if (result.ok) return;
-      expect(result.kind).toBe("persistence_failed");
-
-      // No artefact file may survive a failed write. Restore perms first so we
-      // can inspect + afterEach can clean up.
-      if (existsSync(agentDir)) {
-        chmodSync(agentDir, 0o700);
-        expect(walkFiles(agentDir)).toEqual([]);
-      }
-    },
-  );
 });

--- a/src/__tests__/lib/refine-rewrite.test.ts
+++ b/src/__tests__/lib/refine-rewrite.test.ts
@@ -1,33 +1,31 @@
 /**
- * INTEGRATION — the refine + lazy-capture loop's PERSIST + ROUND-TRIP composition
- * over a real temp $SIL_DATA_DIR (tier: integration — real filesystem artefact
- * interaction, no mock of the store, no network, no host).
+ * UNIT — the per-query refine / lazy-augment loop, re-expressed at the DOMAIN
+ * grain (tier: unit, real temp dir via the SIL_DATA_DIR override, no network, no
+ * host).
  *
- * Card: spec-driven-shopping-sds-for-created-experts — Founder review round 2
- * (PR #33 bounced a SECOND time). The refine loop AND the per-query augment path
- * both COMPOSE the existing `sil_profile_get` (load) + `sil_profile_materialize`
- * (atomic in-place re-write) store paths — no new code. These tests pin the
- * EXISTING profile-store re-write semantics the loop relies on, in the SDS
- * five-artefact shape:
+ * Card: single-multi-domain-sil-shopper — Slice 1. The "refine an expert" loop
+ * becomes "refine a DOMAIN": re-running `sil_profile_materialize` with the SAME
+ * { agentId, domain.slug } overwrites that domain's pack IN PLACE (the per-query
+ * web refresh / taste augmentation). The store's "fresh-create teardown vs
+ * re-materialize per-file-atomic" split (profile-store.ts) re-applies one level
+ * deeper — with the domains/<slug>/ leaf as the unit:
  *
- *   (a) re-running materializeProfile over a PRE-EXISTING agents/<id>/ dir
- *       overwrites the artefact bodies IN PLACE (the refinement / per-query
- *       augmentation persists);
- *   (b) an injected write failure on a PRE-EXISTING dir leaves the PRIOR
- *       artefacts INTACT — the `dirPreexisted` guard never tears down a dir it
- *       did not create, so a failed re-write never half-refines an expert;
- *   (c) materialize → re-materialize-with-an-updated-spec → readAgentProfile
+ *   (a) re-minting an EXISTING domain overwrites its three bodies in place;
+ *   (b) a write failure on an EXISTING domain's leaf is DIR-PRESERVING — the leaf
+ *       is NOT torn down (it is not "ours, freshly created"; it holds the prior
+ *       pack), so a failed re-mint never deletes a domain the user already has;
+ *   (c) the re-mint is per-FILE atomic, NOT a cross-file transaction — a partial
+ *       re-write leaves each individual body intact (never torn), and a
+ *       referenced-but-missing body fails the read closed (see
+ *       profile-store-sds.test.ts);
+ *   (d) materialize → re-materialize(updated domain) → readAgentProfile(slug)
  *       returns the UPDATED bodies — the load-then-refine-then-reload loop closes.
  *
- * After the SDS reframe: NO persona in the store (it is the host SOUL.md). Round-2
- * correction: ALL FOUR sil specs (domain_spec / intent_spec / user_spec /
- * playbook) are REQUIRED and PRESENT from creation (seeded partial), then lazily
- * AUGMENTED in place per-query — never "added from absent". Refine can target any
- * of the four. The per-query INTENT (filled dimensions) is never persisted — only
- * the intent_spec.md SCHEMA is — so it is never a refine target and never
- * re-materialized.
+ * Contrast with profile-store-sds.test.ts: there, a failed FIRST mint of a NEW
+ * domain tears the fresh leaf DOWN. Here, a failed re-mint of an EXISTING domain
+ * PRESERVES it. Same split, one level deeper.
  *
- * Hermetic via the SIL_DATA_DIR temp-dir override (the repo's standard knob).
+ * Hermetic via the SIL_DATA_DIR temp-dir override.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
@@ -36,10 +34,7 @@ import {
   rmSync,
   existsSync,
   readFileSync,
-  readdirSync,
   statSync,
-  writeFileSync,
-  mkdirSync,
   chmodSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -49,6 +44,7 @@ import {
   materializeProfile,
   readAgentProfile,
   getAgentArtefactDir,
+  type ProfileSpec,
 } from "../../lib/profile-store.js";
 
 let dataDir: string;
@@ -63,7 +59,6 @@ beforeEach(() => {
 afterEach(() => {
   if (priorSilDataDir === undefined) delete process.env["SIL_DATA_DIR"];
   else process.env["SIL_DATA_DIR"] = priorSilDataDir;
-  // Restore perms so rmSync can clean a dir a failure-injection test chmod'd RO.
   try {
     chmodSync(dataDir, 0o700);
   } catch {
@@ -72,354 +67,126 @@ afterEach(() => {
   rmSync(dataDir, { recursive: true, force: true });
 });
 
-/** The SDS expert as first created — ALL FOUR REQUIRED specs (round-2: every sil
- * doc is present non-blank from creation, seeded partial). */
-const CREATED = {
-  agentId: "road-cycling-buyer",
-  name: "Road Cycling Buyer",
-  domainSpec:
-    "# Domain spec (deep)\nFit mechanics (stack/reach, saddle setback, crank"
-    + " length), gearing theory, frame geometry. Trade-offs noted.",
-  intentSpec:
-    "# Intent spec — dimensions\nuse-case, terrain, budget, timeline, compatibility,"
-    + " performance priorities, aesthetics.",
-  userSpec:
-    "# User spec (seeded partial)\nFacts: endurance geometry, inseam 81cm.\n"
-    + "HARD-NO: rim brakes.",
-  playbook: "# Buying taste (seeded partial)\nBudget ~€1500; brand-agnostic.",
+const AGENT_ID = "sil-shopper";
+const USER_SPEC = "# User spec (shared)\n- Ships to Berlin.\nHARD-NO: leather.";
+
+/** The cycling pack, as first minted. */
+const CYCLING_V1 = {
+  slug: "road-cycling",
+  name: "Road cycling",
+  domainSpec: "# Domain spec (seeded)\nFit + gearing basics.",
+  intentSpec: "# Intent spec\nuse-case, terrain, budget.",
+  playbook: "# Taste (seeded)\n~€1500; brand-agnostic.",
 } as const;
 
-/** The refined spec — SAME agentId, the domain spec ENHANCED (a per-query web
- * refresh persisted in place). The intent spec is unchanged. */
-const REFINED = {
-  ...CREATED,
-  domainSpec:
-    "# Domain spec (deep)\nFit mechanics (stack/reach, saddle setback, crank"
-    + " length), gearing theory, frame geometry. Trade-offs noted.\n"
-    + "## 2026 update (web refresh)\nSRAM Red AXS 2x13 now shipping; UDH/T-Type"
-    + " compatibility matters for new frames.",
+/** The same domain, refreshed by a later query — domain_spec ENHANCED. */
+const CYCLING_V2 = {
+  ...CYCLING_V1,
+  domainSpec: CYCLING_V1.domainSpec + "\n(refreshed: aero vs comfort trade-offs).",
 } as const;
 
-/** Every file under `dir`, recursively (relative paths) — to assert no `.tmp`
- * sibling survives a re-write, and that a failed re-write left only the priors. */
-function walkFiles(dir: string, base = dir): string[] {
-  if (!existsSync(dir)) return [];
-  const out: string[] = [];
-  for (const e of readdirSync(dir, { withFileTypes: true })) {
-    const full = join(dir, e.name);
-    if (e.isDirectory()) out.push(...walkFiles(full, base));
-    else out.push(full.slice(base.length + 1));
-  }
-  return out;
+function createShopper(userSpec = USER_SPEC): void {
+  const r = materializeProfile({ agentId: AGENT_ID, name: "sil shopper", userSpec });
+  if (!r.ok) throw new Error(`createShopper failed: ${JSON.stringify(r)}`);
 }
 
-describe("refine persist — re-materialize over a PRE-EXISTING dir overwrites the bodies in place", () => {
-  it("a second materialize with an updated domain spec overwrites domain_spec.md (the web-refresh sticks)", () => {
-    // Create the expert, then web-refresh its domain spec: re-run materialize with
-    // the ENHANCED domainSpec for the SAME agentId. domain_spec.md is overwritten
-    // in place — the persisted file now holds the refreshed content (Correction 5:
-    // the domain spec is web-refreshed per-query and persisted via re-materialize).
-    const first = materializeProfile({ ...CREATED });
-    expect(first.ok).toBe(true);
-    if (!first.ok) return;
-    expect(readFileSync(first.domainSpecPath, "utf8")).toBe(CREATED.domainSpec);
+function mint(domain: NonNullable<ProfileSpec["domain"]>, userSpec = USER_SPEC) {
+  return materializeProfile({ agentId: AGENT_ID, name: "sil shopper", userSpec, domain });
+}
 
-    const dir = getAgentArtefactDir(CREATED.agentId);
-    expect(existsSync(dir)).toBe(true); // the dir pre-exists the re-write
+function domainDir(slug: string): string {
+  return join(getAgentArtefactDir(AGENT_ID), "domains", slug);
+}
 
-    const second = materializeProfile({ ...REFINED });
-    expect(second.ok).toBe(true);
-    if (!second.ok) return;
+function readManifest(): Record<string, unknown> {
+  return JSON.parse(
+    readFileSync(join(getAgentArtefactDir(AGENT_ID), "profile.json"), "utf8"),
+  ) as Record<string, unknown>;
+}
 
-    expect(second.dir).toBe(dir);
-    expect(readFileSync(second.domainSpecPath, "utf8")).toBe(REFINED.domainSpec);
-    // The intent spec is unchanged by a domain-only refresh.
-    expect(readFileSync(second.intentSpecPath, "utf8")).toBe(CREATED.intentSpec);
-    const manifest = JSON.parse(
-      readFileSync(join(dir, "profile.json"), "utf8"),
-    ) as { agentId: string; name: string };
-    expect(manifest.agentId).toBe(REFINED.agentId);
-    // No `.tmp` sibling survives the atomic re-write (tmp → rename ran).
-    expect(walkFiles(dir).filter((f) => f.includes(".tmp"))).toEqual([]);
-  });
-
-  it("re-materialize does NOT create a sibling dir or leak outside agents/<agentId>/ (single-id scope)", () => {
-    materializeProfile({ ...CREATED });
-    materializeProfile({ ...REFINED });
-    const agentsRoot = join(dataDir, "agents");
-    const entries = readdirSync(agentsRoot, { withFileTypes: true })
-      .filter((e) => e.isDirectory())
-      .map((e) => e.name);
-    expect(entries).toEqual([CREATED.agentId]);
-  });
-});
-
-describe("refine persist — a write failure on a PRE-EXISTING dir leaves the PRIOR artefacts intact (dirPreexisted guard)", () => {
-  // chmod 0500 cannot block writes for root — skip there rather than false-fail.
-  const asRoot = typeof process.getuid === "function" && process.getuid() === 0;
-
-  it.skipIf(asRoot)(
-    "when the re-write fails (dir made read-only), the original artefacts survive — never a half-refined expert",
-    () => {
-      const first = materializeProfile({ ...CREATED });
-      expect(first.ok).toBe(true);
-      if (!first.ok) return;
-      const dir = getAgentArtefactDir(CREATED.agentId);
-
-      // Make the PRE-EXISTING dir read-only so the refine re-write's tmp-file
-      // write fails EACCES. The `dirPreexisted` guard must NOT tear the dir down —
-      // it did not create it.
-      chmodSync(dir, 0o500);
-
-      const second = materializeProfile({ ...REFINED });
-      expect(second.ok).toBe(false);
-      if (second.ok) return;
-      expect(second.kind).toBe("persistence_failed");
-
-      // Restore perms to inspect + let afterEach clean up.
-      chmodSync(dir, 0o700);
-
-      // The PRIOR artefacts survive untouched — the original content, not the
-      // refined content, and not a partial mix.
-      expect(existsSync(join(dir, "domain_spec.md"))).toBe(true);
-      expect(readFileSync(join(dir, "domain_spec.md"), "utf8")).toBe(CREATED.domainSpec);
-      expect(readFileSync(join(dir, "intent_spec.md"), "utf8")).toBe(CREATED.intentSpec);
-      expect(existsSync(join(dir, "profile.json"))).toBe(true);
-      expect(walkFiles(dir).filter((f) => f.includes(".tmp"))).toEqual([]);
-    },
-  );
-
-  it("a re-write blocked at the manifest stage degrades to not_found on read — never serves a coherent HALF-refined expert (the store's per-file, NOT cross-file, atomicity)", () => {
-    // ADVERSARIAL FINDING the developer must know: materializeProfile is per-FILE
-    // atomic (tmp → rename, each file is all-or-nothing) but NOT transactional
-    // ACROSS its files. A failure at the MANIFEST stage — AFTER the bodies have
-    // already been overwritten — does NOT roll the bodies back. So the "a failed
-    // re-write leaves the PRIOR artefacts intact" guarantee holds STRICTLY for a
-    // failure at the FIRST write; a mid-sequence failure leaves the bodies updated
-    // but the manifest stale/broken.
-    //
-    // What the store DOES still guarantee, and what protects the user, is two
-    // things, both asserted here: (1) the `dirPreexisted` guard never tears the
-    // expert dir down (the expert is not deleted), and (2) readAgentProfile
-    // composes manifest + bodies and degrades to `not_found` when the manifest is
-    // unreadable — so the loop NEVER serves a coherent-looking half-refined expert
-    // off a broken manifest; the read fails closed.
-    const first = materializeProfile({ ...CREATED });
-    expect(first.ok).toBe(true);
-    if (!first.ok) return;
-    const dir = getAgentArtefactDir(CREATED.agentId);
-
-    // Occupy the manifest path with a directory — rename(tmp → profile.json) over
-    // a directory target fails (EISDIR/ENOTEMPTY), failing the manifest write.
-    const profilePath = join(dir, "profile.json");
-    rmSync(profilePath, { force: true });
-    mkdirSync(profilePath);
-    writeFileSync(join(profilePath, "occupied"), "blocks the rename");
-
-    const second = materializeProfile({ ...REFINED });
-    expect(second.ok).toBe(false);
-    if (second.ok) return;
-    expect(second.kind).toBe("persistence_failed");
-
-    // (1) The expert dir was NOT torn down (dirPreexisted guard).
-    expect(existsSync(dir)).toBe(true);
-    expect(existsSync(join(dir, "domain_spec.md"))).toBe(true);
-    expect(statSync(profilePath).isDirectory()).toBe(true); // blocker untouched
-
-    // (2) The read fails closed: with the manifest unreadable, readAgentProfile
-    // returns not_found rather than serving an expert off a half-written state.
-    const read = readAgentProfile(CREATED.agentId);
-    expect(read.ok).toBe(false);
-    if (read.ok) return;
-    expect(read.kind).toBe("not_found");
-  });
-});
-
-describe("refine round-trip — materialize → re-materialize(updated) → readAgentProfile returns the UPDATED bodies", () => {
-  it("a later read inside the refined expert loads the kept domain refresh (the loop closes)", () => {
-    expect(materializeProfile({ ...CREATED }).ok).toBe(true);
-    expect(materializeProfile({ ...REFINED }).ok).toBe(true);
-
-    const read = readAgentProfile(CREATED.agentId);
-    expect(read.ok).toBe(true);
-    if (!read.ok) return;
-
-    expect(read.agentId).toBe(REFINED.agentId);
-    expect(read.name).toBe(REFINED.name);
-    // The kept refresh is what a later session loads — the UPDATED domain spec.
-    expect(read.domainSpec).toBe(REFINED.domainSpec);
-    expect(read.domainSpec).not.toBe(CREATED.domainSpec);
-    // The intent spec is unchanged.
-    expect(read.intentSpec).toBe(CREATED.intentSpec);
-  });
-
-  it("the read after refine carries the refreshed manifest fields (the load path sees the new spec)", () => {
-    materializeProfile({ ...CREATED });
-    materializeProfile({ ...REFINED });
-
-    const read = readAgentProfile(CREATED.agentId);
-    expect(read.ok).toBe(true);
-    if (!read.ok) return;
-    expect(read.profilePath).toBe(
-      join(getAgentArtefactDir(CREATED.agentId), "profile.json"),
+describe("re-mint — re-running over an EXISTING domain overwrites its pack in place", () => {
+  it("a second mint of the same slug overwrites domain_spec.md with the refreshed body", () => {
+    createShopper();
+    expect(mint(CYCLING_V1).ok).toBe(true);
+    expect(readFileSync(join(domainDir("road-cycling"), "domain_spec.md"), "utf8")).toBe(
+      CYCLING_V1.domainSpec,
     );
-    expect(Number.isNaN(Date.parse(read.createdAt))).toBe(false);
+
+    expect(mint(CYCLING_V2).ok).toBe(true);
+    // domain_spec is overwritten in place; intent/playbook (unchanged) round-trip.
+    expect(readFileSync(join(domainDir("road-cycling"), "domain_spec.md"), "utf8")).toBe(
+      CYCLING_V2.domainSpec,
+    );
+    expect(readFileSync(join(domainDir("road-cycling"), "intent_spec.md"), "utf8")).toBe(
+      CYCLING_V1.intentSpec,
+    );
+    // Still exactly one domain — a re-mint is an upsert, not a duplicate.
+    expect(Object.keys((readManifest()["domains"] ?? {}) as Record<string, unknown>)).toEqual([
+      "road-cycling",
+    ]);
   });
 });
 
-// ===========================================================================
-// PER-QUERY AUGMENT + REFINE OF THE SDS LAYERS — domain_spec / intent_spec /
-// user_spec / playbook re-materialize in place
-//
-// Card: spec-driven-shopping-sds-for-created-experts (Founder review round 2).
-// All four sil docs are PRESENT from creation (seeded partial); the per-query
-// augment path and the refine path both re-materialize a layer IN PLACE through
-// the same `sil_profile_materialize` store path — augmenting an already-present
-// doc, never adding one from absent. The three properties the domain re-write
-// proved above must hold for each layer:
-//   (a) re-materialize over a PRE-EXISTING dir overwrites the layer in place (the
-//       kept augmentation/refinement sticks);
-//   (b) a failed re-write on a PRE-EXISTING dir leaves the PRIOR SDS artefacts
-//       intact (never a half-augmented user spec);
-//   (c) augmenting ONE layer leaves the OTHERS intact — a user_spec augment is not
-//       a full-expert rewrite that drops domain_spec/intent_spec.
-//
-// The per-query INTENT (filled dimensions) is deliberately ABSENT here: it is
-// ephemeral and never persisted, so it is never a refine target and never
-// re-materialized. Only the intent_spec.md SCHEMA is persisted.
-// ===========================================================================
+describe("re-mint round-trip — materialize → re-materialize(updated) → read returns the UPDATED bodies", () => {
+  it("a later read of the refined domain loads the kept domain refresh (the loop closes)", () => {
+    createShopper();
+    expect(mint(CYCLING_V1).ok).toBe(true);
+    expect(mint(CYCLING_V2).ok).toBe(true);
 
-/** The SDS expert as first created — ALL FOUR REQUIRED specs present (seeded
- * partial; round-2). */
-const SDS_CREATED = {
-  agentId: "road-cycling-buyer",
-  name: "Road Cycling Buyer",
-  domainSpec: "# Domain spec\nFit mechanics, gearing theory, frame geometry.",
-  intentSpec: "# Intent spec — dimensions\nuse-case, terrain, budget, compatibility.",
-  userSpec:
-    "# User spec (seeded partial)\n## Domain-relevant facts (soft)\n- Endurance geometry.\n"
-    + "## Hard constraints (INVIOLABLE)\n- HARD-NO: rim brakes.",
-  playbook: "# Buying taste (seeded partial)\nBrand-agnostic.",
-} as const;
-
-/** Same expert, the already-present user_spec AUGMENTED in place (a fact the user
- * surfaced mid-query) — domain/intent unchanged. */
-const SDS_USER_AUGMENTED = {
-  ...SDS_CREATED,
-  userSpec:
-    "# User spec\n## Domain-relevant facts (soft)\n- Endurance geometry, inseam 81cm.\n"
-    + "## Hard constraints (INVIOLABLE)\n- HARD-NO: rim brakes.",
-} as const;
-
-/** Same expert, the user_spec then SHARPENED again (a refine targeting a user_spec
- * hard constraint) PLUS the playbook taste augmented in place. */
-const SDS_USER_REFINED = {
-  ...SDS_USER_AUGMENTED,
-  userSpec:
-    "# User spec\n## Domain-relevant facts (soft)\n- Endurance geometry, inseam 81cm.\n"
-    + "## Hard constraints (INVIOLABLE)\n- HARD-NO: rim brakes.\n"
-    + "- HARD-NO: anything over 9kg (the user said it three times).",
-  playbook: "# Buying taste\nBudget ~€1500; brand-agnostic.",
-} as const;
-
-describe("per-query augment — re-materialize AUGMENTS an already-present user_spec/playbook in place", () => {
-  it("a second materialize with an augmented userSpec overwrites user_spec.md in place; domain/intent survive untouched", () => {
-    const first = materializeProfile({ ...SDS_CREATED });
-    expect(first.ok).toBe(true);
-    if (!first.ok) return;
-    const dir = getAgentArtefactDir(SDS_CREATED.agentId);
-    // The user_spec is PRESENT from creation (round-2) — augmentation overwrites it.
-    expect(readFileSync(join(dir, "user_spec.md"), "utf8")).toBe(SDS_CREATED.userSpec);
-
-    const second = materializeProfile({ ...SDS_USER_AUGMENTED });
-    expect(second.ok).toBe(true);
-    if (!second.ok) return;
-
-    // user_spec.md now holds the augmented fact + hard constraint…
-    expect(readFileSync(join(dir, "user_spec.md"), "utf8")).toBe(SDS_USER_AUGMENTED.userSpec);
-    expect(readFileSync(join(dir, "user_spec.md"), "utf8")).toContain("inseam 81cm");
-    // …and the other specs are untouched by a user-side augmentation.
-    expect(readFileSync(join(dir, "domain_spec.md"), "utf8")).toBe(SDS_CREATED.domainSpec);
-    expect(readFileSync(join(dir, "intent_spec.md"), "utf8")).toBe(SDS_CREATED.intentSpec);
-    expect(readFileSync(join(dir, "playbook.md"), "utf8")).toBe(SDS_CREATED.playbook);
-    expect(walkFiles(dir).filter((f) => f.includes(".tmp"))).toEqual([]);
-  });
-
-  it("a later refine sharpens user_spec AND augments the playbook taste; domain/intent still survive", () => {
-    materializeProfile({ ...SDS_CREATED });
-    materializeProfile({ ...SDS_USER_AUGMENTED });
-    const dir = getAgentArtefactDir(SDS_CREATED.agentId);
-
-    const third = materializeProfile({ ...SDS_USER_REFINED });
-    expect(third.ok).toBe(true);
-    if (!third.ok) return;
-
-    expect(readFileSync(join(dir, "user_spec.md"), "utf8")).toBe(SDS_USER_REFINED.userSpec);
-    expect(readFileSync(join(dir, "user_spec.md"), "utf8")).toContain("over 9kg");
-    // The buying taste (playbook) is augmented in place…
-    expect(readFileSync(join(dir, "playbook.md"), "utf8")).toBe(SDS_USER_REFINED.playbook);
-    // …and the required specs survive.
-    expect(readFileSync(join(dir, "domain_spec.md"), "utf8")).toBe(SDS_CREATED.domainSpec);
-    expect(readFileSync(join(dir, "intent_spec.md"), "utf8")).toBe(SDS_CREATED.intentSpec);
-  });
-
-  it("the round-trip closes: read after a user_spec refine returns the UPDATED user spec, not the stale one", () => {
-    materializeProfile({ ...SDS_CREATED });
-    materializeProfile({ ...SDS_USER_AUGMENTED });
-    materializeProfile({ ...SDS_USER_REFINED });
-    const read = readAgentProfile(SDS_CREATED.agentId);
+    const read = readAgentProfile(AGENT_ID, "road-cycling");
     expect(read.ok).toBe(true);
     if (!read.ok) return;
-    expect(read.userSpec).toBe(SDS_USER_REFINED.userSpec);
-    expect(read.userSpec).not.toBe(SDS_USER_AUGMENTED.userSpec);
-    // The intent spec (the persisted dimension schema) is unchanged — a user-spec
-    // refine is not an intent-spec rewrite.
-    expect(read.intentSpec).toBe(SDS_CREATED.intentSpec);
-  });
-
-  it("refine can target the intent_spec.md SCHEMA in place (re-derived dimensions persist; the per-query intent is never persisted)", () => {
-    // Correction 4: intent_spec.md is refine-mutable (the persisted dimension
-    // schema). A re-materialize with an updated intentSpec overwrites the schema in
-    // place — but NO intent.md of filled per-query values is ever written.
-    materializeProfile({ ...SDS_CREATED });
-    const dir = getAgentArtefactDir(SDS_CREATED.agentId);
-    const newIntentSchema =
-      "# Intent spec — dimensions (v2)\nuse-case, terrain, budget, timeline,"
-      + " compatibility, performance priorities, aesthetics, weight-weenie-ness.";
-    const refined = materializeProfile({ ...SDS_CREATED, intentSpec: newIntentSchema });
-    expect(refined.ok).toBe(true);
-    if (!refined.ok) return;
-    expect(readFileSync(join(dir, "intent_spec.md"), "utf8")).toBe(newIntentSchema);
-    // The schema overwrote in place; no intent.md instance file appears.
-    expect(existsSync(join(dir, "intent.md"))).toBe(false);
+    expect(read.domainSpec).toBe(CYCLING_V2.domainSpec);
+    expect(read.domainSpec).not.toBe(CYCLING_V1.domainSpec);
+    // The unchanged dimensions are preserved across the refine.
+    expect(read.intentSpec).toBe(CYCLING_V1.intentSpec);
   });
 });
 
-describe("refine SDS layers — a failed re-write leaves the PRIOR layers intact", () => {
+describe("re-mint atomicity — a failed re-mint of an EXISTING domain is DIR-PRESERVING (never deletes a domain the user has)", () => {
+  // chmod 0500 can't block writes for root — skip there rather than false-fail.
   const asRoot = typeof process.getuid === "function" && process.getuid() === 0;
-
   it.skipIf(asRoot)(
-    "when the re-write fails (dir read-only), the original user_spec + domain_spec survive — never a half-refined SDS expert",
+    "when the re-write into an existing leaf fails (leaf made read-only), the PRIOR pack survives intact",
     () => {
-      materializeProfile({ ...SDS_CREATED });
-      materializeProfile({ ...SDS_USER_AUGMENTED });
-      const dir = getAgentArtefactDir(SDS_CREATED.agentId);
+      createShopper();
+      expect(mint(CYCLING_V1).ok).toBe(true);
+      const leaf = domainDir("road-cycling");
 
-      // Block the re-write: make the PRE-EXISTING dir read-only so the tmp write
-      // fails EACCES. The dirPreexisted guard must NOT tear the expert down.
-      chmodSync(dir, 0o500);
-      const refined = materializeProfile({ ...SDS_USER_REFINED });
-      expect(refined.ok).toBe(false);
-      if (refined.ok) return;
-      expect(refined.kind).toBe("persistence_failed");
-      chmodSync(dir, 0o700);
+      // Make the EXISTING leaf read-only so the refine re-write's tmp-file write
+      // inside it fails EACCES.
+      chmodSync(leaf, 0o500);
+      const result = mint(CYCLING_V2);
+      chmodSync(leaf, 0o700); // restore for assertions + cleanup
 
-      // The PRIOR SDS artefacts survive untouched — the augmented bodies, not the
-      // refined ones, and not a partial mix.
-      expect(readFileSync(join(dir, "user_spec.md"), "utf8")).toBe(SDS_USER_AUGMENTED.userSpec);
-      expect(readFileSync(join(dir, "domain_spec.md"), "utf8")).toBe(SDS_CREATED.domainSpec);
-      expect(readFileSync(join(dir, "intent_spec.md"), "utf8")).toBe(SDS_CREATED.intentSpec);
-      expect(walkFiles(dir).filter((f) => f.includes(".tmp"))).toEqual([]);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.kind).toBe("persistence_failed");
+
+      // DIR-PRESERVING: the existing domain leaf is NOT torn down (unlike a failed
+      // NEW-domain mint) — it holds the prior pack, which survives byte-for-byte.
+      expect(existsSync(leaf)).toBe(true);
+      expect(readFileSync(join(leaf, "domain_spec.md"), "utf8")).toBe(CYCLING_V1.domainSpec);
+      expect(readFileSync(join(leaf, "intent_spec.md"), "utf8")).toBe(CYCLING_V1.intentSpec);
+      // Still registered — a failed refine never de-registers a domain the user has.
+      expect(
+        Object.keys((readManifest()["domains"] ?? {}) as Record<string, unknown>),
+      ).toEqual(["road-cycling"]);
+      // The prior pack is still readable, never served half-refined.
+      const read = readAgentProfile(AGENT_ID, "road-cycling");
+      expect(read.ok).toBe(true);
+      if (!read.ok) return;
+      expect(read.domainSpec).toBe(CYCLING_V1.domainSpec);
     },
   );
+
+  it("a successful refine leaves only the three pack files in the leaf (no .tmp survivor)", () => {
+    createShopper();
+    expect(mint(CYCLING_V1).ok).toBe(true);
+    expect(mint(CYCLING_V2).ok).toBe(true);
+    const leaf = domainDir("road-cycling");
+    for (const n of ["domain_spec.md", "intent_spec.md", "playbook.md"]) {
+      expect(statSync(join(leaf, n)).isFile()).toBe(true);
+    }
+  });
 });

--- a/src/__tests__/tools/profile-manage.test.ts
+++ b/src/__tests__/tools/profile-manage.test.ts
@@ -1,38 +1,24 @@
 /**
- * UNIT — sil_profile_list / sil_profile_get / sil_profile_remove tools:
- * registration shape + the structured envelope each maps the store outcome to
- * (tier: unit, mock api + temp data dir, no network, no host).
+ * UNIT — sil_profile_list / sil_profile_get / sil_profile_remove tools after the
+ * single-multi-domain shopper reshape (tier: unit, mock api + temp data dir, no
+ * network, no host).
  *
- * Card: list-view-and-remove-local-expert-agents. The pure store-primitive
- * invariants live in `lib/profile-store-manage.test.ts`; here we pin the TOOL
- * boundary — the three management tools that wrap list/read/remove:
+ * Card: single-multi-domain-sil-shopper — Slice 1. The lifecycle tools shift from
+ * "experts" to "DOMAINS" semantics (same 4 tool NAMES — manifest-contract stays
+ * green untouched):
  *
- *   sil_profile_list   (no args)      → { status:"ok", experts[], unreadable[] }
- *   sil_profile_get    (agentId)      → ok | not_found | invalid_request
- *   sil_profile_remove (agentId)      → removed | not_found | invalid_request
- *                                       | persistence_failed
+ *   sil_profile_list   (no args)              → { status:"ok", shoppers[], unreadable[] }
+ *   sil_profile_get    ({ agentId, domainSlug? })
+ *        - no slug ⇒ shopper overview (identity + shared user_spec + domain index)
+ *        - slug    ⇒ that domain's 3 bodies + the shared user_spec
+ *   sil_profile_remove ({ agentId, domainSlug })  — domainSlug REQUIRED: remove ONE
+ *        domain pack (artefact-only), NOT the shopper. No omit-deletes-everything.
  *
- * Adversarial, behaviour-first: the tools must map every store variant to the
- * agreed envelope, and the destructive one (remove) must clear EXACTLY the named
- * expert's dir while a sibling expert's dir survives (the scoped-delete +
- * non-destructiveness criteria at the tool seam). Reads no token (generic
- * shopping is identity-decoupled).
+ * The pure store-primitive invariants live in lib/profile-store-manage.test.ts;
+ * here we pin the TOOL boundary — registration shapes + the structured envelopes,
+ * and that remove clears exactly the named domain leaf while a sibling survives.
  *
- * Hermetic via the SIL_DATA_DIR temp-dir override (mirrors
- * profile-materialize.test.ts:68-80).
- *
- * Contract this file pins for the implementation (expert-developer),
- * `src/tools/profile.ts#registerProfileTools(api)`:
- *   - registers sil_profile_list (Type.Object({})), sil_profile_get and
- *     sil_profile_remove (Type.Object({agentId})) — agentId required;
- *   - list  → jsonResult({status:"ok", experts, unreadable}), createdAt DESC;
- *   - get   → {status:"ok", agentId, name, domainSpec, intentSpec, userSpec,
- *     playbook, profilePath, createdAt} (NO persona; all four present) /
- *     {status:"not_found", agentId, …recovery} /
- *     {status:"invalid_request", field, message};
- *   - remove→ {status:"removed", agentId} / {status:"not_found", agentId} /
- *     {status:"invalid_request", field} / {status:"persistence_failed", error,
- *     recovery} — and clears only the named expert's dir.
+ * Hermetic via the SIL_DATA_DIR temp-dir override.
  */
 
 import {
@@ -56,6 +42,7 @@ import { registerProfileTools } from "../../tools/profile.js";
 import {
   materializeProfile,
   getAgentArtefactDir,
+  type ProfileSpec,
 } from "../../lib/profile-store.js";
 import { getTokensPath } from "../../lib/credentials.js";
 import {
@@ -80,42 +67,43 @@ function payloadOf(result: { content: { text?: string }[] }): Record<string, unk
   return JSON.parse(text) as Record<string, unknown>;
 }
 
-/** Materialize an expert via the real store writer (never a hand fixture), so
- * the tools read the genuine on-disk shape. Optionally pin createdAt.
- *
- * After the SDS reframe the store holds NO persona. Round-2: ALL FOUR specs are
- * REQUIRED and present from creation, so the fixture ALWAYS supplies all four.
- * Callers may override any of the four via opts. */
-function makeExpert(
+const SHOPPER = "sil-shopper";
+const USER_SPEC = "# User spec (shared)\n- Ships to Berlin.\nHARD-NO: leather.";
+
+function pack(slug: string, name: string): NonNullable<ProfileSpec["domain"]> {
+  return {
+    slug,
+    name,
+    domainSpec: `# Domain spec — ${name}\nResearched mechanics.`,
+    intentSpec: `# Intent spec — ${name}\nDecomposition dimensions.`,
+    playbook: `# Taste — ${name}\nSeeded preferences.`,
+  };
+}
+
+/** Create the shopper, then mint each (slug → name) domain via the real store. */
+function makeShopper(
   agentId: string,
-  opts: {
-    name?: string;
-    domainSpec?: string;
-    intentSpec?: string;
-    userSpec?: string;
-    playbook?: string;
-    createdAt?: string;
-  } = {},
+  domains: ReadonlyArray<readonly [string, string]> = [],
 ): void {
-  const result = materializeProfile({
-    agentId,
-    name: opts.name ?? `Expert ${agentId}`,
-    domainSpec: opts.domainSpec ?? `# Domain spec for ${agentId}\nResearched dimensions.`,
-    intentSpec: opts.intentSpec ?? `# Intent spec for ${agentId}\nDecomposition dimensions.`,
-    userSpec: opts.userSpec ?? `# User spec for ${agentId}\nFacts + hard constraints.`,
-    playbook: opts.playbook ?? `# Buying taste for ${agentId}\nSeeded preferences.`,
-  });
-  if (!result.ok) throw new Error(`fixture setup failed: ${JSON.stringify(result)}`);
-  if (opts.createdAt !== undefined) {
-    const manifestPath = join(getAgentArtefactDir(agentId), "profile.json");
-    const m = JSON.parse(readFileSync(manifestPath, "utf8")) as Record<string, unknown>;
-    m["createdAt"] = opts.createdAt;
-    writeFileSync(manifestPath, JSON.stringify(m, null, 2) + "\n");
+  const created = materializeProfile({ agentId, name: `Shopper ${agentId}`, userSpec: USER_SPEC });
+  if (!created.ok) throw new Error(`create failed: ${JSON.stringify(created)}`);
+  for (const [slug, name] of domains) {
+    const r = materializeProfile({
+      agentId,
+      name: `Shopper ${agentId}`,
+      userSpec: USER_SPEC,
+      domain: pack(slug, name),
+    });
+    if (!r.ok) throw new Error(`mint ${slug} failed: ${JSON.stringify(r)}`);
   }
 }
 
+function domainDir(slug: string, agentId = SHOPPER): string {
+  return join(getAgentArtefactDir(agentId), "domains", slug);
+}
+
 beforeEach(() => {
-  dataDir = mkdtempSync(join(tmpdir(), "sil-profile-manage-tool-"));
+  dataDir = mkdtempSync(join(tmpdir(), "sil-manage-tool-"));
   priorSilDataDir = process.env["SIL_DATA_DIR"];
   process.env["SIL_DATA_DIR"] = dataDir;
   api = createMockPluginApi();
@@ -136,17 +124,12 @@ describe("management tools — registration shape", () => {
   it("registers sil_profile_list with a no-arg TypeBox object schema", () => {
     const tool = getTool(api, LIST);
     expect(tool.name).toBe(LIST);
-    const schema = tool.parameters as unknown as {
-      type?: string;
-      properties?: Record<string, unknown>;
-      required?: string[];
-    };
+    const schema = tool.parameters as unknown as { type?: string; required?: string[] };
     expect(schema.type).toBe("object");
-    // No required args — list takes nothing.
     expect(schema.required ?? []).toEqual([]);
   });
 
-  it("registers sil_profile_get with a required agentId string param", () => {
+  it("registers sil_profile_get with a required agentId + an OPTIONAL domainSlug", () => {
     const tool = getTool(api, GET);
     expect(tool.name).toBe(GET);
     const schema = tool.parameters as unknown as {
@@ -156,10 +139,13 @@ describe("management tools — registration shape", () => {
     };
     expect(schema.type).toBe("object");
     expect(schema.properties?.["agentId"]?.type).toBe("string");
+    expect(schema.properties?.["domainSlug"]?.type).toBe("string");
     expect(schema.required ?? []).toContain("agentId");
+    // domainSlug is optional — get with no slug returns the shopper overview.
+    expect(schema.required ?? []).not.toContain("domainSlug");
   });
 
-  it("registers sil_profile_remove with a required agentId string param", () => {
+  it("registers sil_profile_remove with BOTH agentId and domainSlug required (no omit-deletes-everything)", () => {
     const tool = getTool(api, REMOVE);
     expect(tool.name).toBe(REMOVE);
     const schema = tool.parameters as unknown as {
@@ -169,7 +155,9 @@ describe("management tools — registration shape", () => {
     };
     expect(schema.type).toBe("object");
     expect(schema.properties?.["agentId"]?.type).toBe("string");
+    expect(schema.properties?.["domainSlug"]?.type).toBe("string");
     expect(schema.required ?? []).toContain("agentId");
+    expect(schema.required ?? []).toContain("domainSlug");
   });
 });
 
@@ -178,180 +166,172 @@ describe("management tools — registration shape", () => {
 // ===========================================================================
 
 describe("sil_profile_list — ok envelope", () => {
-  it("empty store → status ok with empty experts (a normal outcome)", async () => {
-    const tool = getTool(api, LIST);
-    const payload = payloadOf(await tool.execute("c-1", {}));
+  it("empty store → status ok with empty shoppers (a normal outcome)", async () => {
+    const payload = payloadOf(await getTool(api, LIST).execute("c-1", {}));
     expect(payload["status"]).toBe("ok");
-    expect(payload["experts"]).toEqual([]);
+    expect(payload["shoppers"]).toEqual([]);
     expect(payload["unreadable"]).toEqual([]);
   });
 
-  it("lists every expert (name + agentId from the manifest), createdAt DESC", async () => {
-    // Round-2: with all four specs required+present, a hasPlaybook flag is trivially
-    // true for every expert and carries no discriminating signal — so we do NOT
-    // assert it. The durable behaviour is enumeration + createdAt-DESC ordering +
-    // the manifest name.
-    makeExpert("oldest", { name: "Oldest", createdAt: "2026-01-01T00:00:00.000Z" });
-    makeExpert("newest", { name: "Newest", createdAt: "2026-06-22T00:00:00.000Z" });
-
-    const tool = getTool(api, LIST);
-    const payload = payloadOf(await tool.execute("c-2", {}));
+  it("a shopper with N domains → its identity + domain index (slug/name) from the map", async () => {
+    makeShopper(SHOPPER, [
+      ["road-cycling", "Road cycling"],
+      ["running-shoes", "Running shoes"],
+    ]);
+    const payload = payloadOf(await getTool(api, LIST).execute("c-2", {}));
     expect(payload["status"]).toBe("ok");
-    const experts = payload["experts"] as Array<Record<string, unknown>>;
-    // Most-recently-created first.
-    expect(experts.map((e) => e["agentId"])).toEqual(["newest", "oldest"]);
-    expect(experts[0]!["name"]).toBe("Newest");
-    expect(experts[1]!["name"]).toBe("Oldest");
+    const shoppers = payload["shoppers"] as Array<Record<string, unknown>>;
+    const shopper = shoppers.find((s) => s["agentId"] === SHOPPER);
+    expect(shopper).toBeDefined();
+    const domains = shopper!["domains"] as Array<Record<string, unknown>>;
+    expect(domains.map((d) => d["slug"]).sort()).toEqual(["road-cycling", "running-shoes"]);
   });
 
-  it("one corrupt manifest → healthy experts still list, broken one in unreadable[]", async () => {
-    makeExpert("healthy", { name: "Healthy" });
-    makeExpert("broken", { name: "Broken" });
+  it("an empty-`domains` shopper still lists (status ok, empty domain list — NOT not_found)", async () => {
+    makeShopper(SHOPPER, []);
+    const payload = payloadOf(await getTool(api, LIST).execute("c-3", {}));
+    expect(payload["status"]).toBe("ok");
+    const shoppers = payload["shoppers"] as Array<Record<string, unknown>>;
+    const shopper = shoppers.find((s) => s["agentId"] === SHOPPER);
+    expect(shopper).toBeDefined();
+    expect(shopper!["domains"]).toEqual([]);
+  });
+
+  it("one corrupt manifest → healthy shopper still lists, broken one in unreadable[]", async () => {
+    makeShopper("healthy", [["a-niche", "A niche"]]);
+    makeShopper("broken", []);
     writeFileSync(join(getAgentArtefactDir("broken"), "profile.json"), "not json {{{");
 
-    const tool = getTool(api, LIST);
-    const payload = payloadOf(await tool.execute("c-3", {}));
+    const payload = payloadOf(await getTool(api, LIST).execute("c-4", {}));
     expect(payload["status"]).toBe("ok");
-    const experts = payload["experts"] as Array<Record<string, unknown>>;
+    const shoppers = payload["shoppers"] as Array<Record<string, unknown>>;
     const unreadable = payload["unreadable"] as Array<Record<string, unknown>>;
-    expect(experts.map((e) => e["agentId"])).toEqual(["healthy"]);
+    expect(shoppers.map((s) => s["agentId"])).toEqual(["healthy"]);
     expect(unreadable.map((u) => u["agentId"])).toContain("broken");
   });
 });
 
 // ===========================================================================
-// sil_profile_get
+// sil_profile_get — overview vs per-domain
 // ===========================================================================
 
-describe("sil_profile_get — ok envelope (full detail from artefacts)", () => {
-  it("returns status ok with name, the spec bodies, the lazy bodies, profilePath, createdAt — NO persona", async () => {
-    makeExpert("gift-buyer", {
-      name: "Gift Buyer",
-      domainSpec: "# Gift-buying domain spec\nRecipient, occasion, budget dimensions.",
-      intentSpec: "# Intent spec\nrecipient, occasion, budget.",
-      userSpec: "# User spec\nHARD-NO: nothing over €50.",
-      playbook: "# Buying taste\nValue-conscious.",
-    });
-    const tool = getTool(api, GET);
-    const payload = payloadOf(await tool.execute("c-4", { agentId: "gift-buyer" }));
+describe("sil_profile_get — overview (no domainSlug): identity + shared user_spec + domain index", () => {
+  it("returns status ok with the identity, the shared user_spec, and the domain index", async () => {
+    makeShopper(SHOPPER, [["road-cycling", "Road cycling"]]);
+    const payload = payloadOf(await getTool(api, GET).execute("c-5", { agentId: SHOPPER }));
     expect(payload["status"]).toBe("ok");
-    expect(payload["agentId"]).toBe("gift-buyer");
-    expect(payload["name"]).toBe("Gift Buyer");
-    expect(payload["domainSpec"]).toBe(
-      "# Gift-buying domain spec\nRecipient, occasion, budget dimensions.",
-    );
-    expect(payload["intentSpec"]).toBe("# Intent spec\nrecipient, occasion, budget.");
-    expect(payload["userSpec"]).toBe("# User spec\nHARD-NO: nothing over €50.");
-    expect(payload["playbook"]).toBe("# Buying taste\nValue-conscious.");
-    // Persona left the store — the envelope carries none.
-    expect(payload["persona"]).toBeUndefined();
-    expect(payload["profilePath"]).toBe(
-      join(getAgentArtefactDir("gift-buyer"), "profile.json"),
-    );
-    expect(typeof payload["createdAt"]).toBe("string");
+    expect(payload["agentId"]).toBe(SHOPPER);
+    expect(payload["userSpec"]).toBe(USER_SPEC);
+    const domains = payload["domains"] as Array<Record<string, unknown>>;
+    expect(domains.map((d) => d["slug"])).toEqual(["road-cycling"]);
   });
+});
 
-  it("returns ALL FOUR spec bodies for a created expert (round-2: none is absent at creation)", async () => {
-    makeExpert("grocery", { name: "Grocery" }); // all four seeded by default
-    const tool = getTool(api, GET);
-    const payload = payloadOf(await tool.execute("c-5", { agentId: "grocery" }));
+describe("sil_profile_get — per-domain (domainSlug): the 3 bodies + the shared user_spec", () => {
+  it("returns status ok with domainSpec + intentSpec + playbook AND the shared user_spec", async () => {
+    makeShopper(SHOPPER, [["road-cycling", "Road cycling"]]);
+    const payload = payloadOf(
+      await getTool(api, GET).execute("c-6", { agentId: SHOPPER, domainSlug: "road-cycling" }),
+    );
     expect(payload["status"]).toBe("ok");
-    // All four specs are present from creation now.
-    expect(typeof payload["domainSpec"]).toBe("string");
-    expect(typeof payload["intentSpec"]).toBe("string");
-    expect(typeof payload["userSpec"]).toBe("string");
-    expect(typeof payload["playbook"]).toBe("string");
+    expect(payload["slug"]).toBe("road-cycling");
+    expect(payload["domainSpec"]).toBe("# Domain spec — Road cycling\nResearched mechanics.");
+    expect(payload["intentSpec"]).toBe("# Intent spec — Road cycling\nDecomposition dimensions.");
+    expect(payload["playbook"]).toBe("# Taste — Road cycling\nSeeded preferences.");
+    expect(payload["userSpec"]).toBe(USER_SPEC);
   });
 });
 
 describe("sil_profile_get — graceful failures", () => {
-  it("unknown id → status not_found naming the agentId, with a list-then-retry recovery hint", async () => {
-    makeExpert("exists", {}); // a neighbour, to prove get is scoped
-    const tool = getTool(api, GET);
-    const payload = payloadOf(await tool.execute("c-6", { agentId: "ghost" }));
+  it("unknown agentId → status not_found with a list-then-retry recovery hint", async () => {
+    makeShopper(SHOPPER, [["road-cycling", "Road cycling"]]);
+    const payload = payloadOf(await getTool(api, GET).execute("c-7", { agentId: "ghost" }));
     expect(payload["status"]).toBe("not_found");
     expect(payload["agentId"]).toBe("ghost");
-    // The recovery hint steers the agent to list, not to re-register.
     expect(payload["recovery"]).toBe("sil_profile_list");
-    // No stack trace / raw path leaked — the message is a plain string.
-    expect(typeof payload["message"]).toBe("string");
   });
 
-  it.each(["../escape", "gift/buyer", "..", "main", "Gift-Buyer"])(
-    "traversal/main/malformed id %j → status invalid_request(field=agentId), reads nothing",
+  it.each(["../escape", "shop/per", "..", "main", "Sil-Shopper"])(
+    "a traversal/main agentId %j → status invalid_request(field=agentId)",
     async (bad) => {
-      const tool = getTool(api, GET);
-      const payload = payloadOf(await tool.execute("c-7", { agentId: bad }));
+      const payload = payloadOf(await getTool(api, GET).execute("c-8", { agentId: bad }));
       expect(payload["status"]).toBe("invalid_request");
       expect(payload["field"]).toBe("agentId");
-      expect(typeof payload["message"]).toBe("string");
     },
   );
-});
 
-// ===========================================================================
-// sil_profile_remove
-// ===========================================================================
-
-describe("sil_profile_remove — clears the target dir, sibling survives (scoped)", () => {
-  it("removed → status removed and the target dir is gone; a sibling expert's dir survives", async () => {
-    makeExpert("target", { name: "Target", playbook: "doomed" });
-    makeExpert("survivor", { name: "Survivor", playbook: "keep me" });
-    const targetDir = getAgentArtefactDir("target");
-    const survivorDir = getAgentArtefactDir("survivor");
-    expect(existsSync(targetDir)).toBe(true);
-
-    const tool = getTool(api, REMOVE);
-    const payload = payloadOf(await tool.execute("c-8", { agentId: "target" }));
-    expect(payload["status"]).toBe("removed");
-    expect(payload["agentId"]).toBe("target");
-
-    // Scoped: target gone, sibling untouched.
-    expect(existsSync(targetDir)).toBe(false);
-    expect(existsSync(survivorDir)).toBe(true);
-    expect(existsSync(join(survivorDir, "profile.json"))).toBe(true);
-    expect(existsSync(join(survivorDir, "playbook.md"))).toBe(true);
+  it("a traversal domainSlug → status invalid_request(field=domainSlug)", async () => {
+    makeShopper(SHOPPER, [["road-cycling", "Road cycling"]]);
+    const payload = payloadOf(
+      await getTool(api, GET).execute("c-9", { agentId: SHOPPER, domainSlug: "../escape" }),
+    );
+    expect(payload["status"]).toBe("invalid_request");
+    expect(payload["field"]).toBe("domainSlug");
   });
 });
 
-describe("sil_profile_remove — graceful + fail-closed", () => {
-  it("unknown id → status not_found (idempotent: a re-run is also not_found), deletes nothing", async () => {
-    makeExpert("neighbour", { name: "Neighbour" });
-    const tool = getTool(api, REMOVE);
+// ===========================================================================
+// sil_profile_remove — one domain pack, scoped
+// ===========================================================================
 
-    const first = payloadOf(await tool.execute("c-9", { agentId: "ghost" }));
+describe("sil_profile_remove — clears one domain leaf, sibling + shopper survive (scoped)", () => {
+  it("removed → status removed; the target leaf is gone; a sibling domain + the shopper survive", async () => {
+    makeShopper(SHOPPER, [
+      ["road-cycling", "Road cycling"],
+      ["running-shoes", "Running shoes"],
+    ]);
+    expect(existsSync(domainDir("road-cycling"))).toBe(true);
+
+    const payload = payloadOf(
+      await getTool(api, REMOVE).execute("c-10", { agentId: SHOPPER, domainSlug: "road-cycling" }),
+    );
+    expect(payload["status"]).toBe("removed");
+    expect(payload["domainSlug"]).toBe("road-cycling");
+
+    expect(existsSync(domainDir("road-cycling"))).toBe(false);
+    expect(existsSync(domainDir("running-shoes"))).toBe(true);
+    // The shopper + the shared user_spec survive (artefact-only removal).
+    expect(existsSync(join(getAgentArtefactDir(SHOPPER), "user_spec.md"))).toBe(true);
+  });
+});
+
+describe("sil_profile_remove — required slug, idempotent, fail-closed", () => {
+  it("a MISSING domainSlug → status invalid_request(field=domainSlug), deletes nothing", async () => {
+    makeShopper(SHOPPER, [["road-cycling", "Road cycling"]]);
+    // Omit domainSlug entirely — the tool must refuse, never fall through to a
+    // whole-shopper delete.
+    const payload = payloadOf(await getTool(api, REMOVE).execute("c-11", { agentId: SHOPPER }));
+    expect(payload["status"]).toBe("invalid_request");
+    expect(payload["field"]).toBe("domainSlug");
+    expect(existsSync(domainDir("road-cycling"))).toBe(true);
+    expect(existsSync(getAgentArtefactDir(SHOPPER))).toBe(true);
+  });
+
+  it("absent slug → status not_found (idempotent: a re-run is also not_found), deletes nothing", async () => {
+    makeShopper(SHOPPER, [["road-cycling", "Road cycling"]]);
+    const first = payloadOf(
+      await getTool(api, REMOVE).execute("c-12", { agentId: SHOPPER, domainSlug: "never-minted" }),
+    );
     expect(first["status"]).toBe("not_found");
-    expect(first["agentId"]).toBe("ghost");
-    expect(existsSync(getAgentArtefactDir("neighbour"))).toBe(true);
-
-    // Idempotent re-run.
-    const second = payloadOf(await tool.execute("c-10", { agentId: "ghost" }));
+    expect(existsSync(domainDir("road-cycling"))).toBe(true);
+    const second = payloadOf(
+      await getTool(api, REMOVE).execute("c-13", { agentId: SHOPPER, domainSlug: "never-minted" }),
+    );
     expect(second["status"]).toBe("not_found");
   });
 
-  it.each(["../escape", "gift/buyer", "..", "main", "Gift-Buyer"])(
-    "traversal/main/malformed id %j → status invalid_request(field=agentId), deletes nothing",
+  it.each(["../escape", "road/cycling", "..", "main", "Road-Cycling"])(
+    "a traversal/main domainSlug %j → status invalid_request(field=domainSlug), deletes nothing",
     async (bad) => {
-      makeExpert("alpha", { name: "Alpha", playbook: "keep" });
-      const tool = getTool(api, REMOVE);
-      const payload = payloadOf(await tool.execute("c-11", { agentId: bad }));
+      makeShopper(SHOPPER, [["road-cycling", "Road cycling"]]);
+      const payload = payloadOf(
+        await getTool(api, REMOVE).execute("c-14", { agentId: SHOPPER, domainSlug: bad }),
+      );
       expect(payload["status"]).toBe("invalid_request");
-      expect(payload["field"]).toBe("agentId");
-      // The real expert is untouched — the bad id deleted nothing.
-      expect(existsSync(getAgentArtefactDir("alpha"))).toBe(true);
+      expect(payload["field"]).toBe("domainSlug");
+      expect(existsSync(domainDir("road-cycling"))).toBe(true);
     },
   );
-
-  it("removed → re-remove of the same id returns not_found (full removed→not_found cycle)", async () => {
-    makeExpert("transient", { name: "Transient" });
-    const tool = getTool(api, REMOVE);
-    expect(payloadOf(await tool.execute("c-12", { agentId: "transient" }))["status"]).toBe(
-      "removed",
-    );
-    expect(payloadOf(await tool.execute("c-13", { agentId: "transient" }))["status"]).toBe(
-      "not_found",
-    );
-  });
 });
 
 // ===========================================================================
@@ -360,10 +340,10 @@ describe("sil_profile_remove — graceful + fail-closed", () => {
 
 describe("management tools — no identity coupling (no token side effect)", () => {
   it("list, get, and remove read/write no token across a full cycle", async () => {
-    makeExpert("cycle", { name: "Cycle", playbook: "pb" });
-    await getTool(api, LIST).execute("c-14", {});
-    await getTool(api, GET).execute("c-15", { agentId: "cycle" });
-    await getTool(api, REMOVE).execute("c-16", { agentId: "cycle" });
+    makeShopper(SHOPPER, [["road-cycling", "Road cycling"]]);
+    await getTool(api, LIST).execute("c-15", {});
+    await getTool(api, GET).execute("c-16", { agentId: SHOPPER, domainSlug: "road-cycling" });
+    await getTool(api, REMOVE).execute("c-17", { agentId: SHOPPER, domainSlug: "road-cycling" });
     expect(existsSync(getTokensPath())).toBe(false);
   });
 });

--- a/src/__tests__/tools/profile-materialize.test.ts
+++ b/src/__tests__/tools/profile-materialize.test.ts
@@ -1,24 +1,24 @@
 /**
  * UNIT — sil_profile_materialize tool: registration shape + the structured
- * envelope it maps each store outcome to (tier: unit, mock api + temp data dir,
- * no network, no host).
+ * envelope it maps each store outcome to, after the single-multi-domain shopper
+ * reshape (tier: unit, mock api + temp data dir, no network, no host).
  *
- * Card: spec-driven-shopping-sds-for-created-experts — Founder review round 2
- * (PR #33 bounced a SECOND time). After the SDS reframe the tool no longer carries
- * `persona` (the persona is the host SOUL.md, written by the engine via the host
- * CLI). Round-2: it REQUIRES ALL FOUR specs — domainSpec + intentSpec + userSpec +
- * playbook (present non-blank from creation, seeded partial then augmented
- * per-query). The pure artefact-writer invariants live in `lib/profile-store.test.ts`
- * / `lib/profile-store-sds.test.ts`; here we pin the TOOL boundary:
- *   - the tool registers as `sil_profile_materialize` with a TypeBox object
- *     schema carrying agentId / name / domainSpec / intentSpec / userSpec /
- *     playbook — all required — and NO persona;
- *   - a valid spec returns the `ok` envelope with the artefact paths and the
- *     artefacts actually land under $SIL_DATA_DIR/agents/<agentId>/;
- *   - an invalid field returns the `invalid_request` envelope naming the field
- *     and writes nothing;
- *   - the tool makes NO host-config write and reads NO token (no coupling) —
- *     it is the behaviour-artefact half only.
+ * Card: single-multi-domain-sil-shopper — Slice 1. The tool stays ONE tool
+ * (`sil_profile_materialize`) with an OPTIONAL `domain` object — the 8-tool
+ * manifest is FROZEN, so no tool is added/renamed (manifest-contract stays green).
+ * The flat four-spec-per-expert shape is GONE. The params are now agent-level +
+ * an optional domain pack:
+ *
+ *   { agentId, name, userSpec, domain?: { slug, name, domainSpec, intentSpec, playbook } }
+ *
+ *   - NO domain  ⇒ create the shopper (shared user_spec + `domains: {}`);
+ *   - WITH domain ⇒ lazily mint domains/<slug>/* + a shared-user_spec rewrite +
+ *     an upsert into `domains[slug]`, one atomic call.
+ *
+ * The pure store invariants live in lib/profile-store*.test.ts; here we pin the
+ * TOOL boundary: the schema (agentId/name/userSpec required; domain optional;
+ * NO top-level domainSpec/intentSpec/playbook), and the ok / invalid_request
+ * envelopes for both a create and a mint.
  *
  * Hermetic via the SIL_DATA_DIR temp-dir override.
  */
@@ -30,7 +30,7 @@ import {
   beforeEach,
   afterEach,
 } from "vitest";
-import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { mkdtempSync, rmSync, existsSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -56,22 +56,34 @@ function payloadOf(result: { content: { text?: string }[] }): Record<string, unk
   return JSON.parse(text) as Record<string, unknown>;
 }
 
-const GOOD_PARAMS = {
-  agentId: "gift-buyer",
-  name: "Gift Buyer",
-  domainSpec: "# Gift-buying domain spec\nDimensions: recipient, occasion, budget, taste.",
-  intentSpec: "# Intent spec — dimensions\nrecipient, occasion, budget, timeline, taste.",
-  userSpec: "# User spec\nBuys for partner.\nHARD-NO: nothing over €50.",
-  playbook: "# Buying taste\nValue-conscious.",
+const USER_SPEC = "# User spec (shared)\n- Ships to Berlin.\nHARD-NO: leather (ethics).";
+
+/** Create the shopper (no domain). */
+const CREATE = {
+  agentId: "sil-shopper",
+  name: "sil shopper",
+  userSpec: USER_SPEC,
 };
 
-/** The minimum valid create. After Founder review round 2, all four sil specs are
- * REQUIRED + present from creation — so the minimum create IS the full four-spec
- * create. Kept as a named alias for call-site legibility. */
-const MIN_PARAMS = GOOD_PARAMS;
+const DOMAIN = {
+  slug: "road-cycling",
+  name: "Road cycling",
+  domainSpec: "# Domain spec — road cycling\nFit, gearing, geometry.",
+  intentSpec: "# Intent spec — cycling\nuse-case, terrain, budget, timeline.",
+  playbook: "# Taste — cycling\n~€1500; Shimano over SRAM.",
+};
+
+/** Mint a niche onto the shopper. */
+const MINT = { ...CREATE, domain: DOMAIN };
+
+function readManifest(agentId: string): Record<string, unknown> {
+  return JSON.parse(
+    readFileSync(join(getDataDir(), "agents", agentId, "profile.json"), "utf8"),
+  ) as Record<string, unknown>;
+}
 
 beforeEach(() => {
-  dataDir = mkdtempSync(join(tmpdir(), "sil-profile-tool-"));
+  dataDir = mkdtempSync(join(tmpdir(), "sil-materialize-tool-"));
   priorSilDataDir = process.env["SIL_DATA_DIR"];
   process.env["SIL_DATA_DIR"] = dataDir;
   api = createMockPluginApi();
@@ -84,132 +96,141 @@ afterEach(() => {
   rmSync(dataDir, { recursive: true, force: true });
 });
 
-describe("sil_profile_materialize — registration shape", () => {
-  it("registers a sil_profile_materialize tool with a TypeBox object schema (no persona; ALL FOUR specs required — round-2)", () => {
+describe("sil_profile_materialize — registration shape (agent-level + an optional domain pack)", () => {
+  it("requires agentId/name/userSpec; domain is OPTIONAL; NO top-level domainSpec/intentSpec/playbook", () => {
     const tool = getTool(api, TOOL);
     expect(tool.name).toBe(TOOL);
     const schema = tool.parameters as unknown as {
       type?: string;
-      properties?: Record<string, unknown>;
+      properties?: Record<string, { type?: string; properties?: Record<string, unknown> }>;
       required?: string[];
     };
     expect(schema.type).toBe("object");
-    expect(Object.keys(schema.properties ?? {})).toEqual(
-      expect.arrayContaining(["agentId", "name", "domainSpec", "intentSpec", "userSpec", "playbook"]),
-    );
-    // Persona left the store — it is not a tool param.
-    expect(Object.keys(schema.properties ?? {})).not.toContain("persona");
-    // Round-2: agentId, name, AND all four specs are required (userSpec + playbook
-    // are no longer optional — they are present from creation).
+
+    const props = Object.keys(schema.properties ?? {});
+    expect(props).toEqual(expect.arrayContaining(["agentId", "name", "userSpec", "domain"]));
+    // The flat per-niche specs left the top level — they live inside `domain` now.
+    expect(props).not.toContain("domainSpec");
+    expect(props).not.toContain("intentSpec");
+    expect(props).not.toContain("playbook");
+    expect(props).not.toContain("persona");
+
+    // Only the three agent-level fields are required — domain is optional.
     expect(schema.required).toEqual(
-      expect.arrayContaining([
-        "agentId",
-        "name",
-        "domainSpec",
-        "intentSpec",
-        "userSpec",
-        "playbook",
-      ]),
+      expect.arrayContaining(["agentId", "name", "userSpec"]),
     );
-    expect(schema.required ?? []).not.toContain("persona");
+    expect(schema.required ?? []).not.toContain("domain");
+  });
+
+  it("the optional `domain` object declares slug/name/domainSpec/intentSpec/playbook", () => {
+    const tool = getTool(api, TOOL);
+    const schema = tool.parameters as unknown as {
+      properties?: Record<string, { type?: string; properties?: Record<string, unknown> }>;
+    };
+    const domain = schema.properties?.["domain"];
+    expect(domain?.type).toBe("object");
+    const nested = Object.keys(domain?.properties ?? {});
+    expect(nested).toEqual(
+      expect.arrayContaining(["slug", "name", "domainSpec", "intentSpec", "playbook"]),
+    );
   });
 });
 
-describe("sil_profile_materialize — valid spec materializes the artefacts (ok envelope)", () => {
-  it("returns status ok with the artefact paths, and the artefacts land under $SIL_DATA_DIR/agents/<id>/", async () => {
+describe("sil_profile_materialize — create the shopper (no domain): ok envelope + agent-level files", () => {
+  it("returns status ok and writes ONLY user_spec.md + profile.json (domains:{}), no domains/ dir", async () => {
     const tool = getTool(api, TOOL);
-    const payload = payloadOf(await tool.execute("call-1", { ...GOOD_PARAMS }));
-
+    const payload = payloadOf(await tool.execute("c-1", { ...CREATE }));
     expect(payload["status"]).toBe("ok");
-    expect(payload["agentId"]).toBe(GOOD_PARAMS.agentId);
+    expect(payload["agentId"]).toBe(CREATE.agentId);
 
-    const expectedDir = join(getDataDir(), "agents", GOOD_PARAMS.agentId);
-    expect(payload["dir"]).toBe(expectedDir);
-    expect(payload["domainSpecPath"]).toBe(join(expectedDir, "domain_spec.md"));
-    expect(payload["intentSpecPath"]).toBe(join(expectedDir, "intent_spec.md"));
-    expect(payload["profilePath"]).toBe(join(expectedDir, "profile.json"));
-    // Persona is no longer materialized into the store.
-    expect(payload["personaPath"]).toBeUndefined();
-
-    expect(existsSync(join(expectedDir, "domain_spec.md"))).toBe(true);
-    expect(existsSync(join(expectedDir, "intent_spec.md"))).toBe(true);
-    expect(existsSync(join(expectedDir, "profile.json"))).toBe(true);
-    expect(existsSync(join(expectedDir, "persona.md"))).toBe(false);
+    const dir = join(getDataDir(), "agents", CREATE.agentId);
+    expect(payload["userSpecPath"]).toBe(join(dir, "user_spec.md"));
+    expect(payload["profilePath"]).toBe(join(dir, "profile.json"));
+    expect(existsSync(join(dir, "user_spec.md"))).toBe(true);
+    expect(existsSync(join(dir, "domains"))).toBe(false);
+    // The flat per-niche artefacts never appear at the agent level.
+    expect(existsSync(join(dir, "domain_spec.md"))).toBe(false);
+    expect(readManifest(CREATE.agentId)["domains"]).toEqual({});
   });
 
-  it("returns ALL FOUR spec paths and lands all four files for a create (round-2: none is lazily absent)", async () => {
+  it("reads no token (behaviour-artefact half only)", async () => {
     const tool = getTool(api, TOOL);
-    const payload = payloadOf(await tool.execute("call-2", { ...MIN_PARAMS }));
-
-    expect(payload["status"]).toBe("ok");
-    expect(payload["userSpecPath"]).toBeDefined();
-    expect(payload["playbookPath"]).toBeDefined();
-    const expectedDir = join(getDataDir(), "agents", GOOD_PARAMS.agentId);
-    expect(existsSync(join(expectedDir, "user_spec.md"))).toBe(true);
-    expect(existsSync(join(expectedDir, "playbook.md"))).toBe(true);
-  });
-
-  it("makes no host-config write and reads no token (behaviour-artefact half only)", async () => {
-    const tool = getTool(api, TOOL);
-    await tool.execute("call-3", { ...GOOD_PARAMS });
-    // No token side effect — creation is identity-decoupled.
+    await tool.execute("c-2", { ...CREATE });
     expect(existsSync(getTokensPath())).toBe(false);
   });
 });
 
-describe("sil_profile_materialize — invalid spec returns invalid_request, writes nothing", () => {
-  it("missing domainSpec (required) → invalid_request naming the field, no artefact dir", async () => {
+describe("sil_profile_materialize — mint a niche (with domain): ok envelope + the pack lands under domains/<slug>/", () => {
+  it("returns status ok with the minted domain echo, and writes the pack + upserts domains[slug]", async () => {
     const tool = getTool(api, TOOL);
-    const { domainSpec: _d, ...noDomain } = GOOD_PARAMS;
-    const payload = payloadOf(await tool.execute("call-4", { ...noDomain }));
-    expect(payload["status"]).toBe("invalid_request");
-    expect(payload["field"]).toBe("domainSpec");
-    expect(typeof payload["message"]).toBe("string");
-    expect(existsSync(join(getDataDir(), "agents", GOOD_PARAMS.agentId))).toBe(false);
-  });
+    // Create the shopper first, then mint.
+    await tool.execute("c-3", { ...CREATE });
+    const payload = payloadOf(await tool.execute("c-4", { ...MINT }));
+    expect(payload["status"]).toBe("ok");
 
-  it("missing intentSpec (required) → invalid_request naming the field, no artefact dir", async () => {
-    const tool = getTool(api, TOOL);
-    const { intentSpec: _i, ...noIntent } = GOOD_PARAMS;
-    const payload = payloadOf(await tool.execute("call-5", { ...noIntent }));
-    expect(payload["status"]).toBe("invalid_request");
-    expect(payload["field"]).toBe("intentSpec");
-    expect(existsSync(join(getDataDir(), "agents", GOOD_PARAMS.agentId))).toBe(false);
-  });
+    const domainDir = join(getDataDir(), "agents", CREATE.agentId, "domains", DOMAIN.slug);
+    expect(existsSync(join(domainDir, "domain_spec.md"))).toBe(true);
+    expect(existsSync(join(domainDir, "intent_spec.md"))).toBe(true);
+    expect(existsSync(join(domainDir, "playbook.md"))).toBe(true);
+    expect(readFileSync(join(domainDir, "domain_spec.md"), "utf8")).toBe(DOMAIN.domainSpec);
 
-  it("missing userSpec (required, round-2) → invalid_request naming the field, no artefact dir", async () => {
+    // The envelope echoes the minted domain entry (slug + the three per-domain paths).
+    const domain = payload["domain"] as Record<string, unknown> | undefined;
+    expect(domain).toBeDefined();
+    expect(domain!["slug"]).toBe(DOMAIN.slug);
+    expect(domain!["domainSpecPath"]).toBe(join(domainDir, "domain_spec.md"));
+
+    // The manifest's domains map registers it.
+    const domains = (readManifest(CREATE.agentId)["domains"] ?? {}) as Record<string, unknown>;
+    expect(Object.keys(domains)).toEqual([DOMAIN.slug]);
+  });
+});
+
+describe("sil_profile_materialize — invalid spec → invalid_request envelope, writes nothing", () => {
+  it("missing userSpec → invalid_request(field=userSpec), no artefact dir", async () => {
     const tool = getTool(api, TOOL);
-    const { userSpec: _u, ...noUser } = GOOD_PARAMS;
-    const payload = payloadOf(await tool.execute("call-5u", { ...noUser }));
+    const { userSpec: _u, ...noUser } = CREATE;
+    const payload = payloadOf(await tool.execute("c-5", { ...noUser }));
     expect(payload["status"]).toBe("invalid_request");
     expect(payload["field"]).toBe("userSpec");
-    expect(existsSync(join(getDataDir(), "agents", GOOD_PARAMS.agentId))).toBe(false);
-  });
-
-  it("missing playbook (required, round-2) → invalid_request naming the field, no artefact dir", async () => {
-    const tool = getTool(api, TOOL);
-    const { playbook: _p, ...noPlaybook } = GOOD_PARAMS;
-    const payload = payloadOf(await tool.execute("call-5p", { ...noPlaybook }));
-    expect(payload["status"]).toBe("invalid_request");
-    expect(payload["field"]).toBe("playbook");
-    expect(existsSync(join(getDataDir(), "agents", GOOD_PARAMS.agentId))).toBe(false);
+    expect(existsSync(join(getDataDir(), "agents", CREATE.agentId))).toBe(false);
   });
 
   it("missing agentId → invalid_request(field=agentId), no write", async () => {
     const tool = getTool(api, TOOL);
-    const { agentId: _drop, ...noId } = GOOD_PARAMS;
-    const payload = payloadOf(await tool.execute("call-6", { ...noId }));
+    const { agentId: _a, ...noId } = CREATE;
+    const payload = payloadOf(await tool.execute("c-6", { ...noId }));
     expect(payload["status"]).toBe("invalid_request");
     expect(payload["field"]).toBe("agentId");
   });
 
   it('reserved "main" agentId → invalid_request(field=agentId), no write', async () => {
     const tool = getTool(api, TOOL);
-    const payload = payloadOf(
-      await tool.execute("call-7", { ...GOOD_PARAMS, agentId: "main" }),
-    );
+    const payload = payloadOf(await tool.execute("c-7", { ...CREATE, agentId: "main" }));
     expect(payload["status"]).toBe("invalid_request");
     expect(payload["field"]).toBe("agentId");
     expect(existsSync(join(getDataDir(), "agents", "main"))).toBe(false);
+  });
+
+  it("a traversal-shaped domain.slug → invalid_request(field=domain.slug), no domain pack", async () => {
+    const tool = getTool(api, TOOL);
+    await tool.execute("c-8", { ...CREATE }); // shopper exists
+    const payload = payloadOf(
+      await tool.execute("c-9", { ...MINT, domain: { ...DOMAIN, slug: "../escape" } }),
+    );
+    expect(payload["status"]).toBe("invalid_request");
+    expect(payload["field"]).toBe("domain.slug");
+    expect(existsSync(join(getDataDir(), "agents", CREATE.agentId, "domains"))).toBe(false);
+  });
+
+  it("a blank domain.domainSpec → invalid_request(field=domain.domainSpec), no domain pack", async () => {
+    const tool = getTool(api, TOOL);
+    await tool.execute("c-10", { ...CREATE });
+    const payload = payloadOf(
+      await tool.execute("c-11", { ...MINT, domain: { ...DOMAIN, domainSpec: "   " } }),
+    );
+    expect(payload["status"]).toBe("invalid_request");
+    expect(payload["field"]).toBe("domain.domainSpec");
+    expect(existsSync(join(getDataDir(), "agents", CREATE.agentId, "domains"))).toBe(false);
   });
 });

--- a/src/__tests__/tools/profile-sds.test.ts
+++ b/src/__tests__/tools/profile-sds.test.ts
@@ -1,28 +1,26 @@
 /**
- * UNIT — the SDS tool seam after the five-artefact reframe (tier: unit, mock api
- * + temp data dir, no network, no host).
+ * UNIT — the domain-scoped profile tool seam, end-to-end at the tool boundary
+ * (tier: unit, mock api + temp data dir, no network, no host).
  *
- * Card: spec-driven-shopping-sds-for-created-experts — Founder review round 2
- * (PR #33 bounced a SECOND time). The pure store invariants live in
- * `lib/profile-store-sds.test.ts`; here we pin the TOOL boundary after the
- * reframe — WITHOUT adding a new tool (the 8-tool manifest is FROZEN;
- * manifest-contract stays green unchanged). The round-2 correction: ALL FOUR sil
- * specs are REQUIRED (present non-blank from creation, seeded partial then
- * augmented per-query) — userSpec + playbook are no longer lazy/optional:
+ * Card: single-multi-domain-sil-shopper — Slice 1. This file pins the tool seam's
+ * NEW behaviour WITHOUT adding a tool — the surface stays lean (routing is
+ * skill-reasoning, NOT a new tool). It covers the create→shop→cross-niche-reuse
+ * spine the success signal rests on, proven at the registered-tool boundary:
  *
- *   sil_profile_materialize — drops `persona` entirely (the persona is the host
- *     SOUL.md, written by the engine via the host CLI). REQUIRES domainSpec +
- *     intentSpec + userSpec + playbook (all four). The ok envelope returns all four
- *     paths. A missing or present-but-blank spec → invalid_request naming it.
- *   sil_profile_get         — the ok envelope returns the domainSpec / intentSpec /
- *     userSpec / playbook bodies (no persona; all four always present).
- *   sil_profile_list        — the summary lists experts. With all four specs
- *     required+present, hasUserSpec / hasPlaybook would be trivially true and carry
- *     no signal — so we pin the durable list shape (the expert is listed), not a
- *     no-signal flag.
+ *   - `registerProfileTools` registers EXACTLY the four profile tools (no new
+ *     domain-routing/classification tool) — the lean-surface invariant, the
+ *     companion to manifest-contract's frozen 8-name set.
+ *   - `sil_profile_materialize` distinguishes CREATE (no domain → no domain echo)
+ *     from MINT (with domain → a domain echo).
+ *   - A fact captured into the SHARED user_spec while minting niche B is read back
+ *     when viewing niche A — the cross-niche reuse signal, at the tool seam.
+ *   - `sil_profile_get` distinguishes the overview (no slug → domain index, no
+ *     bodies) from a per-domain read (slug → the 3 bodies).
  *
- * Hermetic via the SIL_DATA_DIR temp-dir override (mirrors
- * profile-materialize.test.ts / profile-manage.test.ts).
+ * The schema/envelope mechanics live in profile-materialize.test.ts /
+ * profile-manage.test.ts; here the focus is the cross-tool flow.
+ *
+ * Hermetic via the SIL_DATA_DIR temp-dir override.
  */
 
 import {
@@ -32,22 +30,20 @@ import {
   beforeEach,
   afterEach,
 } from "vitest";
-import { mkdtempSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { registerProfileTools } from "../../tools/profile.js";
-import { getDataDir } from "../../lib/credentials.js";
-import { getAgentArtefactDir } from "../../lib/profile-store.js";
 import {
   createMockPluginApi,
   getTool,
+  registeredToolNames,
   type MockPluginAPI,
 } from "../helpers/mock-plugin-api.js";
 
 const MATERIALIZE = "sil_profile_materialize";
 const GET = "sil_profile_get";
-const LIST = "sil_profile_list";
 
 let dataDir: string;
 let priorSilDataDir: string | undefined;
@@ -61,34 +57,27 @@ function payloadOf(result: { content: { text?: string }[] }): Record<string, unk
   return JSON.parse(text) as Record<string, unknown>;
 }
 
-const DOMAIN_SPEC =
-  "# Domain spec — road cycling (deep)\nFit mechanics (stack/reach, saddle"
-  + " setback, crank length), gearing theory, frame geometry, the full fitting"
-  + " process. Trade-offs noted.";
-const INTENT_SPEC =
-  "# Intent spec — decomposition dimensions\nuse-case, terrain, budget, timeline,"
-  + " compatibility, performance priorities, aesthetics.";
-const USER_SPEC =
-  "# User spec\nFacts: inseam 81cm, endurance geometry.\nHARD-NO: rim brakes; over 9kg.";
-const PLAYBOOK = "# Buying taste\nBudget ~€1500; brand-agnostic.";
+const SHOPPER = "sil-shopper";
+const USER_SPEC_V1 = "# User spec (shared)\n- Ships to Berlin.\nHARD-NO: leather.";
+const USER_SPEC_V2 = USER_SPEC_V1 + "\n- Allergic to wool (captured while shopping running).";
 
-/** A full create — all four REQUIRED specs (round-2: none is lazy/optional). */
-const GOOD_PARAMS = {
-  agentId: "road-cycling-buyer",
-  name: "Road Cycling Buyer",
-  domainSpec: DOMAIN_SPEC,
-  intentSpec: INTENT_SPEC,
-  userSpec: USER_SPEC,
-  playbook: PLAYBOOK,
+const CYCLING = {
+  slug: "road-cycling",
+  name: "Road cycling",
+  domainSpec: "# Domain spec — cycling\nFit, gearing, geometry.",
+  intentSpec: "# Intent spec — cycling\nuse-case, terrain, budget.",
+  playbook: "# Taste — cycling\n~€1500; Shimano over SRAM.",
+};
+const RUNNING = {
+  slug: "running-shoes",
+  name: "Running shoes",
+  domainSpec: "# Domain spec — running\nLast, stack, drop, foam.",
+  intentSpec: "# Intent spec — running\nsurface, distance, gait.",
+  playbook: "# Taste — running\nUnder €160; neutral foam.",
 };
 
-/** The minimum valid create. After Founder review round 2, all four sil specs are
- * REQUIRED + present from creation — so the minimum create IS the full four-spec
- * create. Kept as a named alias for call-site legibility. */
-const MIN_PARAMS = GOOD_PARAMS;
-
 beforeEach(() => {
-  dataDir = mkdtempSync(join(tmpdir(), "sil-profile-sds-tool-"));
+  dataDir = mkdtempSync(join(tmpdir(), "sil-sds-tool-"));
   priorSilDataDir = process.env["SIL_DATA_DIR"];
   process.env["SIL_DATA_DIR"] = dataDir;
   api = createMockPluginApi();
@@ -101,181 +90,108 @@ afterEach(() => {
   rmSync(dataDir, { recursive: true, force: true });
 });
 
-describe("sil_profile_materialize — schema: persona GONE, ALL FOUR specs REQUIRED (round-2)", () => {
-  it("declares NO persona param; domainSpec + intentSpec + userSpec + playbook are ALL required", () => {
-    const tool = getTool(api, MATERIALIZE);
-    const schema = tool.parameters as unknown as {
-      type?: string;
-      properties?: Record<string, { type?: string }>;
-      required?: string[];
-    };
-    expect(schema.type).toBe("object");
-
-    // Persona left the store — there is no persona param.
-    expect(schema.properties?.["persona"]).toBeUndefined();
-    expect(schema.required ?? []).not.toContain("persona");
-
-    // All four specs exist as strings AND are in the required gate (round-2:
-    // userSpec + playbook are no longer optional — they are present from creation).
-    expect(schema.properties?.["domainSpec"]?.type).toBe("string");
-    expect(schema.properties?.["intentSpec"]?.type).toBe("string");
-    expect(schema.properties?.["userSpec"]?.type).toBe("string");
-    expect(schema.properties?.["playbook"]?.type).toBe("string");
-    expect(schema.required).toEqual(
-      expect.arrayContaining([
-        "agentId",
-        "name",
-        "domainSpec",
-        "intentSpec",
-        "userSpec",
-        "playbook",
-      ]),
+describe("the profile surface stays LEAN — no new domain-routing tool", () => {
+  it("registerProfileTools registers EXACTLY the four profile tools (routing is skill-reasoning)", () => {
+    expect([...registeredToolNames(api)].sort()).toEqual(
+      [
+        "sil_profile_get",
+        "sil_profile_list",
+        "sil_profile_materialize",
+        "sil_profile_remove",
+      ].sort(),
     );
   });
 });
 
-describe("sil_profile_materialize — ok envelope returns the spec paths; no persona.md lands", () => {
-  it("returns domainSpecPath + intentSpecPath (+ userSpecPath/playbookPath), and the artefacts land — never persona.md", async () => {
-    const tool = getTool(api, MATERIALIZE);
-    const payload = payloadOf(await tool.execute("c-1", { ...GOOD_PARAMS }));
+describe("sil_profile_materialize — CREATE (no domain) vs MINT (with domain)", () => {
+  it("a create (no domain) returns ok with NO domain echo", async () => {
+    const payload = payloadOf(
+      await getTool(api, MATERIALIZE).execute("c-1", {
+        agentId: SHOPPER,
+        name: "sil shopper",
+        userSpec: USER_SPEC_V1,
+      }),
+    );
     expect(payload["status"]).toBe("ok");
-
-    const dir = join(getDataDir(), "agents", GOOD_PARAMS.agentId);
-    expect(payload["domainSpecPath"]).toBe(join(dir, "domain_spec.md"));
-    expect(payload["intentSpecPath"]).toBe(join(dir, "intent_spec.md"));
-    expect(payload["userSpecPath"]).toBe(join(dir, "user_spec.md"));
-    expect(payload["playbookPath"]).toBe(join(dir, "playbook.md"));
-    // Persona left the store — no personaPath, no persona.md.
-    expect(payload["personaPath"]).toBeUndefined();
-    expect(existsSync(join(dir, "persona.md"))).toBe(false);
-
-    expect(readFileSync(join(dir, "domain_spec.md"), "utf8")).toBe(DOMAIN_SPEC);
-    expect(readFileSync(join(dir, "intent_spec.md"), "utf8")).toBe(INTENT_SPEC);
-    expect(readFileSync(join(dir, "user_spec.md"), "utf8")).toBe(USER_SPEC);
-    expect(readFileSync(join(dir, "playbook.md"), "utf8")).toBe(PLAYBOOK);
+    // A create did not mint a niche — there is no domain in the envelope.
+    expect(payload["domain"]).toBeUndefined();
   });
 
-  it("a create returns ALL FOUR spec paths and lands all four files (round-2: none is lazily absent)", async () => {
-    const tool = getTool(api, MATERIALIZE);
-    const payload = payloadOf(await tool.execute("c-2", { ...MIN_PARAMS }));
+  it("a mint (with domain) returns ok WITH the minted domain echo", async () => {
+    await getTool(api, MATERIALIZE).execute("c-2", {
+      agentId: SHOPPER,
+      name: "sil shopper",
+      userSpec: USER_SPEC_V1,
+    });
+    const payload = payloadOf(
+      await getTool(api, MATERIALIZE).execute("c-3", {
+        agentId: SHOPPER,
+        name: "sil shopper",
+        userSpec: USER_SPEC_V1,
+        domain: CYCLING,
+      }),
+    );
     expect(payload["status"]).toBe("ok");
-    expect(payload["domainSpecPath"]).toBeDefined();
-    expect(payload["intentSpecPath"]).toBeDefined();
-    expect(payload["userSpecPath"]).toBeDefined();
-    expect(payload["playbookPath"]).toBeDefined();
-    const dir = join(getDataDir(), "agents", GOOD_PARAMS.agentId);
-    expect(existsSync(join(dir, "user_spec.md"))).toBe(true);
-    expect(existsSync(join(dir, "playbook.md"))).toBe(true);
+    const domain = payload["domain"] as Record<string, unknown> | undefined;
+    expect(domain).toBeDefined();
+    expect(domain!["slug"]).toBe(CYCLING.slug);
   });
 });
 
-describe("sil_profile_materialize — a missing/blank REQUIRED spec → invalid_request, writes nothing", () => {
-  it("omitted domainSpec → invalid_request(field=domainSpec), no artefact dir", async () => {
-    const tool = getTool(api, MATERIALIZE);
-    const { domainSpec: _d, ...noDomain } = GOOD_PARAMS;
-    const payload = payloadOf(await tool.execute("c-3", { ...noDomain }));
-    expect(payload["status"]).toBe("invalid_request");
-    expect(payload["field"]).toBe("domainSpec");
-    expect(existsSync(getAgentArtefactDir(GOOD_PARAMS.agentId))).toBe(false);
-  });
-
-  it("omitted intentSpec → invalid_request(field=intentSpec), no artefact dir", async () => {
-    const tool = getTool(api, MATERIALIZE);
-    const { intentSpec: _i, ...noIntent } = GOOD_PARAMS;
-    const payload = payloadOf(await tool.execute("c-4", { ...noIntent }));
-    expect(payload["status"]).toBe("invalid_request");
-    expect(payload["field"]).toBe("intentSpec");
-    expect(existsSync(getAgentArtefactDir(GOOD_PARAMS.agentId))).toBe(false);
-  });
-
-  it("omitted userSpec → invalid_request(field=userSpec), no artefact dir (round-2: user_spec is REQUIRED)", async () => {
-    const tool = getTool(api, MATERIALIZE);
-    const { userSpec: _u, ...noUser } = GOOD_PARAMS;
-    const payload = payloadOf(await tool.execute("c-4u", { ...noUser }));
-    expect(payload["status"]).toBe("invalid_request");
-    expect(payload["field"]).toBe("userSpec");
-    expect(existsSync(getAgentArtefactDir(GOOD_PARAMS.agentId))).toBe(false);
-  });
-
-  it("omitted playbook → invalid_request(field=playbook), no artefact dir (round-2: playbook is REQUIRED)", async () => {
-    const tool = getTool(api, MATERIALIZE);
-    const { playbook: _p, ...noPlaybook } = GOOD_PARAMS;
-    const payload = payloadOf(await tool.execute("c-4p", { ...noPlaybook }));
-    expect(payload["status"]).toBe("invalid_request");
-    expect(payload["field"]).toBe("playbook");
-    expect(existsSync(getAgentArtefactDir(GOOD_PARAMS.agentId))).toBe(false);
-  });
-
-  it("blank domainSpec → invalid_request(field=domainSpec), no artefact dir", async () => {
-    const tool = getTool(api, MATERIALIZE);
-    const payload = payloadOf(
-      await tool.execute("c-5", { ...GOOD_PARAMS, domainSpec: "   " }),
-    );
-    expect(payload["status"]).toBe("invalid_request");
-    expect(payload["field"]).toBe("domainSpec");
-    expect(typeof payload["message"]).toBe("string");
-    expect(existsSync(getAgentArtefactDir(GOOD_PARAMS.agentId))).toBe(false);
-  });
-
-  it("blank intentSpec → invalid_request(field=intentSpec), no artefact dir", async () => {
-    const tool = getTool(api, MATERIALIZE);
-    const payload = payloadOf(
-      await tool.execute("c-6", { ...GOOD_PARAMS, intentSpec: "" }),
-    );
-    expect(payload["status"]).toBe("invalid_request");
-    expect(payload["field"]).toBe("intentSpec");
-    expect(existsSync(getAgentArtefactDir(GOOD_PARAMS.agentId))).toBe(false);
-  });
-});
-
-describe("sil_profile_get — ok envelope returns the four spec bodies, no persona", () => {
-  it("returns domainSpec + intentSpec + userSpec + playbook bodies; carries no persona", async () => {
-    await getTool(api, MATERIALIZE).execute("c-7", { ...GOOD_PARAMS });
-    const payload = payloadOf(
-      await getTool(api, GET).execute("c-8", { agentId: GOOD_PARAMS.agentId }),
-    );
-    expect(payload["status"]).toBe("ok");
-    expect(payload["domainSpec"]).toBe(DOMAIN_SPEC);
-    expect(payload["intentSpec"]).toBe(INTENT_SPEC);
-    expect(payload["userSpec"]).toBe(USER_SPEC);
-    expect(payload["playbook"]).toBe(PLAYBOOK);
-    // Persona is no longer a stored artefact — the envelope carries none.
-    expect(payload["persona"]).toBeUndefined();
-  });
-
-  it("a created expert returns ALL FOUR bodies in the envelope (round-2: none is absent at creation)", async () => {
-    await getTool(api, MATERIALIZE).execute("c-9", { ...MIN_PARAMS });
-    const payload = payloadOf(
-      await getTool(api, GET).execute("c-10", { agentId: GOOD_PARAMS.agentId }),
-    );
-    expect(payload["status"]).toBe("ok");
-    expect(payload["domainSpec"]).toBe(DOMAIN_SPEC);
-    expect(payload["intentSpec"]).toBe(INTENT_SPEC);
-    expect(payload["userSpec"]).toBe(USER_SPEC);
-    expect(payload["playbook"]).toBe(PLAYBOOK);
-  });
-});
-
-describe("sil_profile_list — lists every created expert (name + agentId from the manifest)", () => {
-  it("lists each created expert with its manifest name + agentId — the durable list shape", async () => {
-    // Round-2: with all four specs required+present, hasUserSpec / hasPlaybook
-    // would be trivially true for EVERY created expert and carry no discriminating
-    // signal — so we do NOT assert them. The durable behaviour the list must hold
-    // is: every created expert is enumerated with its manifest name + agentId.
-    await getTool(api, MATERIALIZE).execute("c-11", { ...GOOD_PARAMS });
-    await getTool(api, MATERIALIZE).execute("c-12", {
-      ...GOOD_PARAMS,
-      agentId: "second-expert",
-      name: "Second Expert",
+describe("cross-niche reuse — a shared-user_spec fact from niche B is reused in niche A (the success signal)", () => {
+  it("create → mint cycling → mint running (augmented shared spec) → get cycling returns the augmented spec", async () => {
+    const mat = getTool(api, MATERIALIZE);
+    // Create the ONE shopper.
+    await mat.execute("c-4", { agentId: SHOPPER, name: "sil shopper", userSpec: USER_SPEC_V1 });
+    // Shop niche A (cycling) — pack minted on the fly.
+    await mat.execute("c-5", {
+      agentId: SHOPPER,
+      name: "sil shopper",
+      userSpec: USER_SPEC_V1,
+      domain: CYCLING,
+    });
+    // Shop niche B (running) in the SAME session — a new standing fact (wool
+    // allergy) is captured into the SHARED user_spec alongside the running mint.
+    await mat.execute("c-6", {
+      agentId: SHOPPER,
+      name: "sil shopper",
+      userSpec: USER_SPEC_V2,
+      domain: RUNNING,
     });
 
-    const payload = payloadOf(await getTool(api, LIST).execute("c-13", {}));
-    expect(payload["status"]).toBe("ok");
-    const experts = payload["experts"] as Array<Record<string, unknown>>;
-    const byId = new Map(experts.map((e) => [e["agentId"], e]));
-    expect(byId.has(GOOD_PARAMS.agentId)).toBe(true);
-    expect(byId.has("second-expert")).toBe(true);
-    expect(byId.get(GOOD_PARAMS.agentId)!["name"]).toBe(GOOD_PARAMS.name);
-    expect(byId.get("second-expert")!["name"]).toBe("Second Expert");
+    // Viewing niche A surfaces the LATEST shared user_spec — the fact added during
+    // niche B is already there, WITHOUT being re-asked. That is the card's signal.
+    const cycling = payloadOf(
+      await getTool(api, GET).execute("c-7", { agentId: SHOPPER, domainSlug: "road-cycling" }),
+    );
+    expect(cycling["status"]).toBe("ok");
+    expect(cycling["userSpec"]).toBe(USER_SPEC_V2);
+    expect(String(cycling["userSpec"])).toContain("Allergic to wool");
+  });
+});
+
+describe("sil_profile_get — overview (no slug) vs per-domain (slug)", () => {
+  it("the overview carries the domain index but NO domain bodies; a per-domain read carries the bodies", async () => {
+    const mat = getTool(api, MATERIALIZE);
+    await mat.execute("c-8", { agentId: SHOPPER, name: "sil shopper", userSpec: USER_SPEC_V1 });
+    await mat.execute("c-9", {
+      agentId: SHOPPER,
+      name: "sil shopper",
+      userSpec: USER_SPEC_V1,
+      domain: CYCLING,
+    });
+
+    const overview = payloadOf(await getTool(api, GET).execute("c-10", { agentId: SHOPPER }));
+    expect(overview["status"]).toBe("ok");
+    const domains = overview["domains"] as Array<Record<string, unknown>>;
+    expect(domains.map((d) => d["slug"])).toEqual(["road-cycling"]);
+    // The overview is the cheap index — it does not inline the per-domain bodies.
+    expect(overview["domainSpec"]).toBeUndefined();
+
+    const domain = payloadOf(
+      await getTool(api, GET).execute("c-11", { agentId: SHOPPER, domainSlug: "road-cycling" }),
+    );
+    expect(domain["status"]).toBe("ok");
+    expect(domain["domainSpec"]).toBe(CYCLING.domainSpec);
   });
 });

--- a/src/lib/profile-store.ts
+++ b/src/lib/profile-store.ts
@@ -1,68 +1,65 @@
 /**
- * sil shopping-expert behaviour-artefact store.
+ * sil shopper behaviour-artefact store — the single multi-domain shopper layout.
  *
  * The agent-creation engine (the bundled `sil-shopping/SKILL.md` procedure driving
- * the OpenClaw host CLI) registers the *wiring* of a new sil-wired agent into
- * the host's own config — the `agents.list[]` entry, the enabled `sil` plugin,
- * the attached `sil` skill. That host-config write is the host agent driving
- * its own `openclaw …` CLI; the plugin never touches `~/.openclaw`.
+ * the OpenClaw host CLI) registers the *wiring* of the one sil shopper into the
+ * host's own config — the `agents.list[]` entry, the enabled `sil` plugin, the
+ * attached `sil` skill. That host-config write is the host agent driving its own
+ * `openclaw …` CLI; the plugin never touches `~/.openclaw`.
  *
- * What the plugin DOES own is the agent's *behaviour* layer, materialized into
+ * What the plugin DOES own is the shopper's *behaviour* layer, materialized into
  * its own disclosed `filesystemScope` — `$SIL_DATA_DIR` (the same directory
- * `lib/credentials.ts` uses for tokens/identity). The created expert runs
- * entirely on Spec-Driven Shopping (SDS): the engine writes the SDS behaviour
- * artefacts there, read by the sil skill at runtime:
+ * `lib/credentials.ts` uses for tokens/identity). There is ONE persistent shopper
+ * that holds MANY domains and routes by domain at shop time. The store keeps a
+ * SHARED, agent-level user spec (the one person) plus a per-domain pack that is
+ * minted LAZILY on the first shop in a niche:
  *
- *   $SIL_DATA_DIR/agents/<agentId>/
- *     ├─ domain_spec.md   the SDS DOMAIN SPEC — deep researched niche expertise:
- *     │                   how to buy well, the full mechanics (gearing theory,
- *     │                   frame geometry, the complete bike-fit process…).
- *     │                   REQUIRED at creation; web-refreshed every query.
- *     ├─ intent_spec.md   the SDS INTENT SPEC — the agent-specific decomposition
- *     │                   DIMENSIONS (a PRD-style template) a query must resolve,
- *     │                   derived from domain_spec. REQUIRED at creation. The
- *     │                   per-query intent (dimensions filled in) is EPHEMERAL —
- *     │                   never persisted.
- *     ├─ user_spec.md     the SDS USER SPEC — the user's domain-relevant facts +
- *     │                   hard constraints. REQUIRED at creation (seeded partial
- *     │                   by the ≤10-question setup), AUGMENTED every query.
- *     ├─ playbook.md      the SDS PLAYBOOK — the user's buying TASTE (price
- *     │                   sensitivity, brand, preferences). REQUIRED at creation
- *     │                   (seeded partial), AUGMENTED every query.
- *     └─ profile.json     the strictly-typed manifest the sil skill resolves the
- *                         artefacts from (no filesystem guessing)
+ *   $SIL_DATA_DIR/agents/<shopperId>/
+ *     ├─ user_spec.md            SHARED, agent-level — the one person: addresses,
+ *     │                          sizes, allergy/ethics HARD constraints, budget
+ *     │                          psychology. Read by EVERY domain's shop loop, so a
+ *     │                          fact captured while shopping niche A is reused in
+ *     │                          niche B without being re-asked. Overwritten
+ *     │                          (full-body) on every materialize call.
+ *     ├─ profile.json            the strictly-typed manifest the sil skill resolves
+ *     │                          artefacts from — identity + userSpecPath + a
+ *     │                          slug-keyed `domains` MAP (the source of truth; no
+ *     │                          filesystem guessing). `domains: {}` is the HEALTHY
+ *     │                          state of a freshly-created shopper.
+ *     └─ domains/<slug>/
+ *         ├─ domain_spec.md      per-domain: deep researched niche expertise.
+ *         ├─ intent_spec.md      per-domain: the decomposition DIMENSIONS a query
+ *         │                      must resolve (the dimension SCHEMA only — the
+ *         │                      per-query intent is ephemeral, never persisted).
+ *         └─ playbook.md         per-domain: the user's buying TASTE for THIS niche.
  *
- * The persona is NOT a sil artefact: the agent's identity/voice/standing rules
+ * The persona is NOT a sil artefact: the shopper's identity/voice/standing rules
  * are the host workspace `SOUL.md`, written directly via the host CLI by the
- * engine — there is no `persona.md` in this store and no copy step. This store
- * holds only the four SDS BEHAVIOUR artefacts.
+ * engine — there is no `persona.md` here and no copy step. This store holds only
+ * the SHARED user spec and the per-domain SDS packs.
  *
- * All FOUR slots are REQUIRED at creation (`domainSpec` + `intentSpec` +
- * `userSpec` + `playbook`) — SDS is the operating model, not an optional layer,
- * so a created expert without all four is a defect (Founder review round 2: all
- * four sil docs are present, non-blank, from creation). They are seeded *partial*
- * (the ≤10-question setup + a quick initial research pass), then lazily
- * AUGMENTED / reinforced on EVERY query — domain_spec web-refreshed, intent_spec
- * dimensions sharpened, user_spec facts and playbook taste reinforced. We keep
- * learning. All four are refine-mutable in place. The per-query intent is NOT a
- * slot here: only the intent_spec *dimension schema* is persisted; the filled
- * dimensions for one request are ephemeral, derived in the conversation.
+ * `sil_profile_materialize` stays ONE tool with an OPTIONAL `domain` pack:
+ *   - no `domain`  ⇒ CREATE the shopper: write the shared `user_spec.md` + a
+ *     `profile.json` with `domains: {}`. NO `domains/` dir is created yet.
+ *   - with `domain` ⇒ lazily MINT/refresh that niche: write
+ *     `domains/<slug>/{domain_spec,intent_spec,playbook}.md`, overwrite the shared
+ *     `user_spec.md`, and upsert `domains[slug]` — one atomic call. Persisting a
+ *     cross-niche fact surfaced in the same query is therefore native.
  *
- * Store boundary: host config + `SOUL.md` (identity/wiring) = host; the four SDS
- * behaviour artefacts = `$SIL_DATA_DIR` via this plugin tool. Identity/tokens
- * already live in `$SIL_DATA_DIR` but stay logically separate (no identity
- * coupling — creating an expert reads/writes no token).
- *
- * Write safety (Product invariant 7): a bad spec writes NOTHING (validate
- * first). Each artefact is written atomically — tmp file → write → rename over
- * target → chmod 0600, dir 0700 (mirroring `credentials.ts`) — so a reader never
- * sees a half-written file. On a mid-write failure the guarantee depends on
- * whether the expert is new: a FRESH create (the dir did not pre-exist) is torn
- * down, leaving no partial directory behind (all-or-nothing); a RE-MATERIALIZE
- * over an existing expert is per-file atomic and dir-preserving — it is NOT a
- * cross-file transaction, so on failure the prior expert is left intact and is
- * never served half-refined (a referenced-but-missing body fails the read closed
- * — see `readAgentProfile`). The catch block below encodes exactly this split.
+ * Write safety: a bad spec writes NOTHING (validate-first). Each artefact is
+ * written atomically — tmp file → write → rename over target → chmod 0600, dir
+ * 0700 (mirroring `credentials.ts`) — so a reader never sees a half-written file.
+ * Write order on a mint is `domains/<slug>/* → shared user_spec → profile.json
+ * LAST`, so a crash never leaves a registered-but-absent pack: the worst outcome
+ * is an ORPHANED, unreferenced `domains/<slug>/` leaf, which readers gate out via
+ * the manifest (fail-closed). On a mid-write failure the teardown is keyed on
+ * MANIFEST MEMBERSHIP, NOT filesystem pre-existence: a failed FIRST mint of a NEW
+ * domain (slug ∉ the existing `domains` map) tears down ONLY that fresh leaf — the
+ * agent dir, the shared user_spec, and sibling domains survive; a failed re-mint
+ * of an EXISTING domain is dir-preserving (the prior pack is left intact and is
+ * never served half-refined — a referenced-but-missing body fails the read closed,
+ * see `readAgentProfile`). A leaf we did not create (the path was already occupied)
+ * is never torn down.
  */
 
 import {
@@ -89,91 +86,119 @@ const FILE_MODE = 0o600;
 /** The sub-tree under `$SIL_DATA_DIR` that holds per-agent behaviour artefacts. */
 const AGENTS_SUBDIR = "agents";
 
+/** The sub-tree under an agent dir that holds the per-domain packs. */
+const DOMAINS_SUBDIR = "domains";
+
 /** Artefact filenames (stable — the sil skill resolves them from profile.json,
- * but the names are also documented so a human can find them). The three SDS
- * *specs* carry the `_spec.md` suffix; `playbook.md` (taste) does not. */
+ * but the names are also documented so a human can find them). The shared user
+ * spec sits at the agent level; the three SDS pack files sit under each domain. */
+const USER_SPEC_FILE = "user_spec.md";
 const DOMAIN_SPEC_FILE = "domain_spec.md";
 const INTENT_SPEC_FILE = "intent_spec.md";
-const USER_SPEC_FILE = "user_spec.md";
 const PLAYBOOK_FILE = "playbook.md";
 const PROFILE_FILE = "profile.json";
 
+/** A complete per-domain pack — the niche artefacts, minted lazily on first shop. */
+export interface DomainPackSpec {
+  /** The domain slug — keys the `domains/<slug>/` leaf. Lower-kebab, not `main`
+   * (host-reserved). A NEW filesystem path segment: guarded exactly like agentId. */
+  slug: string;
+  /** Human-readable domain name (recorded in the manifest entry). */
+  name: string;
+  /** The SDS domain spec — deep researched niche expertise (how to buy well, the
+   * full mechanics). REQUIRED non-blank. Materialized as `domain_spec.md`. */
+  domainSpec: string;
+  /** The SDS intent spec — the agent-specific decomposition DIMENSIONS a query must
+   * resolve, derived from the domain spec. REQUIRED non-blank. The dimension SCHEMA
+   * only (the per-query intent is ephemeral). Materialized as `intent_spec.md`. */
+  intentSpec: string;
+  /** The SDS playbook — the user's buying TASTE for THIS niche. REQUIRED non-blank.
+   * Materialized as `playbook.md`. */
+  playbook: string;
+}
+
 /**
- * The validated spec the engine hands the store. `agentId` is the host agent
- * id (the `agents.list[].id` the host CLI created); the artefact directory is
- * keyed by it so the sil skill can resolve "this agent's behaviour" at runtime.
+ * The validated spec the engine hands the store. `agentId` is the host agent id
+ * (the `agents.list[].id` the host CLI created); the artefact directory is keyed
+ * by it. `userSpec` is the SHARED, agent-level user spec — REQUIRED non-blank on
+ * EVERY call (create AND mint), overwritten full-body each time. `domain` is the
+ * OPTIONAL per-domain pack: absent ⇒ create the shopper; present ⇒ mint/refresh
+ * that niche.
  */
 export interface ProfileSpec {
   /** Host agent id — the directory key. Lower-kebab, not `main` (host-reserved). */
   agentId: string;
-  /** Human-readable expert name (recorded in the manifest). */
+  /** Human-readable shopper name (recorded in the manifest). */
   name: string;
-  /** The SDS domain spec — deep researched niche expertise (how to buy well, the
-   * full mechanics), authored at creation and web-refreshed every query. REQUIRED
-   * and non-blank: a created expert always carries a domain spec (SDS is the
-   * operating model, not an optional layer). */
-  domainSpec: string;
-  /** The SDS intent spec — the agent-specific decomposition DIMENSIONS (a
-   * PRD-style schema) a query must resolve, derived from `domainSpec` at creation.
-   * REQUIRED and non-blank. NOTE: this is the *dimension schema only* — the
-   * per-query intent (dimensions filled in for one request) is EPHEMERAL and is
-   * never passed here or persisted. */
-  intentSpec: string;
-  /** The SDS user spec — the user's domain-relevant facts + hard constraints.
-   * REQUIRED and non-blank (Founder review round 2): present from creation
-   * (seeded partial by the ≤10-question setup), then AUGMENTED every query.
-   * Per-user + per-expert, local. */
+  /** The SHARED, agent-level user spec — the one person's standing facts + hard
+   * constraints that carry across every niche. REQUIRED non-blank on every call;
+   * overwritten full-body so a cross-niche fact surfaced during a mint persists. */
   userSpec: string;
-  /** The SDS playbook — the user's buying TASTE (price sensitivity, brand,
-   * preferences). REQUIRED and non-blank: present from creation (seeded partial),
-   * then AUGMENTED every query. */
-  playbook: string;
+  /** The OPTIONAL per-domain pack. Absent ⇒ create the shopper (no `domains/`
+   * dir). Present ⇒ lazily mint/refresh `domains/<slug>/*` and upsert the map. */
+  domain?: DomainPackSpec;
+}
+
+/** One registered domain in the manifest's `domains` map — the source of truth the
+ * sil skill reads to resolve a niche's pack (no filesystem guessing). */
+export interface DomainEntry {
+  slug: string;
+  name: string;
+  /** Absolute path to the per-domain `domain_spec.md`. */
+  domainSpecPath: string;
+  /** Absolute path to the per-domain `intent_spec.md`. */
+  intentSpecPath: string;
+  /** Absolute path to the per-domain `playbook.md`. */
+  playbookPath: string;
+  /** ISO 8601 — when this domain was first minted (preserved across re-mints). */
+  createdAt: string;
+  /** ISO 8601 — when this domain's pack was last (re-)minted. */
+  updatedAt: string;
 }
 
 /** The strictly-typed manifest persisted as `profile.json`. The sil skill reads
- * this to locate + load the behaviour artefacts for the active agent. */
+ * this to locate the shared user spec + resolve each domain's pack. */
 export interface ProfileManifest {
   agentId: string;
   name: string;
-  /** Absolute path to the SDS domain-spec artefact. REQUIRED — a created expert
-   * always has a domain spec; `readManifestFile` gates on it. */
-  domainSpecPath: string;
-  /** Absolute path to the SDS intent-spec (dimension schema) artefact. REQUIRED —
-   * a created expert always has an intent spec; `readManifestFile` gates on it. */
-  intentSpecPath: string;
-  /** Absolute path to the SDS user-spec artefact. REQUIRED — a created expert
-   * always carries a user spec (seeded partial at creation); `readManifestFile`
-   * gates on it. */
-  userSpecPath: string;
-  /** Absolute path to the SDS playbook artefact. REQUIRED — a created expert
-   * always carries a buying-taste playbook (seeded partial at creation);
+  /** Absolute path to the SHARED, agent-level user-spec artefact. REQUIRED —
    * `readManifestFile` gates on it. */
-  playbookPath: string;
-  /** ISO 8601 creation timestamp. */
+  userSpecPath: string;
+  /** ISO 8601 creation timestamp of the shopper. */
   createdAt: string;
+  /** The slug-keyed domain map — the source of truth. `{}` is the HEALTHY state
+   * of a freshly-created shopper that has not shopped yet. */
+  domains: Record<string, DomainEntry>;
 }
 
-/** The discriminated result the store returns — never throws across the
- * boundary; the tool maps each variant to the structured envelope. */
+/** A structured invalid-request outcome, shared across every store primitive. The
+ * `field` is the offending field — the DOTTED name for nested domain fields
+ * (`"domain.slug"`, `"domain.domainSpec"`, …) so the agent-level `name` is never
+ * confused with `domain.name`. */
+export interface InvalidRequest {
+  ok: false;
+  kind: "invalid_request";
+  field: string;
+  message: string;
+}
+
+/** The discriminated result the writer returns — never throws across the
+ * boundary; the tool maps each variant to the structured envelope. `domain` is
+ * echoed (the upserted `DomainEntry`) ONLY for a mint, never for a create. */
 export type MaterializeResult =
   | {
       ok: true;
       agentId: string;
       /** The artefact directory ($SIL_DATA_DIR/agents/<agentId>). */
       dir: string;
-      domainSpecPath: string;
-      intentSpecPath: string;
+      /** Absolute path to the SHARED user-spec artefact. */
       userSpecPath: string;
-      playbookPath: string;
+      /** Absolute path to the manifest. */
       profilePath: string;
+      /** The upserted domain entry — present ONLY for a mint. */
+      domain?: DomainEntry;
     }
-  | {
-      ok: false;
-      kind: "invalid_request";
-      /** The offending spec field. */
-      field: string;
-      message: string;
-    }
+  | InvalidRequest
   | {
       ok: false;
       kind: "persistence_failed";
@@ -182,24 +207,30 @@ export type MaterializeResult =
       message: string;
     };
 
-/** A host-agent id must be lower-kebab and is never `main` (host-reserved). */
+/** A host-agent id / domain slug must be lower-kebab and is never `main`
+ * (host-reserved). Both are joined as filesystem path segments, so both share
+ * this guard. */
 const AGENT_ID_RE = /^[a-z0-9][a-z0-9-]*$/;
 
 /** Resolve the per-agent artefact directory under the plugin's data dir. Never
  * hardcoded — `getDataDir()` honors `$SIL_DATA_DIR`/`$XDG_DATA_HOME`.
  *
  * SAFETY: this resolver does NOT guard `agentId` — it joins it as a path segment
- * verbatim. The path-traversal guard lives at the only caller, `materializeProfile`,
- * which validates `agentId` against `AGENT_ID_RE` (lower-kebab, not `main`) BEFORE
- * the join, so a traversal-shaped id (a parent-directory hop, a nested back-step,
- * a bare dot) never reaches here. The guard is
- * placed at the caller (not here) because validation must precede ALL writes for
- * the validate-first / write-nothing-on-bad-input invariant to hold; a guard
- * duplicated here would be redundant for that path. A FUTURE DIRECT CALLER of this
- * exported resolver would bypass the guard — re-run `AGENT_ID_RE` (or route through
- * `materializeProfile`) before trusting the returned path with any filesystem op. */
+ * verbatim. Every caller validates `agentId` with `rejectBadSegment` (`AGENT_ID_RE`
+ * + non-`main`) BEFORE the join, so a traversal-shaped id never reaches here. A
+ * FUTURE DIRECT CALLER would bypass the guard — re-validate before trusting the
+ * returned path with any filesystem op. */
 export function getAgentArtefactDir(agentId: string): string {
   return join(getDataDir(), AGENTS_SUBDIR, agentId);
+}
+
+/** Resolve a per-domain pack directory under an agent dir. Mirrors
+ * `getAgentArtefactDir`'s SAFETY contract for the NEW path segment: `slug` is
+ * joined verbatim, so every caller MUST validate it with `rejectBadSegment`
+ * (`AGENT_ID_RE` + non-`main`) BEFORE the join. `agentId` is validated too — a
+ * direct caller must guard BOTH segments. */
+export function getDomainArtefactDir(agentId: string, slug: string): string {
+  return join(getAgentArtefactDir(agentId), DOMAINS_SUBDIR, slug);
 }
 
 /** True when `s` is a present, non-blank string. */
@@ -207,96 +238,166 @@ function nonBlank(s: unknown): s is string {
   return typeof s === "string" && s.trim().length > 0;
 }
 
-function invalid(field: string, message: string): MaterializeResult {
+function invalid(field: string, message: string): InvalidRequest {
   return { ok: false, kind: "invalid_request", field, message };
 }
 
+/** Validate one path-segment field (agentId or a slug) the SAME way at every
+ * caller: present + non-blank, never `main`, lower-kebab. Returns `null` when
+ * valid, an `invalid_request` naming the field otherwise — applied BEFORE any
+ * join/read/delete so a parent-directory traversal, an absolute path, a bare dot,
+ * or `main` never becomes a filesystem path segment. */
+function rejectBadSegment(value: unknown, field: string): InvalidRequest | null {
+  if (!nonBlank(value)) {
+    return invalid(field, field + " is required and must be non-empty.");
+  }
+  if (value === "main") {
+    return invalid(field, '"main" is host-reserved and cannot be a ' + field + ".");
+  }
+  if (!AGENT_ID_RE.test(value)) {
+    return invalid(
+      field,
+      field + " must be lower-kebab (a-z, 0-9, hyphen) — got: " + JSON.stringify(value),
+    );
+  }
+  return null;
+}
+
 /**
- * Materialize the behaviour artefacts for a created sil-wired agent.
+ * Materialize the shopper / a domain pack.
  *
- * Validate-first: any invalid field returns `invalid_request` and writes
- * NOTHING. On a write failure, the partial directory is removed and
- * `persistence_failed` is returned with `<dir>: <cause>` — no partial artefact
- * set ever survives (Product invariant 7, atomic outcome).
+ * Validate-first (deterministic field order: `agentId` → `name` → `userSpec` →,
+ * when `domain` is present, `domain.slug` → `domain.name` → `domain.domainSpec` →
+ * `domain.intentSpec` → `domain.playbook`): any invalid field returns
+ * `invalid_request` naming it and writes NOTHING.
+ *
+ * - no `domain`  ⇒ write the shared `user_spec.md` + `profile.json` (`domains: {}`);
+ *   no `domains/` dir.
+ * - with `domain` ⇒ write `domains/<slug>/*` → overwrite the shared `user_spec.md`
+ *   → write `profile.json` LAST (upsert `domains[slug]`; preserve `createdAt` on a
+ *   re-mint, advance `updatedAt`). `domain` is echoed in the ok result.
  */
 export function materializeProfile(spec: ProfileSpec): MaterializeResult {
   // --- validate-first (nothing is written until every field is good) ---
-  if (!nonBlank(spec.agentId)) {
-    return invalid("agentId", "agentId is required and must be non-empty.");
-  }
-  if (spec.agentId === "main") {
-    return invalid("agentId", '"main" is host-reserved and cannot be a sil expert id.');
-  }
-  if (!AGENT_ID_RE.test(spec.agentId)) {
-    return invalid(
-      "agentId",
-      "agentId must be lower-kebab (a-z, 0-9, hyphen) — got: " + JSON.stringify(spec.agentId),
-    );
-  }
+  const badId = rejectBadSegment(spec.agentId, "agentId");
+  if (badId) return badId;
   if (!nonBlank(spec.name)) {
     return invalid("name", "name is required and must be non-empty.");
   }
-  // All FOUR SDS specs are REQUIRED at creation — SDS is the operating model,
-  // not an optional layer. A created expert always carries all four (Founder
-  // review round 2): they are seeded *partial* at creation, then augmented every
-  // query. A present-but-blank or omitted spec is rejected (validate-first; write
-  // nothing).
-  if (!nonBlank(spec.domainSpec)) {
-    return invalid("domainSpec", "domainSpec is required and must be non-empty.");
-  }
-  if (!nonBlank(spec.intentSpec)) {
-    return invalid("intentSpec", "intentSpec is required and must be non-empty.");
-  }
+  // The SHARED user spec is REQUIRED non-blank on EVERY call — create AND mint —
+  // so a mint can never blank out the one person's standing facts/constraints.
   if (!nonBlank(spec.userSpec)) {
     return invalid("userSpec", "userSpec is required and must be non-empty.");
   }
-  if (!nonBlank(spec.playbook)) {
-    return invalid("playbook", "playbook is required and must be non-empty.");
+
+  const domain = spec.domain;
+  if (domain !== undefined) {
+    // The slug is a NEW filesystem path segment — guard it exactly like agentId
+    // BEFORE any join. All five pack fields are REQUIRED non-blank.
+    const badSlug = rejectBadSegment(domain.slug, "domain.slug");
+    if (badSlug) return badSlug;
+    if (!nonBlank(domain.name)) {
+      return invalid("domain.name", "domain.name is required and must be non-empty.");
+    }
+    if (!nonBlank(domain.domainSpec)) {
+      return invalid("domain.domainSpec", "domain.domainSpec is required and must be non-empty.");
+    }
+    if (!nonBlank(domain.intentSpec)) {
+      return invalid("domain.intentSpec", "domain.intentSpec is required and must be non-empty.");
+    }
+    if (!nonBlank(domain.playbook)) {
+      return invalid("domain.playbook", "domain.playbook is required and must be non-empty.");
+    }
   }
 
   const dir = getAgentArtefactDir(spec.agentId);
-  const domainSpecPath = join(dir, DOMAIN_SPEC_FILE);
-  const intentSpecPath = join(dir, INTENT_SPEC_FILE);
   const userSpecPath = join(dir, USER_SPEC_FILE);
-  const playbookPath = join(dir, PLAYBOOK_FILE);
   const profilePath = join(dir, PROFILE_FILE);
+
+  // The manifest is the source of truth: read what is already on disk so a mint is
+  // an UPSERT (the createdAt of the shopper and of any existing domain is
+  // preserved) rather than a clobber. A corrupt/absent manifest is treated as a
+  // fresh shopper — re-materialize heals it.
+  const existing = tryReadManifest(profilePath);
+  const createdAt = existing?.createdAt ?? new Date().toISOString();
+  const domains: Record<string, DomainEntry> = existing ? { ...existing.domains } : {};
+
+  // Per-mint state, resolved BEFORE the write so the catch block knows whether the
+  // failed leaf is ours to tear down (manifest membership) and whether the path
+  // pre-existed (never delete a path we did not create).
+  let leaf = "";
+  let entry: DomainEntry | undefined;
+  let domainIsNew = false;
+  let leafPreexisted = false;
+
+  if (domain !== undefined) {
+    leaf = getDomainArtefactDir(spec.agentId, domain.slug);
+    const prior = domains[domain.slug];
+    domainIsNew = prior === undefined;
+    leafPreexisted = existsSync(leaf);
+    const now = new Date().toISOString();
+    entry = {
+      slug: domain.slug,
+      name: domain.name,
+      domainSpecPath: join(leaf, DOMAIN_SPEC_FILE),
+      intentSpecPath: join(leaf, INTENT_SPEC_FILE),
+      playbookPath: join(leaf, PLAYBOOK_FILE),
+      createdAt: prior?.createdAt ?? now,
+      updatedAt: now,
+    };
+    domains[domain.slug] = entry;
+  }
 
   const manifest: ProfileManifest = {
     agentId: spec.agentId,
     name: spec.name,
-    domainSpecPath,
-    intentSpecPath,
     userSpecPath,
-    playbookPath,
-    createdAt: new Date().toISOString(),
+    createdAt,
+    domains,
   };
 
-  // Whether the artefact directory already existed before this call. If it did,
-  // it is not ours to delete on failure (it may hold a prior expert's artefacts,
-  // or — if the path is occupied by a non-directory — a user's file). We only
-  // remove what THIS call created (Product invariant 7: nothing partial, without
-  // destroying anything pre-existing).
+  // Whether the agent dir already existed. A fresh CREATE that fails is torn down
+  // whole (all-or-nothing); a MINT never tears down the agent dir (it holds the
+  // shared user_spec + sibling domains) — only the fresh leaf, and only if it is
+  // ours.
   const dirPreexisted = existsSync(dir);
 
   try {
-    // Ensure the data home (`$SIL_DATA_DIR`, 0700) exists first — its creation
-    // and mode are owned by credentials.ts (the data-dir owner), and this also
-    // re-heals it if it was deleted mid-session. Then create the per-agent leaf
-    // (`agents/<id>`), which is profile-store's own concern.
+    // Ensure the data home (`$SIL_DATA_DIR`, 0700) exists first — its creation and
+    // mode are owned by credentials.ts — then the per-agent leaf.
     ensureDataDir();
     mkdirSync(dir, { recursive: true, mode: DIR_MODE });
-    atomicWrite(domainSpecPath, spec.domainSpec);
-    atomicWrite(intentSpecPath, spec.intentSpec);
+    if (domain !== undefined && entry !== undefined) {
+      // Write order: the domain pack FIRST, the shared user_spec, the manifest
+      // LAST — so a crash before the manifest write leaves only an orphaned,
+      // unreferenced leaf (invisible to readers), never a registered-but-absent
+      // pack.
+      mkdirSync(leaf, { recursive: true, mode: DIR_MODE });
+      atomicWrite(entry.domainSpecPath, domain.domainSpec);
+      atomicWrite(entry.intentSpecPath, domain.intentSpec);
+      atomicWrite(entry.playbookPath, domain.playbook);
+    }
     atomicWrite(userSpecPath, spec.userSpec);
-    atomicWrite(playbookPath, spec.playbook);
     atomicWrite(profilePath, JSON.stringify(manifest, null, 2) + "\n");
   } catch (err) {
-    // Leave nothing partial behind — but only tear down the dir if WE created it.
-    if (!dirPreexisted) {
+    if (domain !== undefined) {
+      // MINT teardown — keyed on manifest membership, NOT filesystem pre-existence:
+      // tear down ONLY a fresh leaf this call created for a NEW domain. A re-mint of
+      // an EXISTING domain is dir-preserving (the prior pack survives), and a leaf
+      // path already occupied (the test's blocking file) is never our leaf to remove.
+      if (domainIsNew && !leafPreexisted) {
+        try {
+          rmSync(leaf, { recursive: true, force: true });
+        } catch {
+          // Cleanup is best-effort; the original cause is what the caller needs.
+        }
+      }
+    } else if (!dirPreexisted) {
+      // Fresh CREATE — leave nothing partial behind, but only if WE created the dir.
       try {
         rmSync(dir, { recursive: true, force: true });
       } catch {
-        // Cleanup is best-effort; the original cause is what the caller needs.
+        // best-effort
       }
     }
     const cause = err instanceof Error ? err.message : String(err);
@@ -305,23 +406,17 @@ export function materializeProfile(spec: ProfileSpec): MaterializeResult {
       kind: "persistence_failed",
       error: dir + ": " + cause,
       message:
-        "The shopping-expert behaviour artefacts could NOT be written to the sil"
-        + " data directory, so the profile did not stick. Fix the data directory"
-        + " (it must be writable — check permissions / free space / that"
-        + " $SIL_DATA_DIR is a directory), then create the expert again.",
+        "The shopper behaviour artefacts could NOT be written to the sil data"
+        + " directory, so the change did not stick. Fix the data directory (it must"
+        + " be writable — check permissions / free space / that $SIL_DATA_DIR is a"
+        + " directory), then try again.",
     };
   }
 
-  return {
-    ok: true,
-    agentId: spec.agentId,
-    dir,
-    domainSpecPath,
-    intentSpecPath,
-    userSpecPath,
-    playbookPath,
-    profilePath,
-  };
+  if (domain !== undefined && entry !== undefined) {
+    return { ok: true, agentId: spec.agentId, dir, userSpecPath, profilePath, domain: entry };
+  }
+  return { ok: true, agentId: spec.agentId, dir, userSpecPath, profilePath };
 }
 
 /** Atomic single-file write: tmp sibling → write → rename over target → chmod.
@@ -335,72 +430,43 @@ function atomicWrite(path: string, contents: string): void {
 }
 
 // ===========================================================================
-// Local expert lifecycle — list / view / remove the artefact half.
+// Shopper / domain lifecycle — list / view / remove the artefact half.
 //
-// The manifest (`profile.json`) is the source of truth for "is this a sil
-// expert": a directory under `agents/<id>/` with a readable profile.json IS an
-// expert; a bare host `agents.list[]` entry without one is not ours to manage.
-// The host-config (wiring) half of list/remove is the host agent driving its
-// own `openclaw …` CLI — these primitives only ever touch `$SIL_DATA_DIR`.
+// The manifest (`profile.json`) is the source of truth: a directory under
+// `agents/<id>/` with a readable profile.json IS the shopper, and its `domains`
+// map is the authoritative niche index. The host-config (wiring) half of
+// list/remove is the host agent driving its own `openclaw …` CLI — these
+// primitives only ever touch `$SIL_DATA_DIR`.
 //
 // Each primitive returns a discriminated result and NEVER throws across the
-// boundary (mirroring MaterializeResult), so one corrupt manifest or a single
-// failed delete degrades only its own outcome — never the whole operation.
+// boundary, so one corrupt manifest or a single failed delete degrades only its
+// own outcome — never the whole operation.
 // ===========================================================================
 
-/** Resolve the agents subtree root under the plugin's data dir — the parent of
- * every per-agent artefact directory. The deleter asserts a target is strictly
- * a child of this (and never this itself), so a delete can never reach the
- * parent and wipe sibling experts. */
+/** Resolve the agents subtree root — the parent of every per-agent dir. */
 function getAgentsRoot(): string {
   return join(getDataDir(), AGENTS_SUBDIR);
 }
 
-/** Re-run the writer's exact `agentId` gate at a DIRECT caller of
- * `getAgentArtefactDir`. Returns `null` when valid; an `invalid_request`
- * variant naming the field otherwise. The gate is identical to
- * `materializeProfile`'s validate-first block (`AGENT_ID_RE` + non-`main`),
- * applied BEFORE any path join, read, or delete so a parent-directory traversal,
- * an absolute path, a bare dot, or `main` never becomes a filesystem path segment. `getAgentArtefactDir`'s SAFETY note
- * mandates exactly this for every direct caller — list does not (it never
- * trusts a caller-supplied id; it reads only ids it discovered on disk), but
- * read and remove DO take a caller id and so call this first. */
-function rejectBadAgentId(
-  agentId: unknown,
-): { ok: false; kind: "invalid_request"; field: "agentId"; message: string } | null {
-  if (!nonBlank(agentId)) {
-    return invalidAgentId("agentId is required and must be non-empty.");
-  }
-  if (agentId === "main") {
-    return invalidAgentId('"main" is host-reserved and is not a sil expert id.');
-  }
-  if (!AGENT_ID_RE.test(agentId)) {
-    return invalidAgentId(
-      "agentId must be lower-kebab (a-z, 0-9, hyphen) — got: " + JSON.stringify(agentId),
-    );
-  }
-  return null;
+/** A domain summarized for an index view — no body read, no paths (list/overview
+ * stay cheap). */
+export interface DomainSummary {
+  slug: string;
+  name: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
-function invalidAgentId(
-  message: string,
-): { ok: false; kind: "invalid_request"; field: "agentId"; message: string } {
-  return { ok: false, kind: "invalid_request", field: "agentId", message };
-}
-
-/** One listed expert, summarized from its manifest (no body read — list stays
- * cheap). After Founder review round 2 every created expert carries all four SDS
- * specs (all required + present from creation), so per-slot presence flags would
- * be trivially true for every expert and carry no discriminating signal — the
- * list therefore exposes only the durable identity (agentId + name + createdAt). */
-export interface ListedProfile {
+/** One listed shopper, summarized from its manifest plus its domain index. */
+export interface ListedShopper {
   agentId: string;
   name: string;
   createdAt: string;
+  domains: DomainSummary[];
 }
 
 /** A `profile.json` that could not be read or parsed — surfaced inline so one
- * corrupt expert never blinds the user to the healthy ones (Product rule 6). */
+ * corrupt shopper never blinds the user to a healthy one. */
 export interface UnreadableProfile {
   /** The directory name (best-effort id); the manifest may be unreadable. */
   agentId: string;
@@ -409,45 +475,51 @@ export interface UnreadableProfile {
 }
 
 /** `listAgentProfiles()` result — always `ok: true` (an empty/absent store is a
- * normal, successful empty listing, not an error). The `ok` discriminator keeps
- * the shape uniform with the read/remove results so callers narrow identically. */
+ * normal, successful empty listing, not an error). */
 export interface ListResult {
   ok: true;
-  experts: ListedProfile[];
+  shoppers: ListedShopper[];
   unreadable: UnreadableProfile[];
 }
 
-/** `readAgentProfile(agentId)` result — discriminated, never throws. */
+/** `readAgentProfile(agentId, slug?)` result — discriminated, never throws.
+ *
+ * One success variant covers BOTH the overview (no slug → `domains` index, no
+ * bodies) and the per-domain read (slug → `slug` + the three bodies). The
+ * per-domain-only fields are optional and present only for a per-domain read; the
+ * tool decides what to expose in each envelope. `domains` (the index) is always
+ * populated so an overview read can list it. */
 export type ReadResult =
   | {
       ok: true;
       agentId: string;
       name: string;
-      /** The SDS domain spec body. Always present for a created expert (required);
-       * a referenced-but-missing body fails the read closed (`not_found`). */
-      domainSpec: string;
-      /** The SDS intent spec (dimension schema) body. Always present for a created
-       * expert (required); a referenced-but-missing body fails the read closed. */
-      intentSpec: string;
-      /** The SDS user spec body. Always present for a created expert (required —
-       * seeded partial at creation, augmented every query); a referenced-but-missing
-       * body fails the read closed (`not_found`). */
-      userSpec: string;
-      /** The SDS playbook (taste) body. Always present for a created expert
-       * (required — seeded partial at creation, augmented every query); a
+      /** The SHARED, agent-level user-spec body. Present for both reads; a
        * referenced-but-missing body fails the read closed (`not_found`). */
-      playbook: string;
+      userSpec: string;
+      /** The domain index (always populated). The overview view exposes this. */
+      domains: DomainSummary[];
       profilePath: string;
       createdAt: string;
+      /** Per-domain only: the requested domain slug. */
+      slug?: string;
+      /** Per-domain only: the SDS domain-spec body. */
+      domainSpec?: string;
+      /** Per-domain only: the SDS intent-spec body. */
+      intentSpec?: string;
+      /** Per-domain only: the SDS playbook body. */
+      playbook?: string;
+      /** Per-domain only: the domain's last-mint timestamp. */
+      updatedAt?: string;
     }
   | { ok: false; kind: "not_found"; agentId: string; message: string }
-  | { ok: false; kind: "invalid_request"; field: "agentId"; message: string };
+  | InvalidRequest;
 
-/** `removeAgentArtefacts(agentId)` result — discriminated, never throws. */
+/** `removeAgentArtefacts(agentId, slug)` result — discriminated, never throws. */
 export type RemoveResult =
-  | { ok: true; agentId: string }
+  | { ok: true; agentId: string; domainSlug: string }
   | { ok: false; kind: "not_found"; agentId: string; message: string }
-  | { ok: false; kind: "invalid_request"; field: "agentId"; message: string }
+  | InvalidRequest
   | {
       ok: false;
       kind: "persistence_failed";
@@ -457,11 +529,11 @@ export type RemoveResult =
       recovery: "fix_data_dir";
     };
 
-/** Read + parse one `agents/<id>/profile.json` into a typed manifest, or throw
- * a descriptive error the caller maps to an `unreadable`/`not_found` outcome.
- * A manifest whose JSON parses but is missing the required string fields is
- * treated as corrupt (an interrupted or hand-edited write) — not silently
- * coerced. */
+/** Read + parse one `agents/<id>/profile.json` into a typed manifest, or throw a
+ * descriptive error the caller maps to an `unreadable`/`not_found` outcome. A
+ * manifest whose JSON parses but is missing the required fields (identity +
+ * userSpecPath + createdAt + a `domains` object) is treated as corrupt — not
+ * silently coerced. */
 function readManifestFile(profilePath: string): ProfileManifest {
   const raw = readFileSync(profilePath, "utf8");
   const parsed = JSON.parse(raw) as unknown;
@@ -470,47 +542,60 @@ function readManifestFile(profilePath: string): ProfileManifest {
     parsed === null ||
     typeof (parsed as { agentId?: unknown }).agentId !== "string" ||
     typeof (parsed as { name?: unknown }).name !== "string" ||
-    typeof (parsed as { domainSpecPath?: unknown }).domainSpecPath !== "string" ||
-    typeof (parsed as { intentSpecPath?: unknown }).intentSpecPath !== "string" ||
     typeof (parsed as { userSpecPath?: unknown }).userSpecPath !== "string" ||
-    typeof (parsed as { playbookPath?: unknown }).playbookPath !== "string" ||
-    typeof (parsed as { createdAt?: unknown }).createdAt !== "string"
+    typeof (parsed as { createdAt?: unknown }).createdAt !== "string" ||
+    typeof (parsed as { domains?: unknown }).domains !== "object" ||
+    (parsed as { domains?: unknown }).domains === null ||
+    Array.isArray((parsed as { domains?: unknown }).domains)
   ) {
     throw new Error("profile.json is missing required manifest fields");
   }
   return parsed as ProfileManifest;
 }
 
+/** Read the manifest if it exists and parses; `null` otherwise. Used by the
+ * upsert/de-register paths that must merge with whatever is already on disk. */
+function tryReadManifest(profilePath: string): ProfileManifest | null {
+  if (!existsSync(profilePath)) return null;
+  try {
+    return readManifestFile(profilePath);
+  } catch {
+    return null;
+  }
+}
+
+/** Project a manifest's `domains` map to the cheap summary index, ordered by
+ * first-mint time (then slug) so the index is deterministic. */
+function toDomainSummaries(manifest: ProfileManifest): DomainSummary[] {
+  return Object.values(manifest.domains)
+    .map((d) => ({ slug: d.slug, name: d.name, createdAt: d.createdAt, updatedAt: d.updatedAt }))
+    .sort((a, b) => createdAtAsc(a.createdAt, b.createdAt) || (a.slug < b.slug ? -1 : a.slug > b.slug ? 1 : 0));
+}
+
 /**
- * Enumerate the materialized experts under each `$SIL_DATA_DIR/agents/<id>/`.
+ * Enumerate the materialized shopper(s) under each `$SIL_DATA_DIR/agents/<id>/`.
  *
  * The manifest is the source of truth — each `agents/<id>/profile.json` is read
- * and parsed (no dirname guessing). Experts are returned `createdAt` DESC (the
- * just-made expert first, the one the user most likely wants to act on). An
- * absent/empty store yields a normal empty listing. One unreadable or corrupt
- * manifest lands in `unreadable[]` and never aborts the listing — the healthy
- * experts still list. Reads only; never writes, never reads a token.
+ * and parsed (no dirname guessing) into a shopper identity + its domain index.
+ * Shoppers are returned `createdAt` DESC. An absent/empty store yields a normal
+ * empty listing. One unreadable or corrupt manifest lands in `unreadable[]` and
+ * never aborts the listing. Reads only; never writes, never reads a token.
  */
 export function listAgentProfiles(): ListResult {
   const root = getAgentsRoot();
   if (!existsSync(root)) {
-    return { ok: true, experts: [], unreadable: [] };
+    return { ok: true, shoppers: [], unreadable: [] };
   }
 
-  const experts: ListedProfile[] = [];
+  const shoppers: ListedShopper[] = [];
   const unreadable: UnreadableProfile[] = [];
 
   let entries: Dirent[];
   try {
     entries = readdirSync(root, { withFileTypes: true });
   } catch (err) {
-    // The agents root exists but cannot be enumerated (e.g. EACCES). Surface it
-    // as a single degraded entry rather than throwing across the boundary.
-    unreadable.push({
-      agentId: AGENTS_SUBDIR,
-      error: errCause(err),
-    });
-    return { ok: true, experts, unreadable };
+    unreadable.push({ agentId: AGENTS_SUBDIR, error: errCause(err) });
+    return { ok: true, shoppers, unreadable };
   }
 
   for (const entry of entries) {
@@ -518,30 +603,27 @@ export function listAgentProfiles(): ListResult {
     const agentId = entry.name;
     const profilePath = join(root, agentId, PROFILE_FILE);
     if (!existsSync(profilePath)) {
-      // A directory under agents/ with no manifest is not a (loadable) sil
-      // expert — report it degraded so the user sees the residue (e.g. a
-      // remove that cleared the manifest but left a stray file).
       unreadable.push({ agentId, error: "no profile.json manifest" });
       continue;
     }
     try {
       const manifest = readManifestFile(profilePath);
-      experts.push({
+      shoppers.push({
         agentId: manifest.agentId,
         name: manifest.name,
         createdAt: manifest.createdAt,
+        domains: toDomainSummaries(manifest),
       });
     } catch (err) {
       unreadable.push({ agentId, error: errCause(err) });
     }
   }
 
-  // Most-recently-created first (Product Flow 1). createdAt is ISO 8601, so a
-  // lexical compare is also chronological; fall back to it when Date.parse is
-  // NaN (a corrupt-but-parseable date) so the sort is total and stable-ish.
-  experts.sort((a, b) => createdAtDesc(a.createdAt, b.createdAt));
+  // Most-recently-created shopper first. createdAt is ISO 8601, so a lexical
+  // compare is also chronological; fall back to it when Date.parse is NaN.
+  shoppers.sort((a, b) => createdAtDesc(a.createdAt, b.createdAt));
 
-  return { ok: true, experts, unreadable };
+  return { ok: true, shoppers, unreadable };
 }
 
 /** Compare two ISO 8601 createdAt strings, most-recent first. */
@@ -549,28 +631,42 @@ function createdAtDesc(a: string, b: string): number {
   const ta = Date.parse(a);
   const tb = Date.parse(b);
   if (Number.isNaN(ta) || Number.isNaN(tb)) {
-    // Lexical fallback keeps the sort total when a timestamp is unparseable.
     return a < b ? 1 : a > b ? -1 : 0;
   }
   return tb - ta;
 }
 
+/** Compare two ISO 8601 createdAt strings, oldest first. */
+function createdAtAsc(a: string, b: string): number {
+  const ta = Date.parse(a);
+  const tb = Date.parse(b);
+  if (Number.isNaN(ta) || Number.isNaN(tb)) {
+    return a < b ? -1 : a > b ? 1 : 0;
+  }
+  return ta - tb;
+}
+
 /**
- * Read one expert's full detail — the manifest PLUS the SDS artefact bodies from
- * the files it points at — so the skill can render a complete view.
+ * Read the shopper overview OR one domain's full pack.
  *
  * Re-runs the writer's `agentId` gate BEFORE any `join`/read (a traversal-shaped
- * id → `invalid_request`, reading nothing). An unknown id, an absent/unreadable
- * manifest, or an absent body of ANY of the four REQUIRED SDS specs
- * (`domain_spec.md` / `intent_spec.md` / `user_spec.md` / `playbook.md`) →
- * `not_found` (Founder review round 2: all four always exist; a degraded expert
- * is, from the user's view, not viewable). There is no degrade-to-undefined path
- * any more — a referenced-but-missing body of any of the four fails the read
- * closed. Never throws across the boundary; reads only.
+ * id → `invalid_request`); a present-but-bad `domainSlug` is guarded the same way
+ * (`field:"domainSlug"`). Fail-closed: an unknown id, an absent/corrupt manifest,
+ * or a missing SHARED user-spec body → `not_found`. With a slug: a slug NOT in the
+ * `domains` map (manifest-gated — an orphaned leaf is invisible) OR any of the 3
+ * referenced domain bodies missing → `not_found` (never a half pack). A freshly-
+ * created shopper with `domains: {}` is HEALTHY — the overview reads back `ok`
+ * with an empty index, never `not_found`. Never throws; reads only.
  */
-export function readAgentProfile(agentId: string): ReadResult {
-  const bad = rejectBadAgentId(agentId);
-  if (bad) return bad;
+export function readAgentProfile(agentId: string, domainSlug?: string): ReadResult {
+  const badId = rejectBadSegment(agentId, "agentId");
+  if (badId) return badId;
+
+  const wantsDomain = nonBlank(domainSlug);
+  if (wantsDomain) {
+    const badSlug = rejectBadSegment(domainSlug, "domainSlug");
+    if (badSlug) return badSlug;
+  }
 
   const dir = getAgentArtefactDir(agentId);
   const profilePath = join(dir, PROFILE_FILE);
@@ -582,29 +678,46 @@ export function readAgentProfile(agentId: string): ReadResult {
   try {
     manifest = readManifestFile(profilePath);
   } catch {
-    // A corrupt/half-written manifest is, to the viewer, an expert that cannot
-    // be loaded — surface not_found (the skill lists the healthy ones), never a
-    // raw parse error across the boundary.
     return notFoundRead(agentId);
   }
 
-  // All FOUR SDS spec bodies are REQUIRED for a created expert — they gate the
-  // read fail-closed (the role the persona body played pre-SDS). A manifest that
-  // points at a domain_spec.md / intent_spec.md / user_spec.md / playbook.md whose
-  // body is gone (a partial write, a hand-deleted file) is, to the viewer, an
-  // expert that cannot be loaded. This is the per-file-atomic, NOT-cross-file-
-  // transactional safety boundary: a partial write degrades to a fail-closed
-  // not_found, never a coherent-but-incomplete expert (Founder review round 2:
-  // all four are present from creation, so none degrades to absence).
+  // The SHARED user-spec body gates BOTH reads fail-closed — a manifest pointing at
+  // a user_spec.md whose body is gone is, to the viewer, a shopper that cannot load.
+  let userSpec: string;
+  try {
+    userSpec = readFileSync(manifest.userSpecPath, "utf8");
+  } catch {
+    return notFoundRead(agentId);
+  }
+
+  const domains = toDomainSummaries(manifest);
+
+  if (!wantsDomain) {
+    return {
+      ok: true,
+      agentId: manifest.agentId,
+      name: manifest.name,
+      userSpec,
+      domains,
+      profilePath,
+      createdAt: manifest.createdAt,
+    };
+  }
+
+  // Per-domain: manifest-gated — a slug not in the map (incl. an orphaned on-disk
+  // leaf) is not_found, never a filesystem guess.
+  const entry = manifest.domains[domainSlug as string];
+  if (entry === undefined) {
+    return notFoundRead(agentId);
+  }
+
   let domainSpec: string;
   let intentSpec: string;
-  let userSpec: string;
   let playbook: string;
   try {
-    domainSpec = readFileSync(manifest.domainSpecPath, "utf8");
-    intentSpec = readFileSync(manifest.intentSpecPath, "utf8");
-    userSpec = readFileSync(manifest.userSpecPath, "utf8");
-    playbook = readFileSync(manifest.playbookPath, "utf8");
+    domainSpec = readFileSync(entry.domainSpecPath, "utf8");
+    intentSpec = readFileSync(entry.intentSpecPath, "utf8");
+    playbook = readFileSync(entry.playbookPath, "utf8");
   } catch {
     return notFoundRead(agentId);
   }
@@ -613,12 +726,15 @@ export function readAgentProfile(agentId: string): ReadResult {
     ok: true,
     agentId: manifest.agentId,
     name: manifest.name,
+    userSpec,
+    domains,
+    profilePath,
+    createdAt: entry.createdAt,
+    slug: entry.slug,
     domainSpec,
     intentSpec,
-    userSpec,
     playbook,
-    profilePath,
-    createdAt: manifest.createdAt,
+    updatedAt: entry.updatedAt,
   };
 }
 
@@ -627,72 +743,96 @@ function notFoundRead(agentId: string): ReadResult {
     ok: false,
     kind: "not_found",
     agentId,
-    message: 'No sil expert "' + agentId + '" — list your experts to see which exist.',
+    message: 'No sil shopper "' + agentId + '" — list your shoppers to see which exist.',
   };
 }
 
 /**
- * Remove one expert's behaviour-artefact directory — the sil-side half of a
- * clean removal (the host-wiring half is the skill's `openclaw` CLI step; the
- * plugin cannot write `~/.openclaw`).
+ * Remove exactly ONE of the shopper's domain packs — the sil-side half of a clean
+ * domain removal (the host-wiring half, if any, is the skill's `openclaw` CLI
+ * step; the plugin cannot write `~/.openclaw`).
  *
- * Fail-closed and scoped to exactly the named expert:
- *   - re-runs the writer's `agentId` gate ITSELF (never trusts the caller) — a
- *     bad/`main`/traversal-shaped id → `invalid_request`, deletes NOTHING;
- *   - asserts the resolved target is strictly UNDER `getDataDir()/agents/` and
- *     is NOT the `agents/` parent, so a delete can never escape the subtree or
- *     wipe sibling experts;
- *   - recursively delete the single validated leaf dir.
+ * Fail-closed and scoped to one domain leaf:
+ *   - re-runs the `agentId` gate AND the `domainSlug` gate (never trusts the
+ *     caller) — a bad/`main`/traversal/missing slug → `invalid_request`
+ *     (`field:"domainSlug"`), deletes NOTHING (no omit-deletes-everything trap);
+ *   - asserts the resolved leaf is strictly UNDER `<agentDir>/domains/` and is NOT
+ *     that parent, so a delete can never escape the subtree or wipe a sibling;
+ *   - manifest-gated: an unregistered slug → `not_found` (idempotent);
+ *   - removes the single leaf, THEN rewrites `profile.json` to de-register
+ *     `domains[slug]` — the shopper and the SHARED user_spec survive.
  *
- * Absent target → `not_found` (idempotent — a re-run after a partial host-CLI
- * failure is safe). A genuine delete failure (e.g. EACCES) →
- * `persistence_failed` with `<dir>: <cause>`. Never throws across the boundary.
+ * A genuine delete/rewrite failure → `persistence_failed` with `<dir>: <cause>`.
+ * Never throws across the boundary.
  */
-export function removeAgentArtefacts(agentId: string): RemoveResult {
-  const bad = rejectBadAgentId(agentId);
-  if (bad) return bad;
+export function removeAgentArtefacts(agentId: string, domainSlug: string): RemoveResult {
+  const badId = rejectBadSegment(agentId, "agentId");
+  if (badId) return badId;
+  const badSlug = rejectBadSegment(domainSlug, "domainSlug");
+  if (badSlug) return badSlug;
 
-  const dir = getAgentArtefactDir(agentId);
+  const agentDir = getAgentArtefactDir(agentId);
+  const domainsRoot = join(agentDir, DOMAINS_SUBDIR);
+  const leaf = getDomainArtefactDir(agentId, domainSlug);
 
-  // Defence in depth beyond the id gate: assert the resolved path is strictly a
-  // child of the agents root and never the root itself. Deleting the parent
-  // directory would wipe every sibling expert — refuse it even if some future
-  // change to the gate let a separator-bearing id through.
-  const root = getAgentsRoot();
-  if (dirname(dir) !== root || dir === root) {
-    return invalidAgentId(
-      "agentId resolves outside the agents subtree — refusing to delete: " +
-        JSON.stringify(agentId),
+  // Defence in depth beyond the slug gate: the leaf must be a STRICT child of the
+  // domains root and never the root itself — deleting the parent would wipe every
+  // sibling domain.
+  if (dirname(leaf) !== domainsRoot || leaf === domainsRoot) {
+    return invalid(
+      "domainSlug",
+      "domainSlug resolves outside the domains subtree — refusing to delete: " +
+        JSON.stringify(domainSlug),
     );
   }
 
-  if (!existsSync(dir)) {
+  const profilePath = join(agentDir, PROFILE_FILE);
+  const manifest = tryReadManifest(profilePath);
+  // Manifest-gated: an unregistered (or absent) domain is already gone.
+  if (manifest === null || !(domainSlug in manifest.domains)) {
     return {
       ok: false,
       kind: "not_found",
       agentId,
       message:
-        'No sil expert "' + agentId + '" to remove (already gone) — list your'
-        + " experts to see which exist. A re-run is safe (idempotent).",
+        'No domain "' + domainSlug + '" on shopper "' + agentId + '" to remove (already'
+        + " gone) — list the shopper's domains to see which exist. A re-run is safe.",
     };
   }
 
+  // Remove the leaf FIRST; only de-register once the bytes are actually gone, so a
+  // failed delete never leaves the map pointing at a still-present pack.
   try {
-    rmSync(dir, { recursive: true, force: true });
+    rmSync(leaf, { recursive: true, force: true });
   } catch (err) {
-    return {
-      ok: false,
-      kind: "persistence_failed",
-      error: dir + ": " + errCause(err),
-      message:
-        "The expert's behaviour artefacts could NOT be removed from the sil data"
-        + " directory. Fix the data directory (it must be writable — check"
-        + " permissions), then remove the expert again.",
-      recovery: "fix_data_dir",
-    };
+    return persistenceFailedRemove(leaf, err);
   }
 
-  return { ok: true, agentId };
+  const nextDomains: Record<string, DomainEntry> = {};
+  for (const [slug, entry] of Object.entries(manifest.domains)) {
+    if (slug !== domainSlug) nextDomains[slug] = entry;
+  }
+  const updated: ProfileManifest = { ...manifest, domains: nextDomains };
+  try {
+    atomicWrite(profilePath, JSON.stringify(updated, null, 2) + "\n");
+  } catch (err) {
+    return persistenceFailedRemove(profilePath, err);
+  }
+
+  return { ok: true, agentId, domainSlug };
+}
+
+function persistenceFailedRemove(path: string, err: unknown): RemoveResult {
+  return {
+    ok: false,
+    kind: "persistence_failed",
+    error: path + ": " + errCause(err),
+    message:
+      "The domain's behaviour artefacts could NOT be removed from the sil data"
+      + " directory. Fix the data directory (it must be writable — check"
+      + " permissions), then remove the domain again.",
+    recovery: "fix_data_dir",
+  };
 }
 
 /** Extract a human-readable cause from an unknown thrown value (never PII). */

--- a/src/tools/profile.ts
+++ b/src/tools/profile.ts
@@ -1,30 +1,28 @@
 /**
- * sil shopping-expert profile tools.
+ * sil shopper profile tools — the single multi-domain shopper seam.
  *
- * `sil_profile_materialize` is the plugin's half of the agent-creation engine:
- * it writes the created expert's *SDS behaviour* artefacts (all four required —
- * domain spec + intent-spec dimension schema + user spec + playbook taste,
- * present from creation and augmented every query — and a typed manifest) into
- * the plugin's own data directory (`$SIL_DATA_DIR`, the
- * disclosed `filesystemScope`). The persona is NOT written here — the agent's
- * identity/voice is the host workspace `SOUL.md`, written directly via the host
- * CLI. The *wiring* half — the host `agents.list[]` entry, the enabled `sil`
- * plugin, the attached `sil` skill, the `SOUL.md` — is the host agent driving
- * its own `openclaw …` CLI under the bundled `sil-shopping/SKILL.md` procedure; the
- * plugin never writes `~/.openclaw` (`security.noChildProcess: true`, host
- * config is outside `filesystemScope`).
+ * `sil_profile_materialize` is the plugin's half of the agent-creation engine and
+ * the lazy domain-mint path: it writes the SHARED, agent-level user spec and, when
+ * a `domain` pack is supplied, that niche's SDS artefacts
+ * (`domains/<slug>/{domain_spec,intent_spec,playbook}.md`) into the plugin's own
+ * data directory (`$SIL_DATA_DIR`, the disclosed `filesystemScope`). It stays ONE
+ * tool with an OPTIONAL `domain`: no `domain` ⇒ create the one shopper; with
+ * `domain` ⇒ lazily mint/refresh a niche AND persist any cross-niche fact captured
+ * into the shared user spec — one atomic call. The persona is NOT written here —
+ * the shopper's identity/voice is the host workspace `SOUL.md`. The wiring half
+ * (the host `agents.list[]` entry, the enabled `sil` plugin, the attached skill,
+ * the `SOUL.md`) is the host agent driving its own `openclaw …` CLI; the plugin
+ * never writes `~/.openclaw` (`security.noChildProcess: true`).
  *
- * Why a tool (not skill-driven `write`-tool prose): the host agent's only way
- * to invoke plugin code is a registered tool, and a plugin write buys
- * host-validated typed inputs, the structured-error envelope, and ATOMIC
- * all-or-nothing writes — all of which serve the goal's primary correctness
- * bar (a created expert that actually shops). The artefact write lives here;
- * the host-config write stays host-CLI.
+ * Domain classification / routing at shop time stays SKILL-REASONING — there is no
+ * routing tool. The surface is the same four profile tools; the skill reads
+ * `profile.json.domains` (via `sil_profile_list` / `sil_profile_get`) to pick or
+ * lazily mint a niche.
  *
  * This follows `identity.ts` (the reference group): a `registerXTools(api)`
  * function, a `Type.Object` schema the host validates inputs against, the
- * `jsonResult` success/structured-error envelope, and ALL I/O inside
- * `execute()` (register() opens nothing).
+ * `jsonResult` success/structured-error envelope, and ALL I/O inside `execute()`
+ * (register() opens nothing).
  */
 
 import type { PluginAPI } from "openclaw/plugin-sdk";
@@ -39,6 +37,12 @@ import {
 } from "../lib/profile-store.js";
 import { jsonResult } from "../lib/tool-result.js";
 
+/** Narrow a host-validated param to a string, defaulting to "" so the store does
+ * the real, structured-error validation (validate-first / write-nothing). */
+function asString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
 export function registerProfileTools(api: PluginAPI): void {
   registerMaterialize(api);
   registerList(api);
@@ -49,98 +53,126 @@ export function registerProfileTools(api: PluginAPI): void {
 function registerMaterialize(api: PluginAPI): void {
   api.registerTool({
     name: "sil_profile_materialize",
-    label: "Materialize a sil shopping-expert's SDS behaviour artefacts",
+    label: "Materialize the sil shopper / mint a domain pack",
     description:
-      "Write a created sil shopping expert's SDS behaviour artefacts into the sil"
-      + " data directory — ALL FOUR are REQUIRED and present from creation (seeded"
-      + " partial by the light ≤10-question setup + an initial research pass, then"
-      + " augmented every query): the domain spec (deep researched niche expertise"
-      + " — how to buy well, the full mechanics), the intent spec (the"
-      + " agent-specific decomposition dimensions a query must resolve, derived"
-      + " from the domain spec), the user spec (the user's domain-relevant facts +"
-      + " hard constraints) and the playbook (the user's buying taste), plus a"
-      + " typed manifest the sil skill reads at runtime to load them. The persona"
-      + " is NOT written here — it is the host workspace SOUL.md, written via the"
-      + " host CLI. Re-run it over the SAME agentId to refine an expert in place or"
-      + " augment a spec from a query (pass the full updated body — it overwrites"
-      + " atomically). Call this AFTER the host agent has been created (openclaw"
-      + " agents add) and BEFORE openclaw config validate. It does NOT touch the"
-      + " host OpenClaw config — the plugin enable + skill attach are driven by the"
-      + " host CLI, not this tool. Writes are atomic: an invalid spec writes"
-      + " nothing, and a write failure leaves nothing partial.",
+      "Write the one sil shopper's behaviour artefacts into the sil data directory."
+      + " ONE tool, two modes. WITHOUT a `domain`: create the shopper — write the"
+      + " SHARED, agent-level user spec (the one person's standing facts + hard"
+      + " constraints that carry across every niche) and a manifest with an empty"
+      + " domains map. WITH a `domain`: lazily mint or refresh that niche on first"
+      + " shop — write its domain spec (deep researched niche expertise), intent"
+      + " spec (the decomposition dimensions a query must resolve) and playbook (the"
+      + " niche buying taste) under domains/<slug>/, AND overwrite the shared user"
+      + " spec (so a cross-niche fact surfaced in the same query is persisted) — all"
+      + " in one atomic call that upserts domains[slug]. `userSpec` is REQUIRED on"
+      + " every call (pass the full updated body — it overwrites atomically). The"
+      + " persona is NOT written here — it is the host workspace SOUL.md. Re-run with"
+      + " the SAME { agentId, domain.slug } to refresh a niche in place. Does NOT"
+      + " touch the host OpenClaw config. Writes are atomic: an invalid spec writes"
+      + " nothing, and a write failure leaves nothing partial (a failed new-domain"
+      + " mint tears down only that fresh leaf; the shopper and siblings survive).",
     parameters: Type.Object({
       agentId: Type.String({
         description:
-          "The host agent id the expert was created under (agents.list[].id),"
-          + " lower-kebab; not \"main\" (host-reserved). Keys the artefact dir.",
+          "The host agent id of the shopper (agents.list[].id), lower-kebab; not"
+          + " \"main\" (host-reserved). Keys the artefact dir.",
       }),
       name: Type.String({
-        description: "The human-readable expert name (recorded in the manifest).",
-      }),
-      domainSpec: Type.String({
-        description:
-          "The SDS domain spec — deep researched niche expertise: how to buy well"
-          + " in the niche and its full mechanics (for cycling: gearing theory,"
-          + " frame geometry, the complete bike-fit process). Researched by the"
-          + " agent itself (web + knowledge), not interrogated from the user."
-          + " REQUIRED, non-empty. Materialized as domain_spec.md; web-refreshed"
-          + " every query.",
-      }),
-      intentSpec: Type.String({
-        description:
-          "The SDS intent spec — the agent-specific decomposition DIMENSIONS (a"
-          + " PRD-style template) a shopping query must resolve, derived from the"
-          + " domain spec (for cycling: use-case, terrain, budget, timeline,"
-          + " compatibility, performance priorities, aesthetics). REQUIRED,"
-          + " non-empty. This is the dimension SCHEMA only — the per-query intent"
-          + " (dimensions filled in) is ephemeral and is never stored. Materialized"
-          + " as intent_spec.md.",
+        description: "The human-readable shopper name (recorded in the manifest).",
       }),
       userSpec: Type.String({
         description:
-          "The SDS user spec — the user's domain-relevant facts + hard"
-          + " constraints (body measurements, climate, the rules they never"
-          + " break). REQUIRED, non-empty: present from creation (seeded partial"
-          + " by the light ≤10-question setup), then augmented every query."
-          + " Materialized as user_spec.md (per-user, per-expert, local). On a"
-          + " per-query augment / refine, pass the full updated body.",
+          "The SHARED, agent-level user spec — the one person's domain-relevant"
+          + " facts + hard constraints (addresses, sizes, allergy/ethics rules they"
+          + " never break, budget psychology) that carry across EVERY niche."
+          + " REQUIRED, non-empty on every call. Materialized as user_spec.md and"
+          + " read by every domain's shop loop, so a fact captured while shopping one"
+          + " niche is reused in another without being re-asked. On any augment, pass"
+          + " the full updated body — it overwrites atomically.",
       }),
-      playbook: Type.String({
-        description:
-          "The SDS playbook — the user's buying TASTE (price sensitivity, brand"
-          + " preferences, general taste). REQUIRED, non-empty: present from"
-          + " creation (seeded partial), then augmented every query. Materialized"
-          + " as playbook.md. On a per-query augment / refine, pass the full"
-          + " updated body.",
-      }),
+      domain: Type.Optional(
+        Type.Object(
+          {
+            slug: Type.String({
+              description:
+                "The domain slug, lower-kebab; not \"main\". Keys domains/<slug>/."
+                + " Reuse the slug of an existing matching niche before minting a new"
+                + " one (the skill dedups; the store enforces only shape).",
+            }),
+            name: Type.String({
+              description: "The human-readable domain name (e.g. \"Road cycling\").",
+            }),
+            domainSpec: Type.String({
+              description:
+                "The SDS domain spec — deep researched niche expertise: how to buy"
+                + " well in the niche and its full mechanics. REQUIRED, non-empty."
+                + " Materialized as domains/<slug>/domain_spec.md; web-refreshed every"
+                + " query.",
+            }),
+            intentSpec: Type.String({
+              description:
+                "The SDS intent spec — the decomposition DIMENSIONS a shopping query"
+                + " in this niche must resolve (use-case, budget, compatibility…),"
+                + " derived from the domain spec. REQUIRED, non-empty. The dimension"
+                + " SCHEMA only — the per-query intent is ephemeral. Materialized as"
+                + " domains/<slug>/intent_spec.md.",
+            }),
+            playbook: Type.String({
+              description:
+                "The SDS playbook — the user's buying TASTE for THIS niche (price"
+                + " band, brand leanings, niche-mechanical preferences). REQUIRED,"
+                + " non-empty. Materialized as domains/<slug>/playbook.md. On a"
+                + " per-query augment, pass the full updated body.",
+            }),
+          },
+          {
+            description:
+              "OPTIONAL per-domain pack. Omit to create/refresh the shopper only;"
+              + " include to lazily mint or refresh a niche.",
+          },
+        ),
+      ),
     }),
     async execute(_callId, params) {
       // The host validates `params` against the schema above before we run, but
       // narrow at the read site (the SDK types params as Record<string,unknown>)
       // and let the store do the real, structured-error validation.
+      const rawDomain = params["domain"];
+      let domain: ProfileSpec["domain"];
+      if (typeof rawDomain === "object" && rawDomain !== null) {
+        const d = rawDomain as Record<string, unknown>;
+        domain = {
+          slug: asString(d["slug"]),
+          name: asString(d["name"]),
+          domainSpec: asString(d["domainSpec"]),
+          intentSpec: asString(d["intentSpec"]),
+          playbook: asString(d["playbook"]),
+        };
+      }
+
       const spec: ProfileSpec = {
-        agentId: typeof params["agentId"] === "string" ? params["agentId"] : "",
-        name: typeof params["name"] === "string" ? params["name"] : "",
-        domainSpec: typeof params["domainSpec"] === "string" ? params["domainSpec"] : "",
-        intentSpec: typeof params["intentSpec"] === "string" ? params["intentSpec"] : "",
-        userSpec: typeof params["userSpec"] === "string" ? params["userSpec"] : "",
-        playbook: typeof params["playbook"] === "string" ? params["playbook"] : "",
+        agentId: asString(params["agentId"]),
+        name: asString(params["name"]),
+        userSpec: asString(params["userSpec"]),
+        ...(domain ? { domain } : {}),
       };
 
       const result = materializeProfile(spec);
 
       if (result.ok) {
-        api.logger.info("sil_profile_materialized", { agent_id: result.agentId });
-        return jsonResult({
+        api.logger.info("sil_profile_materialized", {
+          agent_id: result.agentId,
+          domain_slug: result.domain?.slug,
+        });
+        const payload: Record<string, unknown> = {
           status: "ok",
           agentId: result.agentId,
           dir: result.dir,
-          domainSpecPath: result.domainSpecPath,
-          intentSpecPath: result.intentSpecPath,
           userSpecPath: result.userSpecPath,
-          playbookPath: result.playbookPath,
           profilePath: result.profilePath,
-        });
+        };
+        if (result.domain) payload["domain"] = result.domain;
+        return jsonResult(payload);
       }
 
       if (result.kind === "invalid_request") {
@@ -165,90 +197,112 @@ function registerMaterialize(api: PluginAPI): void {
 }
 
 /**
- * `sil_profile_list` — enumerate the user's sil shopping experts (read-only).
- *
- * The artefact store is the source of truth for "what is a sil expert" (a
- * readable `agents/<id>/profile.json`), not the host agent list. Returns each
- * expert summarized from its manifest, most-recently-created first, plus an
- * `unreadable[]` bucket so one corrupt manifest never blinds the user to the
- * rest. An empty store is a normal `ok` outcome (like an empty `sil_search`).
+ * `sil_profile_list` — enumerate the shopper(s) and each one's domain index
+ * (read-only, no args). The artefact store is the source of truth (a readable
+ * `agents/<id>/profile.json`). An empty store, or a shopper with `domains: {}`, is
+ * a normal `ok` outcome (a shopper that has not shopped yet). One corrupt manifest
+ * lands in `unreadable[]` and never aborts the listing.
  */
 function registerList(api: PluginAPI): void {
   api.registerTool({
     name: "sil_profile_list",
-    label: "List the user's sil shopping experts",
+    label: "List the sil shopper's domains",
     description:
-      "List the sil shopping experts the user has created — read-only, no"
-      + " arguments. Sourced from the sil data directory's artefact store (each"
-      + " agents/<id>/profile.json is the authoritative \"is a sil expert\""
-      + " signal — a bare host agent without one is not listed). Returns the"
-      + " experts most-recently-created first, each with its agentId, name, and"
-      + " createdAt. Every expert carries all four SDS specs (domain + intent +"
-      + " user + playbook, all required and present from creation), so per-slot"
-      + " presence is not flagged. An empty store is a normal, successful empty"
-      + " listing — not an error. One unreadable or corrupt manifest is reported"
-      + " inline in `unreadable` and never aborts the listing. Reads no token and"
-      + " writes nothing.",
+      "List the sil shopper(s) and each one's domains — read-only, no arguments."
+      + " Sourced from the sil data directory's artefact store (each"
+      + " agents/<id>/profile.json is the authoritative shopper signal; its domains"
+      + " map is the niche index). Returns each shopper's agentId, name and createdAt"
+      + " plus its domains (slug, name, createdAt, updatedAt). A shopper with no"
+      + " domains yet still lists, with an empty domain list — that is healthy, not"
+      + " an error; so is an empty store. One unreadable or corrupt manifest is"
+      + " reported inline in `unreadable` and never aborts the listing. Reads no"
+      + " token and writes nothing.",
     parameters: Type.Object({}),
     async execute(_callId, _params) {
-      const { experts, unreadable } = listAgentProfiles();
+      const { shoppers, unreadable } = listAgentProfiles();
       api.logger.info("sil_profile_listed", {
-        expert_count: experts.length,
+        shopper_count: shoppers.length,
         unreadable_count: unreadable.length,
       });
-      return jsonResult({
-        status: "ok",
-        experts,
-        unreadable,
-      });
+      return jsonResult({ status: "ok", shoppers, unreadable });
     },
   });
 }
 
 /**
- * `sil_profile_get` — view one expert's full detail (read-only).
+ * `sil_profile_get` — view the shopper overview OR one domain's pack (read-only).
  *
- * Re-runs the writer's `agentId` gate before any read (a traversal-shaped id →
- * `invalid_request`). Returns the manifest plus the SDS artefact bodies so the
- * skill can render a complete view. An unknown or unloadable expert →
- * `not_found` (the skill lists the healthy experts) — never a stack trace or a
- * raw path. Reads no token and writes nothing.
+ * With no `domainSlug`: the shopper overview (identity + the SHARED user spec + the
+ * domain index, no bodies). With a `domainSlug`: that domain's three bodies + the
+ * SHARED user spec. Re-runs the `agentId` gate (and a slug gate) before any read.
+ * An unknown/unloadable shopper or domain → `not_found`; a malformed/traversal id
+ * or slug → `invalid_request`. Reads no token and writes nothing.
  */
 function registerGet(api: PluginAPI): void {
   api.registerTool({
     name: "sil_profile_get",
-    label: "View one sil shopping expert's detail",
+    label: "View the sil shopper overview or one domain",
     description:
-      "Show one sil shopping expert's full detail — read-only. Pass its"
-      + " `agentId`. Returns the expert's name, its four SDS specs (domain, intent,"
-      + " user spec / facts, and playbook / buying taste — all present), the"
-      + " manifest path, and createdAt, read from the artefact store so the agent"
-      + " can summarize the expert. The persona is not here — it is the host"
-      + " workspace SOUL.md. An unknown expert returns `not_found` (list the"
-      + " experts to see which exist) — never a stack trace or a raw path. A"
-      + " malformed/traversal id returns `invalid_request`. Reads no token and"
-      + " writes nothing.",
+      "Show the sil shopper's detail — read-only. Pass `agentId`. WITHOUT a"
+      + " `domainSlug`: the shopper overview — its name, the SHARED user spec (the"
+      + " one person's facts + hard constraints) and the domain index (each niche's"
+      + " slug/name/timestamps), no per-domain bodies. WITH a `domainSlug`: that"
+      + " one domain's pack — its domain spec, intent spec and playbook (buying"
+      + " taste) PLUS the SHARED user spec. The persona is not here — it is the host"
+      + " workspace SOUL.md. A freshly-created shopper with no domains is healthy"
+      + " (the overview returns ok with an empty domain index). An unknown shopper"
+      + " or an unminted/unloadable domain returns `not_found` (list to see what"
+      + " exists). A malformed/traversal id or slug returns `invalid_request`. Reads"
+      + " no token and writes nothing.",
     parameters: Type.Object({
       agentId: Type.String({
         description:
-          "The expert's host agent id (lower-kebab, e.g. \"gift-buyer\"; not"
-          + " \"main\"). Keys the artefact directory the detail is read from.",
+          "The shopper's host agent id (lower-kebab; not \"main\"). Keys the"
+          + " artefact directory the detail is read from.",
       }),
+      domainSlug: Type.Optional(
+        Type.String({
+          description:
+            "OPTIONAL. A domain slug to view that niche's pack; omit for the shopper"
+            + " overview (identity + shared user spec + domain index).",
+        }),
+      ),
     }),
     async execute(_callId, params) {
-      const agentId = typeof params["agentId"] === "string" ? params["agentId"] : "";
-      const result = readAgentProfile(agentId);
+      const agentId = asString(params["agentId"]);
+      const rawSlug = params["domainSlug"];
+      const domainSlug = typeof rawSlug === "string" ? rawSlug : undefined;
+      const result = readAgentProfile(agentId, domainSlug);
 
       if (result.ok) {
+        if (result.slug !== undefined) {
+          // Per-domain read — the niche's three bodies + the shared user spec.
+          api.logger.info("sil_profile_viewed", {
+            agent_id: result.agentId,
+            domain_slug: result.slug,
+          });
+          return jsonResult({
+            status: "ok",
+            agentId: result.agentId,
+            name: result.name,
+            slug: result.slug,
+            userSpec: result.userSpec,
+            domainSpec: result.domainSpec,
+            intentSpec: result.intentSpec,
+            playbook: result.playbook,
+            profilePath: result.profilePath,
+            createdAt: result.createdAt,
+            updatedAt: result.updatedAt,
+          });
+        }
+        // Overview — identity + shared user spec + the domain index (no bodies).
         api.logger.info("sil_profile_viewed", { agent_id: result.agentId });
         return jsonResult({
           status: "ok",
           agentId: result.agentId,
           name: result.name,
-          domainSpec: result.domainSpec,
-          intentSpec: result.intentSpec,
           userSpec: result.userSpec,
-          playbook: result.playbook,
+          domains: result.domains,
           profilePath: result.profilePath,
           createdAt: result.createdAt,
         });
@@ -276,50 +330,56 @@ function registerGet(api: PluginAPI): void {
 }
 
 /**
- * `sil_profile_remove` — remove one expert's behaviour artefacts (the sil-side
- * half of a clean removal).
+ * `sil_profile_remove` — remove ONE of the shopper's domain packs (artefact half).
  *
- * This is the ARTEFACT half ONLY. The host-wiring half (the `agents.list[]`
- * entry) is the skill's `openclaw agents remove <agentId>` CLI step, which the
- * skill runs FIRST — the plugin cannot write `~/.openclaw` (`noChildProcess`).
- *
- * Fail-closed: re-runs the `agentId` gate itself, deletes only the single
- * validated leaf directory under `agents/`, and deletes NOTHING on a bad id.
- * Absent target → `not_found` (idempotent — safe to re-run after a partial host
- * failure). A genuine `rmSync` failure → `persistence_failed`. Reads no token.
+ * `domainSlug` is REQUIRED — there is no omit-deletes-everything trap; removing the
+ * whole shopper is a host concern, not this tool. Removes exactly the one
+ * `domains/<slug>/` leaf and de-registers it from the manifest; the shopper and the
+ * SHARED user spec survive. Re-runs the gates itself, deletes NOTHING on a bad/
+ * missing slug. Absent (unregistered) slug → `not_found` (idempotent). A genuine
+ * `rmSync`/rewrite failure → `persistence_failed`. Reads no token.
  */
 function registerRemove(api: PluginAPI): void {
   api.registerTool({
     name: "sil_profile_remove",
-    label: "Remove a sil shopping expert's behaviour artefacts",
+    label: "Remove one of the sil shopper's domains",
     description:
-      "Remove one sil shopping expert's behaviour artefacts from the sil data"
-      + " directory (its agents/<id>/ directory). This is the SIL-SIDE half of"
-      + " removal only — the host wiring (the agents.list[] entry) is removed"
-      + " separately by the host CLI, which the skill runs FIRST (this plugin"
-      + " cannot write the host config). Pass the `agentId`. Scoped to exactly"
-      + " that one expert: a malformed/traversal/\"main\" id returns"
-      + " `invalid_request` and deletes nothing; an unknown id returns"
-      + " `not_found` (idempotent — safe to re-run after a partial failure); a"
-      + " genuine filesystem failure returns `persistence_failed`. Confirm with"
-      + " the user before removing — it is destructive and irreversible.",
+      "Remove ONE of the sil shopper's domain packs from the sil data directory"
+      + " (its domains/<slug>/ directory) — the SIL-SIDE artefact half only. Pass"
+      + " BOTH `agentId` and `domainSlug`; `domainSlug` is REQUIRED — this never"
+      + " deletes the whole shopper (decommissioning the shopper is a host concern)."
+      + " Scoped to exactly that one domain: the shopper, the SHARED user spec, and"
+      + " every sibling domain survive. A malformed/traversal/\"main\" or missing"
+      + " slug returns `invalid_request` and deletes nothing; an unregistered slug"
+      + " returns `not_found` (idempotent — safe to re-run after a partial failure);"
+      + " a genuine filesystem failure returns `persistence_failed`. Confirm with the"
+      + " user before removing — it is destructive and irreversible.",
     parameters: Type.Object({
       agentId: Type.String({
         description:
-          "The expert's host agent id (lower-kebab, e.g. \"gift-buyer\"; not"
-          + " \"main\"). Keys the artefact directory to remove. Exactly one"
-          + " expert is affected.",
+          "The shopper's host agent id (lower-kebab; not \"main\"). Keys the"
+          + " artefact directory the domain is removed from.",
+      }),
+      domainSlug: Type.String({
+        description:
+          "The domain slug to remove (lower-kebab; not \"main\"). REQUIRED —"
+          + " exactly one domain pack is affected; the shopper itself is not.",
       }),
     }),
     async execute(_callId, params) {
-      const agentId = typeof params["agentId"] === "string" ? params["agentId"] : "";
-      const result = removeAgentArtefacts(agentId);
+      const agentId = asString(params["agentId"]);
+      const domainSlug = asString(params["domainSlug"]);
+      const result = removeAgentArtefacts(agentId, domainSlug);
 
       if (result.ok) {
-        api.logger.info("sil_profile_removed", { agent_id: result.agentId });
+        api.logger.info("sil_profile_removed", {
+          agent_id: result.agentId,
+          domain_slug: result.domainSlug,
+        });
         return jsonResult({
           status: "removed",
           agentId: result.agentId,
+          domainSlug: result.domainSlug,
         });
       }
 


### PR DESCRIPTION
## Card
`cards/single-multi-domain-sil-shopper.md` (gitignored / local-only — see the card body for the full intent + handoffs). This PR is **Slice 1** of that card.

## What this is
Reshape the profile store + tools from **one-expert-per-niche** to **ONE persistent "sil shopper"** that holds many domains and routes by domain at shop time. **No backwards compatibility** — the flat per-niche layout and the four flat `*Path` manifest keys are **deleted**, not run alongside.

New on-disk layout:
```
$SIL_DATA_DIR/agents/<shopperId>/
  ├─ user_spec.md          SHARED, agent-level (the one person)
  ├─ profile.json          manifest: identity + userSpecPath + a slug-keyed `domains` map
  └─ domains/<slug>/{ domain_spec.md, intent_spec.md, playbook.md }   minted lazily on first shop
```

## Summary
- `ProfileSpec` → `{ agentId, name, userSpec, domain? }`; `ProfileManifest` → `{ agentId, name, userSpecPath, createdAt, domains: Record<slug, DomainEntry> }`. The four flat `*Path` keys are gone.
- `sil_profile_materialize` stays **one** tool with an **optional** `domain` pack: no `domain` ⇒ create the shopper (shared `user_spec.md` + `profile.json` with `domains: {}`, no `domains/` dir); with `domain` ⇒ atomic lazy mint of `domains/<slug>/*` + a shared-`user_spec` rewrite + an upsert into `domains[slug]`.
- Write order `domains/<slug>/* → user_spec → profile.json LAST`. Mint teardown is keyed on **manifest membership**: a failed mint of a **new** domain tears down only the fresh leaf; a re-mint of an **existing** domain is dir-preserving; a pre-occupied leaf is never removed. A crash before `profile.json` leaves only an orphaned, manifest-invisible leaf (fail-closed).
- New `getDomainArtefactDir` + a slug path-segment guard reusing `AGENT_ID_RE` (slug is now a filesystem segment — security-relevant).
- Lifecycle: `listAgentProfiles` → shoppers + domain index; `readAgentProfile(id, slug?)` → overview vs domain pack (fail-closed on any missing required body; **empty `domains` is healthy**, never `not_found`); `removeAgentArtefacts(id, slug)` removes one leaf + de-registers the slug (`domainSlug` required, traversal-guarded, scoped — the shopper + shared user_spec survive).
- **8 tool names unchanged** — `manifest-contract.integration.test.ts` stays green (no new routing tool; routing stays skill-reasoning).

## Test plan
- [x] `tsc --noEmit` — 0 errors
- [x] 7 rewritten profile suites (128 tests) green: `profile-store{,-sds,-manage}`, `refine-rewrite`, `profile-{materialize,manage,sds}`
- [x] `manifest-contract.integration.test.ts` green (8 names frozen)
- [x] Full suite: 957 passed; the only failures are the 10 pre-existing `repo-scaffold.integration.test.ts` cases (gitignored `CLAUDE.md`/`docs/` not checked out in a worktree — unrelated to this change)

Tiers: `[unit, integration]`.

## Out of scope / follow-ups
- **Slice 2 (deferred)** — the five-reference skill rewrite (`agent_creation_engine.md`, `expert_shopping.md`, `brainstorm_interview.md`, `manage_experts.md`, `refine_expert.md`) + the coupled `SKILL.md` router, the worked example, and the `skill-content.test.ts` drift guards. Sequenced AFTER this card AND the `allow-list-sil-tools-on-expert-creation` card merge. No skill markdown is touched here.
- **e2e / cross-niche bar (live-verification, not a repo gate)** — create ONE shopper → shop ≥2 unrelated niches in one session → 2nd pack minted on the fly → a shared-`user_spec` fact from niche A reused in niche B without re-asking. There is no host-load gate in this repo; this is verified on a real `alpine/openclaw` host (sil-stage), not as a vitest tier.

## Distillation target
Knowledge capture happens after Review PASS in the `distilling` stage (`solutions-architect`, same branch/PR).