### PR TITLE
feature: one-tap shopper create via a single wrapper bin

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   },
   "main": "./dist/index.js",
   "bin": {
-    "sil-openclaw-allowlist": "./scripts/allowlist-openclaw.mjs"
+    "sil-openclaw-allowlist": "./scripts/allowlist-openclaw.mjs",
+    "sil-openclaw-create-shopper": "./scripts/create-shopper.mjs"
   },
   "files": [
     "dist",

--- a/scripts/create-shopper.mjs
+++ b/scripts/create-shopper.mjs
@@ -294,6 +294,15 @@ function teardown({ configPath, snapshot, mode, bakPreexisted, workspace, worksp
 
   // 3. Remove the singleton shopper dir ONLY if it did not pre-exist (the singleton
   //    pre-flight guarantees it was ours this run).
+  // KNOWN GAP (narrow): this keys on WHOLE-DIR pre-existence, not on the leaf we
+  //    wrote — it DIVERGES from `materializeProfile`'s `!leafPreexisted` discipline
+  //    (profile-store.ts). If `shopper/` pre-existed but EMPTY (no profile.json), the
+  //    singleton read passes ("no shopper") yet `shopperDirPreexisted` is true, so a
+  //    post-materialize failure leaves THIS run's profile.json/user_spec.md un-removed
+  //    and does NOT surface as residue → `teardown_failed`. Extremely narrow (normal
+  //    operation never leaves an empty `shopper/`; a materialize-STEP failure is
+  //    already covered by materializeProfile's own leaf teardown). To close it, key
+  //    this removal on "we wrote profile.json this run", mirroring `!leafPreexisted`.
   if (!shopperDirPreexisted) {
     const shopperDir = getShopperArtefactDir();
     try {

--- a/scripts/create-shopper.mjs
+++ b/scripts/create-shopper.mjs
@@ -1,0 +1,507 @@
+#!/usr/bin/env node
+/**
+ * Operator bin: create the user's ONE sil-wired shopper in a single atomic run.
+ *
+ * This is Change 3 of the onboarding-ux plan — it collapses the nine-step,
+ * agent-driven host-CLI choreography (`agent_creation_engine.md`) into ONE shipped
+ * package `bin`, a sibling of `scripts/allowlist-openclaw.mjs`. Like that bin it is
+ * a standalone operator script — NOT the plugin process — so the plugin's
+ * "never write host config / `noChildProcess: true`" guarantees do not bind it; it
+ * legitimately drives `openclaw …` via `execFileSync`.
+ *
+ * It runs POST-endorsement: the interview (`brainstorm_interview.md`) owns the
+ * consent gate; this bin executes an already-assembled, already-endorsed spec
+ * non-interactively. It never prompts, never re-runs the interview.
+ *
+ * Input — ONE JSON object `{ agentId, name, workspace, persona, userSpec }`, read
+ * from stdin (primary) or `--spec <path>` (fallback). Passing multiline
+ * persona/userSpec as JSON dodges shell-arg escaping. Unparseable/blank input →
+ * `invalid_request`, nothing attempted.
+ *
+ * Choreography (validate-first, then atomic, fail-closed):
+ *   1. validate the spec           — bad/blank field ⇒ invalid_request, nothing attempted
+ *   2. resolve the host config     — none ⇒ persistence_failed (precondition), nothing written
+ *   3. singleton + agentId pre-flight — a shopper OR the agentId already exists ⇒ collision;
+ *      an INCONCLUSIVE read (degraded store / CLI error) fails closed — never fabricates
+ *      a "no shopper" verdict, never proceeds to `agents add`
+ *   4. snapshot openclaw.json      — the whole-file teardown anchor, taken BEFORE step 5
+ *   5. openclaw agents add         — create the real agents.list entry + workspace bootstrap
+ *   6. write <workspace>/SOUL.md   — the persona (atomic tmp→rename); never a sil artefact
+ *   7. materializeProfile          — REUSED; { name, userSpec }, NO domain ⇒ shared user_spec.md
+ *                                    + profile.json with an empty `domains: {}` map
+ *   8. attach the sil skill + enable the sil plugin (openclaw config set --strict-json)
+ *   9. sil-openclaw-allowlist      — REUSED whole; additive/idempotent/atomic three-surface
+ *                                    trust merge (plugins.allow + tools.alsoAllow + plugins.entries.sil)
+ *  10. openclaw config validate    — success keys off `.valid`, never an `ok` field
+ *  11. one { status, … } JSON result; exit 0 ONLY on `created`.
+ *
+ * Teardown on ANY failure after step 5 = whole-file snapshot-restore of
+ * openclaw.json (reverses the agents.list entry + skill + plugin + trust in ONE
+ * atomic op, superseding the allowlist bin's inner `.bak`), plus removal of the
+ * workspace dir (only if WE created it) and the singleton shopper dir (only if it
+ * did not pre-exist — the singleton pre-flight guarantees it was ours). This
+ * returns the host to its EXACT pre-run state, so a co-installed `klodi` that was
+ * trusted pre-run stays trusted. A teardown that CANNOT fully revert is a distinct,
+ * LOUDER outcome (`teardown_failed`) that names the residue — never a green-washed
+ * `persistence_failed`.
+ *
+ * Outcome taxonomy (four terminal, + the louder teardown_failed), in sil's
+ * `snake_case_marker` NDJSON style (no api.logger outside the gateway). No PII, no
+ * secrets — the persona/userSpec text is NEVER logged:
+ *   - created            (info,  stdout) — carries name + agentId + workspace [+ warnings]
+ *   - invalid_request    (error, stderr) — bad/blank spec; nothing attempted; names the field
+ *   - collision          (error, stderr) — singleton / agentId clash; nothing written
+ *   - persistence_failed (error, stderr) — a step failed after writes began; teardown fully
+ *                                          reverted; nothing partial; names path + cause
+ *   - teardown_failed    (error, stderr) — teardown could NOT fully revert; names the residue
+ *
+ * All real write/merge logic lives in the typed libs (`materializeProfile` from
+ * `dist/lib/profile-store.js`, the `sil-openclaw-allowlist` bin). This shell is
+ * thin choreography + teardown only — it re-implements none of it.
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { randomBytes } from "node:crypto";
+import { fileURLToPath } from "node:url";
+
+import {
+  materializeProfile,
+  readAgentProfile,
+  getShopperArtefactDir,
+} from "../dist/lib/profile-store.js";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+/** The sibling operator bin that performs the additive, self-validating trust merge. */
+const ALLOWLIST_BIN = resolve(ROOT, "scripts", "allowlist-openclaw.mjs");
+
+/** A shopper id path-segment shape — lower-kebab, never `main` (host-reserved). */
+const AGENT_ID_RE = /^[a-z0-9][a-z0-9-]*$/;
+
+const CREATED_EVENT = "sil_shopper_created";
+const FAILED_EVENT = "sil_shopper_create_failed";
+
+/** Emit one structured NDJSON line in sil's marker style: `{event, level, ...}`. */
+function logMarker(stream, level, event, fields) {
+  stream.write(JSON.stringify({ event, level, ...fields }) + "\n");
+}
+
+/** Terminal success emit — one `created` object on stdout, exit 0. */
+function emitCreated(fields) {
+  logMarker(process.stdout, "info", CREATED_EVENT, { status: "created", ...fields });
+  process.exit(0);
+}
+
+/** Terminal failure emit — one object on stderr carrying the taxonomy `status`,
+ * exit 1. Never carries persona/userSpec text. */
+function emitFailure(status, fields) {
+  logMarker(process.stderr, "error", FAILED_EVENT, { status, ...fields });
+  process.exit(1);
+}
+
+/** True when `s` is a present, non-blank string. */
+function nonBlank(s) {
+  return typeof s === "string" && s.trim().length > 0;
+}
+
+/** Human-readable cause from an unknown thrown value (never PII). */
+function errCause(err) {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** Atomic single-file write: tmp sibling → write → rename over target, preserving
+ * the given mode. A reader sees the old file or the new one, never a half-written
+ * one (mirrors `allowlist-openclaw.mjs` / `profile-store.ts`). */
+function atomicWrite(path, contents, mode) {
+  const tmp = path + "." + randomBytes(6).toString("hex") + ".tmp";
+  writeFileSync(tmp, contents, mode !== undefined ? { mode } : undefined);
+  renameSync(tmp, path);
+}
+
+/** Resolve the host config path by precedence (first existing wins) — identical to
+ * `allowlist-openclaw.mjs` so every subprocess agrees on ONE config file. Returns
+ * the resolved path, or null if none exists (caller fails closed). */
+function resolveConfigPath() {
+  const candidates = [];
+  if (process.env["OPENCLAW_CONFIG_PATH"]) {
+    candidates.push(process.env["OPENCLAW_CONFIG_PATH"]);
+  }
+  if (process.env["OPENCLAW_STATE_DIR"]) {
+    candidates.push(join(process.env["OPENCLAW_STATE_DIR"], "openclaw.json"));
+  }
+  candidates.push(join(homedir(), ".openclaw", "openclaw.json"));
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+/** Read the raw spec text — `--spec <path>` if present, else stdin (fd 0). Returns
+ * `{ raw }` or `{ error }` (a structured cause, never the spec contents). */
+function readSpecRaw() {
+  const argv = process.argv.slice(2);
+  const specIdx = argv.indexOf("--spec");
+  if (specIdx >= 0) {
+    const path = argv[specIdx + 1];
+    if (!path) return { error: "--spec requires a file path argument" };
+    try {
+      return { raw: readFileSync(path, "utf8") };
+    } catch (err) {
+      return { error: "could not read --spec file: " + errCause(err) };
+    }
+  }
+  try {
+    return { raw: readFileSync(0, "utf8") };
+  } catch (err) {
+    return { error: "could not read the spec from stdin: " + errCause(err) };
+  }
+}
+
+/** Validate the endorsed spec — deterministic field order (agentId → name →
+ * workspace → persona → userSpec). Returns `{ field, message }` on the FIRST bad
+ * field, or null when the whole spec is good. Writes/attempts nothing. */
+function validateSpec(spec) {
+  if (typeof spec !== "object" || spec === null || Array.isArray(spec)) {
+    return {
+      field: "spec",
+      message: "spec must be a JSON object with { agentId, name, workspace, persona, userSpec }.",
+    };
+  }
+  if (!nonBlank(spec.agentId)) {
+    return { field: "agentId", message: "agentId is required and must be non-empty." };
+  }
+  if (spec.agentId === "main") {
+    return { field: "agentId", message: '"main" is host-reserved and cannot be an agentId.' };
+  }
+  if (!AGENT_ID_RE.test(spec.agentId)) {
+    return {
+      field: "agentId",
+      message: "agentId must be lower-kebab (a-z, 0-9, hyphen) — got: " + JSON.stringify(spec.agentId),
+    };
+  }
+  if (!nonBlank(spec.name)) {
+    return { field: "name", message: "name is required and must be non-empty." };
+  }
+  if (!nonBlank(spec.workspace)) {
+    return { field: "workspace", message: "workspace is required and must be non-empty." };
+  }
+  if (!nonBlank(spec.persona)) {
+    return { field: "persona", message: "persona is required and must be non-empty." };
+  }
+  if (!nonBlank(spec.userSpec)) {
+    return { field: "userSpec", message: "userSpec is required and must be non-empty." };
+  }
+  return null;
+}
+
+/** Run `openclaw <args>` pinned to the resolved config. Returns
+ * `{ ok, stdout, stderr, code }` — never throws across the boundary. */
+function runOpenclaw(args, configPath) {
+  try {
+    const stdout = execFileSync("openclaw", args, {
+      env: { ...process.env, OPENCLAW_CONFIG_PATH: configPath },
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { ok: true, stdout, stderr: "", code: 0 };
+  } catch (err) {
+    return {
+      ok: false,
+      stdout: typeof err?.stdout === "string" ? err.stdout : "",
+      stderr: typeof err?.stderr === "string" ? err.stderr : "",
+      code: err?.code,
+    };
+  }
+}
+
+/** Read + parse the host config JSON, or null on any read/parse failure. */
+function readConfig(configPath) {
+  try {
+    return JSON.parse(readFileSync(configPath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+/** The agentId path-segment ids already registered in the host config's
+ * `agents.list` — the authoritative, shim-independent clash source. */
+function existingAgentIds(config) {
+  const list = Array.isArray(config?.agents?.list) ? config.agents.list : [];
+  return list.map((a) => a?.id).filter((id) => typeof id === "string");
+}
+
+/** The index of `agentId` in `agents.list`, or -1 (used to target the skill attach). */
+function agentIndex(config, agentId) {
+  const list = Array.isArray(config?.agents?.list) ? config.agents.list : [];
+  return list.findIndex((a) => a?.id === agentId);
+}
+
+/** Best-effort web-capability check (SA ruling: warn, never hard-fail). The shopper
+ * lazily mints/refreshes a domain over the web (inherited from `agents.defaults`);
+ * bare `sil_search` works without it. Warn ONLY when `agents.defaults` is present
+ * yet names no web/fetch capability — never fabricate a gap on an absent defaults
+ * block (the host may grant web by other means). */
+function webCapabilityWarnings(config) {
+  const defaults = config?.agents?.defaults;
+  if (defaults === undefined || defaults === null || typeof defaults !== "object") return [];
+  const json = JSON.stringify(defaults).toLowerCase();
+  const WEB_TOKENS = ["web", "fetch", "browse", "http"];
+  if (WEB_TOKENS.some((t) => json.includes(t))) return [];
+  return [
+    "the created shopper inherits its tool profile from agents.defaults, which does not appear to"
+      + " grant a web/fetch tool — a domain cannot be lazily minted or web-refreshed without it"
+      + " (bare sil_search still works). Confirm agents.defaults grants a web capability.",
+  ];
+}
+
+/**
+ * Whole-file snapshot-restore teardown. Reverses everything this run created and
+ * returns the residue it could NOT revert (empty ⇒ clean, host at exact pre-run
+ * state). Each step is best-effort/idempotent so one failure never aborts the rest.
+ */
+function teardown({ configPath, snapshot, mode, bakPreexisted, workspace, workspacePreexisted, shopperDirPreexisted }) {
+  const residue = [];
+
+  // 1. Restore openclaw.json to its exact pre-run bytes — reverses the agents.list
+  //    entry, the skill attach, the plugin enable, AND the trust merge in one op.
+  if (snapshot !== null && configPath) {
+    try {
+      atomicWrite(configPath, snapshot, mode);
+    } catch (err) {
+      residue.push({ path: configPath, cause: "could not restore openclaw.json: " + errCause(err) });
+    }
+    // Remove the allowlist bin's inner `.bak` if it did not pre-exist this run.
+    const bakPath = configPath + ".bak";
+    if (!bakPreexisted && existsSync(bakPath)) {
+      try {
+        rmSync(bakPath, { force: true });
+      } catch {
+        // A lingering .bak is cosmetic — not host state; do not escalate to residue.
+      }
+    }
+  }
+
+  // 2. Remove the workspace dir ONLY if WE created it (never a pre-existing one).
+  if (workspace && !workspacePreexisted) {
+    try {
+      rmSync(workspace, { recursive: true, force: true });
+    } catch (err) {
+      residue.push({ path: workspace, cause: "could not remove the workspace dir: " + errCause(err) });
+    }
+  }
+
+  // 3. Remove the singleton shopper dir ONLY if it did not pre-exist (the singleton
+  //    pre-flight guarantees it was ours this run).
+  if (!shopperDirPreexisted) {
+    const shopperDir = getShopperArtefactDir();
+    try {
+      rmSync(shopperDir, { recursive: true, force: true });
+    } catch (err) {
+      residue.push({ path: shopperDir, cause: "could not remove the shopper dir: " + errCause(err) });
+    }
+  }
+
+  return residue;
+}
+
+function main() {
+  // --- 1. Read + validate the endorsed spec (validate-first, nothing attempted) ---
+  const specRaw = readSpecRaw();
+  if (specRaw.error) {
+    emitFailure("invalid_request", { field: "spec", cause: specRaw.error });
+  }
+  let spec;
+  try {
+    spec = JSON.parse(specRaw.raw);
+  } catch (err) {
+    emitFailure("invalid_request", {
+      field: "spec",
+      cause: "the spec is not valid JSON: " + errCause(err),
+    });
+  }
+  const bad = validateSpec(spec);
+  if (bad) {
+    emitFailure("invalid_request", { field: bad.field, cause: bad.message });
+  }
+  const { agentId, name, workspace, persona, userSpec } = spec;
+
+  // --- 2. Resolve the host config (precondition — nothing written yet) ---
+  const configPath = resolveConfigPath();
+  if (configPath === null) {
+    emitFailure("persistence_failed", {
+      path: null,
+      cause:
+        "no OpenClaw config found at OPENCLAW_CONFIG_PATH, $OPENCLAW_STATE_DIR/openclaw.json, or "
+        + "~/.openclaw/openclaw.json — start the OpenClaw gateway once so it writes its base config, then re-run",
+    });
+  }
+  const preConfig = readConfig(configPath);
+  if (preConfig === null) {
+    emitFailure("persistence_failed", {
+      path: configPath,
+      cause: "the host openclaw.json is not readable/parseable JSON — fix it, then re-run",
+    });
+  }
+
+  // --- 3. Singleton + agentId pre-flight (nothing written; inconclusive → fail closed) ---
+  // The sil artefact store is the source of truth for "a shopper exists".
+  const overview = readAgentProfile();
+  if (!overview.ok) {
+    emitFailure("persistence_failed", {
+      path: getShopperArtefactDir(),
+      cause: "could not read the sil shopper store to check the singleton — failing closed rather than risk a second shopper",
+    });
+  }
+  if (Array.isArray(overview.unreadable) && overview.unreadable.length > 0) {
+    // A degraded store is INCONCLUSIVE — never fabricate a "no shopper" verdict.
+    emitFailure("persistence_failed", {
+      path: getShopperArtefactDir(),
+      cause: "the sil shopper store is degraded (" + overview.unreadable.map((u) => u.error).join("; ")
+        + ") — cannot confirm the singleton; failing closed",
+    });
+  }
+  if (nonBlank(overview.name)) {
+    emitFailure("collision", {
+      cause:
+        "a shopper already exists — a user has exactly ONE shopper. Shop a new niche (it lazily mints a"
+        + " domain on the spot) or refine the existing shopper; never mint a second shopper.",
+    });
+  }
+  // Run the host-native agent list (ordered before the add) — a CLI error is
+  // inconclusive and fails closed; the config file is the authoritative clash source.
+  const listRes = runOpenclaw(["agents", "list", "--json"], configPath);
+  if (!listRes.ok) {
+    emitFailure("persistence_failed", {
+      path: configPath,
+      cause: "could not list host agents (`openclaw agents list --json` failed) — failing closed",
+    });
+  }
+  if (existingAgentIds(preConfig).includes(agentId)) {
+    emitFailure("collision", {
+      cause: "the agentId " + JSON.stringify(agentId)
+        + " already exists in the host agents.list — refusing to overwrite an existing agent's persona or wiring.",
+    });
+  }
+
+  // --- 4. Snapshot openclaw.json (the teardown anchor) BEFORE the first mutation ---
+  const snapshot = readFileSync(configPath, "utf8");
+  const mode = statSync(configPath).mode & 0o777;
+  const bakPreexisted = existsSync(configPath + ".bak");
+  const workspacePreexisted = existsSync(workspace);
+  const shopperDirPreexisted = existsSync(getShopperArtefactDir());
+  const teardownCtx = {
+    configPath,
+    snapshot,
+    mode,
+    bakPreexisted,
+    workspace,
+    workspacePreexisted,
+    shopperDirPreexisted,
+  };
+
+  /** Unwind everything and emit the honest terminal outcome: persistence_failed
+   * when teardown fully reverted, the LOUDER teardown_failed when it could not. */
+  const failAndTeardown = (path, cause) => {
+    const residue = teardown(teardownCtx);
+    if (residue.length > 0) {
+      emitFailure("teardown_failed", {
+        path,
+        cause,
+        residue,
+        note: "teardown could NOT fully revert — the host was NOT returned to its pre-run state; the residue above remains",
+      });
+    }
+    emitFailure("persistence_failed", { path, cause });
+  };
+
+  // --- 5. Create the host agent shell (workspace bootstrap: SOUL.md, AGENTS.md, …) ---
+  const addRes = runOpenclaw(
+    ["agents", "add", agentId, "--workspace", workspace, "--non-interactive", "--json"],
+    configPath,
+  );
+  if (!addRes.ok) {
+    failAndTeardown(configPath, "`openclaw agents add` failed: " + (addRes.stderr || "non-zero exit"));
+  }
+
+  // --- 6. Write the persona into the workspace SOUL.md (host CLI has no writer) ---
+  const soulPath = join(workspace, "SOUL.md");
+  try {
+    atomicWrite(soulPath, persona.endsWith("\n") ? persona : persona + "\n");
+  } catch (err) {
+    failAndTeardown(soulPath, "could not write SOUL.md: " + errCause(err));
+  }
+
+  // --- 7. Materialize the shared user spec — REUSED lib; NO domain at create ---
+  const mat = materializeProfile({ name, userSpec });
+  if (!mat.ok) {
+    const path = mat.kind === "persistence_failed" ? (mat.error?.split(":")[0] ?? getShopperArtefactDir()) : getShopperArtefactDir();
+    failAndTeardown(path, "sil_profile_materialize " + mat.kind + ": " + (mat.message ?? mat.error ?? "failed"));
+  }
+
+  // --- 8. Attach the sil skill + enable the sil plugin (value-mode, --strict-json) ---
+  const postAddConfig = readConfig(configPath);
+  const idx = agentIndex(postAddConfig, agentId);
+  if (idx < 0) {
+    failAndTeardown(configPath, "the created agent " + JSON.stringify(agentId) + " is not in agents.list after `openclaw agents add`");
+  }
+  const skillRes = runOpenclaw(
+    ["config", "set", `agents.list[${idx}].skills`, '["sil"]', "--strict-json"],
+    configPath,
+  );
+  if (!skillRes.ok) {
+    failAndTeardown(configPath, "attaching the sil skill failed: " + (skillRes.stderr || "non-zero exit"));
+  }
+  const enableRes = runOpenclaw(
+    ["config", "set", "plugins.entries.sil.enabled", "true", "--strict-json"],
+    configPath,
+  );
+  if (!enableRes.ok) {
+    failAndTeardown(configPath, "enabling the sil plugin failed: " + (enableRes.stderr || "non-zero exit"));
+  }
+
+  // --- 9. Admit sil at the three allow surfaces — REUSED whole allowlist bin ---
+  let allowlistOk = true;
+  let allowlistCause = "";
+  try {
+    execFileSync(process.execPath, [ALLOWLIST_BIN], {
+      env: { ...process.env, OPENCLAW_CONFIG_PATH: configPath },
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (err) {
+    allowlistOk = false;
+    allowlistCause = typeof err?.stderr === "string" && err.stderr.trim().length > 0
+      ? err.stderr.trim()
+      : "non-zero exit";
+  }
+  if (!allowlistOk) {
+    // A failed admission leaves the sil_* tools filtered — NEVER a green `created`.
+    failAndTeardown(configPath, "the sil-openclaw-allowlist admission helper failed: " + allowlistCause);
+  }
+
+  // --- 10. Validate with the host's OWN check — success keys off `.valid` ---
+  // The shim/host writes its structured verdict to stdout even on a non-zero exit,
+  // so read stdout regardless of the exit code (fail closed if it is not JSON).
+  const validateRes = runOpenclaw(["config", "validate", "--json"], configPath);
+  let verdict = null;
+  try {
+    verdict = JSON.parse(validateRes.stdout);
+  } catch {
+    verdict = null;
+  }
+  if (verdict === null || verdict.valid !== true) {
+    const issues = verdict && verdict.issues !== undefined ? JSON.stringify(verdict.issues) : undefined;
+    const cause = verdict && (verdict.error || verdict.message)
+      ? String(verdict.error || verdict.message)
+      : "`openclaw config validate` did not return valid: true";
+    failAndTeardown(configPath, issues ? cause + " — issues: " + issues : cause);
+  }
+
+  // --- 11. Declare created — carry the identity so the agent can open the shopper ---
+  const warnings = webCapabilityWarnings(readConfig(configPath) ?? postAddConfig);
+  emitCreated({ name, agentId, workspace, warnings });
+}
+
+main();

--- a/sil-shopping/references/agent_creation_engine.md
+++ b/sil-shopping/references/agent_creation_engine.md
@@ -1,14 +1,27 @@
 # Create your sil-wired shopper — the agent-creation engine
 
-**Precondition: run this ONLY after the user has explicitly endorsed the assembled draft from [`brainstorm_interview.md`](brainstorm_interview.md).** Any step below before that endorsement is forbidden — the interview owns the gate.
+**Precondition: run this ONLY after the user has explicitly endorsed the assembled draft from [`brainstorm_interview.md`](brainstorm_interview.md).** Anything below before that endorsement is forbidden — the interview owns the gate.
 
 When the user wants to **set up shopping**, author and persist **one** valid OpenClaw agent profile — the user's **shopper**: a real new agent under the host `agents` config, with the **sil plugin enabled**, the **sil skill attached**, its persona written into the workspace **`SOUL.md`**, plus the shopper's **shared user spec** in the sil data directory — so it shops with **no further setup**. The shopper is a **singleton**: you create it **once**, then it learns **domains** (niches) lazily on first shop — you never mint a second shopper.
 
-The shopper runs **entirely on Spec-Driven Shopping (SDS)** — the operating model, not an optional layer. At create time the engine persists exactly **one** sil artefact: the **shared, agent-level `userSpec`** (the person's cross-niche facts + hard constraints, seeded *partial* by the interview). It does **NOT** research any niche or write any per-domain pack at create time — there is **no** `domainSpec` / `intentSpec` / `playbook` here. Those are minted **lazily, per niche, on first shop** ([`shop_loop.md`](shop_loop.md)) into `domains/<slug>/`. A freshly-created shopper has an **empty `domains` map** — that is **healthy**, not a deficiency.
+The shopper runs **entirely on Spec-Driven Shopping (SDS)** — the operating model, not an optional layer. At create time exactly **one** sil artefact is persisted: the **shared, agent-level `userSpec`** (the person's cross-niche facts + hard constraints, seeded *partial* by the interview). **No** niche is researched and **no** per-domain pack is written at create time — there is **no** `domainSpec` / `intentSpec` / `playbook` here. Those are minted **lazily, per niche, on first shop** ([`shop_loop.md`](shop_loop.md)) into `domains/<slug>/`. A freshly-created shopper has an **empty `domains` map** — that is **healthy**, not a deficiency.
 
-You are the engine: the host config write (and the `SOUL.md` write) is **you driving the host's own `openclaw …` CLI** — the sil plugin never writes the host config. Run the steps **in order, top to bottom** — the order is the spec.
+## The one command
 
-## The profile spec (input)
+After the explicit endorsement, you run exactly **ONE** shipped command — the package `bin` **`sil-openclaw-create-shopper`** — and it runs the whole choreography **atomically** and fail-closed. You do **NOT** hand-run the nine host-CLI steps yourself; the bin runs them **for you, in order, as one transaction**, then returns a single structured JSON result. Feed it the endorsed spec as **one JSON object on `stdin`** (or via **`--spec <path>`**):
+
+```
+sil-openclaw-create-shopper <<'JSON'
+{ "agentId": "my-shopper", "name": "My Shopper", "workspace": "~/.openclaw/workspace-my-shopper",
+  "persona": "…the endorsed persona…", "userSpec": "…the seeded shared user spec…" }
+JSON
+```
+
+Passing the multiline `persona` / `userSpec` as JSON dodges shell-arg escaping. The bin is **non-interactive**: it executes an **already-assembled, already-endorsed** spec — it never re-runs the interview and never prompts (the endorsement gate lives upstream in the interview; the bin's own validate-first + singleton pre-flight still protect a direct caller). Creation is **local and offline** — the bin reads **no token**, performs **no** `sil_register` / `sil_whoami`, and makes **no network call**. The `sil` **plugin** and `sil` **skill** are always wired (that is what makes it *sil-wired*). Do **not** present sil registration as a prerequisite — the shopper registers the user later, on first shop, via `sil_register`.
+
+> The bin is a standalone operator script (the same class as the other shipped `sil-openclaw` operator bins), **not** the plugin process — so the plugin's `noChildProcess` / "never write host config" guarantee is intact; the bin legitimately drives the host `openclaw …` CLI on your behalf.
+
+## The profile spec (input) — the JSON the bin reads
 
 The endorsed draft feeds two stores. The **persona** becomes the host workspace **`SOUL.md`** (its identity / voice / standing rules — via the host CLI, **not** a sil artefact). The **shared user spec** becomes the sil data-dir artefact:
 
@@ -22,53 +35,51 @@ The endorsed draft feeds two stores. The **persona** becomes the host workspace 
 
 There is **no** per-niche input at create time. The deep `domainSpec`, the derived `intentSpec` schema, and the niche `playbook` are **not** authored here — they are researched and minted on first shop in each niche.
 
-The **sil plugin** and **sil skill** are always attached (that is what makes it *sil-wired*). Creation is **local and offline** — it does **not** require or perform sil registration, reads no token, and writes nothing to identity storage. The shopper registers the user later, on first shop, via `sil_register`. Do **not** present registration as a prerequisite.
-
 ## The created shopper needs WEB tools
 
-The shopper **lazily mints a domain on first shop** (its research pass reaches the web) and **web-refreshes each domain spec on every query**. So the created agent must have **web/fetch tools in its tool profile** — inherited from `agents.defaults` when its shell is created (step 3). Confirm that profile grants a web-fetch/browse capability and **do not deny it** (alongside not denying the `sil_*` tools). If `agents.defaults` does **not** grant a web tool, the shopper cannot research or refresh a domain — surface that to the user as a host-capability gap; do **not** pretend the research happened.
+The shopper **lazily mints a domain on first shop** (its research pass reaches the web) and **web-refreshes each domain spec on every query**. So the created agent must have **web/fetch tools in its tool profile** — inherited from `agents.defaults` when its shell is created. If `agents.defaults` does **not** grant a web tool, the bin reports **`created` with a `warnings` entry** naming the gap (bare `sil_search` still works, so it does **not** hard-fail) — it never silently swallows the gap and never pretends the research happened. Surface that warning to the user.
 
-## Engine steps (run in this exact order)
+## What the bin does atomically (the choreography it runs for you, in this exact order)
 
-1. **Validate the spec FIRST — before anything is written.** Check `agentId` (present, lower-kebab, unique-looking, ≠ `main`), `name`, `persona`, `workspace`, and the **shared `userSpec` — present and non-blank** (the only sil artefact at create; it is seeded *partial* by the interview, never omitted). There is **no** `domainSpec` / `intentSpec` / `playbook` to validate here — those are minted lazily on first shop. On any failure, stop with **`invalid_request`** naming the field and **write nothing**. This runs ahead of every host command, so a bad spec never reaches the host.
+1. **Validates the spec FIRST — before anything is written.** It checks `agentId` (present, lower-kebab, ≠ `main`), `name`, `persona`, `workspace`, and the **shared `userSpec` — present and non-blank** (the only sil artefact at create; seeded *partial* by the interview, never omitted). There is **no** `domainSpec` / `intentSpec` / `playbook` to validate here. On any failure it stops with **`invalid_request`** naming the field and **writes nothing**. This runs ahead of every host command, so a bad spec never reaches the host.
 
-2. **Singleton check — a user has exactly ONE shopper.** The shopper is a singleton: a user creates it **once**, then adds domains to it. Run `openclaw agents list --json` and read the sil artefact store (the no-args `sil_profile_get`, whose overview is `ok` empty-is-healthy when no shopper exists); if a sil shopper **already exists**, stop with **`collision`** — **"a shopper already exists"** — and **do not** run `openclaw agents add`. Steer the user to **shop a new niche** (which lazily mints a domain on the spot) or **refine the existing shopper** — **never mint a second shopper**. (An `agentId` that collides with any existing agent is likewise refused — never overwrite an existing agent's persona or wiring.)
+2. **Singleton check — a user has exactly ONE shopper.** The bin runs `openclaw agents list --json` and reads the sil artefact store (the no-args `sil_profile_get` overview, `ok` empty-is-healthy when no shopper exists) **before** the add; if a sil shopper **already exists**, it stops with **`collision`** — **"a shopper already exists"** — and **does not** run `openclaw agents add`. That steers the user to **shop a new niche** (which lazily mints a domain on the spot) or **refine the existing shopper** — **never mint a second shopper**. An `agentId` that collides with any existing agent is likewise refused (`collision`) — never overwriting an existing agent's persona or wiring. If either read is **inconclusive** (a CLI error, a degraded store), the bin fails closed rather than fabricate a "no shopper" verdict.
 
-3. **Create the agent shell (host CLI).** Run:
+3. **Creates the agent shell (host CLI).** It runs:
    ```
    openclaw agents add <agentId> --workspace <workspace> --non-interactive --json
    ```
-   This creates the real `agents.list[]` entry and the workspace bootstrap files (`SOUL.md`, `AGENTS.md`, …), inheriting model and **tool profile** (which must grant **web/fetch** — see above) from `agents.defaults`. `--non-interactive --json` lets you drive it without a prompt and read the result.
+   This creates the real `agents.list[]` entry and the workspace bootstrap files (`SOUL.md`, `AGENTS.md`, …), inheriting model and **tool profile** (which must grant **web/fetch** — see above) from `agents.defaults`. `--non-interactive --json` drives it without a prompt.
 
-4. **Write the persona into the workspace `SOUL.md` (host CLI).** The persona is the shopper's soul / system framing — the host's `SOUL.md`, **not** a sil artefact. Write the endorsed persona text straight into the new agent's `SOUL.md` via the host CLI. There is **no** `persona.md` in the sil store and **no** copy step — the persona lives in exactly one place.
+4. **Writes the persona into the workspace `SOUL.md` (host CLI).** The persona is the shopper's soul / system framing — the host's `SOUL.md`, **not** a sil artefact. The bin writes the endorsed persona text **straight into** the new agent's `SOUL.md`. There is **no** `persona.md` in the sil store and **no copy** step — the persona lives in exactly one place.
 
-5. **Materialize the shared user spec — NO `domain`.** Call **`sil_profile_materialize`** with **`{ name, userSpec }`** — the shared `userSpec` seeded by the interview (partial, augmented per-query). The shopper is a singleton, so this sil-tool call takes **no `agentId`** (the host agent id lives only in the host-CLI wiring above). **Pass NO `domain`** at create: with no `domain`, the tool writes the shared **`user_spec.md`** + **`profile.json`** (with an **empty `domains: {}` map**) into the fixed **`$SIL_DATA_DIR/shopper/`**, atomically. There is **no** `domain_spec.md` / `intent_spec.md` / `playbook.md` yet — the first shop in a niche mints that niche's pack (with a `domain` object) lazily. There is **no `persona.md`** here. The tool's outcomes are `ok` / `invalid_request` / `persistence_failed` — on `invalid_request` it wrote nothing; on `persistence_failed` it left nothing partial.
+5. **Materializes the shared user spec — NO `domain`.** The bin calls **`sil_profile_materialize`** with **`{ name, userSpec }`** — the shared `userSpec` seeded by the interview. The shopper is a singleton, so this takes **no `agentId`**. **With no `domain`** at create, the tool writes the shared **`user_spec.md`** + **`profile.json`** (with an **empty `domains: {}` map**) into the fixed **`$SIL_DATA_DIR/shopper/`**, atomically. There is **no** `domain_spec.md` / `intent_spec.md` / `playbook.md` yet — the first shop in a niche mints that niche's pack (with a `domain` object) lazily. On `invalid_request` it wrote nothing; on `persistence_failed` it left nothing partial.
 
-6. **Wire the sil skill + plugin (host CLI).** Asserted against the pinned host — **`alpine/openclaw:2026.6.9`** — both value-mode sets with `--strict-json` (the only set mode this image accepts):
+6. **Wires the sil skill + plugin (host CLI).** Asserted against the pinned host — **`alpine/openclaw:2026.6.9`** — both value-mode sets with `--strict-json` (the only set mode this image accepts):
    ```
    openclaw config set 'agents.list[<i>].skills' '["sil"]' --strict-json
    openclaw config set plugins.entries.sil.enabled true --strict-json
    ```
-   The skill attach makes the agent **know how** to drive the tools; the plugin enable turns the sil plugin **on** — but it does **not** by itself un-filter the `sil_*` tools (see the admission step next). Keep `sil` in the agent's skill list and do not deny the `sil_*` tools.
+   The skill **attach** makes the agent **know how** to drive the tools; the plugin **enable** turns the sil plugin **on** — but it does **not** by itself un-filter the `sil_*` tools (see the admission step next). `sil` stays in the agent's skill list and the `sil_*` tools are not denied.
 
-7. **Admit sil at the host allow surfaces — run the shipped helper.** Enabling the plugin is necessary but not sufficient: until `sil` is admitted at the **global** allow surfaces `plugins.allow` + **`tools.alsoAllow`**, the host keeps the `sil_*` tools **filtered**, so the shopper can't call them. Admission is **plugin-ID only** — there is no per-tool key. The value-mode `openclaw config set` above is **overwrite-only** on this image, so it cannot additively merge those shared global arrays without clobbering another already-admitted plugin (e.g. `klodi`). Run the shipped admission helper — the package `bin` that ships with the plugin (same artefact as the `openclaw:allowlist` script) — which performs the **additive, idempotent, atomic, self-validating** three-surface merge (`plugins.allow` + `tools.alsoAllow` + `plugins.entries.sil`):
-   ```
-   sil-openclaw-allowlist
-   ```
-   It re-confirms the plugin-enable as an idempotent no-op, so re-running it on every creation never duplicates or clobbers an existing entry. **If the helper exits non-zero (a failed admission), report `persistence_failed` with the path + cause and do NOT declare `created`** — never a green `created` over still-filtered tools, exactly as a rejected `openclaw config validate` is handled in the next step.
+7. **Admits sil at the host allow surfaces — the shipped helper.** Enabling the plugin is necessary but not sufficient: until `sil` is admitted at the **global** allow surfaces `plugins.allow` + **`tools.alsoAllow`**, the host keeps the `sil_*` tools **filtered**. Admission is **plugin-ID only** — no per-tool key. The value-mode `openclaw config set` above is **overwrite-only** on this image, so it cannot additively merge those shared global arrays without clobbering another already-admitted plugin (e.g. `klodi`). The bin therefore runs the shipped admission helper — the sibling package `bin` `sil-openclaw-allowlist` (same artefact as the `openclaw:allowlist` script) — which performs the **additive, idempotent, atomic, self-validating** three-surface merge (`plugins.allow` + `tools.alsoAllow` + `plugins.entries.sil`). **If the helper exits non-zero (a failed admission), the bin reports `persistence_failed` with the path + cause and does NOT declare `created`** — never a green `created` over still-filtered tools.
 
-8. **Validate with the host's OWN check, THEN declare created.** Run `openclaw config validate --json`. The verdict is `{ valid, path, issues? }` — success keys off **`.valid`**, never an `ok` field. Only when `valid: true` **and** the allow-list admission (step 7) succeeded do you report **`created`**. If `valid: false`, the admission helper exited non-zero, or any CLI step failed, report **`persistence_failed`** with the failing **path** + **cause** (the `issues?`), leaving nothing partial.
+8. **Validates with the host's OWN check, THEN declares created.** The bin runs `openclaw config validate --json`. The verdict is `{ valid, path, issues? }` — success keys off **`.valid`**, never an `ok` field. Only when `valid: true` **and** the admission (step 7) succeeded does it report **`created`**. If `valid: false`, the admission helper exited non-zero, or any step failed, it reports **`persistence_failed`** with the failing **path** + **cause** (the `issues?`).
 
-9. **Tell the user it is ready.** On `created`, tell them their shopper exists and how to open it. Opening it loads the persona (`SOUL.md`) and the shared user spec + the (empty) `domains` map (`profile.json`), and — because the `sil_*` tools were admitted in step 7 — the shopper calls `sil_search` / `sil_product_get` (and `sil_register` / `sil_whoami` as needed) on the user's intent with **no further setup**, **minting each niche's domain pack on the fly** the first time the user shops it.
+9. **On any failure after writes begin, tears down — leaving nothing partial.** The bin snapshots `openclaw.json` before step 3 and, on any failure, **restores that whole-file snapshot** (reversing the `agents.list` entry + the skill + the plugin + the trust admission in one atomic op), then removes the workspace dir (only if it created it) and the singleton shopper dir (only if it did not pre-exist). This returns the host to its **exact pre-run state** — a co-installed `klodi` that was trusted pre-run stays trusted — so `persistence_failed` truthfully means **nothing partial** is left.
+
+The bin emits **one** `{ status, … }` JSON result and exits 0 **only** on `created`.
 
 ## Status taxonomy (agent-creation engine)
 
 | `status` | Meaning | What to do |
 |---|---|---|
-| `created` | Shopper added, shared user spec materialized, sil plugin + skill wired, `openclaw config validate` accepted it. | Tell the user it's ready and how to open it. |
-| `invalid_request` | Spec failed validation (missing/blank field). **Nothing written.** | Name the field, fix it, run again — do NOT proceed to `openclaw agents add`. |
-| `collision` | A shopper already exists (the singleton). | Surface it — "a shopper already exists"; steer to shop-a-new-niche (lazy mint) or refine. **Never mint a second shopper.** |
-| `persistence_failed` | A write, the allow-list admission helper (non-zero exit), or `openclaw config validate` step failed. **Nothing partial** left. | Fix the reported path/cause, create again. |
+| `created` | Shopper added, shared user spec materialized, sil plugin + skill wired, `openclaw config validate` accepted it. Carries `name` + `agentId` + `workspace`. | Tell the user it's ready and how to open it. |
+| `invalid_request` | Spec failed validation (missing/blank field). **Nothing attempted.** | Name the field, fix it, run the command again — nothing reached `openclaw agents add`. |
+| `collision` | A shopper already exists (the singleton), or the `agentId` clashes. **Nothing written.** | Surface it — "a shopper already exists"; steer to shop-a-new-niche (lazy mint) or refine. **Never mint a second shopper.** |
+| `persistence_failed` | A write, the allow-list admission helper (non-zero exit), or `openclaw config validate` step failed. Teardown ran — **nothing partial** left. | Fix the reported path/cause, run the command again (a re-run is safe). |
+
+In the **rare** case teardown itself cannot fully revert (e.g. the agent was added but reverting it fails), the bin reports a **distinct, louder** outcome that **names the residue** — do **not** voice that as `persistence_failed`'s "nothing partial"; tell the user exactly what remains and where.
 
 ## Runtime — how the shopper loads its behaviour
 
@@ -76,4 +87,4 @@ When you (the sil skill) start a session as the shopper, the host has already in
 - the **shared `user_spec.md`** — the person's cross-niche facts + hard constraints (seeded partial, augmented per-query), reused across **every** niche;
 - the slug-keyed **`domains`** map — the niches the shopper has already learned. An **empty** map is healthy; the per-domain packs (`domains/<slug>/{domain_spec,intent_spec,playbook}.md`) load **lazily at shop time**, not here.
 
-Loading these is what lets the shopper shop any niche with no further setup. When the user states a shopping intent, shop per [`shop_loop.md`](shop_loop.md) — the loop that classifies the niche, **reuses an existing domain or mints one on the fly**, then on **every query** web-refreshes that domain's spec, decomposes the request along its intent-spec dimensions (the ephemeral per-query intent), and **learns** every query (a fact → the shared `user_spec.md`, a taste → the active domain's `playbook.md`, each via a single `sil_remember` append). To sharpen the shopper or one of its domains from observed sessions, see [`refine_shopper.md`](refine_shopper.md).
+Loading these is what lets the shopper shop any niche with no further setup. When the user states a shopping intent, shop per [`shop_loop.md`](shop_loop.md) — the loop that classifies the niche, **reuses an existing domain or mints one on the fly**, then on **every query** web-refreshes that domain's spec, decomposes the request along its intent-spec dimensions (the ephemeral per-query intent), and **learns** every query (a fact → the shared `user_spec.md`, a taste → the active domain's `playbook.md`, each via a single `sil_remember` append). Because the `sil_*` tools were admitted at create, the shopper calls **`sil_search`** / **`sil_product_get`** (and `sil_register` / `sil_whoami` as needed) on the user's intent with **no further setup**, minting each niche's domain pack on the fly the first time the user shops it. To sharpen the shopper or one of its domains from observed sessions, see [`refine_shopper.md`](refine_shopper.md).

--- a/sil-shopping/references/brainstorm_interview.md
+++ b/sil-shopping/references/brainstorm_interview.md
@@ -1,8 +1,17 @@
 # Set up your shopper — the onboarding interview
 
-When the user asks to **set up shopping** — "create my shopper", "set up an agent that shops for me", "I want something that shops for me" — do **not** jump to the engine. Run a short, **two-touchpoint** onboarding that shapes the shopper *with* the user, then **create nothing** until the user endorses the assembled draft. The agent-creation engine ([`agent_creation_engine.md`](agent_creation_engine.md)) only runs **after** that explicit endorsement.
+When the user asks to **set up shopping** — "create my shopper", "set up an agent that shops for me", "I want something that shops for me" — do **not** jump to the engine. Run a short, **two-touchpoint** onboarding that shapes the shopper *with* the user — **pre-seeded from what they already said this session** — then **create nothing** until the user endorses the assembled draft. The agent-creation engine ([`agent_creation_engine.md`](agent_creation_engine.md)) only runs **after** that explicit endorsement.
 
-This is a **conversation, not a form-fill** — and a **short** one. The shopper is a **generalist**: it goes deep on whatever the user later buys, **lazily minting a domain on first shop in each niche**. So onboarding does **NOT** research any niche and does **NOT** ask the user to pick one. It touches exactly **two** things: the **persona** (how their shopper should behave) and a **shared user-spec seed** (cross-niche facts + hard constraints). Everything niche-specific — how to shop a niche well, what each request in it should resolve, the niche shopping taste — is **deferred to first shop**, not authored here.
+This is a **conversation, not a form-fill** — and a **short** one. Because you **pre-seed** from the session, you open by **reflecting a filled draft back**, not with a cold question. The shopper is a **generalist**: it goes deep on whatever the user later buys, **lazily minting a domain on first shop in each niche**. So onboarding does **NOT** research any niche and does **NOT** ask the user to pick one. It touches exactly **two** things: the **persona** (how their shopper should behave) and a **shared user-spec seed** (cross-niche facts + hard constraints). Everything niche-specific — how to shop a niche well, what each request in it should resolve, the niche shopping taste — is **deferred to first shop**, not authored here.
+
+## Session pre-seed — open with a reflected draft, never a cold question
+
+Before you ask anything, assemble a **draft** from what the user has **already said** *this session*: the **persona** (their own words on how the shopper should behave) and the **shared user-spec seed** (any sizes, hard limits, or ethics rules they mentioned in passing). Then **open by reflecting that draft back** — *"from what you've told me, here's the shopper I'd set up…"* — and ask only to **confirm-or-adjust**. That is the **rich** (a filled draft, so the shopper demonstrably listened) + **light** (one confirm) shape.
+
+- **Pre-seed, don't interrogate.** **Pre-fill** the persona + the shared `user_spec` from the session; ask only to fill genuine gaps, never to re-collect what the user already told you.
+- **Never invent facts you did not hear.** If the session gave little, seed a **minimal honest** draft ("cross-niche facts to be learned as we shop; no hard constraints stated yet") and say so — never fabricate a size or a limit.
+- **Session-only — local + offline.** The seed is assembled **only** from this conversation. It does **NOT** pull `sil_whoami`, reads **no** token, and makes no network call. (The shopper registers the user later, on first shop, via `sil_register` — never a prerequisite here.)
+- **The endorsement gate is untouched.** A rich pre-fill is a **proposal**, never consent — see the gate in §3 below.
 
 ## The two onboarding touchpoints — persona + shared user spec
 
@@ -10,52 +19,53 @@ A created shopper runs on a persona (`SOUL.md`) plus the **shared, agent-level `
 
 | Artefact | Where | What it holds | Seeded |
 |---|---|---|---|
-| **`SOUL.md`** (persona) | host workspace (via host CLI) | the shopper's identity / voice / standing rules — a **generalist**, not a niche specialist | at onboarding (§1 below); refined on persona refine, stable per query |
-| **`user_spec.md`** (shared) | sil data dir (**required**) | the user's **cross-niche** facts + hard constraints (addresses, sizes, allergy/ethics rules, budget psychology) | seeded partial at onboarding (§2); augmented every query, reused across **every** niche |
+| **`SOUL.md`** (persona) | host workspace (via host CLI) | the shopper's identity / voice / standing rules — a **generalist**, not a niche specialist | pre-seeded from the session (§1 below); refined on persona refine, stable per query |
+| **`user_spec.md`** (shared) | sil data dir (**required**) | the user's **cross-niche** facts + hard constraints (addresses, sizes, allergy/ethics rules, budget psychology) | pre-seeded partial from the session (§2); augmented every query, reused across **every** niche |
 
 The niche packs — the deep niche know-how, the per-request template a query is resolved against, and the niche shopping taste — are **NOT** authored here; they are minted **on first shop in each niche** ([`shop_loop.md`](shop_loop.md)). The per-query fill (the template filled in for one request) is **ephemeral** — never persisted, never authored here.
 
 ## Principles for the interview
 
+- **Pre-seed from the session; open with the draft.** Assemble the persona + shared user-spec draft from what the user already said, and lead with it (reflect-back), not a cold questionnaire. The interview is **rich but light** — a filled draft plus one confirm-or-adjust per touchpoint.
 - **Two touchpoints, no niche research.** Touch the persona and the shared user spec — that is the whole onboarding. The shopper is a **generalist**; there is **no narrow-the-niche step** and **no domain interview**. The deep niche expertise is researched **lazily, at first shop**, never interrogated here.
-- **The persona question shapes voice, not a niche.** Asking "how should your shopper behave?" surfaces the **voice / standing rules** — terse vs. chatty, cautious vs. opinionated, any never-break rules. It does **not** bind the shopper to one niche.
-- **Seed the shared facts, ask little.** The shared user spec holds cross-niche facts + hard constraints that carry across every niche. Seed what the user volunteers — don't run a questionnaire; the rest is **augmented per-query** at shop time.
+- **The persona question shapes voice, not a niche.** The persona surfaces the **voice / standing rules** — terse vs. chatty, cautious vs. opinionated, any never-break rules. It does **not** bind the shopper to one niche.
+- **Seed the shared facts, ask little.** The shared user spec holds cross-niche facts + hard constraints that carry across every niche. Seed what the user volunteered — don't run a questionnaire; the rest is **augmented per-query** at shop time.
 - **Converge, don't accumulate.** Reflect a short summary back and get a yes/adjust before advancing. The flow is **collaborative** and **re-entrant** — the user can revise an earlier touchpoint at any point.
 - **Endorsement is a gate, not a formality.** Until the user explicitly says "create it", run **zero** engine steps. The draft lives only in the conversation.
 
 ## Run the interview in this order — two touchpoints
 
-### 1. `SOUL.md` — ASK FIRST: persona + behaviour (a generalist shopper)
+### 1. `SOUL.md` — persona + behaviour (a generalist shopper), pre-seeded
 
-Open by reflecting the request back ("let's set up your shopper"), then ask the **persona/identity** question: **"How do you want your shopper to behave?"** — its voice/tone (terse vs. chatty, cautious vs. opinionated) and any **standing rules** it should always follow. This is the shopper's **system framing**, a **generalist** that will shop whatever the user buys — **not** a niche choice; the niche is decided later, per query, when the user actually shops. Reflect a short persona summary back and confirm. This becomes the host workspace **`SOUL.md`** (the persona is the agent's system framing — **not** a sil artefact, no `persona.md`).
+Open by **reflecting the session-seeded persona draft back** ("from what you've told me, your shopper sounds like…"), then confirm-or-adjust its **voice/tone** (terse vs. chatty, cautious vs. opinionated) and any **standing rules** it should always follow. Only ask the persona/identity question cold if the session gave you nothing to reflect. This is the shopper's **system framing**, a **generalist** that will shop whatever the user buys — **not** a niche choice; the niche is decided later, per query, when the user actually shops. This becomes the host workspace **`SOUL.md`** (the persona is the agent's system framing — **not** a sil artefact, no `persona.md`).
 
 ### 2. `user_spec.md` (shared) — seed the cross-niche facts + hard constraints
 
-Seed the **shared user spec**: the user's **cross-niche** facts and any **hard constraints** that should hold in *every* niche — addresses / sizes the user volunteers, an allergy or ethics rule ("never leather"), a budget psychology. Mark each as **hard** (inviolable — an allergy, an ethics rule, an age gate) vs **soft** (a bendable preference). Don't run a questionnaire — seed what the user offers; the rest is **augmented per-query** at shop time, and a niche-specific fact is learned when that niche is first shopped. If the user gives little, seed a minimal honest body (e.g. "cross-niche facts to be learned as we shop; no hard constraints stated yet") — non-blank, but partial. This lands in `userSpec` (→ the shared `user_spec.md`). **No niche taste, no domain question, no intent dimensions are gathered here** — those belong to first-shop lazy mint.
+**Pre-fill** the **shared user spec** from the session: the user's **cross-niche** facts and any **hard constraints** that should hold in *every* niche — addresses / sizes the user volunteered, an allergy or ethics rule ("never leather"), a budget psychology. Reflect the pre-filled seed back and mark each as **hard** (inviolable — an allergy, an ethics rule, an age gate) vs **soft** (a bendable preference). Don't run a questionnaire — seed what the user offered; the rest is **augmented per-query** at shop time, and a niche-specific fact is learned when that niche is first shopped. If the user gave little, seed a minimal honest body (e.g. "cross-niche facts to be learned as we shop; no hard constraints stated yet") — non-blank, but partial. This lands in `userSpec` (→ the shared `user_spec.md`). **No niche taste, no domain question, no intent dimensions are gathered here** — those belong to first-shop lazy mint.
 
 ### 3. Derive the identity, assemble, endorse
 
 - **Identity.** Propose an `agentId` (lower-kebab, `^[a-z0-9][a-z0-9-]*$`, never `main`) and a human-readable `name` ("My Shopper" / `my-shopper`). **Confirm both** — never silently invent them.
 - **Assemble + present.** Compose **`{ agentId, name, persona, userSpec }`** and present a **readable summary**: who the shopper is (its persona/voice + standing rules) and the **seeded shared user spec** (cross-niche facts + hard constraints, partial, to grow per-query). Self-check the shape against the engine's contract: `agentId` lower-kebab & ≠ `main` (it keys the host `openclaw agents add`, not the sil tool), non-blank `name`/`persona`, and a non-blank shared `userSpec` — the only sil artefact at create (the engine passes just `name` + `userSpec` to the singleton `sil_profile_materialize`; no niche pack is authored here). This is shape-only — it writes nothing; the engine's validate-first step is the authoritative gate.
-- **Endorse — the gate.** Ask for an explicit go-ahead ("shall I create your shopper?"). Endorsement is an **affirmative user act** on the assembled draft — "yes, create it" / "go ahead". It is **NOT** inferred from the user answering the last question, and **NOT** from silence. **Only on that explicit endorsement** do you proceed to the engine ([`agent_creation_engine.md`](agent_creation_engine.md)).
+- **Endorse — the gate.** Ask for an explicit go-ahead ("shall I create your shopper?"). Endorsement is an **affirmative user act** on the assembled draft — "yes, create it" / "go ahead". It is **NOT** inferred from the user answering the last question, and **NOT** from silence. **Only on that explicit endorsement** do you proceed to the engine ([`agent_creation_engine.md`](agent_creation_engine.md)) and run the one command.
 
 ## Edge cases the interview handles gracefully
 
 - **A shopper already exists (the singleton).** The shopper is a singleton — the engine refuses a second create (its `collision` outcome, "a shopper already exists") and never clobbers the existing one. Surface it and steer the user to **shop a new niche** (which lazily mints a domain on the spot) or **refine the existing shopper** — **never** mint a second shopper, never silently mutate the existing one.
 - **Abandon mid-flow.** Because **no engine step runs before endorsement**, abandonment leaves **nothing created** — no host agent, no artefacts, no wiring, no teardown. Never "save progress" by writing artefacts early.
-- **Creation is local + offline (for the user's identity).** Creating a shopper neither requires nor performs sil registration. Do **NOT** present sil registration or a token as a prerequisite to create the shopper; it registers the user later, on first shop, via `sil_register`. (No web access is needed at onboarding either — the niche research that reaches the web happens later, at first shop.)
+- **Creation is local + offline (for the user's identity).** Creating a shopper neither requires nor performs sil registration. Do **NOT** present sil registration or a token as a prerequisite to create the shopper; the session seed does **not** pull `sil_whoami`, reads no token, and never reaches the network. It registers the user later, on first shop, via `sil_register`. (No web access is needed at onboarding either — the niche research that reaches the web happens later, at first shop.)
 
 ## Business rules (invariants the interview holds on every path)
 
 1. **No creation without explicit endorsement.** Nothing is written — not the host agent, the `SOUL.md`, the shared user spec, or the wiring — until the user explicitly endorses. The draft lives only in the conversation until then.
-2. **Abandon-mid-flow creates nothing.** No engine step runs pre-endorsement, so an abandoned interview leaves no partial shopper — automatic, not a teardown.
-3. **Two touchpoints only — persona, then shared user spec.** `SOUL.md` (ask first — persona/voice, a generalist, NOT a niche) and the shared `user_spec.md` (cross-niche facts + hard constraints). **No** niche know-how, no niche shopping taste, and no per-request template work at onboarding — those move to first-shop lazy mint.
+2. **Abandon-mid-flow creates nothing.** No engine step runs pre-endorsement (**zero engine steps** before the explicit "yes"), so an abandoned interview leaves no partial shopper — automatic, not a teardown. Nothing is created, nothing partial.
+3. **Two touchpoints only — persona, then shared user spec.** `SOUL.md` (persona/voice, a generalist, NOT a niche) and the shared `user_spec.md` (cross-niche facts + hard constraints), both **pre-seeded from the session**. **No** niche know-how, no niche shopping taste, and no per-request template work at onboarding — those move to first-shop lazy mint.
 4. **No niche is researched or chosen at onboarding.** The shopper is a generalist; the deep niche know-how, the per-request template, and the niche shopping taste are minted **lazily, on first shop** in each niche ([`shop_loop.md`](shop_loop.md)). Onboarding never interrogates a niche or asks the user to pick one.
 5. **Converge each touchpoint before advancing; stay re-entrant.** Reflect-and-confirm per touchpoint; let the user revise an earlier one.
 6. **Singleton: refuse a second shopper; never clobber.** Defer to the engine's `collision` refusal ("a shopper already exists"); steer to shop-a-new-niche or refine.
-7. **Creation is local + offline for the user's identity.** Never present sil registration / a token as a prerequisite to create.
+7. **Creation is local + offline for the user's identity.** Never present sil registration / a token as a prerequisite to create, and never pull `sil_whoami` to seed — the seed is session-only.
 8. **The persona is the host `SOUL.md`, not a sil artefact.** No `persona.md` in the sil store. The only sil artefact seeded at create is the **shared** `user_spec.md`; the niche packs (the deep niche know-how, the per-request template, the niche shopping taste) are minted later, per niche.
 
 ## After endorsement
 
-Once the user has **explicitly endorsed** the assembled draft, proceed to [`agent_creation_engine.md`](agent_creation_engine.md) and run the engine steps in order. Until that explicit endorsement, **zero engine steps** have run.
+Once the user has **explicitly endorsed** the assembled draft, proceed to [`agent_creation_engine.md`](agent_creation_engine.md) and run the **one command**. Until that explicit endorsement, **zero engine steps** have run.

--- a/src/__tests__/create-shopper.integration.test.ts
+++ b/src/__tests__/create-shopper.integration.test.ts
@@ -764,6 +764,31 @@ describe("persistence_failed — snapshot-restore teardown leaves the host byte-
     expect(existsSync(spec.workspace)).toBe(false);
   });
 
+  it("a failed `config set` (skill-attach, step 8) ⇒ persistence_failed; teardown reverts; no orphans", () => {
+    // Step 8 (attach the sil skill via `openclaw config set …`) is the one enumerated
+    // fault-injection point the round-1 review flagged as never exercised. It fails
+    // AFTER agents-add + SOUL.md + materialize wrote — so the teardown path here has
+    // real accumulated state to unwind (host agent entry + shopper dir + workspace),
+    // proving the snapshot-restore reverts every earlier mutation, not just the config.
+    writeConfig(freshConfig());
+    const preConfig = readFileSync(configPath, "utf8");
+    const spec = validSpec();
+
+    const r = runBin({ spec, fail: ["config-set"] });
+
+    expect(r.status).not.toBe(0);
+    expect(parseMarker(r.stderr)["status"]).toBe("persistence_failed");
+    expect(r.stdout.includes("sil_shopper_created")).toBe(false);
+    // The skill-attach did run (writes had begun) — proving this exercises the
+    // step-8 teardown branch, not a pre-flight refusal.
+    expect(shimLog()).toContain("config set");
+    // Whole-file snapshot-restore returned the host to its EXACT pre-run bytes,
+    // and removed the shopper dir + workspace this run created.
+    expect(readFileSync(configPath, "utf8")).toBe(preConfig);
+    expect(existsSync(shopperDir())).toBe(false);
+    expect(existsSync(spec.workspace)).toBe(false);
+  });
+
   it("a failed allow-list admission (non-zero) ⇒ persistence_failed — NEVER a green created over filtered tools", () => {
     // Isolate the step-9 allowlist failure WITHOUT touching `config validate`: a
     // non-array `plugins.allow` makes the merge core throw AllowlistShapeError, so
@@ -808,6 +833,87 @@ describe("persistence_failed — snapshot-restore teardown leaves the host byte-
       expect(readFileSync(configPath, "utf8")).toBe(preConfig);
       expect(existsSync(shopperDir())).toBe(false);
       expect(existsSync(spec.workspace)).toBe(false);
+    },
+  );
+});
+
+// ===========================================================================
+// teardown_failed — the LOUDER honesty-rail outcome. When snapshot-restore itself
+// cannot revert (EBUSY/permission/disk-full analog), the bin MUST surface the
+// residue and NEVER green-wash it into `persistence_failed` — the trust hinge the
+// discovery council spent the most ink on ("a teardown that cannot fully revert is
+// a distinct louder outcome, never a green-washed persistence_failed").
+// ===========================================================================
+describe("teardown_failed — a non-revertable teardown surfaces residue, never a green-washed persistence_failed", () => {
+  it.skipIf(AS_ROOT)(
+    "an unwritable config dir fails BOTH the trust merge AND its rollback ⇒ teardown_failed(residue), no green-wash, no leak",
+    () => {
+      // Realistic fault: the host config directory is read-only. Every in-place
+      // config overwrite (agents add / config set) still works, and the workspace +
+      // shopper artefacts land in a SEPARATE writable dir (under $SIL_DATA_DIR) — so
+      // the whole choreography runs and mutates openclaw.json. Then step 9 (the
+      // shelled `sil-openclaw-allowlist` bin) fails: its `.bak` copy needs a NEW file
+      // in the read-only dir → EACCES. Teardown then tries to snapshot-restore
+      // openclaw.json — its atomic tmp write ALSO needs a NEW file in the read-only
+      // dir → EACCES → the config mutation is un-revertable → residue. The workspace
+      // + shopper-dir removals (writable dir) DO succeed, so the residue is exactly
+      // the one thing teardown could not undo: the config file.
+      writeConfig(freshConfig());
+      const preRunConfig = readFileSync(configPath, "utf8");
+      // Keep the workspace + artefacts OUT of the config dir so agents-add/SOUL.md/
+      // materialize all succeed — only the config dir is unwritable.
+      const spec = validSpec({ workspace: join(dataDir, "ws-teardown-fail") });
+      // Pre-create the shim log so the read-only dir doesn't suppress it (an existing
+      // file stays appendable); lets us prove writes began.
+      writeFileSync(logPath, "");
+
+      // Make the config directory read-only AFTER all setup writes are in place.
+      chmodSync(workdir, 0o500);
+      const r = runBin({ spec });
+      // Restore perms so afterEach can clean up regardless of assertion outcome.
+      chmodSync(workdir, 0o700);
+
+      expect(r.status).not.toBe(0);
+      const m = parseMarker(r.stderr);
+      expect(m["event"]).toBe("sil_shopper_create_failed");
+      // The LOUDER fifth outcome — NOT the four-value collapse.
+      expect(m["status"]).toBe("teardown_failed");
+      expect(m["status"]).not.toBe("persistence_failed");
+      expect(m["status"]).not.toBe("created");
+      // Never green-washed: no success marker anywhere.
+      expect(r.stdout.includes("sil_shopper_created")).toBe(false);
+
+      // The residue names WHAT could not be reverted — a populated {path, cause} list.
+      expect(Array.isArray(m["residue"])).toBe(true);
+      expect((m["residue"] as unknown[]).length).toBeGreaterThan(0);
+      for (const entry of m["residue"] as Array<Record<string, unknown>>) {
+        expect(typeof entry["path"]).toBe("string");
+        expect((entry["path"] as string).length).toBeGreaterThan(0);
+        expect(typeof entry["cause"]).toBe("string");
+        expect((entry["cause"] as string).length).toBeGreaterThan(0);
+      }
+      // The un-revertable config file is the surfaced residue.
+      expect(
+        (m["residue"] as Array<Record<string, unknown>>).some((e) => e["path"] === configPath),
+      ).toBe(true);
+      // The residue is TRUTHFUL, not a spurious claim: the host really was left
+      // un-reverted. The failed restore means openclaw.json keeps the mid-run
+      // mutations (the agents.list entry + skill + plugin/trust from steps 5–8), so
+      // it is NOT byte-identical to its pre-run snapshot — teardown_failed reflects
+      // real un-restored state, never a green-washed "nothing left" over dirty state.
+      expect(readFileSync(configPath, "utf8")).not.toBe(preRunConfig);
+      // The louder outcome voices that the host was NOT returned to pre-run state.
+      expect(typeof m["note"]).toBe("string");
+      expect((m["note"] as string).length).toBeGreaterThan(0);
+      // Writes had begun before the fault — this is a genuine mid-choreography failure,
+      // not a pre-flight refusal.
+      expect(shimLog()).toContain("agents add");
+
+      // Even on the loudest failure path, the persona/userSpec text never leaks.
+      expect(r.stdout).not.toContain(PERSONA_SECRET);
+      expect(r.stdout).not.toContain(USERSPEC_SECRET);
+      expect(r.stderr).not.toContain(PERSONA_SECRET);
+      expect(r.stderr).not.toContain(USERSPEC_SECRET);
     },
   );
 });

--- a/src/__tests__/create-shopper.integration.test.ts
+++ b/src/__tests__/create-shopper.integration.test.ts
@@ -1,0 +1,928 @@
+/**
+ * INTEGRATION — the one-tap create-shopper BIN, end-to-end against a real temp
+ * host (tier: integration — spawns `scripts/create-shopper.mjs` as a child
+ * process, real fs reads/writes, real exit codes, real `materializeProfile` +
+ * the real `sil-openclaw-allowlist` bin; the ONLY test double is a PATH-shimmed
+ * `openclaw` binary, the EXTERNAL host CLI boundary — never a stub of sil's own
+ * logic, per `.claude/rules/complete-work-is-stub-free.md`).
+ *
+ * Card: one-tap-shopper-create-via-a-single-wrapper-bin. The bin collapses the
+ * nine-step agent-driven host-CLI choreography into ONE shipped operator `bin`
+ * (a sibling of `sil-openclaw-allowlist`) that runs it atomically + fail-closed.
+ * This suite pins the LOAD-BEARING invariant — the FOUR-OUTCOME taxonomy and its
+ * exact state effects — as a black box over the bin's `{ status, … }` JSON result
+ * and the observable filesystem (temp `openclaw.json` + temp `$SIL_DATA_DIR` +
+ * the workspace dir):
+ *
+ *   created            — a valid spec + no shopper + a validating host config ⇒
+ *                        host agent added, SOUL.md carries the persona, the sil
+ *                        artefacts materialized (shared user_spec.md + profile.json
+ *                        with an EMPTY `domains: {}` map), the sil skill attached,
+ *                        `sil` admitted at ALL THREE allow surfaces, exit 0, the
+ *                        result carries name + agentId.
+ *   invalid_request    — a bad/blank/malformed spec ⇒ NOTHING attempted (validate-
+ *                        first runs ahead of every host command); names the field.
+ *   collision          — a singleton violation OR an agentId clash ⇒ NOTHING
+ *                        written; `openclaw agents add` never runs; DISTINCT from
+ *                        persistence_failed (different recovery).
+ *   persistence_failed — a step fails AFTER writes begin ⇒ whole-file snapshot-
+ *                        restore returns the host to its EXACT pre-run state (no
+ *                        orphan agent entry / workspace dir / shopper dir / residual
+ *                        trust edit; a co-installed peer's trust survives); carries
+ *                        path + cause; NEVER declares created.
+ *
+ * Plus: creation is LOCAL + OFFLINE (reads no token, calls no `sil_whoami`, makes
+ * no network call) and the markers NEVER leak the persona/userSpec text.
+ *
+ * The bin imports the COMPILED libs (`dist/lib/profile-store.js`) and shells the
+ * `sil-openclaw-allowlist` bin (which imports `dist/lib/openclaw-allowlist.js`), so
+ * beforeAll builds dist FROM THE CURRENT SOURCE — never a possibly-stale dist (a
+ * stale dist silently tests old logic). The build is the same `tsc -p
+ * tsconfig.build.json` the bin's `../dist` import needs.
+ *
+ * THE fake `openclaw` shim is a faithful test double of the EXTERNAL host CLI: it
+ * answers `agents list` / `agents add` / `config set` / `config validate` (and the
+ * nested allowlist bin's internal `config validate`) with the MINIMAL real fs effect
+ * a later step reads — the bin checks `agents list`/`agents add` only by EXIT CODE
+ * and re-reads the config FILE, so the shim's job is to mutate `openclaw.json` +
+ * bootstrap the workspace, not to fake output shapes. A per-run `OPENCLAW_SHIM_FAIL`
+ * knob injects a non-zero/invalid result at a chosen step.
+ *
+ * THESE ASSERTIONS ARE THE SPEC. Do NOT weaken them to match the bin.
+ * Hermetic: each test gets its own mkdtemp dirs + config fixture; full teardown in
+ * afterEach. NO shared state, NO order dependence.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import { execFileSync } from "node:child_process";
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  chmodSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+/** Repo root of the checkout under test (…/src/__tests__ → root). */
+const REPO_ROOT = join(HERE, "..", "..");
+const SCRIPT = join(REPO_ROOT, "scripts", "create-shopper.mjs");
+
+const SIL_ID = "sil";
+/** Running as root bypasses filesystem permission bits, so the chmod-based
+ * "unwritable $SIL_DATA_DIR" fault-injection cannot fire — skip it there. */
+const AS_ROOT = typeof process.getuid === "function" && process.getuid() === 0;
+
+// Distinctive secrets planted in persona/userSpec — the bin must NEVER echo them
+// into its stdout/stderr markers (no PII/secret leakage).
+const PERSONA_SECRET = "PERSONA-SECRET-b3a1f7";
+const USERSPEC_SECRET = "USERSPEC-SECRET-9c2d0e";
+
+interface RunResult {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+interface Spec {
+  agentId: string;
+  name: string;
+  workspace: string;
+  persona: string;
+  userSpec: string;
+}
+
+/**
+ * The fake `openclaw` host CLI — a CommonJS script (a bare `openclaw` file with a
+ * node shebang runs as CJS: no `.mjs` extension, no package.json in its temp dir).
+ * It is a test double of the EXTERNAL binary boundary, NOT a stub of sil's logic.
+ *
+ * Contract (matches what the bin actually needs — the bin reads `agents list`/
+ * `agents add` only by exit code, then re-reads the config FILE):
+ *   agents list --json     → exit 0 (empty output is fine)               [fail: agents-list]
+ *   agents add <id> …      → append {id,skills:[]} to agents.list, mkdir
+ *                            the --workspace dir + bootstrap SOUL.md/AGENTS.md, exit 0
+ *                                                                        [fail: agents-add]
+ *   config set <path> <v>  → apply the set to openclaw.json, exit 0      [fail: config-set]
+ *   config validate --json → {valid:true,path}                          [fail: config-validate
+ *                            ⇒ {valid:false,path,issues,error}, exit 0]
+ * Every invocation's argv is appended to $OPENCLAW_SHIM_LOG so a test can prove
+ * WHICH host commands ran (e.g. "agents add NEVER ran" on a collision).
+ */
+const OPENCLAW_SHIM = String.raw`#!/usr/bin/env node
+"use strict";
+const { readFileSync, writeFileSync, mkdirSync, appendFileSync } = require("node:fs");
+const { join } = require("node:path");
+
+const argv = process.argv.slice(2);
+const cfgPath = process.env.OPENCLAW_CONFIG_PATH;
+const fails = (process.env.OPENCLAW_SHIM_FAIL || "").split(",").filter(Boolean);
+const logPath = process.env.OPENCLAW_SHIM_LOG;
+if (logPath) { try { appendFileSync(logPath, argv.join(" ") + "\n"); } catch (e) {} }
+
+function readCfg() { return JSON.parse(readFileSync(cfgPath, "utf8")); }
+function writeCfg(c) { writeFileSync(cfgPath, JSON.stringify(c, null, 2) + "\n"); }
+function die(msg) { process.stderr.write("shim: " + msg + "\n"); process.exit(1); }
+
+// Set a value at a dotted path that may contain "[N]" index segments, e.g.
+// "agents.list[0].skills" or "plugins.entries.sil.enabled".
+function setPath(obj, path, val) {
+  const parts = [];
+  for (const seg of path.split(".")) {
+    const m = seg.match(/^([^\[]+)\[(\d+)\]$/);
+    if (m) { parts.push(m[1]); parts.push(Number(m[2])); }
+    else { parts.push(seg); }
+  }
+  let cur = obj;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const k = parts[i];
+    if (cur[k] === undefined || cur[k] === null) {
+      cur[k] = typeof parts[i + 1] === "number" ? [] : {};
+    }
+    cur = cur[k];
+  }
+  cur[parts[parts.length - 1]] = val;
+}
+
+const a0 = argv[0];
+const a1 = argv[1];
+
+if (a0 === "agents" && a1 === "list") {
+  if (fails.includes("agents-list")) die("agents list forced failure");
+  let list = [];
+  try { const c = readCfg(); if (c.agents && Array.isArray(c.agents.list)) list = c.agents.list; } catch (e) {}
+  process.stdout.write(JSON.stringify({ agents: list.map((x) => ({ id: x && x.id })) }) + "\n");
+  process.exit(0);
+}
+
+if (a0 === "agents" && a1 === "add") {
+  if (fails.includes("agents-add")) die("agents add forced failure");
+  const id = argv[2];
+  const wsIdx = argv.indexOf("--workspace");
+  const ws = wsIdx >= 0 ? argv[wsIdx + 1] : null;
+  const c = readCfg();
+  if (!c.agents || typeof c.agents !== "object") c.agents = {};
+  if (!Array.isArray(c.agents.list)) c.agents.list = [];
+  c.agents.list.push({ id: id, skills: [] });
+  writeCfg(c);
+  if (ws) {
+    mkdirSync(ws, { recursive: true });
+    writeFileSync(join(ws, "SOUL.md"), "# placeholder soul (host bootstrap)\n");
+    writeFileSync(join(ws, "AGENTS.md"), "# placeholder agents (host bootstrap)\n");
+  }
+  process.stdout.write(JSON.stringify({ id: id, workspace: ws }) + "\n");
+  process.exit(0);
+}
+
+if (a0 === "config" && a1 === "set") {
+  if (fails.includes("config-set")) die("config set forced failure");
+  const path = argv[2];
+  const rawVal = argv[3];
+  let val;
+  try { val = JSON.parse(rawVal); } catch (e) { val = rawVal; }
+  const c = readCfg();
+  setPath(c, path, val);
+  writeCfg(c);
+  process.exit(0);
+}
+
+if (a0 === "config" && a1 === "validate") {
+  if (fails.includes("config-validate")) {
+    process.stdout.write(JSON.stringify({ valid: false, path: cfgPath, issues: ["shim: forced invalid config"], error: "shim forced the config invalid" }) + "\n");
+    process.exit(0);
+  }
+  process.stdout.write(JSON.stringify({ valid: true, path: cfgPath }) + "\n");
+  process.exit(0);
+}
+
+// Any other subcommand: no-op success (logged above).
+process.exit(0);
+`;
+
+// ---------------------------------------------------------------------------
+// Per-test temp state.
+// ---------------------------------------------------------------------------
+let workdir: string; // holds openclaw.json + the workspace dir
+let dataDir: string; // $SIL_DATA_DIR
+let binDir: string; // holds the `openclaw` shim
+let emptyHome: string; // guaranteed-empty HOME so no real ~/.openclaw resolves
+let logPath: string; // shim invocation log
+let configPath: string;
+
+beforeAll(() => {
+  // The bin imports dist/lib/profile-store.js and shells the allowlist bin
+  // (dist/lib/openclaw-allowlist.js) — build the libs from the CURRENT source so
+  // the integration tier exercises what the dev wrote, never a stale dist. We
+  // invoke the TypeScript compiler's real JS entry (node_modules/.bin/tsc is a
+  // shell wrapper `node` cannot run directly).
+  execFileSync("node", ["node_modules/typescript/bin/tsc", "-p", "tsconfig.build.json"], {
+    cwd: REPO_ROOT,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  for (const rel of ["dist/lib/profile-store.js", "dist/lib/openclaw-allowlist.js"]) {
+    if (!existsSync(join(REPO_ROOT, rel))) {
+      throw new Error(`build did not emit ${rel} — the bin's import would 404`);
+    }
+  }
+}, 120_000);
+
+beforeEach(() => {
+  workdir = mkdtempSync(join(tmpdir(), "sil-create-it-"));
+  dataDir = mkdtempSync(join(tmpdir(), "sil-create-data-"));
+  binDir = mkdtempSync(join(tmpdir(), "sil-create-bin-"));
+  emptyHome = mkdtempSync(join(tmpdir(), "sil-create-home-"));
+  configPath = join(workdir, "openclaw.json");
+  logPath = join(workdir, "shim-invocations.log");
+  writeFileSync(join(binDir, "openclaw"), OPENCLAW_SHIM, { mode: 0o755 });
+});
+
+afterEach(() => {
+  for (const d of [workdir, dataDir, binDir, emptyHome]) {
+    try {
+      chmodSync(d, 0o700);
+    } catch {
+      /* best effort — the unwritable-datadir test drops perms */
+    }
+    rmSync(d, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Helpers.
+// ---------------------------------------------------------------------------
+
+/** A fresh host config: sil discovered, trusted nowhere; no agents yet. */
+function freshConfig(): Record<string, unknown> {
+  return {
+    gateway: { mode: "local", port: 18789 },
+    tools: { profile: "coding", alsoAllow: [] as string[] },
+    plugins: { allow: [] as string[], entries: {} as Record<string, unknown> },
+    meta: { lastTouchedVersion: "2026.6.9" },
+  };
+}
+
+/** A host config where a co-installed peer (`klodi`) is ALREADY trusted at every
+ * surface — the additive/teardown invariant subject. */
+function klodiConfig(): Record<string, unknown> {
+  return {
+    gateway: { mode: "local", port: 18789 },
+    tools: { profile: "coding", alsoAllow: ["klodi"] },
+    plugins: {
+      allow: ["klodi"],
+      entries: { klodi: { enabled: true, config: { apiKey: "operator-set" } } },
+    },
+    meta: { lastTouchedVersion: "2026.6.9" },
+  };
+}
+
+function writeConfig(value: unknown): void {
+  writeFileSync(configPath, JSON.stringify(value, null, 2) + "\n");
+}
+
+function readConfig(): Record<string, any> {
+  return JSON.parse(readFileSync(configPath, "utf8"));
+}
+
+/** A valid, endorsed spec (secrets planted in persona/userSpec). */
+function validSpec(overrides: Partial<Spec> = {}): Spec {
+  const agentId = overrides.agentId ?? "my-shopper";
+  return {
+    agentId,
+    name: overrides.name ?? "My Shopper",
+    workspace: overrides.workspace ?? join(workdir, `workspace-${agentId}`),
+    persona: overrides.persona ?? `A careful generalist buyer. ${PERSONA_SECRET}`,
+    userSpec: overrides.userSpec ?? `Ships to Athens; UK size 10; ${USERSPEC_SECRET}`,
+  };
+}
+
+interface RunOpts {
+  spec?: Spec;
+  /** Raw stdin body — bypasses `spec` to feed malformed JSON. */
+  stdin?: string;
+  /** Pass the spec via a `--spec <path>` file instead of stdin. */
+  viaSpecFile?: boolean;
+  /** OPENCLAW_SHIM_FAIL knob(s). */
+  fail?: string[];
+  /** Override the resolved config env (for the "no config" fail-closed case). */
+  env?: Record<string, string>;
+}
+
+/** Spawn the bin as a child process with a hermetic, explicit env. */
+function runBin(opts: RunOpts = {}): RunResult {
+  const args = [SCRIPT];
+  let input = "";
+  if (opts.stdin !== undefined) {
+    input = opts.stdin;
+  } else if (opts.spec) {
+    if (opts.viaSpecFile) {
+      const specPath = join(workdir, "spec.json");
+      writeFileSync(specPath, JSON.stringify(opts.spec));
+      args.push("--spec", specPath);
+    } else {
+      input = JSON.stringify(opts.spec);
+    }
+  }
+
+  const env: Record<string, string> = {
+    PATH: `${binDir}:${process.env["PATH"] ?? "/usr/bin:/bin"}`,
+    HOME: emptyHome,
+    OPENCLAW_CONFIG_PATH: configPath,
+    SIL_DATA_DIR: dataDir,
+    OPENCLAW_SHIM_LOG: logPath,
+    ...(opts.fail && opts.fail.length ? { OPENCLAW_SHIM_FAIL: opts.fail.join(",") } : {}),
+    ...(opts.env ?? {}),
+  };
+
+  try {
+    const stdout = execFileSync("node", args, {
+      input,
+      env,
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return { status: 0, stdout, stderr: "" };
+  } catch (err: unknown) {
+    const e = err as { status?: number; stdout?: Buffer | string; stderr?: Buffer | string };
+    return {
+      status: e.status ?? 1,
+      stdout: (e.stdout ?? "").toString(),
+      stderr: (e.stderr ?? "").toString(),
+    };
+  }
+}
+
+/** Parse the single NDJSON marker the bin emits on the given stream. */
+function parseMarker(streamText: string): Record<string, any> {
+  const line = streamText.trim().split("\n").filter(Boolean).at(-1) ?? "";
+  return JSON.parse(line) as Record<string, any>;
+}
+
+/** Full text of the shim invocation log (empty string if the shim never ran). */
+function shimLog(): string {
+  return existsSync(logPath) ? readFileSync(logPath, "utf8") : "";
+}
+
+const shopperDir = () => join(dataDir, "shopper");
+const profileJsonPath = () => join(shopperDir(), "profile.json");
+const userSpecPath = () => join(shopperDir(), "user_spec.md");
+
+/** Seed a pre-existing SINGLETON shopper (valid manifest + shared user spec) so the
+ * bin's `readAgentProfile()` pre-flight returns a named overview ⇒ collision. */
+function seedExistingShopper(): void {
+  mkdirSync(shopperDir(), { recursive: true });
+  writeFileSync(userSpecPath(), "# Existing shopper user spec\nships to Berlin\n");
+  writeFileSync(
+    profileJsonPath(),
+    JSON.stringify(
+      {
+        name: "Existing Shopper",
+        userSpecPath: userSpecPath(),
+        createdAt: "2026-01-01T00:00:00.000Z",
+        domains: {},
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+}
+
+// ===========================================================================
+// created — the happy path: every surface wired, exit 0, identity returned.
+// ===========================================================================
+describe("created — one valid run wires every surface and returns the identity", () => {
+  it("exits 0 with status:created and the result carries name + agentId (so the agent can open it)", () => {
+    writeConfig(freshConfig());
+    const spec = validSpec();
+    const r = runBin({ spec });
+
+    expect(r.status).toBe(0);
+    const m = parseMarker(r.stdout);
+    expect(m["event"]).toBe("sil_shopper_created");
+    expect(m["status"]).toBe("created");
+    expect(m["name"]).toBe(spec.name);
+    expect(m["agentId"]).toBe(spec.agentId);
+    // No failure marker on stderr for a clean create.
+    expect(r.stderr.includes("sil_shopper_create_failed")).toBe(false);
+  });
+
+  it("materializes the sil artefacts — shared user_spec.md + profile.json with an EMPTY domains map (healthy)", () => {
+    writeConfig(freshConfig());
+    const spec = validSpec();
+    const r = runBin({ spec });
+    expect(r.status).toBe(0);
+
+    expect(existsSync(profileJsonPath())).toBe(true);
+    const manifest = JSON.parse(readFileSync(profileJsonPath(), "utf8"));
+    expect(manifest.name).toBe(spec.name);
+    // A fresh shopper has NO domains — an empty map is healthy, not a deficiency.
+    expect(manifest.domains).toEqual({});
+    expect(existsSync(userSpecPath())).toBe(true);
+    expect(readFileSync(userSpecPath(), "utf8")).toContain(USERSPEC_SECRET);
+    // No per-domain packs authored at create.
+    expect(existsSync(join(shopperDir(), "domains"))).toBe(false);
+  });
+
+  it("writes the persona into the workspace SOUL.md (host workspace, not a sil artefact)", () => {
+    writeConfig(freshConfig());
+    const spec = validSpec();
+    const r = runBin({ spec });
+    expect(r.status).toBe(0);
+
+    const soul = join(spec.workspace, "SOUL.md");
+    expect(existsSync(soul)).toBe(true);
+    expect(readFileSync(soul, "utf8")).toContain(PERSONA_SECRET);
+    // The persona lives in exactly one place — never a sil persona.md.
+    expect(existsSync(join(shopperDir(), "persona.md"))).toBe(false);
+  });
+
+  it("admits sil at ALL THREE allow surfaces AND attaches the skill + enables the plugin", () => {
+    writeConfig(freshConfig());
+    const spec = validSpec();
+    const r = runBin({ spec });
+    expect(r.status).toBe(0);
+
+    const c = readConfig();
+    // Trust — the three surfaces the shipped allowlist bin merges. The third
+    // surface's invariant is that sil is ENABLED there; the entry's exact object
+    // shape ({enabled:true} vs {enabled:true,config:{}}) is incidental — the create
+    // bin sets `enabled` via `config set` first, then the allowlist merges
+    // idempotently over that pre-existing entry (never clobbering it).
+    expect(c.plugins.allow).toContain(SIL_ID);
+    expect(c.tools.alsoAllow).toContain(SIL_ID);
+    expect(c.plugins.entries[SIL_ID]).toBeTruthy();
+    expect(c.plugins.entries[SIL_ID].enabled).toBe(true);
+    // Wiring — the host agent exists with the sil skill attached.
+    const agent = c.agents.list.find((a: any) => a.id === spec.agentId);
+    expect(agent).toBeTruthy();
+    expect(agent.skills).toEqual([SIL_ID]);
+  });
+
+  it("carries a warnings array (empty on a config with no web-capability gap)", () => {
+    writeConfig(freshConfig());
+    const r = runBin({ spec: validSpec() });
+    expect(r.status).toBe(0);
+    const m = parseMarker(r.stdout);
+    expect(Array.isArray(m["warnings"])).toBe(true);
+    expect(m["warnings"]).toEqual([]);
+  });
+});
+
+// ===========================================================================
+// created — additive: a co-installed peer survives; the shopper is added beside it.
+// ===========================================================================
+describe("created — additive: a co-installed peer (klodi) keeps its trust", () => {
+  it("appends sil at every surface while klodi's pre-existing trust is preserved", () => {
+    writeConfig(klodiConfig());
+    const r = runBin({ spec: validSpec() });
+    expect(r.status).toBe(0);
+
+    const c = readConfig();
+    expect(c.plugins.allow).toContain("klodi");
+    expect(c.plugins.allow).toContain(SIL_ID);
+    expect(c.tools.alsoAllow).toContain("klodi");
+    expect(c.tools.alsoAllow).toContain(SIL_ID);
+    // klodi's operator-set config is untouched.
+    expect(c.plugins.entries["klodi"]).toEqual({
+      enabled: true,
+      config: { apiKey: "operator-set" },
+    });
+  });
+});
+
+// ===========================================================================
+// created — the web-capability gap is a WARNING, never a hard-fail (SA ruling).
+// ===========================================================================
+describe("created — a web-capability gap warns but never blocks (bare sil_search still works)", () => {
+  it("still reaches created, carrying a non-empty warnings entry naming the gap", () => {
+    const cfg = freshConfig() as any;
+    // agents.defaults is present but grants NO web/fetch/browse/http capability.
+    cfg.agents = { defaults: { tools: { profile: "coding", alsoAllow: [] } } };
+    writeConfig(cfg);
+    const r = runBin({ spec: validSpec() });
+    expect(r.status).toBe(0);
+    const m = parseMarker(r.stdout);
+    expect(m["status"]).toBe("created");
+    expect(Array.isArray(m["warnings"])).toBe(true);
+    expect((m["warnings"] as string[]).length).toBeGreaterThan(0);
+  });
+});
+
+// ===========================================================================
+// invalid_request — validate-first: a bad/blank field ⇒ NOTHING attempted.
+// ===========================================================================
+describe("invalid_request — validate-first refuses a bad/blank spec, attempting NOTHING", () => {
+  const REQUIRED: ReadonlyArray<keyof Spec> = [
+    "agentId",
+    "name",
+    "workspace",
+    "persona",
+    "userSpec",
+  ];
+
+  for (const field of REQUIRED) {
+    it(`a MISSING \`${field}\` ⇒ invalid_request naming it, non-zero exit, nothing written, no host command run`, () => {
+      writeConfig(freshConfig());
+      const spec = validSpec();
+      const partial = { ...spec };
+      delete (partial as Record<string, unknown>)[field];
+      const preConfig = readFileSync(configPath, "utf8");
+
+      const r = runBin({ stdin: JSON.stringify(partial) });
+
+      expect(r.status).not.toBe(0);
+      const m = parseMarker(r.stderr);
+      expect(m["event"]).toBe("sil_shopper_create_failed");
+      expect(m["status"]).toBe("invalid_request");
+      // The failure names the offending field (in `field` or the cause text).
+      const namesField =
+        m["field"] === field || String(m["cause"] ?? "").includes(field);
+      expect(namesField, `expected the failure to name '${field}'`).toBe(true);
+
+      // NOTHING attempted: validate-first runs ahead of EVERY host command.
+      expect(shimLog()).toBe("");
+      // NOTHING written: config byte-identical, no shopper dir, no workspace.
+      expect(readFileSync(configPath, "utf8")).toBe(preConfig);
+      expect(existsSync(shopperDir())).toBe(false);
+      expect(existsSync(spec.workspace)).toBe(false);
+    });
+
+    it(`a BLANK (whitespace) \`${field}\` ⇒ invalid_request, nothing attempted`, () => {
+      writeConfig(freshConfig());
+      const spec = validSpec();
+      const r = runBin({ spec: { ...spec, [field]: "   " } as Spec });
+      expect(r.status).not.toBe(0);
+      expect(parseMarker(r.stderr)["status"]).toBe("invalid_request");
+      expect(shimLog()).toBe("");
+      expect(existsSync(shopperDir())).toBe(false);
+    });
+  }
+
+  it("rejects a host-reserved agentId `main` (never a shopper named main)", () => {
+    writeConfig(freshConfig());
+    const r = runBin({ spec: validSpec({ agentId: "main" }) });
+    expect(r.status).not.toBe(0);
+    const m = parseMarker(r.stderr);
+    expect(m["status"]).toBe("invalid_request");
+    expect(shimLog()).toBe("");
+  });
+
+  it("rejects a non-lower-kebab agentId (path-segment shape guard)", () => {
+    writeConfig(freshConfig());
+    const r = runBin({ spec: validSpec({ agentId: "My_Shopper!" }) });
+    expect(r.status).not.toBe(0);
+    expect(parseMarker(r.stderr)["status"]).toBe("invalid_request");
+    expect(shimLog()).toBe("");
+  });
+});
+
+// ===========================================================================
+// invalid_request — malformed/unparseable input fails closed (mirrors the
+// allowlist helper's "config is not valid JSON → fail closed").
+// ===========================================================================
+describe("invalid_request — malformed/unparseable spec fails closed", () => {
+  it("garbage stdin JSON ⇒ non-zero, structured error, nothing attempted, nothing written", () => {
+    writeConfig(freshConfig());
+    const preConfig = readFileSync(configPath, "utf8");
+    const r = runBin({ stdin: "{ this is : not json,, }" });
+    expect(r.status).not.toBe(0);
+    const m = parseMarker(r.stderr);
+    expect(m["event"]).toBe("sil_shopper_create_failed");
+    expect(m["status"]).toBe("invalid_request");
+    expect(shimLog()).toBe("");
+    expect(readFileSync(configPath, "utf8")).toBe(preConfig);
+    expect(existsSync(shopperDir())).toBe(false);
+  });
+
+  it("an empty stdin body ⇒ invalid_request, nothing attempted", () => {
+    writeConfig(freshConfig());
+    const r = runBin({ stdin: "" });
+    expect(r.status).not.toBe(0);
+    expect(parseMarker(r.stderr)["status"]).toBe("invalid_request");
+    expect(shimLog()).toBe("");
+  });
+
+  it("a JSON array (not an object) ⇒ invalid_request, nothing attempted", () => {
+    writeConfig(freshConfig());
+    const r = runBin({ stdin: JSON.stringify(["not", "an", "object"]) });
+    expect(r.status).not.toBe(0);
+    expect(parseMarker(r.stderr)["status"]).toBe("invalid_request");
+    expect(shimLog()).toBe("");
+  });
+
+  it("an unreadable --spec file ⇒ invalid_request, nothing attempted", () => {
+    writeConfig(freshConfig());
+    const args = [SCRIPT, "--spec", join(workdir, "does-not-exist.json")];
+    let status = 0;
+    let stderr = "";
+    try {
+      execFileSync("node", args, {
+        input: "",
+        env: {
+          PATH: `${binDir}:${process.env["PATH"] ?? "/usr/bin:/bin"}`,
+          HOME: emptyHome,
+          OPENCLAW_CONFIG_PATH: configPath,
+          SIL_DATA_DIR: dataDir,
+          OPENCLAW_SHIM_LOG: logPath,
+        },
+        encoding: "utf8",
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+    } catch (err: unknown) {
+      const e = err as { status?: number; stderr?: Buffer | string };
+      status = e.status ?? 1;
+      stderr = (e.stderr ?? "").toString();
+    }
+    expect(status).not.toBe(0);
+    expect(parseMarker(stderr)["status"]).toBe("invalid_request");
+    expect(shimLog()).toBe("");
+  });
+});
+
+// ===========================================================================
+// collision — the singleton invariant + the agentId clash. DISTINCT from
+// persistence_failed; `openclaw agents add` NEVER runs; nothing written.
+// ===========================================================================
+describe("collision — a shopper already exists (singleton): refuse, write nothing, never add", () => {
+  it("a pre-existing sil shopper ⇒ status:collision, `agents add` never runs, config byte-identical", () => {
+    writeConfig(freshConfig());
+    seedExistingShopper();
+    const preConfig = readFileSync(configPath, "utf8");
+    const preProfile = readFileSync(profileJsonPath(), "utf8");
+
+    const r = runBin({ spec: validSpec() });
+
+    expect(r.status).not.toBe(0);
+    const m = parseMarker(r.stderr);
+    expect(m["event"]).toBe("sil_shopper_create_failed");
+    // DISTINCT literal — never green-washed into persistence_failed.
+    expect(m["status"]).toBe("collision");
+    expect(m["status"]).not.toBe("persistence_failed");
+
+    // `openclaw agents add` NEVER ran (the singleton gate precedes the add).
+    expect(shimLog()).not.toContain("agents add");
+    // Nothing written: config byte-identical AND the existing shopper untouched.
+    expect(readFileSync(configPath, "utf8")).toBe(preConfig);
+    expect(readFileSync(profileJsonPath(), "utf8")).toBe(preProfile);
+  });
+
+  it("a second run AFTER a successful created hits the same singleton gate (never a duplicate shopper)", () => {
+    writeConfig(freshConfig());
+    const first = runBin({ spec: validSpec() });
+    expect(first.status).toBe(0);
+    expect(parseMarker(first.stdout)["status"]).toBe("created");
+
+    // Second run — same singleton, now populated by the first create.
+    rmSync(logPath, { force: true });
+    const second = runBin({ spec: validSpec({ agentId: "my-shopper-2", name: "Second" }) });
+    expect(second.status).not.toBe(0);
+    expect(parseMarker(second.stderr)["status"]).toBe("collision");
+    expect(shimLog()).not.toContain("agents add");
+  });
+});
+
+describe("collision — an agentId clash refuses without overwriting the existing agent", () => {
+  it("the proposed agentId already in agents.list ⇒ collision, existing agent untouched, no shopper dir", () => {
+    const cfg = freshConfig() as any;
+    cfg.agents = { list: [{ id: "my-shopper", skills: ["other"], workspace: "/pre/existing" }] };
+    writeConfig(cfg);
+    const preConfig = readFileSync(configPath, "utf8");
+
+    const r = runBin({ spec: validSpec({ agentId: "my-shopper" }) });
+
+    expect(r.status).not.toBe(0);
+    expect(parseMarker(r.stderr)["status"]).toBe("collision");
+    // Never overwrote the existing agent, never minted a shopper dir.
+    expect(readFileSync(configPath, "utf8")).toBe(preConfig);
+    expect(existsSync(shopperDir())).toBe(false);
+  });
+});
+
+// ===========================================================================
+// persistence_failed — a step fails AFTER writes begin ⇒ snapshot-restore
+// leaves the host at its EXACT pre-run state; NEVER declares created.
+// ===========================================================================
+describe("persistence_failed — snapshot-restore teardown leaves the host byte-identical to pre-run", () => {
+  it("a rejected `config validate` ⇒ persistence_failed(path+cause); openclaw.json byte-identical; no orphans; peer survives", () => {
+    writeConfig(klodiConfig());
+    const preConfig = readFileSync(configPath, "utf8");
+    const spec = validSpec();
+
+    const r = runBin({ spec, fail: ["config-validate"] });
+
+    expect(r.status).not.toBe(0);
+    const m = parseMarker(r.stderr);
+    expect(m["status"]).toBe("persistence_failed");
+    // Never declares created on a failed run.
+    expect(m["status"]).not.toBe("created");
+    expect(r.stdout.includes("sil_shopper_created")).toBe(false);
+    // Actionable path + cause.
+    expect(typeof m["path"]).toBe("string");
+    expect(typeof m["cause"]).toBe("string");
+    expect(String(m["cause"]).length).toBeGreaterThan(0);
+
+    // The host is byte-identical to its pre-run state — every mutation reversed.
+    expect(readFileSync(configPath, "utf8")).toBe(preConfig);
+    // No orphan sil shopper dir, no orphan workspace dir.
+    expect(existsSync(shopperDir())).toBe(false);
+    expect(existsSync(spec.workspace)).toBe(false);
+    // The co-installed peer's trust survived the teardown untouched.
+    const c = readConfig();
+    expect(c.plugins.allow).toEqual(["klodi"]);
+    expect(c.tools.alsoAllow).toEqual(["klodi"]);
+    // sil was fully unwound — it is trusted at NO surface.
+    expect(c.plugins.allow).not.toContain(SIL_ID);
+    expect(c.tools.alsoAllow).not.toContain(SIL_ID);
+    expect(c.plugins.entries[SIL_ID]).toBeUndefined();
+    // No orphan .bak left by the nested allowlist bin.
+    expect(existsSync(configPath + ".bak")).toBe(false);
+  });
+
+  it("a failed `openclaw agents add` ⇒ persistence_failed, nothing partial, never created", () => {
+    writeConfig(freshConfig());
+    const preConfig = readFileSync(configPath, "utf8");
+    const spec = validSpec();
+
+    const r = runBin({ spec, fail: ["agents-add"] });
+
+    expect(r.status).not.toBe(0);
+    expect(parseMarker(r.stderr)["status"]).toBe("persistence_failed");
+    expect(r.stdout.includes("sil_shopper_created")).toBe(false);
+    expect(readFileSync(configPath, "utf8")).toBe(preConfig);
+    expect(existsSync(shopperDir())).toBe(false);
+    expect(existsSync(spec.workspace)).toBe(false);
+  });
+
+  it("a failed allow-list admission (non-zero) ⇒ persistence_failed — NEVER a green created over filtered tools", () => {
+    // Isolate the step-9 allowlist failure WITHOUT touching `config validate`: a
+    // non-array `plugins.allow` makes the merge core throw AllowlistShapeError, so
+    // the shelled `sil-openclaw-allowlist` bin exits non-zero. The create bin must
+    // NOT declare `created` over still-filtered sil_* tools — it tears down instead.
+    const cfg = freshConfig() as any;
+    cfg.plugins.allow = "sil"; // a string, not an array — the shape the allowlist core rejects
+    writeConfig(cfg);
+    const preConfig = readFileSync(configPath, "utf8");
+    const spec = validSpec();
+
+    const r = runBin({ spec });
+
+    expect(r.status).not.toBe(0);
+    expect(parseMarker(r.stderr)["status"]).toBe("persistence_failed");
+    expect(r.stdout.includes("sil_shopper_created")).toBe(false);
+    // Snapshot-restore reverted every earlier mutation (the malformed config is
+    // restored EXACTLY — teardown never "fixes" it, only reverts to pre-run).
+    expect(readFileSync(configPath, "utf8")).toBe(preConfig);
+    expect(existsSync(shopperDir())).toBe(false);
+    expect(existsSync(spec.workspace)).toBe(false);
+  });
+
+  it.skipIf(AS_ROOT)(
+    "a failed sil-artefact materialize (unwritable $SIL_DATA_DIR) ⇒ persistence_failed, host restored",
+    () => {
+      writeConfig(freshConfig());
+      const preConfig = readFileSync(configPath, "utf8");
+      const spec = validSpec();
+      // Drop write permission on $SIL_DATA_DIR so materialize's mkdir of the shopper
+      // leaf fails AFTER the host agent + SOUL.md were written (a mid-choreography fault).
+      chmodSync(dataDir, 0o500);
+
+      const r = runBin({ spec });
+
+      // Restore perms so afterEach can clean up regardless of the assertion outcome.
+      chmodSync(dataDir, 0o700);
+
+      expect(r.status).not.toBe(0);
+      expect(parseMarker(r.stderr)["status"]).toBe("persistence_failed");
+      expect(r.stdout.includes("sil_shopper_created")).toBe(false);
+      expect(readFileSync(configPath, "utf8")).toBe(preConfig);
+      expect(existsSync(shopperDir())).toBe(false);
+      expect(existsSync(spec.workspace)).toBe(false);
+    },
+  );
+});
+
+// ===========================================================================
+// Teardown removes ONLY what THIS run created — a pre-existing workspace dir with
+// operator files survives (mirrors materializeProfile's !preexisted discipline).
+// ===========================================================================
+describe("teardown removes only what THIS run created", () => {
+  it("a PRE-EXISTING workspace dir (with an operator file) survives a persistence_failed teardown", () => {
+    writeConfig(freshConfig());
+    const spec = validSpec();
+    // The operator created the workspace before the run, with their own file in it.
+    mkdirSync(spec.workspace, { recursive: true });
+    const operatorFile = join(spec.workspace, "OPERATOR_NOTES.md");
+    writeFileSync(operatorFile, "do not delete me\n");
+
+    const r = runBin({ spec, fail: ["config-validate"] });
+
+    expect(r.status).not.toBe(0);
+    expect(parseMarker(r.stderr)["status"]).toBe("persistence_failed");
+    // The bin must NOT nuke a workspace dir it did not create — the operator file survives.
+    expect(existsSync(operatorFile)).toBe(true);
+    expect(readFileSync(operatorFile, "utf8")).toBe("do not delete me\n");
+  });
+});
+
+// ===========================================================================
+// Local + offline — no token read, no sil_whoami, no network; a co-installed
+// peer's allow-list entries survive teardown (already asserted above; here we
+// pin the offline invariant explicitly).
+// ===========================================================================
+describe("local + offline — creation reads no token, calls no sil_whoami, makes no network call", () => {
+  it("reaches created in a fully hermetic env with NO tokens.json present, and writes no identity artefact", () => {
+    writeConfig(freshConfig());
+    // No tokens.json seeded under $SIL_DATA_DIR and no reachable sil server.
+    const r = runBin({ spec: validSpec() });
+
+    expect(r.status).toBe(0);
+    expect(parseMarker(r.stdout)["status"]).toBe("created");
+    // Creation writes NO identity artefacts — only the shopper behaviour store.
+    expect(existsSync(join(dataDir, "tokens.json"))).toBe(false);
+    expect(existsSync(join(shopperDir(), "tokens.json"))).toBe(false);
+
+    // The only host commands run are the offline agent/config choreography — never
+    // an identity/register/whoami/network subcommand.
+    const log = shimLog();
+    for (const forbidden of ["whoami", "register", "identity", "login", "auth"]) {
+      expect(log.includes(forbidden), `shim saw a forbidden '${forbidden}' subcommand`).toBe(false);
+    }
+    // The commands it DID run are exactly the create choreography.
+    expect(log).toContain("agents list");
+    expect(log).toContain("agents add");
+    expect(log).toContain("config validate");
+  });
+});
+
+// ===========================================================================
+// No PII/secret leakage — the markers never carry the persona/userSpec text.
+// ===========================================================================
+describe("no PII/secret leakage — the markers never echo the persona or userSpec text", () => {
+  it("neither stdout nor stderr contains the persona/userSpec secrets, on created OR on failure", () => {
+    writeConfig(freshConfig());
+
+    const ok = runBin({ spec: validSpec() });
+    expect(ok.status).toBe(0);
+    expect(ok.stdout).not.toContain(PERSONA_SECRET);
+    expect(ok.stdout).not.toContain(USERSPEC_SECRET);
+
+    // A forced failure carries a path + cause — still never the persona/userSpec.
+    const fail = runBin({ spec: validSpec({ agentId: "leak-check" }), fail: ["config-validate"] });
+    expect(fail.status).not.toBe(0);
+    expect(fail.stderr).not.toContain(PERSONA_SECRET);
+    expect(fail.stderr).not.toContain(USERSPEC_SECRET);
+  });
+});
+
+// ===========================================================================
+// Input channels — the --spec <path> fallback works alongside stdin.
+// ===========================================================================
+describe("input channels — the spec arrives via stdin (primary) OR a --spec file (fallback)", () => {
+  it("a --spec <path> file drives an identical created outcome (no stdin needed)", () => {
+    writeConfig(freshConfig());
+    const spec = validSpec({ agentId: "spec-file-shopper", name: "Spec File Shopper" });
+    const r = runBin({ spec, viaSpecFile: true });
+    expect(r.status).toBe(0);
+    const m = parseMarker(r.stdout);
+    expect(m["status"]).toBe("created");
+    expect(m["agentId"]).toBe("spec-file-shopper");
+    expect(existsSync(profileJsonPath())).toBe(true);
+  });
+});
+
+// ===========================================================================
+// Precondition — no resolvable host openclaw.json ⇒ fail closed, nothing created.
+// ===========================================================================
+describe("precondition — no resolvable host config fails closed", () => {
+  it("no config at any resolvable path ⇒ persistence_failed/precondition, non-zero, nothing created", () => {
+    // Do NOT write openclaw.json; point every resolution knob at empty/missing dirs.
+    const missingConfig = join(workdir, "nonexistent", "openclaw.json");
+    const r = runBin({
+      spec: validSpec(),
+      env: {
+        // Override the base env's OPENCLAW_CONFIG_PATH with a missing path, and use
+        // an empty state dir + empty HOME so no candidate resolves.
+        OPENCLAW_CONFIG_PATH: missingConfig,
+        OPENCLAW_STATE_DIR: join(workdir, "no-state"),
+      },
+    });
+    expect(r.status).not.toBe(0);
+    const m = parseMarker(r.stderr);
+    expect(m["status"]).toBe("persistence_failed");
+    expect(r.stdout.includes("sil_shopper_created")).toBe(false);
+    // Nothing fabricated, nothing created.
+    expect(existsSync(missingConfig)).toBe(false);
+    expect(existsSync(shopperDir())).toBe(false);
+  });
+});

--- a/src/__tests__/package-manifest.integration.test.ts
+++ b/src/__tests__/package-manifest.integration.test.ts
@@ -43,6 +43,7 @@ interface PackageJson {
   type?: string;
   main?: string;
   files?: string[];
+  bin?: Record<string, string>;
   scripts?: Record<string, string>;
   openclaw?: {
     extensions?: string[];
@@ -302,5 +303,43 @@ describe("skill basename is sil-unique — no stale `./skill` literal, ships und
       ...skillEntries.filter((e) => e === "skill" || e === "./skill"),
     ];
     expect(stale).toEqual([]);
+  });
+});
+
+describe("package.json#bin — the shipped operator bins (exact set, add-only)", () => {
+  // Card: one-tap-shopper-create-via-a-single-wrapper-bin. The create-shopper bin
+  // ships as a `package.json#bin` sibling of `sil-openclaw-allowlist` — NOT a plugin
+  // tool (contracts.tools is unchanged; the six exact-tool-set/count mirrors are NOT
+  // triggered). This guard is the EXACT-SET drift guard on the bin surface: it
+  // set-equals the two operator bins, so a forgotten new bin OR a stray extra one
+  // FAILS. It is add-only vs today's single-bin set — asserted with `toEqual`, never
+  // loosened to a `toContain`/subset (which would silently stop catching drift).
+  const pkg = readJson<PackageJson>("package.json");
+
+  // The EXACT map the shipped package must declare. Add a bin ⇒ add it HERE too
+  // (add-only); this is the contract, not a lower bound.
+  const EXPECTED_BIN: Record<string, string> = {
+    "sil-openclaw-allowlist": "./scripts/allowlist-openclaw.mjs",
+    "sil-openclaw-create-shopper": "./scripts/create-shopper.mjs",
+  };
+
+  it("declares EXACTLY the two operator bins — never a subset, never a stray extra", () => {
+    expect(pkg.bin).toEqual(EXPECTED_BIN);
+  });
+
+  it("every bin target is an existing scripts/*.mjs file on disk", () => {
+    for (const target of Object.values(EXPECTED_BIN)) {
+      expect(target).toMatch(/^\.\/scripts\/[a-z][a-z0-9-]*\.mjs$/);
+      expect(existsSync(join(REPO_ROOT, target))).toBe(true);
+    }
+  });
+
+  it("`scripts` is listed in #files so the bins ship in the tarball", () => {
+    expect(pkg.files).toContain("scripts");
+  });
+
+  it("scripts/create-shopper.mjs is a node bin (starts with the `#!/usr/bin/env node` shebang, mirroring the sibling bin)", () => {
+    const src = readText("scripts/create-shopper.mjs");
+    expect(src.startsWith("#!/usr/bin/env node")).toBe(true);
   });
 });

--- a/src/__tests__/skill-content.test.ts
+++ b/src/__tests__/skill-content.test.ts
@@ -1721,3 +1721,219 @@ describe("references/search_param_mapping.md — hard constraint → real filter
     expect(disavowsWhoami).toBe(true);
   });
 });
+
+/* ===========================================================================
+ * ONE-TAP CREATE (card: one-tap-shopper-create-via-a-single-wrapper-bin) —
+ * ADD-ONLY guards. The engine rewrite centres on the ONE shipped bin
+ * `sil-openclaw-create-shopper`; the interview session-seeds the persona +
+ * shared user_spec, still gated. Every EXISTING engine/brainstorm describe above
+ * stays UNEDITED + green (the rewrite preserves their tokens/ordering); these
+ * describes are purely additive. Prose pins honour the disavowal discipline
+ * (`docs/knowledge/skill-prose-drift-guard-disavowal-discipline.md`): positive
+ * OR-grouped tokens for the NEW model; any negative is negation-aware, never a
+ * bare `not.toContain`; matchers stay `.toEqual([])` (never loosened).
+ * ========================================================================= */
+
+/** Negation / disavowal markers that turn a `sil_whoami` mention into a legitimate
+ * "the seed does NOT pull it" disavowal when one sits within ~28 chars before —
+ * mirrors `createTimeNicheStepOffenders`' retro-allowance lookback. `\b…\b` so a
+ * markdown-bold `**not**` (asterisks are word boundaries) still counts. */
+const WHOAMI_SEED_NEGATION =
+  /\b(?:not|never|no|without|don't|reads no|offline|local|session[- ]only)\b/;
+
+/**
+ * `sil_whoami` mentions in the (already-lowercased) interview body that are NOT
+ * preceded (within ~28 chars) by a negation/disavowal token — i.e. a real
+ * regression that pulls identity to seed, never a disavowal of it. Returns the
+ * offending contexts (empty ⇒ clean: no mention, or every mention is disavowed).
+ * Never a bare `not.toContain("sil_whoami")` — the corrected interview legitimately
+ * NAMES `sil_whoami` only to disavow it.
+ */
+function whoamiSeedPullOffenders(bodyLower: string): string[] {
+  const offenders: string[] = [];
+  const re = /sil_whoami/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(bodyLower)) !== null) {
+    const before = bodyLower.slice(Math.max(0, m.index - 28), m.index);
+    if (!WHOAMI_SEED_NEGATION.test(before)) {
+      offenders.push(
+        bodyLower
+          .slice(Math.max(0, m.index - 24), m.index + 22)
+          .replace(/\s+/g, " ")
+          .trim(),
+      );
+    }
+  }
+  return offenders;
+}
+
+describe("references/agent_creation_engine.md — the ONE-command bin engine (card: one-tap create-shopper)", () => {
+  it("names the ONE shipped command `sil-openclaw-create-shopper` and frames it as the single command run after endorsement", () => {
+    // NET-NEW: the rewrite collapses the hand-run nine-step choreography into ONE
+    // shipped bin. `sil-openclaw-create-shopper` is 0 hits pre-rewrite (RED at HEAD).
+    const body = engineBodyLower();
+    expect(body).toContain("sil-openclaw-create-shopper");
+    const framesOneCommand =
+      body.includes("one command") ||
+      body.includes("one shipped command") ||
+      body.includes("single command") ||
+      body.includes("exactly one") ||
+      body.includes("exactly **one**");
+    expect(framesOneCommand).toBe(true);
+  });
+
+  it("instructs the agent to RUN the bin fed the endorsed spec as stdin / `--spec` JSON — not hand-run the nine steps", () => {
+    const body = engineBodyLower();
+    // The bin reads the endorsed spec as one JSON object on stdin (or --spec <path>).
+    const namesInputChannel = body.includes("stdin") || body.includes("--spec");
+    expect(namesInputChannel).toBe(true);
+    // Positive: the bin is the executor — it runs the choreography FOR the agent.
+    const binRunsIt =
+      body.includes("runs the whole choreography") ||
+      body.includes("runs them for you") ||
+      body.includes("the bin runs") ||
+      (body.includes("bin") && body.includes("choreography"));
+    expect(binRunsIt).toBe(true);
+  });
+
+  it("states the bin runs the whole choreography ATOMICALLY and fail-closed", () => {
+    const body = engineBodyLower();
+    const atomic =
+      body.includes("atomically") ||
+      body.includes("atomic") ||
+      body.includes("one transaction");
+    const failClosed =
+      body.includes("fail-closed") || body.includes("fail closed") || body.includes("fails closed");
+    expect(atomic).toBe(true);
+    expect(failClosed).toBe(true);
+  });
+
+  it("states a non-zero/invalid outcome reports persistence_failed and tears down, leaving NOTHING partial", () => {
+    const body = engineBodyLower();
+    expect(body).toContain("persistence_failed");
+    const tearsDown =
+      body.includes("teardown") ||
+      body.includes("tears down") ||
+      body.includes("torn down") ||
+      body.includes("restore") ||
+      body.includes("snapshot");
+    expect(tearsDown).toBe(true);
+    const nothingPartial =
+      body.includes("nothing partial") ||
+      body.includes("no partial") ||
+      body.includes("nothing is left half") ||
+      body.includes("nothing left half") ||
+      (body.includes("nothing") && body.includes("partial"));
+    expect(nothingPartial).toBe(true);
+  });
+
+  it("frames the bin as NON-INTERACTIVE + post-endorsement — it never re-runs the interview or prompts", () => {
+    const body = engineBodyLower();
+    expect(body.includes("non-interactive") || body.includes("noninteractive")).toBe(true);
+    const postEndorsement =
+      body.includes("already-assembled") ||
+      body.includes("already-endorsed") ||
+      body.includes("already endorsed") ||
+      body.includes("after the explicit endorsement") ||
+      (body.includes("endors") && body.includes("after"));
+    expect(postEndorsement).toBe(true);
+    const noReprompt =
+      body.includes("never re-runs the interview") ||
+      body.includes("never re-run the interview") ||
+      body.includes("never prompts") ||
+      body.includes("does not prompt") ||
+      (body.includes("interview") && body.includes("never"));
+    expect(noReprompt).toBe(true);
+  });
+
+  it("the rewritten engine prose stays clean under the per-niche-expert whole-word guard", () => {
+    expect(perNicheExpertOffenders(readBody(ENGINE_PATH))).toEqual([]);
+  });
+});
+
+describe("references/brainstorm_interview.md — session-seeded pre-fill, still endorsement-gated (card: one-tap create-shopper)", () => {
+  it("PRE-SEEDS / PRE-FILLS the persona + shared user_spec from what the user already said THIS SESSION", () => {
+    // NET-NEW: the rewrite opens with a session-assembled draft rather than a cold
+    // question. Positive OR-grouped tokens — the pre-seed/this-session half is 0 hits
+    // pre-rewrite (RED at HEAD).
+    const body = brainstormBodyLower();
+    const preSeeds =
+      body.includes("pre-seed") ||
+      body.includes("pre-fill") ||
+      body.includes("preseed") ||
+      body.includes("prefill");
+    expect(preSeeds).toBe(true);
+    const fromThisSession =
+      body.includes("this session") ||
+      body.includes("already said") ||
+      body.includes("already told") ||
+      body.includes("what they already said");
+    expect(fromThisSession).toBe(true);
+    // Seeds BOTH the persona and the shared user spec.
+    expect(body).toContain("persona");
+    const namesSharedUserSpec =
+      body.includes("shared user spec") ||
+      body.includes("shared `user_spec") ||
+      (body.includes("user_spec") && body.includes("shared")) ||
+      (body.includes("user spec") && body.includes("shared"));
+    expect(namesSharedUserSpec).toBe(true);
+  });
+
+  it("opens by presenting the assembled draft (reflect-back), not a cold questionnaire", () => {
+    const body = brainstormBodyLower();
+    const reflectsDraftOpen =
+      body.includes("reflect") &&
+      (body.includes("draft") ||
+        body.includes("what you've told me") ||
+        body.includes("what they already said"));
+    expect(reflectsDraftOpen).toBe(true);
+  });
+
+  it("STILL requires an explicit endorsement before any create — the pre-fill is a proposal, never consent", () => {
+    const body = brainstormBodyLower();
+    const namesEndorse =
+      body.includes("endorse") ||
+      body.includes("explicit yes") ||
+      body.includes("go-ahead") ||
+      body.includes("go ahead");
+    expect(namesEndorse).toBe(true);
+    const proposalNotConsent =
+      body.includes("proposal, never consent") ||
+      body.includes("never consent") ||
+      body.includes("not consent") ||
+      body.includes("never an auto-commit") ||
+      body.includes("not inferred from silence") ||
+      body.includes("not from silence") ||
+      (body.includes("proposal") && body.includes("endors"));
+    expect(proposalNotConsent).toBe(true);
+    // Endorsement precedes the engine handoff (ordering) — the seed never auto-runs it.
+    const endorseIdx = body.indexOf("endorse");
+    const lastEngineHandoffIdx = body.lastIndexOf("agent_creation_engine.md");
+    expect(endorseIdx).toBeGreaterThanOrEqual(0);
+    expect(lastEngineHandoffIdx).toBeGreaterThanOrEqual(0);
+    expect(endorseIdx).toBeLessThan(lastEngineHandoffIdx);
+  });
+
+  it("the session seed is LOCAL + OFFLINE — reads no token, makes no network call", () => {
+    const body = brainstormBodyLower();
+    const localOffline =
+      (body.includes("local") && body.includes("offline")) ||
+      body.includes("session-only") ||
+      body.includes("session only");
+    expect(localOffline).toBe(true);
+    const readsNoToken =
+      body.includes("no token") ||
+      body.includes("reads no token") ||
+      body.includes("no network");
+    expect(readsNoToken).toBe(true);
+  });
+
+  it("does NOT pull identity via sil_whoami to seed (negation-aware — never a bare not.toContain)", () => {
+    // The corrected interview legitimately NAMES sil_whoami only to DISAVOW it
+    // ("does NOT pull sil_whoami", "never pull sil_whoami to seed"). A bare
+    // not.toContain("sil_whoami") would false-RED that disavowal, so flag a mention
+    // ONLY when no negation sits within ~28 chars before it. [] ⇒ clean (no
+    // affirmative pull). Mirrors createTimeNicheStepOffenders' negation-awareness.
+    expect(whoamiSeedPullOffenders(brainstormBodyLower())).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Card
`cards/one-tap-shopper-create-via-a-single-wrapper-bin.md` (lives in the `card/one-tap-shopper-create-via-a-single-wrapper-bin` branch — gitignored, so not in this PR; see the card body for the full intent + handoffs).

## Summary
- **New operator bin `sil-openclaw-create-shopper`** (`scripts/create-shopper.mjs` + `package.json#bin`), a sibling of `sil-openclaw-allowlist` — **not** a plugin tool, so `contracts.tools` is byte-unchanged and the six exact-set/count mirrors are untouched.
- Reads the endorsed spec `{ agentId, name, workspace, persona, userSpec }` as **stdin JSON** (or `--spec <path>`) and runs the choreography atomically: validate → singleton/agentId pre-flight → `openclaw agents add` → write `<workspace>/SOUL.md` → `materializeProfile` (REUSED; no domain → empty `domains: {}`) → attach skill + enable plugin → shell the **whole** `sil-openclaw-allowlist` bin for the additive trust merge → `openclaw config validate` → one `{ status, … }` JSON result.
- **Four-outcome taxonomy** (`created`/`invalid_request`/`collision`/`persistence_failed`) plus a distinct louder `teardown_failed` when snapshot-restore itself cannot fully revert (never a green-washed `persistence_failed`).
- **Teardown = whole-file snapshot-restore of `openclaw.json`** (taken before the first mutation) + workspace-dir rm (`!preexisted`) + shopper-dir rm (`!preexisted`) — returns the host to its exact pre-run state; a co-installed `klodi`'s trust survives.
- Rewrote `sil-shopping/references/agent_creation_engine.md` around the one command and simplified `brainstorm_interview.md` to a **session-seeded, local + offline** pre-fill (no `sil_whoami`), endorsement gate intact — preserving every existing `skill-content` drift guard.

## Test plan
- [x] `create-shopper.integration.test.ts` — 35 host-CLI round-trip cases (fake `openclaw` shim, temp `$SIL_DATA_DIR` + `openclaw.json`): the full taxonomy, snapshot-restore teardown byte-identical, no PII leakage, local+offline, `--spec` fallback, missing-config fail-closed.
- [x] `package-manifest.integration.test.ts` — exact 2-key `#bin` set + shebang + `scripts` ∈ `#files`.
- [x] `skill-content.test.ts` — session-seed describes added; all ~24 engine/brainstorm guards unedited + green.
- [x] `pnpm typecheck` + `pnpm build` clean.
- [x] Live-verification: real-shim create (klodi survives) + forced `config-validate`/`agents-add` teardowns restore the host byte-identical, no orphans/`.bak`.
- Full suite: 1005 pass / 10 fail — all 10 the pre-existing `repo-scaffold` worktree artifact (gitignored `CLAUDE.md`/`docs/` not checked out), not a regression.

## Distillation target
Knowledge capture happens **after Review PASS** in the `distilling` stage — `solutions-architect` runs in this same worktree, commits to this same branch, and pushes here so the PR ends up containing implementation + tests + distillation in one mergeable unit.