### PR TITLE
bug: load the sil-shopping skill into the shopper agent (attach by published name)

### DIFF
--- a/scripts/create-shopper.mjs
+++ b/scripts/create-shopper.mjs
@@ -63,7 +63,7 @@
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { randomBytes } from "node:crypto";
 import { fileURLToPath } from "node:url";
 
@@ -76,6 +76,9 @@ import {
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 /** The sibling operator bin that performs the additive, self-validating trust merge. */
 const ALLOWLIST_BIN = resolve(ROOT, "scripts", "allowlist-openclaw.mjs");
+/** The shipped plugin manifest — the single source of truth for sil's facts (id,
+ * skill name), read the same way `scripts/allowlist-openclaw.mjs` reads it. */
+const MANIFEST_PATH = resolve(ROOT, "openclaw.plugin.json");
 
 /** A shopper id path-segment shape — lower-kebab, never `main` (host-reserved). */
 const AGENT_ID_RE = /^[a-z0-9][a-z0-9-]*$/;
@@ -225,6 +228,32 @@ function readConfig(configPath) {
   }
 }
 
+/** Resolve the sil SKILL's published name to attach at `agents.list[i].skills`,
+ * single-sourced from the shipped manifest (mirrors `allowlist-openclaw.mjs`'s
+ * `readSilFacts`). A skill attaches by its PUBLISHED name = the skill-dir basename
+ * = `basename(openclaw.plugin.json#skills[0])` (`sil-shopping`) — NOT the plugin id
+ * (`sil`), which is the tools/trust key. The per-agent attach is the ONLY skill
+ * surface (no global skill allow-list), so the plugin id here loads no skill at
+ * all. Fail-closed: an unreadable manifest or a blank/absent `skills[0]` returns
+ * `{ error }` so the create errors rather than attaching `[""]`. */
+function readSkillAttachName() {
+  let manifest;
+  try {
+    manifest = JSON.parse(readFileSync(MANIFEST_PATH, "utf8"));
+  } catch (err) {
+    return { error: "the shipped manifest " + MANIFEST_PATH + " is not readable/parseable JSON: " + errCause(err) };
+  }
+  const ref = Array.isArray(manifest.skills) ? manifest.skills[0] : undefined;
+  if (!nonBlank(ref)) {
+    return { error: "the shipped manifest " + MANIFEST_PATH + " declares no skills[0] — cannot resolve the sil skill name to attach" };
+  }
+  const name = basename(ref);
+  if (!nonBlank(name)) {
+    return { error: "the shipped manifest skills[0] " + JSON.stringify(ref) + " has no usable basename" };
+  }
+  return { name };
+}
+
 /** The agentId path-segment ids already registered in the host config's
  * `agents.list` — the authoritative, shim-independent clash source. */
 function existingAgentIds(config) {
@@ -354,6 +383,15 @@ function main() {
     });
   }
 
+  // --- 2b. Resolve the sil skill's published name to attach (shipped manifest is the
+  //     single source of truth) — a packaging defect fails closed BEFORE any host
+  //     write, so nothing is attempted. Reused at step 8. ---
+  const skill = readSkillAttachName();
+  if (skill.error) {
+    emitFailure("persistence_failed", { path: MANIFEST_PATH, cause: skill.error });
+  }
+  const skillAttachName = skill.name;
+
   // --- 3. Singleton + agentId pre-flight (nothing written; inconclusive → fail closed) ---
   // The sil artefact store is the source of truth for "a shopper exists".
   const overview = readAgentProfile();
@@ -455,8 +493,11 @@ function main() {
   if (idx < 0) {
     failAndTeardown(configPath, "the created agent " + JSON.stringify(agentId) + " is not in agents.list after `openclaw agents add`");
   }
+  // Attach the skill by its PUBLISHED name (`sil-shopping`), NOT the plugin id
+  // (`sil`) — a skill and the plugin are two distinct host keys, and the per-agent
+  // attach is the only skill surface, so the plugin id here would load no skill.
   const skillRes = runOpenclaw(
-    ["config", "set", `agents.list[${idx}].skills`, '["sil"]', "--strict-json"],
+    ["config", "set", `agents.list[${idx}].skills`, JSON.stringify([skillAttachName]), "--strict-json"],
     configPath,
   );
   if (!skillRes.ok) {

--- a/src/__tests__/create-shopper.integration.test.ts
+++ b/src/__tests__/create-shopper.integration.test.ts
@@ -72,7 +72,7 @@ import {
   chmodSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -81,6 +81,21 @@ const REPO_ROOT = join(HERE, "..", "..");
 const SCRIPT = join(REPO_ROOT, "scripts", "create-shopper.mjs");
 
 const SIL_ID = "sil";
+/** The bundled skill's PUBLISHED name = the basename of the manifest's skills
+ * ref (`./sil-shopping` → `sil-shopping`) — the key the host attaches a skill by
+ * at `agents.list[i].skills`. Single-sourced from openclaw.plugin.json so a skill
+ * rename tracks here automatically, and so this pins the create bin against the
+ * manifest rather than a second literal. It is the skill NAME, NEVER the plugin
+ * id `sil` — attaching the plugin id is the total skill-load failure this card
+ * kills (the host looks up a skill named `sil`, finds none, `sil-shopping` never
+ * loads). */
+const SIL_SKILL = basename(
+  (
+    JSON.parse(
+      readFileSync(join(REPO_ROOT, "openclaw.plugin.json"), "utf8"),
+    ) as { skills: string[] }
+  ).skills[0]!,
+);
 /** Running as root bypasses filesystem permission bits, so the chmod-based
  * "unwritable $SIL_DATA_DIR" fault-injection cannot fire — skip it there. */
 const AS_ROOT = typeof process.getuid === "function" && process.getuid() === 0;
@@ -463,10 +478,13 @@ describe("created — one valid run wires every surface and returns the identity
     expect(c.tools.alsoAllow).toContain(SIL_ID);
     expect(c.plugins.entries[SIL_ID]).toBeTruthy();
     expect(c.plugins.entries[SIL_ID].enabled).toBe(true);
-    // Wiring — the host agent exists with the sil skill attached.
+    // Wiring — the host agent exists with the sil skill attached BY ITS PUBLISHED
+    // NAME (`sil-shopping` = manifest skills basename), the key the host resolves a
+    // skill by — NEVER the plugin id `sil` (attaching the plugin id is the bug this
+    // card kills: the host finds no skill named `sil` and `sil-shopping` never loads).
     const agent = c.agents.list.find((a: any) => a.id === spec.agentId);
     expect(agent).toBeTruthy();
-    expect(agent.skills).toEqual([SIL_ID]);
+    expect(agent.skills).toEqual([SIL_SKILL]);
   });
 
   it("carries a warnings array (empty on a config with no web-capability gap)", () => {

--- a/src/__tests__/skill-content.test.ts
+++ b/src/__tests__/skill-content.test.ts
@@ -44,7 +44,7 @@
 
 import { describe, it, expect } from "vitest";
 import { readFileSync, existsSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { registerIdentityTools } from "../tools/identity.js";
 import { registerCatalogTools } from "../tools/catalog.js";
@@ -62,6 +62,7 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(HERE, "..", "..");
 const SKILL_DIR = join(REPO_ROOT, "sil-shopping");
 const SKILL_PATH = join(SKILL_DIR, "SKILL.md");
+const MANIFEST_PATH = join(REPO_ROOT, "openclaw.plugin.json");
 
 // The progressive-disclosure reference + example files that own the detailed
 // procedures the router points at. The four RENAMED files carry the single-
@@ -251,6 +252,58 @@ describe("sil-shopping/SKILL.md — single-shopper frontmatter (name == basename
     const fm = parseFrontmatter(readFileSync(SKILL_PATH, "utf8"));
     const description = fm.fields["description"] ?? "";
     expect(PER_NICHE_EXPERT_WORD.test(description)).toBe(false);
+  });
+});
+
+/* ===========================================================================
+ * NAME-AGREEMENT DRIFT GUARD [unit] — the skill's PUBLISHED name is ONE value
+ * across the shipped manifest + SKILL.md, and it is NEVER the plugin id.
+ *
+ * A skill attaches to an agent by its PUBLISHED name = directory basename =
+ * `openclaw.plugin.json#skills[0]` basename = SKILL.md frontmatter `name`. The
+ * create-shopper bin must write THAT name into `agents.list[i].skills` — NEVER the
+ * plugin id `openclaw.plugin.json#id` (`sil`). That plugin-id ⇄ skill-name
+ * conflation is the TOTAL skill-load failure this card kills: create-shopper.mjs
+ * attached `["sil"]`, the host found no skill named `sil`, and `sil-shopping`
+ * never entered the runtime skill list. This is a PURE STATIC check — no
+ * create-shopper flow — that fails the build if that conflation ever reappears,
+ * pinning the invariant the integration attach-value assertion in
+ * create-shopper.integration.test.ts depends on: attach-name == registered name.
+ * ========================================================================= */
+
+interface SkillManifest {
+  id: string;
+  skills: string[];
+}
+
+function readSkillManifest(): SkillManifest {
+  return JSON.parse(readFileSync(MANIFEST_PATH, "utf8")) as SkillManifest;
+}
+
+describe("skill name-agreement drift guard — published name is one value across manifest + SKILL.md, and never the plugin id", () => {
+  it("basename(openclaw.plugin.json#skills[0]) EQUALS the SKILL.md frontmatter `name`", () => {
+    const manifest = readSkillManifest();
+    expect(Array.isArray(manifest.skills)).toBe(true);
+    expect(manifest.skills.length).toBeGreaterThan(0);
+
+    const manifestSkillName = basename(manifest.skills[0]!);
+    const frontmatterName = parseFrontmatter(readFileSync(SKILL_PATH, "utf8")).fields[
+      "name"
+    ];
+
+    expect(manifestSkillName).toBe(frontmatterName);
+  });
+
+  it("the published skill name is NOT the plugin id — the plugin-id/skill-name conflation this card kills", () => {
+    const manifest = readSkillManifest();
+    const manifestSkillName = basename(manifest.skills[0]!);
+
+    // The anti-conflation invariant: the skill-attach key (published name) and the
+    // trust key (plugin id) are two DISTINCT host surfaces and must never collapse
+    // onto one value. `id` is anchored to `sil` (the named plugin id) so the guard
+    // compares against the real id, not an undefined field.
+    expect(manifest.id).toBe("sil");
+    expect(manifestSkillName).not.toBe(manifest.id);
   });
 });
 


### PR DESCRIPTION
## Card
`cards/load-the-sil-shopping-skill-into-the-shopper-agent.md` (gitignored-mode card — lives only in the `card/…` worktree; the body carries the full intent + handoffs).

## Summary
The one-tap create-shopper bin attached the plugin id (`["sil"]`) at `agents.list[i].skills`, but a skill attaches by its **published name** = skill-dir basename = `basename(openclaw.plugin.json#skills[0])` = `sil-shopping` (== `sil-shopping/SKILL.md` frontmatter `name`). The per-agent attach is the **only** skill surface (no global skill allow-list), so the host looked up a skill named `sil`, found none, and `sil-shopping` never entered a freshly-created shopper's runtime "Available skills" list — the whole SDS loop silently degraded to bare catalog search.

- **`scripts/create-shopper.mjs`** — delete the `'["sil"]'` literal; single-source the attach value from the shipped manifest via a new `readSkillAttachName()` (mirrors `allowlist-openclaw.mjs`'s `readSilFacts`). Resolved as a **pre-write precondition** (step 2b) so a blank/absent `skills[0]` **fails closed with nothing attempted** — never attaches `[""]`. Step 8 now attaches `JSON.stringify([basename(skills[0])])`.
- The plugin id (`sil`) stays the trust/tools key (`plugins.allow`, `tools.alsoAllow`, `plugins.entries.sil`); the skill name (`sil-shopping`) is a distinct host key. This PR stops conflating them.

## Test plan
- [x] `pnpm typecheck` — clean.
- [x] `src/__tests__/create-shopper.integration.test.ts` — flipped attach-value assertion (`SIL_SKILL` = `basename(manifest.skills[0])`) goes RED against `["sil"]`, GREEN after the fix.
- [x] `src/__tests__/skill-content.test.ts` — new `[unit]` name-agreement drift guard: `basename(skills[0]) === SKILL.md name` and `!== plugin id`.
- [x] Full suite green (44 files / 1038 tests) excluding `repo-scaffold.integration.test.ts` (known worktree noise — gitignored `docs/` + `CLAUDE.md` not checked out).
- [x] Live functional smoke: the real bin run against a temp host writes `agents.list[i].skills = ["sil-shopping"]`, with trust/tools surfaces still keyed on `sil`. The true `[e2e]` (skill in a runtime "Available skills" list) needs a host-load gate this repo defers; the integration + unit checks + smoke proxy it since the per-agent attach is the only skill surface.

## Distillation target
Knowledge capture happens **after Review PASS** in the `distilling` stage — `solutions-architect` runs in this same worktree, commits to this same branch, and pushes here. Target: correct `docs/decisions/openclaw-allowlist-surface.md:23` (a skill attaches by its published name, NOT the plugin id) — the mis-framing that seeded this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
