### PR TITLE
card/audit-tool-skill-surface: drift-guard hardening for the single-shopper pivot audit

### DIFF
--- a/src/__tests__/helpers/per-niche-expert.ts
+++ b/src/__tests__/helpers/per-niche-expert.ts
@@ -1,0 +1,56 @@
+/**
+ * The per-niche-expert vocabulary disavowal-token discipline, as a SINGLE source
+ * of truth shared by the prose drift guard (`skill-content.test.ts`, integration)
+ * and the tool-description vocabulary guard (`tool-schema-contract.unit.test.ts`,
+ * unit). Both pin the same rule: the single-shopper pivot RETIRED "expert" as
+ * user-facing vocabulary for the current model (the agent is a "shopper", a niche
+ * a "domain"), but a corrected doc/description legitimately NAMES the retired
+ * model to bury it (a *retro-reference*). So the guard forbids the bare agent-noun
+ * "expert"/"experts" — EXCEPT when a legacy/retired/per-niche context sits
+ * immediately before it.
+ *
+ * See docs/knowledge/skill-prose-drift-guard-disavowal-discipline.md (seam 1).
+ * Keeping this in one module means the retro-allowance lookback can never drift
+ * between the prose guard and the tool-description guard.
+ */
+
+/**
+ * Whole-word "expert"/"experts" — the per-niche-expert agent noun the pivot
+ * retires from user-facing vocabulary. Whole-word so legitimate "niche
+ * expertise" / "expertly" (substring) never trips it (the false-token trap).
+ */
+export const PER_NICHE_EXPERT_WORD = /\bexperts?\b/i;
+
+/**
+ * Whole-word "expert" matches that are NOT legitimate retro-references to the
+ * RETIRED per-niche-expert model. An `expert` occurrence is ALLOWED iff it sits
+ * in a legacy/retired/per-niche context (a disavowal, e.g. "the retired
+ * per-niche-expert model", "a legacy expert"); any other occurrence frames the
+ * CURRENT model as a per-niche expert and is forbidden. Returns the offending
+ * contexts (empty ⇒ clean). This is the disavowal-token discipline: a corrected
+ * doc/description may NAME the retired model to bury it — never the bare token as
+ * a blanket forbid.
+ */
+export function perNicheExpertOffenders(body: string): string[] {
+  const offenders: string[] = [];
+  const re = /\bexperts?\b/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(body)) !== null) {
+    const before = body.slice(Math.max(0, m.index - 28), m.index).toLowerCase();
+    const isRetro =
+      before.includes("legacy") ||
+      before.includes("retired") ||
+      before.includes("per-niche") ||
+      before.includes("no longer") ||
+      before.includes("old ");
+    if (!isRetro) {
+      offenders.push(
+        body
+          .slice(Math.max(0, m.index - 24), m.index + m[0].length + 12)
+          .replace(/\s+/g, " ")
+          .trim(),
+      );
+    }
+  }
+  return offenders;
+}

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -129,8 +129,8 @@ describe("plugin entry — registration contract", () => {
     // api with exactly the real tools and NO example stub. This pins the
     // wiring AND the card's "absence" goal: sil_ping / sil_echo gone.
     // sil_profile_materialize (agent-creation engine, card:
-    // create-a-valid-sil-wired-openclaw-agent-profile) and the local expert
-    // lifecycle sil_profile_list / sil_profile_get / sil_profile_remove (card:
+    // create-a-valid-sil-wired-openclaw-agent-profile) and the single shopper's
+    // domain lifecycle sil_profile_list / sil_profile_get / sil_profile_remove (card:
     // list-view-and-remove-local-expert-agents) join the set.
     const api = createMockPluginApi();
     capturedRegisterFn!(api);

--- a/src/__tests__/skill-content.test.ts
+++ b/src/__tests__/skill-content.test.ts
@@ -52,6 +52,10 @@ import {
   createMockPluginApi,
   registeredToolNames,
 } from "./helpers/mock-plugin-api.js";
+import {
+  PER_NICHE_EXPERT_WORD,
+  perNicheExpertOffenders,
+} from "./helpers/per-niche-expert.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(HERE, "..", "..");
@@ -82,47 +86,11 @@ const RETIRED_FILENAMES = [
   "road_cycling_expert_walkthrough.md",
 ] as const;
 
-/** Whole-word "expert"/"experts" — the per-niche-expert agent noun the card
- * retires from user-facing vocabulary. Whole-word so legitimate "niche
- * expertise" / "expertly" never trips it (the false-token trap). */
-const PER_NICHE_EXPERT_WORD = /\bexperts?\b/i;
-
-/**
- * Whole-word "expert" matches that are NOT legitimate retro-references to the
- * RETIRED per-niche-expert model. The card RETIRES "expert" as user-facing
- * vocabulary for the CURRENT model (the agent is a "shopper", a niche a "domain")
- * — but it EXPLICITLY mandates retro-references to the retired model (e.g. the
- * manage reference frames a legacy flat-layout dir as "a legacy expert" and steers
- * re-create; docs name "the retired per-niche-expert model"). So an `expert`
- * occurrence is allowed iff it sits in a legacy/retired/per-niche context; any
- * other occurrence frames the CURRENT model as a per-niche expert and is
- * forbidden. Returns the offending contexts (empty ⇒ clean). This is the
- * disavowal-token discipline: a corrected doc may NAME the retired model to bury
- * it — never the bare token as a blanket forbid.
- */
-function perNicheExpertOffenders(body: string): string[] {
-  const offenders: string[] = [];
-  const re = /\bexperts?\b/gi;
-  let m: RegExpExecArray | null;
-  while ((m = re.exec(body)) !== null) {
-    const before = body.slice(Math.max(0, m.index - 28), m.index).toLowerCase();
-    const isRetro =
-      before.includes("legacy") ||
-      before.includes("retired") ||
-      before.includes("per-niche") ||
-      before.includes("no longer") ||
-      before.includes("old ");
-    if (!isRetro) {
-      offenders.push(
-        body
-          .slice(Math.max(0, m.index - 24), m.index + m[0].length + 12)
-          .replace(/\s+/g, " ")
-          .trim(),
-      );
-    }
-  }
-  return offenders;
-}
+/* `PER_NICHE_EXPERT_WORD` + `perNicheExpertOffenders` (the disavowal-token
+ * discipline + 28-char retro-allowance) live in ./helpers/per-niche-expert.ts —
+ * a single source of truth shared with the unit tool-description vocabulary guard
+ * in tools/tool-schema-contract.unit.test.ts, so the retro-allowance can never
+ * drift between the two guards. */
 
 interface Frontmatter {
   raw: string;
@@ -347,23 +315,19 @@ describe("skill bundle — the rename retired the per-niche-expert filenames (re
     expect(offenders).toEqual([]);
   });
 
-  it("NO card-owned rewrite carries per-niche-expert user-facing vocabulary (whole-word `expert`)", () => {
+  it("NO bundle file carries per-niche-expert user-facing vocabulary (whole-word `expert`, scan derived from BUNDLE_FILES)", () => {
     // The card's headline success signal: zero surviving per-niche-expert prose. The
     // model noun is "shopper", a niche is a "domain". Whole-word `\bexperts?\b` so
     // legitimate "niche expertise" passes; "shopping expert" / "your experts" fail.
-    // search_param_mapping.md (vocab-only edits founder-de-scopable) + the untouched
-    // catalog reference are excluded — they get the link-integrity scan above.
-    const SCAN: ReadonlyArray<readonly [string, string]> = [
-      ["SKILL.md", SKILL_PATH],
-      ["agent_creation_engine.md", ENGINE_PATH],
-      ["brainstorm_interview.md", BRAINSTORM_PATH],
-      ["shop_loop.md", SHOP_LOOP_PATH],
-      ["manage_domains.md", MANAGE_PATH],
-      ["refine_shopper.md", REFINE_PATH],
-      ["multi_domain_shopper_walkthrough.md", EXAMPLE_PATH],
-    ];
+    // The scan set is DERIVED from BUNDLE_FILES (audit forward-gap 1) — not a hand-
+    // maintained subset — so NO bundle file can ever escape it again. This folds in
+    // search_param_mapping.md AND catalog_tools_reference.md, the two files that
+    // previously sat OUTSIDE the scan (covered only by the retired-filename link
+    // scan, which greps filenames, not the word "expert"). Both are clean today, so
+    // this stays GREEN; a future affirmative `expert` reintroduction in ANY bundle
+    // file — including the two newly-folded-in references — is now caught here.
     const offenders: string[] = [];
-    for (const [label, path] of SCAN) {
+    for (const [label, path] of BUNDLE_FILES) {
       for (const ctx of perNicheExpertOffenders(readBody(path))) {
         offenders.push(`${label}: …${ctx}…`);
       }
@@ -869,6 +833,59 @@ function brainstormBodyLower(): string {
   return readBody(BRAINSTORM_PATH).toLowerCase();
 }
 
+/**
+ * The affirmative create-time-niche-work STEP instructions a regression to the
+ * retired five-touchpoint interview would re-introduce: the deep niche research
+ * (old §2), the compare-a-set-of-options taste (old §4), and the intent-dimension
+ * sign-off (old §5) that the single-shopper interview RELOCATED to first-shop lazy
+ * mint. Same phrases the old bare `not.toContain(...)` forbids targeted — but now
+ * negation-aware (audit forward-gap 3): the corrected interview legitimately NAMES
+ * these to DISAVOW them ("does NOT research any niche", "never interrogated here",
+ * "deferred to first shop", "minted lazily"), so a bare forbid false-REDs the
+ * disavowal. This is the disavowal-token discipline applied to a STEP, not a noun.
+ */
+const CREATE_TIME_NICHE_STEP_RE =
+  /research (?:it|the niche) yourself|compare a set of options|ask (?:the user|you) to sign off/gi;
+
+/** Negation / deferral markers that turn an affirmative-step match into a
+ * legitimate disavowal when one sits within ~28 chars before the match (mirrors
+ * `perNicheExpertOffenders`' retro-allowance lookback). */
+const NICHE_STEP_DEFERRAL = [
+  "not ",
+  "never",
+  "no ",
+  "don't",
+  "deferred",
+  "instead",
+  "lazily",
+  "at first shop",
+] as const;
+
+/**
+ * Affirmative create-time-niche-work step instructions that are NOT preceded
+ * (within ~28 chars) by a negation/deferral token — i.e. a real regression that
+ * re-introduces the retired step, never a disavowal of it. Returns the offending
+ * contexts (empty ⇒ clean). Body is expected already-lowercased.
+ */
+function createTimeNicheStepOffenders(body: string): string[] {
+  const offenders: string[] = [];
+  CREATE_TIME_NICHE_STEP_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = CREATE_TIME_NICHE_STEP_RE.exec(body)) !== null) {
+    const before = body.slice(Math.max(0, m.index - 28), m.index);
+    const deferred = NICHE_STEP_DEFERRAL.some((t) => before.includes(t));
+    if (!deferred) {
+      offenders.push(
+        body
+          .slice(Math.max(0, m.index - 24), m.index + m[0].length + 12)
+          .replace(/\s+/g, " ")
+          .trim(),
+      );
+    }
+  }
+  return offenders;
+}
+
 describe("references/brainstorm_interview.md — open, two-sided interview that converges a shopper draft", () => {
   it("names the brainstorm/interview as an open, multi-turn conversation that is NOT a form-fill", () => {
     const body = brainstormBodyLower();
@@ -967,14 +984,15 @@ describe("references/brainstorm_interview.md — exactly TWO create touchpoints 
         body.includes("minted lazily") ||
         body.includes("minted later"));
     expect(relocates).toBe(true);
-    // NEGATIVE: the active old five-touchpoint create-STEP instructions are gone (a
-    // regression to the old model would re-introduce one of these affirmative steps).
-    expect(body).not.toContain("actively research it yourself");
-    expect(body).not.toContain("research it yourself");
-    expect(body).not.toContain("research the niche yourself");
-    expect(body).not.toContain("compare a set of options");
-    expect(body).not.toContain("ask the user to sign off");
-    expect(body).not.toContain("ask you to sign off");
+    // NEGATIVE (negation-aware — audit forward-gap 3): the active old five-touchpoint
+    // create-STEP instructions are gone. A regression re-introduces one of these
+    // affirmative steps ("research the niche yourself", "compare a set of options",
+    // "ask the user to sign off"); the corrected interview only NAMES them to disavow
+    // them. So flag a match ONLY when no negation/deferral token sits within ~28 chars
+    // before it — NEVER a bare `not.toContain(...)`, which would false-RED a future
+    // negated disavowal ("never asks you to research the niche yourself"). Matcher
+    // stays `.toEqual([])` (add-only).
+    expect(createTimeNicheStepOffenders(body)).toEqual([]);
   });
 });
 
@@ -1260,6 +1278,21 @@ describe("references/shop_loop.md — the map/search/compare/recommend loop (pre
       (body.includes("stale") && body.includes("snapshot")) ||
       body.includes("point-in-time");
     expect(neverOffStale).toBe(true);
+
+    // Two-sided contract (audit forward-gap 2): the PROSE deliberately keeps every
+    // buy-substring OUT of Steps 0–7 — it shops with "shop well" / "shopping taste",
+    // never "buy well" / "buying taste" — so the FIRST "buy" substring in the body
+    // is the real Step-8 re-fetch step. Anchor on the FIRST occurrence and assert
+    // its surrounding window co-locates with the `sil_product_get` re-fetch, so a
+    // future "buy well" in an early step moves the first buy UPSTREAM into a window
+    // that names neither `sil_product_get` nor the re-fetch → RED. This is a POSITIVE
+    // window pin, NOT a naive global indexOf("buy") vs indexOf("sil_product_get")
+    // ordering scan (which downstream "unbuyable" / "buying taste" would confound).
+    const firstBuy = body.indexOf("buy");
+    expect(firstBuy).toBeGreaterThanOrEqual(0);
+    const firstBuyWindow = body.slice(Math.max(0, firstBuy - 140), firstBuy + 20);
+    expect(firstBuyWindow).toContain("sil_product_get");
+    expect(firstBuyWindow).toMatch(/re-fetch|before any buy/);
   });
 
   it("handles ok+empty (relax + explain), the unservable 'no' (never junk), and non-ok (follow recovery, never improvise)", () => {

--- a/src/__tests__/tools/tool-schema-contract.unit.test.ts
+++ b/src/__tests__/tools/tool-schema-contract.unit.test.ts
@@ -33,12 +33,15 @@
 
 import { describe, it, expect, beforeEach } from "vitest";
 import { registerIdentityTools } from "../../tools/identity.js";
+import { registerCatalogTools } from "../../tools/catalog.js";
+import { registerProfileTools } from "../../tools/profile.js";
 import {
   createMockPluginApi,
   getTool,
   registeredToolNames,
   type MockPluginAPI,
 } from "../helpers/mock-plugin-api.js";
+import { perNicheExpertOffenders } from "../helpers/per-niche-expert.js";
 
 /**
  * The agent-facing tool contract for the identity surface, captured from
@@ -158,4 +161,55 @@ describe("TypeBox introspection metadata never leaks into the agent-visible sche
       expect(serialized).not.toContain("~readonly");
     });
   }
+});
+
+/* ---------------------------------------------------------------------------
+ * VOCABULARY — no registered tool DESCRIPTION frames the surface as a per-niche
+ * expert (card: audit-tool-skill-surface-for-single-shopper-pivot).
+ *
+ * The single-shopper pivot shipped as targeted slices; the four catalog/identity
+ * tools (`sil_register`, `sil_whoami`, `sil_search`, `sil_product_get`) were never
+ * opened, so their descriptions could regress to implicit per-niche-expert framing
+ * without anyone touching them — and an agent learns the model it is driving almost
+ * entirely from these descriptions. This guard runs the SHARED whole-word
+ * `\bexperts?\b` + 28-char retro-allowance check (`perNicheExpertOffenders`, the
+ * very check the skill-prose guard uses, so the discipline can never drift) over
+ * EVERY registered tool description — the four pivot-untouched tools and the five
+ * profile verbs (`sil_profile_*` + `sil_remember`). Green on the current tree; a
+ * future `expert` reintroduction into any description turns it RED.
+ *
+ * This is a VOCABULARY guard, DISTINCT from the exact-tool-SET guards (the identity
+ * set assertion above, index.test.ts, manifest-contract): it pins HOW a description
+ * talks about the model, never WHICH tools exist — so it deliberately asserts NO
+ * tool count / name set, and adding or removing a tool never turns it RED. Reuses
+ * the retro-allowance rather than a stricter matcher, so a legitimate future retro-
+ * reference ("unlike the retired per-niche expert…") would not false-RED.
+ * ------------------------------------------------------------------------- */
+
+describe("registered tool descriptions carry NO per-niche-expert vocabulary (whole-word `expert`, retro-allowance)", () => {
+  function allRegisteredTools(): MockPluginAPI {
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+    registerCatalogTools(api);
+    registerProfileTools(api);
+    return api;
+  }
+
+  it("every registered tool description scans clean — incl. the four pivot-untouched tools and the five profile verbs", () => {
+    const tools = [...allRegisteredTools()._tools.entries()];
+    // Guard against a vacuous green: descriptions must actually exist AND be
+    // non-blank to be scanned. (NOT a tool count/set pin — passes for any tool set.)
+    expect(tools.length).toBeGreaterThan(0);
+    const emptyDescriptions: string[] = [];
+    const offenders: string[] = [];
+    for (const [name, tool] of tools) {
+      const description = tool.description ?? "";
+      if (description.trim().length === 0) emptyDescriptions.push(name);
+      for (const ctx of perNicheExpertOffenders(description)) {
+        offenders.push(`${name}: …${ctx}…`);
+      }
+    }
+    expect(emptyDescriptions).toEqual([]);
+    expect(offenders).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Audit result

A systematic, **semantic (not just lexical)** sweep of the whole sil-openclaw tool + skill surface — including the four catalog/identity tools the per-niche-expert → single-shopper pivot never opened (`sil_register`, `sil_whoami`, `sil_search`, `sil_product_get`) and all five profile verbs (`sil_profile_*` + `sil_remember`) — **confirmed the surface is already consistent with the single multi-domain shopper model.** Zero residual per-niche-expert framing, lexical or semantic. **No tool source or skill prose was rewritten** — clean is clean (production-grade-first). A green sweep is the card's accepted PASS, not a no-op.

## What changed (all add-only, test-only except one comment)

Closes the three documented drift-guard forward-gaps from `skill-prose-drift-guard-disavowal-discipline.md` + a tool-description vocabulary net:

- **New shared helper** `src/__tests__/helpers/per-niche-expert.ts` — `PER_NICHE_EXPERT_WORD` + `perNicheExpertOffenders` (whole-word `\bexperts?\b` + 28-char retro-allowance), lifted out of `skill-content.test.ts` so the prose guard (integration) and the new tool-description guard (unit) single-source the disavowal-token discipline (it can never drift between them).
- **FG1** — `skill-content.test.ts` whole-word scan now **derived from `BUNDLE_FILES`** instead of a hand-maintained subset, folding in `search_param_mapping.md` AND `catalog_tools_reference.md` (the two files that previously sat outside the scan). Both clean today → GREEN.
- **FG2** — `shop_loop.md` first-`"buy"`-substring window pin: the surrounding window co-locates with the Step-8 `sil_product_get` re-fetch, so a future "buy well" in Steps 0–7 turns it RED. Positive window pin, not a naive global `indexOf` ordering scan.
- **FG3** — `brainstorm_interview.md` **negation-aware** `createTimeNicheStepOffenders` replaces six bare `not.toContain(...)` forbids: an affirmative create-time-niche-work step is flagged ONLY when no negation/deferral token sits within ~28 chars before it (so the interview may NAME the retired step to disavow it without false-RED).
- **New unit guard** in `tool-schema-contract.unit.test.ts` — `perNicheExpertOffenders` over all nine registered tool descriptions (built via the mock `PluginAPI`).
- **Comment reword** in `index.test.ts` — "the local expert lifecycle" → "the single shopper's domain lifecycle" (the two historical card-slug strings left untouched, immutable history).

## Discipline guarantees

- Each of the four guards was **adversarially proven RED-on-plant / GREEN-on-revert**.
- Every offender matcher stays **`.toEqual([])`** — never loosened to `toContain`/subset (that would silently kill drift detection).
- This is the **vocabulary** guard, kept distinct from the **exact-tool-SET** guards: the identity exact-set assertion, TypeBox schema assertions, `index.test.ts`'s nine-name set, the manifest contract, and `SIL_TOOLS` are all **untouched** — no tool was added or removed.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] full suite — 941 passed; the only 10 failures are the known `repo-scaffold.integration.test.ts` worktree baseline (gitignored `docs/` + `CLAUDE.md` not checked out), not a regression
- [x] the three touched files run green in isolation (139 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)