### PR TITLE
feature: post-register shopper nudge and per-search pitch

### DIFF
--- a/sil-shopping/SKILL.md
+++ b/sil-shopping/SKILL.md
@@ -22,6 +22,25 @@ These three principles hold on every path, before any reference is loaded:
 
 Confirm the `sil_*` tools are exposed. If they are missing from the available tool list, the host runtime is filtering them out because sil is not admitted at the host allow surfaces — run the shipped admission helper `sil-openclaw-allowlist` (it additively admits sil at `plugins.allow` + `tools.alsoAllow`, leaving any other trusted plugin untouched), then reopen the session so the tools load. Most flows need an identity: if the user has not registered this session, the catalog tools return an unregistered status whose `recovery` points at `sil_register` (the [catalog tools reference](references/catalog_tools_reference.md) has the full taxonomy) — so calling a catalog tool first lets that outcome route, or run `sil_register` up front when the user's intent clearly requires it.
 
+## After register — offer to set up the shopper (once, only when there's none)
+
+`sil_register` returns `already_registered` with `next_step: "offer_shopper"` on a confirmed registration (a fresh sign-in this session, or a returning session that was already signed in). That hint is a routing breadcrumb, not a decision — act on it by first running a no-arg `sil_profile_get` to read shopper state, then branch:
+
+- **Empty store (no shopper yet):** introduce the shopper in one short beat and offer to set it up. Name the value in its own terms — it shops each niche in depth, reuses the sizes and hard limits it already knows so nothing is re-asked, and explains why each pick fits — a standing buyer's advisor, not a one-off search. Only on a yes, load [`references/brainstorm_interview.md`](references/brainstorm_interview.md) (a two-touchpoint onboarding, never a form). Take no for an answer: bare `sil_search` stays a first-class path, so don't re-offer in the same turn.
+- **A shopper already exists:** skip this beat entirely. The shopper is a singleton — never offer a second one.
+
+## After a bare search — name what a shopper would add (recurring, by design)
+
+When a plain `sil_search` completes with status `ok` in a profile-less session, present the results best-first exactly as they came back, then append **one** short trailing line — a post-result tip with a soft CTA — naming what a shopper would add on top. It is never a pre-search question and never a re-rank: bare search stays a legitimate quick lookup, and these are the same results a shopper would start from.
+
+Name one or two of the three levers a bare search leaves on the table, and rotate which you lead with so the recurring line stays fresh:
+
+- **niche depth** — a shopper weighs these against how the niche actually buys, instead of just listing them;
+- **memory** — it keeps your sizes and hard limits on file, so no search re-asks them;
+- **the why** — it explains which pick fits you and why, instead of a flat ranked list.
+
+This line recurs on **every** completed profile-less search: there is no fire-once or seen-it gate, and no cooldown — the recurrence is the point, and brevity plus lever rotation are all that keep it from nagging. Exactly two things suppress it, and only these two: a shopper already exists (that session is the shopper's — drop the line), or the search did not complete `ok` (a non-`ok` status carries its own recovery, so follow that and add no tip).
+
 ## Routing — match intent to a tool, load its reference on demand
 
 | Intent | Tool | Reference to load |

--- a/src/__tests__/skill-content.test.ts
+++ b/src/__tests__/skill-content.test.ts
@@ -1721,3 +1721,283 @@ describe("references/search_param_mapping.md — hard constraint → real filter
     expect(disavowsWhoami).toBe(true);
   });
 });
+
+/* ===========================================================================
+ * POST-REGISTER SHOPPER NUDGE + PER-SEARCH PITCH — two add-only always-on
+ * SKILL.md beats (card: post-register-shopper-nudge-and-per-search-pitch):
+ *   (1) after a confirmed registration, offer the shopper ONCE — gated on a
+ *       no-arg sil_profile_get empty-store check, routed to brainstorm_interview
+ *       on a yes, skipped for an existing shopper (singleton);
+ *   (2) after every completed profile-less bare sil_search, append one short
+ *       POST-RESULT pitch line naming what a shopper would add — recurring by
+ *       design, Lane 1 untouched (best-first, no re-rank, no pre-search question).
+ *
+ * DISAVOWAL DISCIPLINE ([[skill-prose-drift-guard-disavowal-discipline]]): pin the
+ * NEW model POSITIVELY on NET-NEW anchor tokens (`offer_shopper`, `next_step`,
+ * `post-result`, `re-rank`, `fire-once`, … — all ABSENT from SKILL.md before this
+ * card, so RED-capable), and make EVERY negative NEGATION-AWARE — NEVER a bare
+ * not.toContain(<anti-pattern token>), because the corrected prose legitimately
+ * NAMES the anti-patterns ("never a re-rank", "no fire-once … gate") to DISAVOW
+ * them. Offender matchers stay `.toEqual([])`; no existing assertion is loosened.
+ *
+ * SECTION SCOPING is load-bearing, not decoration: the gate/route tokens the
+ * after-register beat needs (`sil_profile_get`, `references/brainstorm_interview.md`,
+ * `singleton`) ALREADY appear elsewhere in SKILL.md (the routing table + the create
+ * two-step gate), so a whole-body `body.includes(...)` would FALSE-GREEN. Each beat
+ * is isolated to its own H2 section — located by a net-new anchor unique to that
+ * beat, bounded to the enclosing `## ` heading and the next `## ` — so every pin is
+ * meaningful (and RED before the beat exists).
+ * ========================================================================= */
+
+/** The SKILL.md body H2 section that OWNS `anchor` — from its `## ` heading up to
+ * the next `## `. `anchor` is a net-new token unique to one beat, so the section is
+ * that beat and nothing else (no bleed into the adjacent beat or the routing table). */
+function sectionOwning(body: string, anchor: number): string {
+  const headingStart = body.lastIndexOf("\n## ", anchor);
+  const from = headingStart >= 0 ? headingStart + 1 : Math.max(0, anchor - 300);
+  const rest = body.slice(from);
+  const nextH2 = rest.indexOf("\n## ", anchor - from + 1);
+  return nextH2 >= 0 ? rest.slice(0, nextH2) : rest;
+}
+
+/** The after-register beat section, anchored on `offer_shopper` (net-new; appears
+ * ONLY in this beat — RED before the beat exists). */
+function afterRegisterBeat(): string {
+  const body = skillBody(readFileSync(SKILL_PATH, "utf8"));
+  const at = body.indexOf("offer_shopper");
+  expect(at, "SKILL.md must carry the after-register offer_shopper beat").toBeGreaterThanOrEqual(0);
+  return sectionOwning(body, at);
+}
+
+/** The per-search pitch beat section, anchored on `post-result`/`post result`
+ * (net-new; unique to this beat — RED before the beat exists). */
+function perSearchBeat(): string {
+  const body = skillBody(readFileSync(SKILL_PATH, "utf8"));
+  const m = /post-?result/i.exec(body);
+  expect(m, "SKILL.md must carry the per-search post-result pitch beat").not.toBeNull();
+  return sectionOwning(body, m!.index);
+}
+
+/** Negation/deferral markers that turn an affirmative anti-pattern match into a
+ * legitimate DISAVOWAL when one sits within ~28 chars before the match (mirrors
+ * `perNicheExpertOffenders` / `createTimeNicheStepOffenders`' retro-allowance).
+ * The corrected pitch beat says "never a re-rank", "no fire-once … gate" — the
+ * anti-pattern token is present ONLY to be buried, so a bare forbid false-REDs it. */
+const PITCH_DISAVOWAL = [
+  "no ", "not ", "never", "without", "don't", "do not", "n't ", "isn't", "aren't",
+] as const;
+
+/** Affirmative (non-disavowed) matches of `re` in `body` — a match is flagged ONLY
+ * when NO disavowal token sits within ~28 chars before it. Empty ⇒ clean. `body` is
+ * expected already-lowercased; `re` MUST carry the global flag. */
+function affirmativeOffenders(body: string, re: RegExp): string[] {
+  const offenders: string[] = [];
+  re.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(body)) !== null) {
+    const before = body.slice(Math.max(0, m.index - 28), m.index);
+    const disavowed = PITCH_DISAVOWAL.some((t) => before.includes(t));
+    if (!disavowed) {
+      offenders.push(
+        body
+          .slice(Math.max(0, m.index - 24), m.index + m[0].length + 12)
+          .replace(/\s+/g, " ")
+          .trim(),
+      );
+    }
+  }
+  return offenders;
+}
+
+/** Lane-1-violation instructions — an AFFIRMATIVE re-rank of the results, or an
+ * AFFIRMATIVE pre-search question. The corrected beat disavows both ("never a
+ * pre-search question and never a re-rank"). `re-?rank` does NOT match a bare
+ * "ranked list" (no `re` prefix), so the legitimate "flat ranked list" copy is safe. */
+const LANE1_VIOLATION_RE =
+  /re-?rank|pre-?search question|ask (?:the user )?(?:a question )?before (?:the )?search/gi;
+
+/** Frequency-gate (anti-recurrence) instructions — the product-owner REGRESSION: a
+ * fire-once / seen-it / cooldown / one-shot suppression bolted onto the recurring
+ * pitch. The corrected beat disavows them ("no fire-once or seen-it gate, and no
+ * cooldown"). Generic "suppress" is DELIBERATELY excluded — the beat legitimately
+ * says a shopper-owner suppresses the pitch (the one valid STATE gate); only
+ * FREQUENCY gates are the regression this guards. */
+const FREQUENCY_GATE_RE =
+  /fire-?once|seen-?it|one-?shot|cooldown|snooze|dismiss(?:ed|es)?|show (?:it |the (?:tip|pitch|line) )?(?:only )?once|only once/gi;
+
+describe("sil-shopping/SKILL.md — after-register introduce-and-offer beat (add-only, disavowal discipline)", () => {
+  it("names the next_step: 'offer_shopper' hint (byte-identical to identity.ts's already_registered field)", () => {
+    // The SKILL keys the beat off the EXACT machine breadcrumb identity.ts emits —
+    // the two are a contract (product-marketer's naming↔code flag), pinned
+    // byte-identical on both sides. `offer_shopper`/`next_step` are net-new ⇒ RED
+    // before the beat exists.
+    const beat = afterRegisterBeat();
+    expect(beat).toContain("next_step");
+    expect(beat).toContain("offer_shopper");
+    // The breadcrumb rides the confirmed-registration outcome (allowed token —
+    // "already_registered" does not contain the forbidden "not_registered").
+    expect(beat).toContain("already_registered");
+  });
+
+  it("gates the offer on a NO-ARG sil_profile_get empty-store check (offer ONLY when no shopper)", () => {
+    // The skill owns the actual gate (identity.ts stays decoupled from the store):
+    // read shopper state with the no-arg overview, offer ONLY on an empty store.
+    // Section-scoped because `sil_profile_get` also appears in the routing table —
+    // a whole-body check would false-green.
+    const beat = afterRegisterBeat().toLowerCase();
+    expect(beat).toContain("sil_profile_get");
+    const namesNoArg =
+      beat.includes("no-arg") || beat.includes("no arg") ||
+      beat.includes("no `domainslug`") || beat.includes("no domainslug") ||
+      beat.includes("overview");
+    expect(namesNoArg).toBe(true);
+    const gatesOnEmpty =
+      beat.includes("empty store") || beat.includes("empty") ||
+      beat.includes("no shopper") || beat.includes("none yet") ||
+      beat.includes("no shopper yet");
+    expect(gatesOnEmpty).toBe(true);
+  });
+
+  it("routes to references/brainstorm_interview.md ONLY on acceptance (a yes)", () => {
+    // Section-scoped: brainstorm_interview.md also appears in the create two-step
+    // gate, so a whole-body includes would false-green the routing pin.
+    const beat = afterRegisterBeat();
+    expect(beat).toContain("references/brainstorm_interview.md");
+    const onlyOnYes =
+      /only on a yes/i.test(beat) || /on a yes/i.test(beat) ||
+      /on acceptance/i.test(beat) || /if .{0,20}\byes\b/i.test(beat) ||
+      /\baccepts?\b/i.test(beat);
+    expect(onlyOnYes).toBe(true);
+  });
+
+  it("states the SINGLETON skip — an existing shopper is never offered a second one", () => {
+    // Section-scoped: "singleton" also appears in the create two-step gate below.
+    const beat = afterRegisterBeat().toLowerCase();
+    expect(beat).toContain("singleton");
+    const skipsWhenExists =
+      beat.includes("skip this beat") || beat.includes("skip the beat") ||
+      beat.includes("never offer a second") || beat.includes("second one") ||
+      beat.includes("second shopper") ||
+      (beat.includes("already") && beat.includes("shopper") && beat.includes("skip"));
+    expect(skipsWhenExists).toBe(true);
+  });
+});
+
+describe("sil-shopping/SKILL.md — per-search pitch beat (add-only, disavowal discipline)", () => {
+  it("describes a POST-RESULT trailing line on a completed bare sil_search, recurring by design", () => {
+    const beat = perSearchBeat();
+    const lower = beat.toLowerCase();
+    // Post-result (the anchor) + a single trailing line — not a pre-search prompt.
+    expect(/post-?result/i.test(beat)).toBe(true);
+    expect(lower).toContain("sil_search");
+    const trailingLine =
+      lower.includes("trailing line") || lower.includes("trailing tip") ||
+      lower.includes("one short") || lower.includes("a short trailing") ||
+      lower.includes("short trailing line");
+    expect(trailingLine).toBe(true);
+    // Recurring by design — the recurrence IS the feature (product-owner non-goal).
+    const recurs =
+      /recur/i.test(beat) || /every\b[\s\S]{0,30}\bsearch/i.test(beat) ||
+      /each\b[\s\S]{0,30}\bsearch/i.test(beat);
+    expect(recurs).toBe(true);
+  });
+
+  it("names ≥1 of the three levers a bare search leaves on the table (depth / memory / the why)", () => {
+    const lower = perSearchBeat().toLowerCase();
+    const levers = [
+      /niche depth|in depth|how (?:the|this) niche/i, // niche depth
+      /re-?ask|sizes and hard limits|on file|\bmemory\b/i, // memory / facts-reuse
+      /the why|explains?\b[\s\S]{0,40}\bwhy\b|\bwhy\b/i, // the why
+    ].filter((re) => re.test(lower));
+    // AC bar is ≥1 (the instruction enumerates all three for rotation).
+    expect(levers.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("keeps Lane 1 UNTOUCHED — best-first, never a re-rank, never a pre-search question (negation-aware)", () => {
+    const lower = perSearchBeat().toLowerCase();
+    // Positive: results presented best-first / unchanged (no re-order).
+    const bestFirst =
+      /best-?first/i.test(lower) || lower.includes("unchanged") ||
+      lower.includes("exactly as they came back") || lower.includes("as they came back");
+    expect(bestFirst).toBe(true);
+    // Negation-aware: an AFFIRMATIVE re-rank or pre-search question is the Lane-1
+    // violation; the corrected beat NAMES both only to disavow them ("never a
+    // re-rank", "never a pre-search question"), so flag a match ONLY when it is NOT
+    // negated within ~28 chars. NEVER a bare not.toContain("re-rank") (that would
+    // false-RED the disavowal). Matcher stays `.toEqual([])`.
+    expect(affirmativeOffenders(lower, LANE1_VIOLATION_RE)).toEqual([]);
+  });
+
+  it("the recurrence IS the feature — no fire-once / seen-it / cooldown FREQUENCY gate (positive + negation-aware regression guard)", () => {
+    const lower = perSearchBeat().toLowerCase();
+    // Positive: recurrence is explicit; the ONLY gate is the STATE gate.
+    const recurrenceIsThePoint =
+      lower.includes("recurrence is the point") || lower.includes("the recurrence is") ||
+      /recurs on\b[\s\S]{0,24}every/i.test(lower) || lower.includes("no fire-once");
+    expect(recurrenceIsThePoint).toBe(true);
+    // Negation-aware regression guard (product-owner): a future dev reading the
+    // repetition as noise and adding a fire-once / seen-it / cooldown suppression is
+    // a REGRESSION, not a cleanup. The corrected beat DISAVOWS these by name, so a
+    // bare forbid would false-RED it — flag only the AFFIRMATIVE (non-disavowed)
+    // frequency gate. Matcher stays `.toEqual([])`.
+    expect(affirmativeOffenders(lower, FREQUENCY_GATE_RE)).toEqual([]);
+  });
+
+  it("STATE-gated symmetry — the pitch drops for a shopper-owner (profile-less only), the one legitimate suppression", () => {
+    const lower = perSearchBeat().toLowerCase();
+    // Profile-less session only …
+    const profileLess =
+      lower.includes("profile-less") || lower.includes("profileless") ||
+      (lower.includes("no shopper") && lower.includes("session"));
+    expect(profileLess).toBe(true);
+    // … and drops entirely once a shopper exists (Lane 2's session — offering a
+    // shopper they own is wrong). This is the STATE gate — never a frequency gate.
+    const dropsForOwner =
+      lower.includes("a shopper already exists") || lower.includes("once a shopper exists") ||
+      lower.includes("drop the line") || lower.includes("drop this line") ||
+      (lower.includes("shopper") && lower.includes("drop"));
+    expect(dropsForOwner).toBe(true);
+  });
+
+  it("fires ONLY on a completed ok search — a non-ok status is skipped and follows its own recovery", () => {
+    const lower = perSearchBeat().toLowerCase();
+    // Gated on status ok …
+    const okGate =
+      /status\b[\s\S]{0,6}\bok\b/i.test(lower) ||
+      /completes?\b[\s\S]{0,12}\bok\b/i.test(lower) ||
+      /complete\b[\s\S]{0,8}ok\b/i.test(lower);
+    expect(okGate).toBe(true);
+    // … a non-ok status skips the tip + follows its own recovery (never improvises).
+    const nonOkSkips =
+      (/non-?ok/i.test(lower) || lower.includes("did not complete")) &&
+      (lower.includes("recovery") || lower.includes("no tip") ||
+        lower.includes("add no tip") || lower.includes("skip"));
+    expect(nonOkSkips).toBe(true);
+  });
+});
+
+describe("sil-shopping/SKILL.md — the two new beats introduce no lean-router-forbidden token (add-only localization)", () => {
+  it("neither new beat names a forbidden status/engine token, and both stay clean under the whole-word expert guard", () => {
+    // Belt-and-braces localization of the highest-likelihood build-breaker (SA
+    // risk): the existing whole-body guards (L448-462) already forbid these tokens
+    // across the SKILL body, but scoping the check to each NEW beat points a
+    // debugging dev at the exact offending beat rather than "somewhere in SKILL.md".
+    const after = afterRegisterBeat();
+    const perSearch = perSearchBeat();
+    const FORBIDDEN = [
+      "awaiting_browser", "not_registered", "must_reregister", "retryable",
+      "sil_profile_materialize", "openclaw agents add", "openclaw config validate",
+    ];
+    const offenders: string[] = [];
+    for (const [label, region] of [
+      ["after-register", after],
+      ["per-search", perSearch],
+    ] as const) {
+      for (const tok of FORBIDDEN) {
+        if (region.includes(tok)) offenders.push(`${label}: ${tok}`);
+      }
+      for (const ctx of perNicheExpertOffenders(region)) offenders.push(`${label}: …${ctx}…`);
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/src/__tests__/tools/identity.test.ts
+++ b/src/__tests__/tools/identity.test.ts
@@ -318,6 +318,60 @@ describe("sil_register — already-registered short-circuit (F1)", () => {
     const payload = payloadOf(await getTool(api, TOOL).execute("c1", {}));
     expect(payload["auth_url"]).toBeUndefined();
   });
+
+  // ── card: post-register-shopper-nudge-and-per-search-pitch (add-only) ──────
+  // The after-register offer's machine breadcrumb. `already_registered` is the
+  // SOLE agent-visible carrier of registration confirmation (the background poll
+  // is log-only; the agent learns success only by re-calling sil_register →
+  // already_registered — SA handoff), so the intent's "already_registered +
+  // poll-success" collapse to THIS one path. The literal is a contract between
+  // identity.ts (emits it) and SKILL.md (keys the after-register beat off it) —
+  // pinned byte-identical here and in skill-content.test.ts.
+  it("carries next_step: 'offer_shopper' (exact literal) — the after-register offer breadcrumb", async () => {
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", {}));
+    expect(payload["status"]).toBe("already_registered");
+    // Exact literal — snake_case field, snake_case value, the locked noun "shopper".
+    expect(payload["next_step"]).toBe("offer_shopper");
+  });
+
+  it("next_step is PURELY ADDITIVE — status + surfaced identity preserved, still no auth_url", async () => {
+    // The hint must not disturb the pre-existing short-circuit shape: the same
+    // status, the same surfaced user identity, and no browser-flow auth_url. It is
+    // an unconditional additive field, never a reshape of the payload.
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", {}));
+    expect(payload["status"]).toBe("already_registered");
+    expect(JSON.stringify(payload)).toContain("existing-user");
+    expect(payload["auth_url"]).toBeUndefined();
+    // The additive field rides ALONGSIDE the existing keys, never in place of them.
+    expect(payload["next_step"]).toBe("offer_shopper");
+    expect(payload["user"]).not.toBeUndefined();
+  });
+});
+
+describe("sil_whoami — the shopper offer rides ONLY the confirmed-registration path (add-only negative)", () => {
+  // Product-owner AC: "the offer rides ONLY the registered-confirmation path."
+  // `next_step: "offer_shopper"` is emitted on `sil_register` → `already_registered`
+  // and NOWHERE else. A non-confirmed identity read (here: `sil_whoami` with no
+  // stored tokens → `not_registered`) must not carry the offer breadcrumb — offering
+  // to set up a shopper to a session that is not even confirmed-registered is exactly
+  // the premature offer the SA decoupling avoids. The file-level beforeEach seeds an
+  // EMPTY $SIL_DATA_DIR (no tokens.json), so whoami short-circuits to not_registered
+  // with zero network I/O. (The `sil_register` awaiting_browser negative is pinned in
+  // register-link-presentation.test.ts; the poll terminals — timeout/expired/
+  // already_claimed/invalid_request/persist_failed — are log-only, emit NO
+  // agent-visible payload, and so have no next_step surface to assert.)
+  it("sil_whoami's not_registered payload carries NO next_step / offer_shopper", async () => {
+    const api = createMockPluginApi();
+    registerIdentityTools(api);
+    const payload = payloadOf(await getTool(api, "sil_whoami").execute("c1", {}));
+    expect(payload["status"]).toBe("not_registered");
+    expect(payload["next_step"]).toBeUndefined();
+    expect(JSON.stringify(payload)).not.toContain("offer_shopper");
+  });
 });
 
 describe("sil_register — the verifier never reaches disk (F4 invariant)", () => {

--- a/src/__tests__/tools/register-link-presentation.test.ts
+++ b/src/__tests__/tools/register-link-presentation.test.ts
@@ -442,6 +442,41 @@ describe("sil_register — system-browser steer (bounce-webview-auth-links-to-th
   });
 });
 
+describe("sil_register — the shopper offer is strictly POST-registration (add-only negative)", () => {
+  // card: post-register-shopper-nudge-and-per-search-pitch.
+  // The after-register offer breadcrumb `next_step: "offer_shopper"` rides ONLY the
+  // CONFIRMED-registration path (`already_registered`). The fresh, pre-registration
+  // `awaiting_browser` return — the user has NOT registered yet — must carry NO
+  // `next_step`: offering the shopper before registration completes is the premature
+  // offer the SA rejected (identity.ts adds the field only to the already_registered
+  // jsonResult, never the awaiting return). This is the symmetric negative to
+  // identity.test.ts's already_registered positive — the field is REAL in the
+  // codebase, so asserting its absence on the awaiting path is a live regression
+  // guard (a dev planting next_step on the awaiting return turns it RED), not vacuous.
+  let api: MockPluginAPI;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      () => new Promise<Response>(() => {}),
+    );
+    api = createMockPluginApi();
+    registerIdentityTools(api);
+  });
+
+  it("the fresh awaiting_browser payload carries NO next_step / offer_shopper", async () => {
+    const payload = await freshRegister(api);
+    // Anchor on the pre-registration path so the negative is not vacuously true on
+    // some other outcome.
+    expect(payload["status"]).toBe("awaiting_browser");
+    expect(payload["next_step"]).toBeUndefined();
+    // Strong form: the offer noun appears NOWHERE in the pre-registration result
+    // (not in message/instructions prose either) — the offer is strictly deferred
+    // until registration is confirmed.
+    expect(JSON.stringify(payload)).not.toContain("offer_shopper");
+  });
+});
+
 describe("sil_register — A: the atomic-link presentation never leaks the PKCE verifier", () => {
   let api: MockPluginAPI;
   let sentVerifier: string | null;

--- a/src/tools/identity.ts
+++ b/src/tools/identity.ts
@@ -78,11 +78,20 @@ function registerRegister(api: PluginAPI): void {
     parameters: Type.Object({}),
     async execute() {
       // 1 — already registered: short-circuit, no mint, no poll, no overwrite.
+      // `next_step` is an ADDITIVE, UNCONDITIONAL routing hint (not a decision):
+      // it tells the skill "the moment after a confirmed registration is where to
+      // introduce the shopper". identity.ts stays decoupled from the profile store
+      // — it reads NO shopper state here; the skill owns the actual gate (a no-arg
+      // sil_profile_get empty-store check) so a user who already has a shopper is
+      // never offered a second one (the shopper is a singleton). The hint rides
+      // ONLY this confirmed-registration path — never the pre-registration
+      // `awaiting_browser` return, nor any poll/error terminal.
       if (hasTokens()) {
         const config = readConfig();
         return jsonResult({
           status: "already_registered",
           user: config?.user ?? null,
+          next_step: "offer_shopper",
         });
       }
 


### PR DESCRIPTION
## Card
`cards/post-register-shopper-nudge-and-per-search-pitch.md` (gitignored-mode — lives in the `card/post-register-shopper-nudge-and-per-search-pitch` branch's worktree only; not in this diff). Changes 1+2 of the founder-approved onboarding-ux plan (2026-07-06).

## Summary
Make sil's shopper discoverable at the two moments a user is receptive — with **no new plugin tool** and `contracts.tools` unchanged.

- **`src/tools/identity.ts`** — `sil_register`'s `already_registered` payload gains one additive, unconditional field `next_step: "offer_shopper"`. A routing *hint*, not a decision: identity.ts reads no profile store; the SKILL owns the actual gate. Rides ONLY the confirmed-registration path (never `awaiting_browser`, the poll, or `sil_whoami`).
- **`sil-shopping/SKILL.md`** — two always-on beats:
  1. *After register* — key off the `next_step` hint, run a no-arg `sil_profile_get` empty-store check, offer the shopper (route to `references/brainstorm_interview.md` only on a yes), skip when a shopper already exists (singleton).
  2. *After a bare search* — on a completed `ok`, profile-less `sil_search`, append one post-result trailing line naming ≥1 of three rotating value levers. Recurring by design (no frequency gate); suppressed only when a shopper exists or the search did not complete `ok`. **Lane 1 results are untouched** — no code change to `sil_search`, no re-rank, no pre-search question.

## Test plan
- [x] `identity.test.ts` — `already_registered` carries the exact `next_step: "offer_shopper"` literal (additive; user preserved; no `auth_url`); `sil_whoami not_registered` carries none.
- [x] `register-link-presentation.test.ts` — the fresh `awaiting_browser` payload carries NO `next_step` (offer is strictly post-registration).
- [x] `skill-content.test.ts` — 12 add-only, section-scoped, disavowal-disciplined prose guards over both beats (gate/route/singleton, three levers, best-first + negation-aware no-re-rank/no-pre-search, recurring-not-fire-once, state-gate symmetry, `ok`-only, no lean-router-forbidden token).
- [x] Full suite: 970 passed. The only 10 failures are `repo-scaffold.integration.test.ts` — the documented gitignored-worktree failure (CLAUDE.md + `docs/**` not checked out), not a regression.
- [x] `tsc --noEmit` clean; `tsc -p tsconfig.build.json` clean; built-artifact runtime smoke confirms the emitted `next_step` field.

## Distillation target
Knowledge capture happens **after Review PASS** in the `distilling` stage — `solutions-architect` runs in this same worktree, commits to this same branch, and pushes here. Candidate notes: identity↔SKILL `next_step` byte-identical contract; section-scoped + negation-aware prose drift guards (`affirmativeOffenders`/`PITCH_DISAVOWAL`); the deliberate no-frequency-gate product rail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)