### PR TITLE
refactor: thin the sil-shopping SKILL.md router (progressive disclosure)

### DIFF
--- a/sil-shopping/SKILL.md
+++ b/sil-shopping/SKILL.md
@@ -41,18 +41,19 @@ has the taxonomy), or run `sil_register` up front when intent clearly requires i
 ## Routing — read the stage, then match intent to a tool
 
 **Read the stage from state — never guess it.** Two cheap session-level reads
-settle which **stage** this session is in: the no-arg `sil_profile_get` overview
-(its **`name` field** is the whole discriminator — present only when a shopper
-exists) and `sil_whoami` (whether a sil **identity** is **registered** yet). Setup
-is a **five-stage** onboarding **progression**;
-[`references/setup_onboarding.md`](references/setup_onboarding.md) carries its full
-script — the staged ladder, the after-register offer, and the per-search pitch —
-so present only the current stage, and once setup is complete, shed all of it.
+settle it: `sil_whoami` (is a sil **identity** **registered** yet?) and the no-arg
+`sil_profile_get` overview (its **`name` field** is the whole discriminator —
+present only when a shopper exists). Branch on the two, nothing else:
 
+- **No identity** ⇒ setup starts here — guide the user to register.
 - **`name` absent ⇒ profile-less stage** — bare shopping is a first-class quick
-  lookup; the setup path is offered first-class (see setup_onboarding).
+  lookup; the setup path is offered first-class.
 - **`name` present ⇒ shopper stage** — the domain gate governs every
-  `sil_search`-driven intent; setup stages 3–5 live here.
+  `sil_search`-driven intent.
+
+[`references/setup_onboarding.md`](references/setup_onboarding.md) owns the setup
+script — the staged ladder, the after-register offer, and the per-search pitch.
+Load it while setup is incomplete; it sheds once a shopper exists.
 
 ### Intent → tool (load the reference on demand)
 

--- a/sil-shopping/SKILL.md
+++ b/sil-shopping/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sil-shopping
-description: 'This skill should be used whenever the user wants to shop on sil or set up their sil shopper: register or sign in to sil, check who they are, search the sil catalog for purchasable products, or look up specific products by id — and for the full single-shopper lifecycle: "set up an agent that shops for me" / "create my shopper" (a short two-touchpoint onboarding, then create ONE shopper), see what their shopper knows or which domains (niches) it has learned, view or forget a domain, refine the shopper or one domain — or, as the shopper, run a profile-driven Spec-Driven Shopping query on any niche (reusing a learned domain or minting one on the fly) and remember a fact or buying taste it surfaces. Route here for any shopping, identity, or shopper-setup intent on sil. Drives sil_register, sil_whoami, sil_search, sil_product_get, sil_profile_materialize, sil_profile_get, sil_profile_remove, and sil_remember.'
+description: 'Use for any sil shopping, identity, or shopper-setup intent: register or sign in, check the account, search the sil catalog for purchasable products, or look up products by id — plus the single-shopper lifecycle: create the shopper (a short two-touchpoint onboarding), see what it knows or which domains (niches) it has learned, view or forget a domain, refine it — or, as the shopper, run a Spec-Driven Shopping query on any niche and remember a fact or buying taste it surfaces. Drives sil_register, sil_whoami, sil_search, sil_product_get, sil_profile_materialize, sil_profile_get, sil_profile_remove, and sil_remember.'
 metadata:
   openclaw:
     emoji: "\U0001F6D2"
@@ -8,101 +8,126 @@ metadata:
 
 # sil-shopping
 
-Drive the sil plugin's tools on the user's behalf: register them on sil, read their identity, help them find purchasable products in the sil catalog — and, when asked, set up their **shopper** (one sil-wired agent that shops every niche), then see what it knows, view or forget a domain, or refine it. Read user intent, route to the matching tool (loading its reference on demand), call it, and report what came back.
+Drive the sil plugin's tools on the user's behalf: register them, read their
+identity, help them find purchasable products — and, when asked, set up their
+**shopper** (one sil-wired agent that shops every niche), then see what it knows,
+view or forget a domain, or refine it. Read intent, route to the matching tool
+(loading its reference on demand), call it, and report what came back.
 
 ## Always-on behavioural contract
 
-These three principles hold on every path, before any reference is loaded:
+Three principles hold on every path, before any reference loads:
 
-- **Act, don't narrate.** When intent maps to a tool, call it. Don't re-confirm what was already stated.
-- **Fail visibly, recover correctly.** Every tool returns a `status`. On a non-`ok` status, say what happened and follow the tool's own `recovery` hint — never improvise a different one.
-- **Relay prices as point-in-time.** A product's price, availability, and `checkout_url` are a snapshot, not a guarantee. Before the user buys, re-fetch with `sil_product_get` rather than trusting an earlier `sil_search` result.
+- **Act, don't narrate.** When intent maps to a tool, call it — don't re-confirm
+  what was already stated.
+- **Fail visibly, recover correctly.** Every tool returns a `status`. On a
+  non-`ok` status, say what happened and follow the tool's own `recovery` hint —
+  never improvise a different one.
+- **Relay prices as point-in-time.** A price, availability, and `checkout_url`
+  are a snapshot. Before the user buys, re-fetch with `sil_product_get` rather
+  than trusting an earlier `sil_search` result.
 
 ## Session start
 
-Confirm the `sil_*` tools are exposed. If they are missing from the available tool list, the host runtime is filtering them out because sil is not admitted at the host allow surfaces — run the shipped admission helper `sil-openclaw-allowlist` (it additively admits sil at `plugins.allow` + `tools.alsoAllow`, leaving any other trusted plugin untouched), then reopen the session so the tools load. Most flows need an identity: if the user has not registered this session, the catalog tools return an unregistered status whose `recovery` points at `sil_register` (the [catalog tools reference](references/catalog_tools_reference.md) has the full taxonomy) — so calling a catalog tool first lets that outcome route, or run `sil_register` up front when the user's intent clearly requires it.
+Confirm the `sil_*` tools are exposed. If they are missing from the tool list,
+the host is filtering them because sil is not admitted at the host allow
+surfaces — run the shipped admission helper `sil-openclaw-allowlist` (it
+additively admits sil at `plugins.allow` + `tools.alsoAllow`, leaving other
+trusted plugins untouched), then reopen the session so the tools load. Most flows
+need an identity: calling a catalog tool first lets an unregistered outcome route
+to `sil_register` (the [catalog tools reference](references/catalog_tools_reference.md)
+has the taxonomy), or run `sil_register` up front when intent clearly requires it.
 
-## After register — offer to set up the shopper (once, only when there's none)
+## Routing — read the stage, then match intent to a tool
 
-`sil_register` returns `already_registered` with `next_step: "offer_shopper"` on a confirmed registration (a fresh sign-in this session, or a returning session that was already signed in). That hint is a routing breadcrumb, not a decision — act on it by first running a no-arg `sil_profile_get` to read shopper state, then branch:
+**Read the stage from state — never guess it.** Two cheap session-level reads
+settle which **stage** this session is in: the no-arg `sil_profile_get` overview
+(its **`name` field** is the whole discriminator — present only when a shopper
+exists) and `sil_whoami` (whether a sil **identity** is **registered** yet). Setup
+is a **five-stage** onboarding **progression**;
+[`references/setup_onboarding.md`](references/setup_onboarding.md) carries its full
+script — the staged ladder, the after-register offer, and the per-search pitch —
+so present only the current stage, and once setup is complete, shed all of it.
 
-- **Empty store (no shopper yet):** introduce the shopper in one short beat and offer to set it up. Name the value in its own terms — it shops each niche in depth, reuses the sizes and hard limits it already knows so nothing is re-asked, and explains why each pick fits — a standing buyer's advisor, not a one-off search. Only on a yes, load [`references/brainstorm_interview.md`](references/brainstorm_interview.md) (a two-touchpoint onboarding, never a form). Take no for an answer: bare `sil_search` stays a first-class path, so don't re-offer in the same turn.
-- **A shopper already exists:** skip this beat entirely. The shopper is a singleton — never offer a second one.
-
-## After a bare search — name what a shopper would add (recurring, by design)
-
-When a plain `sil_search` completes with status `ok` in a profile-less session, present the results best-first exactly as they came back, then append **one** short trailing line — a post-result tip with a soft CTA — naming what a shopper would add on top. It is never a pre-search question and never a re-rank: bare search stays a legitimate quick lookup, and these are the same results a shopper would start from.
-
-Name one or two of the three levers a bare search leaves on the table, and rotate which you lead with so the recurring line stays fresh:
-
-- **niche depth** — a shopper weighs these against how the niche actually buys, instead of just listing them;
-- **memory** — it keeps your sizes and hard limits on file, so no search re-asks them;
-- **the why** — it explains which pick fits you and why, instead of a flat ranked list.
-
-This line recurs on **every** completed profile-less search: there is no fire-once or seen-it gate, and no cooldown — the recurrence is the point, and brevity plus lever rotation are all that keep it from nagging. Exactly two things suppress it, and only these two: a shopper already exists (that session is the shopper's — drop the line), or the search did not complete `ok` (a non-`ok` status carries its own recovery, so follow that and add no tip).
-
-## Routing — read the stage, present it, then match intent to a tool
-
-**Read the stage from state; never guess it.** Two cheap, session-level reads settle which stage this session is in (never conversation history, never an assumption): the no-arg `sil_profile_get` overview — always `status: ok`, but carrying a `name` field **only when a shopper exists** — and `sil_whoami`, which reports whether a sil identity is registered yet. The `name` field is the whole shopper-vs-profile-less discriminator; `sil_whoami` and the overview's `domains` map refine it into the **five-stage setup progression** below.
-
-- **`name` absent ⇒ profile-less stage.** No shopper yet. Bare shopping is a first-class quick lookup and the setup path is offered first-class (see [After register](#after-register--offer-to-set-up-the-shopper-once-only-when-theres-none)). Route by the table below; the bare "find X" → `sil_search` lane is legitimate and stays **unchanged**. Setup stages 1–2 (unregistered, then registered-without-a-shopper) live here.
-- **`name` present ⇒ shopper stage.** A shopper exists. Every `sil_search`-driven shopping intent runs the domain-gated spine below **before any** `sil_search` — the bare "find X" lane is not reachable in this stage. Setup stages 3–5 live here; the shopper is a singleton, never re-offered.
-- **`name` present with `domains: []` ⇒ shopper with no niche yet.** Still the shopper stage, but the first shopping intent must **force a mint** (below) before search.
-
-### The setup progression — present one stage, shed it on completion
-
-Setting up the shopper is a **staged progression**, and this skill is the first file loaded into the session, so it carries the whole ladder. Present **only the current stage's beat and its single next step** — never the whole ladder at once — and once the shopper is fully set up, **shed every onboarding beat**: none of the stages below apply, and routing goes straight to shopper-stage usage. Every stage is **read from state** (the two reads above), never guessed.
-
-1. **Unregistered** — `sil_whoami` finds no sil identity. Guide the user to register, and **before `sil_register` runs**, set the expectation: state plainly what registering does and **how 4GPTs & sil use their data**, grounded strictly in what this plugin actually does — no invented policy. Registering opens a sign-in link in their **default browser** and creates their **sil identity**, whose credentials are stored **locally on this device** (never logged). What the data is and where it lives: sil holds their account identity — name and saved addresses — which `sil_whoami` reads back; their shopper's setup and anything it remembers stay in a **local profile store** under the sil data directory (`$SIL_DATA_DIR`), never leaving this device via the plugin; catalog searches query sil's product catalog. Next step: `sil_register`.
-2. **Registered, no shopper** — a sil identity exists but `name` is absent. Bare `sil_search` and general research work now, yet this is not the finished state. Guide the user to **set up** their **shopper**, naming up front that it **takes a couple of minutes and asks a few questions** before the onboarding starts. Next step: the [after-register offer](#after-register--offer-to-set-up-the-shopper-once-only-when-theres-none), then — on a yes — the [create two-step](#setting-up-your-shopper--the-endorsement-gated-two-step). Take no for an answer: bare search stays first-class.
-3. **Shopper created, no domain yet** — `name` present, `domains: []`. The singleton exists; the **first shopping intent mints the first domain**, announced in the shopper's voice with the inferred niche stated so the user can correct it (never silent). Next step: state a shopping intent — the shopper stage below runs the forced mint.
-4. **Shopper active** — `name` present, `domains` non-empty. Check off the completion milestones: **first domain created** (`domains` non-empty — the derivable milestone that completes setup) and, softer, the **memory/reinforcement** tool has begun to be used (`sil_remember` has accreted a fact or taste). The memory milestone is a **soft self-check**, not a shed gate: the overview cannot prove it (the shared user spec is non-empty from creation), so judge it from whether this shopper has ever remembered anything, reinforced by the shop loop's per-query persist beat.
-5. **Setup complete** — a shopper with at least one domain. **Shed the whole progression**: no onboarding beat applies. Show only how to use the plugin well — the domain-gated shop loop and Spec-Driven Shopping (the shopper-stage arm below).
+- **`name` absent ⇒ profile-less stage** — bare shopping is a first-class quick
+  lookup; the setup path is offered first-class (see setup_onboarding).
+- **`name` present ⇒ shopper stage** — the domain gate governs every
+  `sil_search`-driven intent; setup stages 3–5 live here.
 
 ### Intent → tool (load the reference on demand)
 
-| Intent | Tool | Reference to load |
+| Intent | Tool | Reference |
 |---|---|---|
-| "sign me up" / "log me in to sil" / "register" | `sil_register` | [`references/catalog_tools_reference.md`](references/catalog_tools_reference.md) |
-| "who am I?" / "what's on my account" / show my saved name + addresses | `sil_whoami` | [`references/catalog_tools_reference.md`](references/catalog_tools_reference.md) |
+| "sign me up" / "log me in" / "register" | `sil_register` | [`references/catalog_tools_reference.md`](references/catalog_tools_reference.md) |
+| "who am I?" / show my saved name + addresses | `sil_whoami` | [`references/catalog_tools_reference.md`](references/catalog_tools_reference.md) |
 | "find X" / "search for X" / browse a category or price range | `sil_search` | [`references/catalog_tools_reference.md`](references/catalog_tools_reference.md) |
-| "look up these items" / re-check ids from a prior result, a saved list, or a deep link | `sil_product_get` | [`references/catalog_tools_reference.md`](references/catalog_tools_reference.md) |
-| "set up an agent that shops for me" / "create my shopper" | (onboarding, then the engine) | see the two-step gate below |
-| "what does my shopper know?" / "which domains has it learned?" | `sil_profile_get` (no `domainSlug` — the shopper overview, which absorbs the old listing) | [`references/manage_domains.md`](references/manage_domains.md) |
-| "show me the shopper / the &lt;niche&gt; domain" | `sil_profile_get` (`domainSlug` for one domain) | [`references/manage_domains.md`](references/manage_domains.md) |
-| "forget / remove the &lt;niche&gt; domain" | `sil_profile_remove` (per-domain; whole-shopper teardown is host-CLI-first — see the reference) | [`references/manage_domains.md`](references/manage_domains.md) |
-| (as the shopper) a shopping intent — "find me something for X" on any niche | `sil_search` → `sil_product_get` (driven by the loaded profile, reusing or minting the domain) | [`references/shop_loop.md`](references/shop_loop.md) |
-| "remember this" — a fact or buying taste the shopper surfaced this query | `sil_remember` | [`references/shop_loop.md`](references/shop_loop.md) |
-| "refine / sharpen my shopper" / "the cycling domain keeps surfacing the wrong stuff — fix it" | (load → propose → confirm → persist — see the reference) | [`references/refine_shopper.md`](references/refine_shopper.md) |
+| "look up these items" / re-check ids from a prior result | `sil_product_get` | [`references/catalog_tools_reference.md`](references/catalog_tools_reference.md) |
+| "set up an agent that shops for me" / "create my shopper" | (onboarding, then the engine) | the two-step below |
+| "what does my shopper know?" / "which domains has it learned?" | `sil_profile_get` (no `domainSlug`) | [`references/manage_domains.md`](references/manage_domains.md) |
+| "show me the &lt;niche&gt; domain" | `sil_profile_get` (`domainSlug`) | [`references/manage_domains.md`](references/manage_domains.md) |
+| "forget the &lt;niche&gt; domain" | `sil_profile_remove` | [`references/manage_domains.md`](references/manage_domains.md) |
+| (as the shopper) a shopping intent on any niche | `sil_search` → `sil_product_get` | [`references/shop_loop.md`](references/shop_loop.md) |
+| "remember this" — a fact or taste the shopper surfaced | `sil_remember` | [`references/shop_loop.md`](references/shop_loop.md) |
+| "refine / sharpen my shopper" / fix a niche | (load → propose → confirm → persist) | [`references/refine_shopper.md`](references/refine_shopper.md) |
 
-[`references/catalog_tools_reference.md`](references/catalog_tools_reference.md) holds the per-tool behaviour for the four core tools and the shared status taxonomy. Basic shopping needs only that one reference.
+[`references/catalog_tools_reference.md`](references/catalog_tools_reference.md)
+holds the per-tool behaviour and the shared status taxonomy — basic shopping needs
+only that one. The shop-time answer→`sil_search`-param mapping lives in
+[`references/search_param_mapping.md`](references/search_param_mapping.md); a full
+worked run is
+[`examples/multi_domain_shopper_walkthrough.md`](examples/multi_domain_shopper_walkthrough.md).
+
+**Setting up the shopper — the endorsement-gated two-step.** Creating the shopper
+is a profile-less-stage intent (a singleton — refused once one exists). (1)
+**Onboard first:** run
+[`references/brainstorm_interview.md`](references/brainstorm_interview.md), the
+two-touchpoint onboarding. (2) **Only after** the user explicitly **endorses** the
+assembled draft, run
+[`references/agent_creation_engine.md`](references/agent_creation_engine.md) — the
+ordered engine that persists the one sil-wired shopper. Running any engine step
+before that endorsement is forbidden.
 
 ### Profile-less stage — the bare lane stays bare
 
-With no shopper (`name` absent), a shopping intent takes the "find X" → `sil_search` row above **unchanged**: no domain check, no mint, no pre-search question. Bare search is a legitimate quick lookup; the only shopper nudge is the post-result per-search pitch ([After a bare search](#after-a-bare-search--name-what-a-shopper-would-add-recurring-by-design)) — never a gate, never a re-rank. The domain gate below does **not** bleed into this stage.
+**`name` absent.** A shopping intent takes the "find X" → `sil_search` row above
+**unchanged** — no domain check, no mint, no pre-search question. Bare search is a
+legitimate quick lookup; the only shopper nudge is the profile-less per-search
+pitch ([`references/setup_onboarding.md`](references/setup_onboarding.md)). The
+domain gate below does **not** bleed into this stage.
 
-### Shopper stage — domain-gated search is the single non-skippable path
+### Shopper stage — domain-gated search, non-skippable
 
-When a shopper exists (`name` present — a loaded profile under `$SIL_DATA_DIR/shopper/`: the shared `user_spec` plus a slug-keyed `domains` map), running **as the shopper** the **domain-exists check is non-skippable on every** `sil_search`-driven query. Before any sil_search: classify the query's niche, read the `sil_profile_get` overview, and **reuse a learned domain or mint one** — the shop loop's first beat. Then follow [`references/shop_loop.md`](references/shop_loop.md): the profile-driven **Spec-Driven Shopping (SDS)** loop that web-refreshes the domain's spec, decomposes the request along its intent spec, and persists each surfaced fact (→ the shared `user_spec`) or taste (→ the active domain) with a single lightweight `sil_remember` append.
+**`name` present.** Running **as the shopper**, the **domain-exists check is
+non-skippable on every** `sil_search`-driven query, and the bare 'find X' lane is
+**not reachable** in this stage. Before any search, read the `sil_profile_get`
+overview, classify the query's niche, and **reuse a learned domain or mint one** —
+the shop loop's first beat. Then follow
+[`references/shop_loop.md`](references/shop_loop.md): the profile-driven
+**Spec-Driven Shopping** loop that web-refreshes the domain, decomposes the
+request, and persists each surfaced fact or taste with a single `sil_remember`.
 
-- **`domains: []` forces a mint first.** A shopper with no niche yet **mints the domain before searching** on the first shopping intent, **announced** in the shopper's voice with the inferred niche **stated so the user can correct it** — never a silent mint.
-- **A `sil_search` reached without an active domain is a process failure.** Warn **visibly** — name that the shopper spine was bypassed and that these would be bare catalog results — then **self-correct** by running the skipped domain check. Never silently pass bare catalog results off as the shopper's work.
+- **`domains: []` forces a mint first.** A shopper with no niche yet **mints the
+  domain before searching** on the first shopping intent, **announced** with the
+  inferred niche **stated so the user can correct it** — never a silent mint.
+- **A domain-less `sil_search` is a process failure.** **Warn visibly** — name
+  that the shopper spine was bypassed and these would be bare catalog results —
+  then **self-correct** by running the skipped domain check. Never silently pass
+  bare catalog results off as the shopper's work.
 
-This gate governs the shopper's **reasoning, not the user's inbox**: a reused domain plus a fully-resolved query passes straight through to search asking nothing — it protects recommendation **quality, never access**. It scopes to `sil_search`-driven product discovery only; identity (`sil_register` / `sil_whoami`), a direct `sil_product_get` id re-check, and shopper-management intents (view / forget a domain) route normally by the table above, **ungated**.
+This gate governs the shopper's **reasoning, not the user's inbox**: a reused
+domain plus a fully-resolved query passes straight through, asking nothing — it
+protects recommendation **quality, never access**. It scopes to
+`sil_search`-driven product discovery only; identity (`sil_register` /
+`sil_whoami`), a direct `sil_product_get` id re-check, and shopper-management
+intents (view / forget a domain) route normally, **ungated**.
 
-**Per-query self-check (prose, not a tool).** At the end of a completed shopper query, self-report the beats you ran — `profile_loaded → domain_classified → domain_reused_or_minted → intent_decomposed → facts_remembered`. It is an in-context guardrail, **not** a new tool, table, or telemetry surface.
+**Per-query self-check (prose, not a tool).** At the end of a completed shopper
+query, self-report the beats you ran — `profile_loaded → domain_classified →
+domain_reused_or_minted → intent_decomposed → facts_remembered`. It is an
+in-context guardrail, not a new tool, table, or telemetry surface.
 
-### The management + refinement references
-
-[`references/manage_domains.md`](references/manage_domains.md) holds the list / view / forget flow over the shopper's domains — including the **two remove granularities** (forget one domain vs decommission the whole shopper, host-CLI-first) and the confirm-before-remove gate. Load it the moment the user wants to see what the shopper knows or forget a niche.
-
-[`references/refine_shopper.md`](references/refine_shopper.md) holds the refinement loop — sharpening the shopper (the shared user spec or the persona) or **one domain** from observed sessions, with a confirm-before-persist gate (nothing changes silently). Load it when the user wants to refine, sharpen, or amend their shopper or a niche.
-
-### Setting up your shopper — the endorsement-gated two-step
-
-Creating the shopper is a **profile-less-stage** intent (a shopper is a singleton; once one exists this path is refused). When the user asks to set up / create their shopper (the one agent that shops every niche):
-
-1. **Onboard first.** Read and run [`references/brainstorm_interview.md`](references/brainstorm_interview.md) — the short, two-touchpoint onboarding (persona + a shared user-spec seed) that converges a draft *with* the user. It researches **no** niche — the shopper is a generalist that mints domains lazily on first shop. While running it, load [`references/search_param_mapping.md`](references/search_param_mapping.md) only if you need the shop-time answer→`sil_search`-param mapping (it is a shop-time reference, not an onboarding one).
-2. **Engine only after explicit endorsement.** Only after the user explicitly endorses the assembled draft, read and follow [`references/agent_creation_engine.md`](references/agent_creation_engine.md) — the ordered engine that persists the one sil-wired shopper. Running ANY engine step before that explicit endorsement is forbidden (the onboarding reference owns the endorsement gate). The shopper is a **singleton**: a second create attempt is refused ("a shopper already exists").
-
-Want a concrete walkthrough? [`examples/multi_domain_shopper_walkthrough.md`](examples/multi_domain_shopper_walkthrough.md) is an end-to-end worked example: create one shopper → shop two unrelated niches in one session (the second minted on the fly) → a shared fact reused across both → per-domain taste that does not leak.
+The management + refinement flows load on demand:
+[`references/manage_domains.md`](references/manage_domains.md) for view/forget over
+the shopper's domains (two remove granularities, confirm-before-remove), and
+[`references/refine_shopper.md`](references/refine_shopper.md) for sharpening the
+shopper or one domain from observed sessions (confirm-before-persist).

--- a/sil-shopping/examples/multi_domain_shopper_walkthrough.md
+++ b/sil-shopping/examples/multi_domain_shopper_walkthrough.md
@@ -1,3 +1,8 @@
+---
+name: multi-domain-shopper-walkthrough
+description: Worked end-to-end example — create one shopper, then shop two unrelated niches in one session with a shared fact reused across both and per-domain taste kept isolated.
+---
+
 # Worked example — one shopper, two unrelated niches, one session
 
 A short walkthrough of the **headline capability**: create **ONE shopper**

--- a/sil-shopping/references/agent_creation_engine.md
+++ b/sil-shopping/references/agent_creation_engine.md
@@ -1,3 +1,8 @@
+---
+name: agent-creation-engine
+description: The ordered, one-command engine that persists the single sil-wired shopper after the user endorses the assembled draft. Load only after explicit endorsement in the interview.
+---
+
 # Create your sil-wired shopper — the agent-creation engine
 
 **Precondition: run this ONLY after the user has explicitly endorsed the assembled draft from [`brainstorm_interview.md`](brainstorm_interview.md).** Anything below before that endorsement is forbidden — the interview owns the gate.

--- a/sil-shopping/references/brainstorm_interview.md
+++ b/sil-shopping/references/brainstorm_interview.md
@@ -1,3 +1,8 @@
+---
+name: brainstorm-interview
+description: The two-touchpoint shopper onboarding — persona + shared user-spec seed, converged with the user and endorsement-gated. Load when the user asks to set up or create their shopper.
+---
+
 # Set up your shopper — the onboarding interview
 
 When the user asks to **set up shopping** — "create my shopper", "set up an agent that shops for me", "I want something that shops for me" — do **not** jump to the engine. Run a short, **two-touchpoint** onboarding that shapes the shopper *with* the user — **pre-seeded from what they already said this session** — then **create nothing** until the user endorses the assembled draft. The agent-creation engine ([`agent_creation_engine.md`](agent_creation_engine.md)) only runs **after** that explicit endorsement.

--- a/sil-shopping/references/catalog_tools_reference.md
+++ b/sil-shopping/references/catalog_tools_reference.md
@@ -1,3 +1,8 @@
+---
+name: catalog-tools-reference
+description: Per-tool behaviour of the four core sil tools (register, whoami, search, product-get) and the shared status taxonomy. Load when driving any core catalog or identity tool.
+---
+
 # sil catalog + identity tools — per-tool behaviour and the shared status taxonomy
 
 Load this reference when driving any of the four core tools — `sil_register`,

--- a/sil-shopping/references/manage_domains.md
+++ b/sil-shopping/references/manage_domains.md
@@ -1,3 +1,8 @@
+---
+name: manage-domains
+description: View or forget the shopper's learned domains — the two sil_profile tools, the two remove granularities, confirm-before-remove. Load when the user wants to see what the shopper knows or forget a niche.
+---
+
 # Manage your shopper's domains — view, forget
 
 Load this when the user wants to see what their **shopper** knows or **forget a domain** (a niche) — "what does my shopper know?", "which domains has it learned?", "show me the cycling domain", "forget the grocery niche". The router in `SKILL.md` names which `sil_profile_*` tool each intent maps to; this reference is what those tools do, plus the **two remove granularities** and the confirm-before-remove gate.

--- a/sil-shopping/references/refine_shopper.md
+++ b/sil-shopping/references/refine_shopper.md
@@ -1,3 +1,8 @@
+---
+name: refine-shopper
+description: The refinement loop — sharpen the shopper or one domain from observed sessions, confirm-before-persist. Load when the user asks to refine, sharpen, or amend their shopper or a niche.
+---
+
 # Refine your shopper or one of its domains — the refinement loop
 
 When the user wants to **sharpen their shopper** — "refine my shopper", "the cycling domain keeps surfacing the wrong stuff, let's fix it", "amend what you know about me" — do **not** re-onboard from scratch and do **not** quietly mutate anything. Run this **targeted-amend** loop: load the relevant artefact, propose concrete refinements drawn from what the shopper actually **observed** in real shopping sessions, let the user **confirm a subset**, and persist **only** the confirmed subset by re-running the existing persist step. Nothing changes silently; nothing persists without the user's explicit confirmation.

--- a/sil-shopping/references/search_param_mapping.md
+++ b/sil-shopping/references/search_param_mapping.md
@@ -1,3 +1,8 @@
+---
+name: search-param-mapping
+description: The shop-time answer→sil_search parameter mapping — real params only, hard-constraint routing, the ship_to rule. Load when mapping a decomposed request into a sil_search call.
+---
+
 # Answer→`sil_search`-param mapping (the mapping is real)
 
 Load this at shop time, when the shop loop maps a decomposed request into a `sil_search` call ([`shop_loop.md`](shop_loop.md) Step 4). The mapping must target the **real `sil_search` parameters** (the shopping loop's catalog tool, named in `SKILL.md`) and nothing else — never invent a filter. (Under SDS there is no stored "answer→param mapping" seller artefact — the niche knowledge of *what* to search on lives in the active domain's domain spec; this reference is the generic param table the mapping draws on.)

--- a/sil-shopping/references/setup_onboarding.md
+++ b/sil-shopping/references/setup_onboarding.md
@@ -26,11 +26,12 @@ stage's beat and its single next step**, never the whole ladder at once.
    shopper's setup and anything it remembers live in a **local profile store**
    under `$SIL_DATA_DIR`, never leaving the device via the plugin; catalog
    **search** queries sil's product catalog. Next step: `sil_register`.
-2. **Registered, no shopper** — a sil identity exists but the overview carries no
-   `name`. Bare `sil_search` works now, but this is not the finished state. Guide
-   the user to **set up their shopper**: name up front, before the onboarding
-   starts, that it takes a **couple of minutes and a few questions**. Next step:
-   the after-register offer below, then — on a yes — the create two-step in SKILL.md.
+2. **Registered, no shopper** — a sil identity exists, but no shopper yet. Bare
+   `sil_search` works now, though this is not the finished state. Guide the user
+   to **set up their shopper**: name up front, before the onboarding starts, that
+   it takes a **couple of minutes and a few questions**. The after-register offer
+   below owns the gate — it reads the store once and offers only on an empty one;
+   on a yes it runs the create two-step in SKILL.md.
 3. **Shopper, no domain yet** — `name` present, `domains: []` (no niche yet). The
    first shopping intent **mints the first domain**, announced in the shopper's
    voice with the inferred niche stated so the user can correct it. Next step:

--- a/sil-shopping/references/setup_onboarding.md
+++ b/sil-shopping/references/setup_onboarding.md
@@ -1,0 +1,88 @@
+---
+name: setup-onboarding
+description: The one-time setup script the router defers to — the five-stage onboarding progression, the after-register shopper offer, and the per-search pitch. Load while a shopper is still being set up (SKILL.md routes here); it is shed once setup is complete.
+---
+
+# Setting up the shopper — the staged onboarding
+
+SKILL.md (the router) reads the stage from state and defers the **one-time setup
+script** to this file: the full five-stage progression, the after-register offer
+beat, and the per-search pitch. None of it applies once setup is complete — the
+router sheds it and routes straight to usage.
+
+Every stage is **read from state**, never guessed: `sil_whoami` (is there a sil
+identity yet?) plus the no-arg `sil_profile_get` overview (does a shopper exist —
+the `name` field — and does it hold any `domains`?). Present **only the current
+stage's beat and its single next step**, never the whole ladder at once.
+
+## The five-stage progression — present one stage, shed it on completion
+
+1. **Unregistered** — `sil_whoami` finds no sil identity. Guide the user to
+   register. **Before `sil_register` runs**, set the expectation: state plainly
+   what registering does and **how 4GPTs & sil use their data**, grounded strictly
+   in what this plugin does — no invented policy. Registering opens a sign-in link
+   in the default browser and creates their **sil identity** (name + saved
+   addresses, read back by `sil_whoami`), stored **locally** on this device; their
+   shopper's setup and anything it remembers live in a **local profile store**
+   under `$SIL_DATA_DIR`, never leaving the device via the plugin; catalog
+   **search** queries sil's product catalog. Next step: `sil_register`.
+2. **Registered, no shopper** — a sil identity exists but the overview carries no
+   `name`. Bare `sil_search` works now, but this is not the finished state. Guide
+   the user to **set up their shopper**: name up front, before the onboarding
+   starts, that it takes a **couple of minutes and a few questions**. Next step:
+   the after-register offer below, then — on a yes — the create two-step in SKILL.md.
+3. **Shopper, no domain yet** — `name` present, `domains: []` (no niche yet). The
+   first shopping intent **mints the first domain**, announced in the shopper's
+   voice with the inferred niche stated so the user can correct it. Next step:
+   state a shopping intent; the shopper-stage gate runs the forced mint.
+4. **Shopper active** — `name` present, `domains` non-empty. Check off the
+   completion **milestones**: the **first domain created** (the `domains` map is
+   now non-empty) and, softer, the memory tool has begun to be used (`sil_remember`
+   has stored a fact or taste). The memory milestone is a soft self-check, not a
+   shed gate — the overview cannot prove it, so judge it from whether this shopper
+   has ever remembered anything.
+5. **Setup complete** — a shopper with at least one domain. **Shed** every
+   onboarding beat: none of the stages above apply. **Show only how to use** the
+   plugin well — the domain-gated **shop loop** and **Spec-Driven Shopping**
+   ([`shop_loop.md`](shop_loop.md)).
+
+## After register — offer to set up the shopper, once (offer_shopper)
+
+`sil_register` returns `already_registered` with `next_step: "offer_shopper"` on a
+confirmed registration (a fresh sign-in this session, or a returning session
+already signed in). That hint is a routing breadcrumb, not a decision — act on it
+by first running a **no-arg `sil_profile_get`** (the overview) to read shopper
+state, then branch:
+
+- **Empty store — no shopper yet:** introduce the shopper in one short beat and
+  offer to set it up — name the value in its own terms: it shops each niche in
+  depth, reuses the sizes and hard limits it already knows so nothing is re-asked,
+  and explains why each pick fits. Only **on a yes**, load
+  [`brainstorm_interview.md`](brainstorm_interview.md) — the two-touchpoint
+  onboarding, never a form. Take no for an answer: bare `sil_search` stays a
+  first-class path, so don't re-offer in the same turn.
+- **A shopper already exists:** **skip this beat** entirely. The shopper is a
+  **singleton** — never offer a second one.
+
+## After a bare search — the per-search pitch (post-result)
+
+When a plain `sil_search` **completes with status `ok`** in a **profile-less**
+session, present the results best-first exactly as they came back, then append
+**one short trailing line** naming what a shopper would add on top. It is never a
+pre-search question and never a re-rank: bare search stays a legitimate quick
+lookup, and these are the same results a shopper would start from.
+
+Name one or two of the three levers a bare search leaves on the table, and rotate
+which you lead with so the recurring line stays fresh:
+
+- **niche depth** — a shopper weighs these picks against how the niche actually
+  buys, in depth, instead of just listing them;
+- **memory** — it keeps your sizes and hard limits on file, so no search re-asks them;
+- **the why** — it explains which pick fits you and why, instead of a flat list.
+
+This line **recurs on every** completed profile-less search — the recurrence is
+the point; there is **no fire-once or seen-it gate, and no cooldown**. Brevity
+plus lever rotation are all that keep it from nagging. Exactly two things suppress
+it: a **shopper already exists** (that session is the shopper's — **drop the
+line**), or the search **did not complete `ok`** (a non-ok status carries its own
+recovery — follow that and add no tip).

--- a/sil-shopping/references/shop_loop.md
+++ b/sil-shopping/references/shop_loop.md
@@ -1,3 +1,8 @@
+---
+name: shop-loop
+description: The Spec-Driven Shopping loop — the shopper shops any niche, minting domains on the fly, over a five-beat spine. Load when running as the shopper and the user states a shopping intent.
+---
+
 # Shop-time loop — how the one shopper shops any niche, minting domains on the fly
 
 Load this when you (the sil skill) are running as the user's **shopper** and they state a shopping intent ("find me something for a steak dinner around $40"). There is **ONE shopper** — a generalist that goes deep on whatever the user shops for — and it holds **many domains** (niches it has learned), each **minted lazily on first shop**. The [engine's Runtime hook](agent_creation_engine.md) ends where this loop begins: the host has injected the shopper's persona via the workspace **`SOUL.md`** (voice, standing rules, hard-no's), and the sil skill has read `$SIL_DATA_DIR/shopper/profile.json` — the **shared `user_spec.md`** (the person's cross-niche facts + hard constraints) plus the slug-keyed **`domains`** map. The per-niche packs load lazily, at shop time, per the beats below.

--- a/src/__tests__/skill-content.test.ts
+++ b/src/__tests__/skill-content.test.ts
@@ -76,6 +76,14 @@ const MAPPING_PATH = join(SKILL_DIR, "references", "search_param_mapping.md");
 const MANAGE_PATH = join(SKILL_DIR, "references", "manage_domains.md");
 const SHOP_LOOP_PATH = join(SKILL_DIR, "references", "shop_loop.md");
 const REFINE_PATH = join(SKILL_DIR, "references", "refine_shopper.md");
+// The one-time SETUP script the thin router evicts to a reference (progressive-
+// disclosure rewrite). The lean SKILL.md keeps the STEADY-STATE decision logic (the
+// stage read, the shopper-stage domain gate, the five-beat self-check); the one-time
+// setup SCRIPT — the five-stage staged-progression detail, the after-register
+// `offer_shopper` beat, and the `post-result` per-search pitch — moves HERE. The
+// `stagedBodyLower` / `afterRegisterBeat` / `perSearchBeat` extractors read THIS
+// file; `routingRaw` / `sessionStartLower` stay pointed at SKILL.md.
+const SETUP_ONBOARDING_PATH = join(SKILL_DIR, "references", "setup_onboarding.md");
 const EXAMPLE_PATH = join(SKILL_DIR, "examples", "multi_domain_shopper_walkthrough.md");
 
 /** The pre-rewrite filenames the rename retired. Must be gone from disk AND from
@@ -166,6 +174,7 @@ function bundleCorpus(): string {
     readBody(MANAGE_PATH),
     readBody(SHOP_LOOP_PATH),
     readBody(REFINE_PATH),
+    readBody(SETUP_ONBOARDING_PATH),
     readBody(EXAMPLE_PATH),
   ].join("\n");
 }
@@ -180,6 +189,7 @@ const BUNDLE_FILES: ReadonlyArray<readonly [string, string]> = [
   ["manage_domains.md", MANAGE_PATH],
   ["shop_loop.md", SHOP_LOOP_PATH],
   ["refine_shopper.md", REFINE_PATH],
+  ["setup_onboarding.md", SETUP_ONBOARDING_PATH],
   ["multi_domain_shopper_walkthrough.md", EXAMPLE_PATH],
 ];
 
@@ -467,6 +477,7 @@ describe("sil-shopping/SKILL.md — lean router routes to the renamed references
       "references/shop_loop.md",
       "references/manage_domains.md",
       "references/refine_shopper.md",
+      "references/setup_onboarding.md",
       "examples/multi_domain_shopper_walkthrough.md",
     ];
     const missing = expected.filter((rel) => !body.includes(rel));
@@ -1816,18 +1827,18 @@ function sectionOwning(body: string, anchor: number): string {
 /** The after-register beat section, anchored on `offer_shopper` (net-new; appears
  * ONLY in this beat — RED before the beat exists). */
 function afterRegisterBeat(): string {
-  const body = skillBody(readFileSync(SKILL_PATH, "utf8"));
+  const body = readBody(SETUP_ONBOARDING_PATH);
   const at = body.indexOf("offer_shopper");
-  expect(at, "SKILL.md must carry the after-register offer_shopper beat").toBeGreaterThanOrEqual(0);
+  expect(at, "setup_onboarding.md must carry the after-register offer_shopper beat").toBeGreaterThanOrEqual(0);
   return sectionOwning(body, at);
 }
 
 /** The per-search pitch beat section, anchored on `post-result`/`post result`
  * (net-new; unique to this beat — RED before the beat exists). */
 function perSearchBeat(): string {
-  const body = skillBody(readFileSync(SKILL_PATH, "utf8"));
+  const body = readBody(SETUP_ONBOARDING_PATH);
   const m = /post-?result/i.exec(body);
-  expect(m, "SKILL.md must carry the per-search post-result pitch beat").not.toBeNull();
+  expect(m, "setup_onboarding.md must carry the per-search post-result pitch beat").not.toBeNull();
   return sectionOwning(body, m!.index);
 }
 
@@ -1915,7 +1926,7 @@ describe("sil-shopping/SKILL.md — after-register introduce-and-offer beat (add
     // Section-scoped: brainstorm_interview.md also appears in the create two-step
     // gate, so a whole-body includes would false-green the routing pin.
     const beat = afterRegisterBeat();
-    expect(beat).toContain("references/brainstorm_interview.md");
+    expect(beat).toContain("brainstorm_interview.md");
     const onlyOnYes =
       /only on a yes/i.test(beat) || /on a yes/i.test(beat) ||
       /on acceptance/i.test(beat) || /if .{0,20}\byes\b/i.test(beat) ||
@@ -2874,7 +2885,7 @@ describe("sil-shopping/SKILL.md — the domain gate scopes to sil_search discove
  * the per-stage anchors scan the whole body; only the progression-gate structure
  * (below) is scoped to `## Routing`, where the founder's delete-first rewrite lands. */
 function stagedBodyLower(): string {
-  return skillBody(readFileSync(SKILL_PATH, "utf8")).toLowerCase();
+  return readBody(SETUP_ONBOARDING_PATH).toLowerCase();
 }
 
 // ---- NET-NEW positive anchors for the staged progression (all 0 in shipped SKILL.md) ----

--- a/src/__tests__/skill-content.test.ts
+++ b/src/__tests__/skill-content.test.ts
@@ -2899,14 +2899,16 @@ const STAGE4_ACTIVE_RE = /shopper active|milestone|first domain created/i;
 const STAGE5_COMPLETE_RE =
   /setup (?:is )?complete|setup-complete|once setup is (?:complete|done)|setup (?:done|finished)/i;
 
-describe("sil-shopping/SKILL.md — Routing presents a five-stage staged onboarding progression, read from sil_whoami + sil_profile_get (founder round-2; add-only)", () => {
-  it("opens Routing with a STAGED progression (not a binary name-presence gate), with the stage read from BOTH sil_whoami and sil_profile_get", () => {
+describe("sil-shopping/SKILL.md — Routing branches on sil_whoami + sil_profile_get; the staged progression lives in setup_onboarding.md (progressive-disclosure rewrite; add-only)", () => {
+  it("reads the stage from BOTH sil_whoami and sil_profile_get; the staged-progression naming lives in the on-demand setup reference", () => {
     const raw = routingRaw();
     const lower = raw.toLowerCase();
-    // NET-NEW RED driver: staged-progression vocabulary (the shipped router was binary — 0 in HEAD).
+    // The router thinned to a pure state branch (no identity / no shopper / shopper);
+    // the staged-progression NAMING moved to the on-demand setup reference, alongside
+    // the five-stage enumeration the sibling `stagedBodyLower` assertions already read there.
     expect(
-      STAGED_PROGRESSION_RE.test(raw),
-      "Routing must present a STAGED onboarding progression (NET-NEW — the shipped router was a binary `name`-presence gate)",
+      STAGED_PROGRESSION_RE.test(readBody(SETUP_ONBOARDING_PATH)),
+      "the staged onboarding progression must be presented in setup_onboarding.md (the router only branches + reads state)",
     ).toBe(true);
     // The stage is the JOINT signal — sil_whoami (registered?) + sil_profile_get (shopper?). The
     // whoami→registration tie is the NET-NEW RED driver (in the binary router whoami is only a


### PR DESCRIPTION
## What & why

`sil-shopping/SKILL.md` — the always-loaded skill router — had accreted the entire one-time **setup script** (the five-stage onboarding ladder, the after-register offer, the per-search pitch). That content is dead weight once a shopper exists, yet it loaded on every session. This restructures for progressive disclosure: the router keeps only **steady-state decision logic**; the one-time **setup script** moves to a new on-demand reference.

## Changes

- **`SKILL.md` → thin router.** Keeps the stage read, the intent→tool table, the endorsement two-step, the profile-less arm, the shopper-stage domain gate, and the five-beat self-check. **Always-loaded body: 2394 → 1042 words (−56%).**
- **New `references/setup_onboarding.md`** carries the five-stage progression detail, the `offer_shopper` beat, and the `post-result` pitch — loads only during setup, shed once complete.
- **Description trimmed** 917 → 622 chars (the only always-*pre*loaded content), keeping all 8 tool names + `shopper`/`domain` triggers.
- **`name`+`description` frontmatter** on every reference + the example.
- **`skill-content.test.ts` repointed** (via `qa-developer`): `afterRegisterBeat` / `perSearchBeat` / `stagedBodyLower` now read `setup_onboarding.md`; it's wired into `BUNDLE_FILES` + `bundleCorpus` + the router-links check. `routingRaw` / `sessionStartLower` stay on `SKILL.md`. **No assertion weakened** — the ~90 behavioral invariants (tool surface, endorsement ordering, singleton refusal, admission sequence, no-`expert`-vocab, domain gate) all stay green.

## Tests

- `skill-content.test.ts`: **160/160 pass.** Full suite: **1078 pass / 10 fail**, typecheck + build clean.
- The 10 reds are all `repo-scaffold.integration.test.ts` asserting `CLAUDE.md` / `docs/` exist — both **gitignored, so absent in any worktree checkout**. Pre-existing worktree-only artifact, not a regression (verified: identical on a clean HEAD worktree).

## Deliberately not done

- **No `shop_loop.md` body changes** beyond frontmatter: a TOC would duplicate the exact anchor phrases the five-beat strict-ordering pins key on, and the flagged "duplication" is two distinct pinned persist beats — guidance kept intentionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)