### PR TITLE
refactor: de-rigidify the sil-shopping skill (scolding → guidance)

### DIFF
--- a/sil-shopping/SKILL.md
+++ b/sil-shopping/SKILL.md
@@ -14,121 +14,105 @@ identity, help them find purchasable products — and, when asked, set up their
 view or forget a domain, or refine it. Read intent, route to the matching tool
 (loading its reference on demand), call it, and report what came back.
 
-## Always-on behavioural contract
-
-Three principles hold on every path, before any reference loads:
+## Always-on contract
 
 - **Act, don't narrate.** When intent maps to a tool, call it — don't re-confirm
   what was already stated.
-- **Fail visibly, recover correctly.** Every tool returns a `status`. On a
-  non-`ok` status, say what happened and follow the tool's own `recovery` hint —
-  never improvise a different one.
-- **Relay prices as point-in-time.** A price, availability, and `checkout_url`
-  are a snapshot. Before the user buys, re-fetch with `sil_product_get` rather
-  than trusting an earlier `sil_search` result.
+- **Follow the tool's own `recovery`.** Every tool returns a `status`; on a
+  non-`ok` one, say what happened and follow that tool's `recovery` hint, never
+  improvise another. The taxonomy lives in
+  [`references/catalog_tools_reference.md`](references/catalog_tools_reference.md).
+- **Prices are point-in-time.** Before the user buys, re-fetch the item with
+  `sil_product_get` rather than trusting an earlier `sil_search` snapshot.
 
 ## Session start
 
-Confirm the `sil_*` tools are exposed. If they are missing from the tool list,
-the host is filtering them because sil is not admitted at the host allow
-surfaces — run the shipped admission helper `sil-openclaw-allowlist` (it
-additively admits sil at `plugins.allow` + `tools.alsoAllow`, leaving other
-trusted plugins untouched), then reopen the session so the tools load. Most flows
-need an identity: calling a catalog tool first lets an unregistered outcome route
-to `sil_register` (the [catalog tools reference](references/catalog_tools_reference.md)
-has the taxonomy), or run `sil_register` up front when intent clearly requires it.
+Confirm the `sil_*` tools are exposed. If they are missing, the host is filtering
+them — run the shipped admission helper `sil-openclaw-allowlist` (it additively
+admits sil at `plugins.allow` + `tools.alsoAllow`), then reopen the session. Most
+flows need an identity: calling a catalog tool first lets an unregistered outcome
+route to `sil_register`, or run `sil_register` up front when intent requires it.
 
 ## Routing — read the stage, then match intent to a tool
 
-**Read the stage from state — never guess it.** Two cheap session-level reads
-settle it: `sil_whoami` (is a sil **identity** **registered** yet?) and the no-arg
+**Read the stage from state — never guess it.** Two cheap reads settle it:
+`sil_whoami` (is a sil identity **registered** yet?) and the no-arg
 `sil_profile_get` overview (its **`name` field** is the whole discriminator —
-present only when a shopper exists). Branch on the two, nothing else:
+present only once a shopper exists).
 
-- **No identity** ⇒ setup starts here — guide the user to register.
+- **No identity** ⇒ guide the user to register.
 - **`name` absent ⇒ profile-less stage** — bare shopping is a first-class quick
-  lookup; the setup path is offered first-class.
-- **`name` present ⇒ shopper stage** — the domain gate governs every
-  `sil_search`-driven intent.
+  lookup; the setup path is offered alongside it.
+- **`name` present ⇒ shopper stage** — shop through what you know about the person.
 
 [`references/setup_onboarding.md`](references/setup_onboarding.md) owns the setup
-script — the staged ladder, the after-register offer, and the per-search pitch.
-Load it while setup is incomplete; it sheds once a shopper exists.
+script — the staged ladder, the after-register offer, the per-search pitch. Load
+it while setup is incomplete; it sheds once a shopper exists.
 
 ### Intent → tool (load the reference on demand)
 
 | Intent | Tool | Reference |
 |---|---|---|
-| "sign me up" / "log me in" / "register" | `sil_register` | [`references/catalog_tools_reference.md`](references/catalog_tools_reference.md) |
-| "who am I?" / show my saved name + addresses | `sil_whoami` | [`references/catalog_tools_reference.md`](references/catalog_tools_reference.md) |
-| "find X" / "search for X" / browse a category or price range | `sil_search` | [`references/catalog_tools_reference.md`](references/catalog_tools_reference.md) |
-| "look up these items" / re-check ids from a prior result | `sil_product_get` | [`references/catalog_tools_reference.md`](references/catalog_tools_reference.md) |
+| "sign me up" / "log me in" / "register" | `sil_register` | [`catalog_tools_reference.md`](references/catalog_tools_reference.md) |
+| "who am I?" / show my saved name + addresses | `sil_whoami` | [`catalog_tools_reference.md`](references/catalog_tools_reference.md) |
+| "find X" / "search for X" / browse a category or price range | `sil_search` | [`catalog_tools_reference.md`](references/catalog_tools_reference.md) |
+| "look up these items" / re-check ids from a prior result | `sil_product_get` | [`catalog_tools_reference.md`](references/catalog_tools_reference.md) |
 | "set up an agent that shops for me" / "create my shopper" | (onboarding, then the engine) | the two-step below |
-| "what does my shopper know?" / "which domains has it learned?" | `sil_profile_get` (no `domainSlug`) | [`references/manage_domains.md`](references/manage_domains.md) |
-| "show me the &lt;niche&gt; domain" | `sil_profile_get` (`domainSlug`) | [`references/manage_domains.md`](references/manage_domains.md) |
-| "forget the &lt;niche&gt; domain" | `sil_profile_remove` | [`references/manage_domains.md`](references/manage_domains.md) |
-| (as the shopper) a shopping intent on any niche | `sil_search` → `sil_product_get` | [`references/shop_loop.md`](references/shop_loop.md) |
-| "remember this" — a fact or taste the shopper surfaced | `sil_remember` | [`references/shop_loop.md`](references/shop_loop.md) |
-| "refine / sharpen my shopper" / fix a niche | (load → propose → confirm → persist) | [`references/refine_shopper.md`](references/refine_shopper.md) |
+| "what does my shopper know?" / "which domains has it learned?" | `sil_profile_get` (no `domainSlug`) | [`manage_domains.md`](references/manage_domains.md) |
+| "show me the &lt;niche&gt; domain" | `sil_profile_get` (`domainSlug`) | [`manage_domains.md`](references/manage_domains.md) |
+| "forget the &lt;niche&gt; domain" | `sil_profile_remove` | [`manage_domains.md`](references/manage_domains.md) |
+| (as the shopper) a shopping intent on any niche | `sil_search` → `sil_product_get` | [`shop_loop.md`](references/shop_loop.md) |
+| "remember this" — a fact or taste the shopper surfaced | `sil_remember` | [`shop_loop.md`](references/shop_loop.md) |
+| "refine / sharpen my shopper" / fix a niche | (load → propose → confirm → persist) | [`refine_shopper.md`](references/refine_shopper.md) |
 
 [`references/catalog_tools_reference.md`](references/catalog_tools_reference.md)
-holds the per-tool behaviour and the shared status taxonomy — basic shopping needs
-only that one. The shop-time answer→`sil_search`-param mapping lives in
+holds the per-tool behaviour + status taxonomy — basic shopping needs only that.
+The answer→`sil_search`-param mapping is
 [`references/search_param_mapping.md`](references/search_param_mapping.md); a full
-worked run is
+run is
 [`examples/multi_domain_shopper_walkthrough.md`](examples/multi_domain_shopper_walkthrough.md).
 
-**Setting up the shopper — the endorsement-gated two-step.** Creating the shopper
-is a profile-less-stage intent (a singleton — refused once one exists). (1)
-**Onboard first:** run
+**Setting up the shopper — the endorsement-gated two-step.** The shopper is a
+singleton (refused once one exists). (1) **Onboard first:** run
 [`references/brainstorm_interview.md`](references/brainstorm_interview.md), the
 two-touchpoint onboarding. (2) **Only after** the user explicitly **endorses** the
 assembled draft, run
-[`references/agent_creation_engine.md`](references/agent_creation_engine.md) — the
-ordered engine that persists the one sil-wired shopper. Running any engine step
-before that endorsement is forbidden.
+[`references/agent_creation_engine.md`](references/agent_creation_engine.md), the
+engine that persists the one sil-wired shopper. No engine step runs before that
+endorsement.
 
 ### Profile-less stage — the bare lane stays bare
 
 **`name` absent.** A shopping intent takes the "find X" → `sil_search` row above
 **unchanged** — no domain check, no mint, no pre-search question. Bare search is a
-legitimate quick lookup; the only shopper nudge is the profile-less per-search
-pitch ([`references/setup_onboarding.md`](references/setup_onboarding.md)). The
-domain gate below does **not** bleed into this stage.
+legitimate quick lookup; the only nudge is the profile-less per-search pitch
+([`references/setup_onboarding.md`](references/setup_onboarding.md)).
 
-### Shopper stage — domain-gated search, non-skippable
+### Shopper stage — shop through what you know
 
-**`name` present.** Running **as the shopper**, the **domain-exists check is
-non-skippable on every** `sil_search`-driven query, and the bare 'find X' lane is
-**not reachable** in this stage. Before any search, read the `sil_profile_get`
-overview, classify the query's niche, and **reuse a learned domain or mint one** —
-the shop loop's first beat. Then follow
-[`references/shop_loop.md`](references/shop_loop.md): the profile-driven
+**`name` present.** As the shopper, shop through what you know about the person:
+classify the query's niche and **reuse a learned domain or mint one before
+searching** — the shop loop's first beat — then follow
+[`references/shop_loop.md`](references/shop_loop.md), the profile-driven
 **Spec-Driven Shopping** loop that web-refreshes the domain, decomposes the
 request, and persists each surfaced fact or taste with a single `sil_remember`.
 
-- **`domains: []` forces a mint first.** A shopper with no niche yet **mints the
-  domain before searching** on the first shopping intent, **announced** with the
-  inferred niche **stated so the user can correct it** — never a silent mint.
-- **A domain-less `sil_search` is a process failure.** **Warn visibly** — name
-  that the shopper spine was bypassed and these would be bare catalog results —
-  then **self-correct** by running the skipped domain check. Never silently pass
-  bare catalog results off as the shopper's work.
+- **An empty `domains` map means no niche yet:** the first shopping intent **mints
+  the domain before searching**, **announced** with the inferred niche stated so
+  the user can correct it — never a silent mint.
 
-This gate governs the shopper's **reasoning, not the user's inbox**: a reused
-domain plus a fully-resolved query passes straight through, asking nothing — it
-protects recommendation **quality, never access**. It scopes to
-`sil_search`-driven product discovery only; identity (`sil_register` /
+This shapes the shopper's **reasoning, not the user's inbox**: a reused domain plus
+a fully-resolved query **passes straight through, asking nothing**. It scopes to
+`sil_search`-driven product discovery only — identity (`sil_register` /
 `sil_whoami`), a direct `sil_product_get` id re-check, and shopper-management
 intents (view / forget a domain) route normally, **ungated**.
 
-**Per-query self-check (prose, not a tool).** At the end of a completed shopper
-query, self-report the beats you ran — `profile_loaded → domain_classified →
-domain_reused_or_minted → intent_decomposed → facts_remembered`. It is an
-in-context guardrail, not a new tool, table, or telemetry surface.
+**Per-query self-check (prose, not a tool).** As you shop, keep track of which
+beat you're on and that you resolved the domain before searching — an in-context
+guardrail, not a new tool, table, or telemetry surface.
 
-The management + refinement flows load on demand:
-[`references/manage_domains.md`](references/manage_domains.md) for view/forget over
-the shopper's domains (two remove granularities, confirm-before-remove), and
-[`references/refine_shopper.md`](references/refine_shopper.md) for sharpening the
-shopper or one domain from observed sessions (confirm-before-persist).
+Management + refinement load on demand:
+[`references/manage_domains.md`](references/manage_domains.md) (view/forget,
+confirm-before-remove) and
+[`references/refine_shopper.md`](references/refine_shopper.md) (sharpen from observed
+sessions, confirm-before-persist).

--- a/sil-shopping/examples/multi_domain_shopper_walkthrough.md
+++ b/sil-shopping/examples/multi_domain_shopper_walkthrough.md
@@ -5,127 +5,61 @@ description: Worked end-to-end example — create one shopper, then shop two unr
 
 # Worked example — one shopper, two unrelated niches, one session
 
-A short walkthrough of the **headline capability**: create **ONE shopper**
+The headline: create **one shopper**
 ([`../references/brainstorm_interview.md`](../references/brainstorm_interview.md) →
-[`../references/agent_creation_engine.md`](../references/agent_creation_engine.md)),
-then shop **two unrelated niches in the same session** — the second **minted on
-the fly** — with a **shared fact reused across both** and **per-domain taste that
-does not leak**. The transcript is illustrative — it shows the *shape*, the gates,
-and the SDS layering, not exact wording.
+[`../references/agent_creation_engine.md`](../references/agent_creation_engine.md)), then
+shop **two unrelated niches in the same session** — the second **minted on the fly** —
+with a **shared fact reused across both** and **per-domain taste that does not leak**. It
+shows the shape and the gates, not exact wording; the machinery lives in the references.
 
-## Onboarding — two touchpoints, NO niche research
+## Onboarding — two touchpoints, no niche research
 
 > **User:** "Set up something that shops for me."
 
-The shopper is a **generalist** — onboarding touches only the persona and the
-shared user spec; it researches **no** niche.
+A **generalist** — onboarding touches only the persona and the shared user spec, no niche.
 
-**1. `SOUL.md` — ask first (persona; a generalist, NOT a niche).**
-
-> **Shopper:** "Let's set up your shopper. How do you want it to behave?"
-> **User:** "Be concise and a bit opinionated — and never recommend anything with
-> leather, it's an ethics thing for me."
-
-→ Persona (→ host **`SOUL.md`**): *concise, lightly opinionated generalist.* No
-niche is chosen — it will shop whatever the user buys.
-
-**2. `user_spec.md` (shared) — seed the cross-niche facts + hard constraints.**
-
+> **Shopper:** "How do you want it to behave?"
+> **User:** "Concise and a bit opinionated — never recommend anything with leather, it's
+> an ethics thing."
 > **Shopper:** "Anything I should always know — sizes, where to ship, hard rules?"
-> **User:** "Ship to 12 Rue Centrale, Lyon, France. And the no-leather rule is
-> absolute."
+> **User:** "Ship to 12 Rue Centrale, Lyon, France. The no-leather rule is absolute."
 
-→ Seeded partial **shared `userSpec`** (→ `user_spec.md`): *ship-to Lyon, France
-(soft fact); **HARD-NO: leather** (inviolable, carries across every niche).* The
-rest is augmented per query.
+→ persona (→ host `SOUL.md`): *concise, lightly opinionated generalist.* Shared
+`userSpec`: *ship-to Lyon (soft fact); **HARD-NO: leather** (inviolable, carries across
+every niche).*
 
-## Assemble + endorse — the gate
-
-Identity confirmed (`my-shopper` / "My Shopper"), the assembled draft splits across
-the two stores — `agentId` + `persona` drive the host wiring (`openclaw agents add`
-+ `SOUL.md`); `name` + the **shared user spec only** feed the singleton
-`sil_profile_materialize` **create** (no `agentId`, no domain pack at create):
+## Assemble + endorse
 
 ```jsonc
 {
-  "agentId": "my-shopper",
-  "name": "My Shopper",
+  "agentId": "my-shopper", "name": "My Shopper",
   "persona": "A concise, lightly opinionated generalist shopper.",
-  "userSpec": "## Shared user spec (seeded partial)\n### Soft facts\n- Ship-to: 12 Rue Centrale, Lyon, France.\n### Hard constraints (INVIOLABLE — every niche)\n- HARD-NO: leather (ethics)."
+  "userSpec": "### Soft facts\n- Ship-to: 12 Rue Centrale, Lyon, France.\n### Hard constraints (INVIOLABLE — every niche)\n- HARD-NO: leather (ethics)."
 }
 ```
 
-> **Shopper:** "Here's your shopper — shall I create it?"
-> **User:** "Yes, create it."
+> **Shopper:** "Here's your shopper — shall I create it?"  **User:** "Yes, create it."
 
-**This affirmative act is the gate** — up to here, **zero engine steps ran**. Only
-now does the engine proceed
-([`../references/agent_creation_engine.md`](../references/agent_creation_engine.md)):
-validate-first → singleton check → `openclaw agents add my-shopper --workspace
-~/.openclaw/workspace-my-shopper --non-interactive --json` (confirm the inherited
-profile grants a web tool) → write the persona into `SOUL.md` →
-`sil_profile_materialize { name, userSpec }` **(NO `domain` — writes the shared
-`user_spec.md` + `profile.json` with an empty `domains: {}`)** → wire sil:
-
-```
-openclaw config set 'agents.list[<i>].skills' '["sil"]' --strict-json
-openclaw config set plugins.entries.sil.enabled true --strict-json
-```
-
-→ then **admit sil at the host allow surfaces** so the `sil_*` tools are un-filtered
-— the shipped helper does the additive, idempotent merge of `plugins.allow` +
-`tools.alsoAllow` (never clobbering another admitted plugin like `klodi`):
-
-```
-sil-openclaw-allowlist
-```
-
-→ `openclaw config validate --json` returns valid → **`created`** (a non-zero
-helper exit would be `persistence_failed`, not `created` — never a green shopper
-over still-filtered tools). The shopper now exists with an **empty `domains` map** —
-healthy; it will mint each niche on first shop.
+**This affirmative act is the gate** — up to here, zero engine steps ran. Only now does
+the engine run — `openclaw agents add my-shopper …` → persona into `SOUL.md` →
+`sil_profile_materialize { name, userSpec }` (no `domain`; writes the shared
+`user_spec.md` + an empty `domains: {}`) → wire + admit sil → validate → **`created`**,
+with an **empty `domains` map** (healthy; each niche mints on first shop).
 
 ## Niche A — road cycling (minted on the fly, announced)
 
 > **User:** "Find me a first road bike, around €1500."
 
-The shop loop ([`../references/shop_loop.md`](../references/shop_loop.md) owns the
-machinery — not repeated here) classifies the niche (**road cycling**), reads
-`profile.json.domains`, finds **no** matching domain, and **mints it on the spot —
-announced**:
+The shop loop classifies the niche (**road cycling**), finds no match, and **mints it on
+the spot — announced** ("I haven't shopped cycling for you yet — setting that up"). It
+researches a deep `domainSpec` (fit is everything; geometry; gearing; material/wheel
+trade-offs), derives the `intentSpec`, seeds a partial `playbook`, and persists with the
+whole-doc `sil_profile_materialize` carrying `domain.slug: "road-cycling"`. It recommends
+with a **"why" that cites the layers** — "for a first bike **fit/comfort outrank outright
+speed** (a domain mechanic), a 54 cm endurance frame fits, kept within your value budget;
+**no leather anywhere** (your standing hard rule)."
 
-> **Shopper:** "I haven't shopped cycling for you yet — setting that up now (road
-> cycling, first bike). One sec while I do the homework."
-
-It **researches** the niche deeply (the deep `domainSpec` — the full how-to-buy:
-**fit is everything** — frame size from height *and* inseam, stack/reach, saddle
-setback, crank length; geometry; gearing theory; material/wheel trade-offs),
-derives the `intentSpec` dimensions, seeds a partial `playbook`, then persists with
-the **whole-doc** mint:
-
-```jsonc
-sil_profile_materialize {
-  name: "My Shopper",
-  userSpec: "…the current shared spec (re-persisted)…",
-  domain: {
-    slug: "road-cycling", name: "Road cycling",
-    domainSpec: "## First road bike — how to buy well (deep)\nFit is everything: size from height AND inseam; stack/reach set torso angle; saddle setback from KOPS; crank length scales with inseam…\n## Geometry: endurance vs race. ## Gearing: gear-inches, compact vs mid-compact. ## Material/wheels: alloy vs carbon; rim depth vs crosswind.",
-    intentSpec: "## Dimensions (schema)\nuse-case; terrain; budget band; fit envelope; timeline; compatibility; performance priorities; aesthetics.",
-    playbook: "## Buying taste (seeded partial)\nTo be learned as we shop."
-  }
-}
-```
-
-Then the loop runs on the active **road-cycling** domain: decompose the intent
-(first bike, ~€1500), map → `sil_search` → compare on the rubric, and recommend
-with a **"why" that cites the layers** — "for a first bike **fit/comfort outrank
-outright speed** (a domain mechanic), a 54 cm endurance frame sits right, and I kept
-it within your value budget; **no leather anywhere** (your standing hard rule)." A
-rationale naming no domain mechanic and reusing no stored fact would **fail the SDS
-bar** even if the bike were fine.
-
-The session surfaces a **taste**, captured the **cheap** way — one append, scoped to
-this domain:
+A taste surfaces, captured the cheap way — one append, scoped to this domain:
 
 > **User:** "I don't chase brands — value over name."
 
@@ -133,30 +67,24 @@ this domain:
 sil_remember { kind: "taste", text: "Value over brand; ~€1500 band.", domain: "road-cycling" }
 ```
 
-That taste lands in **`domains/road-cycling/playbook.md`** — this niche only.
+→ lands in `domains/road-cycling/playbook.md` only.
 
-## Niche B — espresso (a SECOND niche, same session, no switch)
+## Niche B — espresso (a second niche, same session, no switch)
 
-Moments later, **same session, no agent switch, no re-onboarding**:
+> **User:** "Different thing — a home espresso machine, decent but not crazy."
 
-> **User:** "Different thing — I want a home espresso machine, decent but not crazy."
+Same session, **no agent switch, no re-onboarding**. The loop classifies **espresso**,
+finds no match, and **mints espresso on the fly — announced**, with its own deep
+`domainSpec` (boiler type, PID, pressure profiling, grinder pairing) via a second
+whole-doc `sil_profile_materialize` (`domain.slug: "espresso"`).
 
-The loop classifies the niche (**espresso**), reads `profile.json.domains`, finds
-no match, and **mints espresso on the fly — announced** ("new niche for me —
-setting up espresso") with its own deep `domainSpec` (boiler type, PID, pressure
-profiling, portafilter size, grinder pairing), `intentSpec`, and partial `playbook`,
-via a second whole-doc `sil_profile_materialize` with `domain.slug: "espresso"`.
+**The shared fact carries — without being re-asked:** the ship-to from the shared
+`user_spec.md` is reused in espresso with **no re-ask** ("I'll ship to your Lyon address
+as usual"), and the no-leather hard rule still rejects a leather-wrapped tamper handle.
 
-**The shared fact carries — without being re-asked:**
-
-> **Shopper:** "I'll ship to your Lyon address as usual" — **the ship-to from the
-> shared `user_spec.md`, captured during onboarding, reused in espresso with no
-> re-ask.** The **no-leather hard rule** also still applies (it rejects a
-> leather-wrapped tamper handle outright).
-
-**The niche taste does NOT leak:** the *value-over-brand, ~€1500* taste lives in
-`domains/road-cycling/playbook.md` and **does not shape** the espresso picks —
-espresso starts with its own (partial) taste, learned fresh:
+**The niche taste does not leak:** the *value-over-brand* taste lives in
+`domains/road-cycling/playbook.md` and does not shape the espresso picks — espresso learns
+its own:
 
 > **User:** "For coffee I'll happily pay for a known reliable brand."
 
@@ -164,32 +92,27 @@ espresso starts with its own (partial) taste, learned fresh:
 sil_remember { kind: "taste", text: "Pays up for a reliable known brand.", domain: "espresso" }
 ```
 
-→ lands in **`domains/espresso/playbook.md`** only. Road cycling's "value over
-brand" and espresso's "pay for a known brand" coexist **without contradiction** —
-that is per-domain taste isolation. A **fact** (a new measurement, a hard rule) would
-instead go to the **shared** `user_spec.md` (`kind: "fact"`) and carry to *both*
-niches.
+→ `domains/espresso/playbook.md` only. The two tastes coexist without contradiction —
+per-domain taste isolation. A **fact** would instead go to the shared `user_spec.md`
+(`kind: "fact"`) and carry to *both* niches.
 
 ## The singleton edge — refuse a second shopper
 
 > **User:** "Can you make me a second shopper just for coffee?"
-> **Shopper:** "You already have a shopper — it handles every niche. I've added
-> espresso as a domain on it; I won't create a second shopper. Want me to refine
-> the espresso domain instead?"
+> **Shopper:** "You already have a shopper — it handles every niche. I've added espresso
+> as a domain; I won't create a second. Want me to refine the espresso domain instead?"
 
 The engine's **singleton refusal** (`collision`, "a shopper already exists") — one
-shopper, many domains; you never mint a second.
+shopper, many domains.
 
 ## Edge cases this example would have handled
 
-- **Reuse before mint** — asking for "another road bike, this time for winter" reuses
-  the **existing `road-cycling` domain** (semantic dedup), never mints a near-duplicate
-  `cycling` / `bikes` pack.
+- **Reuse before mint** — "another road bike, for winter" reuses the existing
+  `road-cycling` domain (semantic dedup), never a near-duplicate pack.
 - **Forget one domain ≠ decommission the shopper** — "forget espresso" runs
-  `sil_profile_remove { domainSlug: "espresso" }` (artefact-only; the shopper,
-  the shared user spec, and the road-cycling domain survive). Tearing down the whole
-  shopper is the separate host-CLI-first path.
-- **No web tool**: the shopper says so honestly at mint time and composes the domain
-  spec from public buying knowledge — never pretends the research happened.
-- **Creation is local + offline** (for identity): no sil registration to create; the
-  user registers later, on first shop, via `sil_register`.
+  `sil_profile_remove { domainSlug: "espresso" }`; the shopper, shared user spec, and
+  road-cycling domain survive.
+- **No web tool** — the shopper says so honestly at mint time and composes from public
+  knowledge, never pretending the research happened.
+- **Creation is local + offline** — no sil registration to create; the user registers
+  later, on first shop.

--- a/sil-shopping/references/agent_creation_engine.md
+++ b/sil-shopping/references/agent_creation_engine.md
@@ -5,95 +5,135 @@ description: The ordered, one-command engine that persists the single sil-wired 
 
 # Create your sil-wired shopper — the agent-creation engine
 
-**Precondition: run this ONLY after the user has explicitly endorsed the assembled draft from [`brainstorm_interview.md`](brainstorm_interview.md).** Anything below before that endorsement is forbidden — the interview owns the gate.
+**Precondition: run this ONLY after the user has explicitly endorsed the assembled draft
+from [`brainstorm_interview.md`](brainstorm_interview.md).** The interview owns that gate.
 
-When the user wants to **set up shopping**, author and persist **one** valid OpenClaw agent profile — the user's **shopper**: a real new agent under the host `agents` config, with the **sil plugin enabled**, the **sil skill attached**, its persona written into the workspace **`SOUL.md`**, plus the shopper's **shared user spec** in the sil data directory — so it shops with **no further setup**. The shopper is a **singleton**: you create it **once**, then it learns **domains** (niches) lazily on first shop — you never mint a second shopper.
-
-The shopper runs **entirely on Spec-Driven Shopping (SDS)** — the operating model, not an optional layer. At create time exactly **one** sil artefact is persisted: the **shared, agent-level `userSpec`** (the person's cross-niche facts + hard constraints, seeded *partial* by the interview). **No** niche is researched and **no** per-domain pack is written at create time — there is **no** `domainSpec` / `intentSpec` / `playbook` here. Those are minted **lazily, per niche, on first shop** ([`shop_loop.md`](shop_loop.md)) into `domains/<slug>/`. A freshly-created shopper has an **empty `domains` map** — that is **healthy**, not a deficiency.
+This persists **one** valid OpenClaw agent — the user's **shopper**: a real agent under
+the host `agents` config, sil plugin enabled, sil skill attached, its persona in the
+workspace **`SOUL.md`**, plus the **shared user spec** in the sil data dir — so it shops
+with **no further setup**. The shopper is a **singleton**: created once, then it learns
+**domains** lazily on first shop, so a fresh shopper has an **empty `domains` map** —
+healthy. Creation is **local and offline**: no token is read, no `sil_register` /
+`sil_whoami`, no network call. The shopper registers the user later, on first shop.
 
 ## The one command
 
-After the explicit endorsement, you run exactly **ONE** shipped command — the package `bin` **`sil-openclaw-create-shopper`** — and it runs the whole choreography **atomically** and fail-closed. You do **NOT** hand-run the ten host-CLI steps yourself; the bin runs them **for you, in order, as one transaction**, then returns a single structured JSON result. Feed it the endorsed spec as **one JSON object on `stdin`** (or via **`--spec <path>`**):
+After the endorsement, run exactly **one** shipped command — the package bin
+**`sil-openclaw-create-shopper`** — and it runs the whole choreography **atomically** and
+**fail-closed**, then returns one structured JSON result. You do **not** hand-run the
+host-CLI steps; the bin runs them **for you, in order, as one transaction**. Feed it the
+endorsed spec as one JSON object on **`stdin`** (or via **`--spec <path>`**):
 
 ```
 sil-openclaw-create-shopper <<'JSON'
-{ "agentId": "my-shopper", "name": "My Shopper", "workspace": "~/.openclaw/workspace-my-shopper",
+{ "agentId": "my-shopper", "name": "My Shopper",
+  "workspace": "~/.openclaw/workspace-my-shopper",
   "persona": "…the endorsed persona…", "userSpec": "…the seeded shared user spec…",
   "channel": "telegram" }
 JSON
 ```
 
-Pass **`channel`** with the channel the setup conversation is running on (e.g. `telegram`) — that is what auto-routes the new shopper so the user's next message reaches it with **no manual bind and no restart**. It is **optional and fail-open**: absent/blank/unresolvable, or already owned by another agent, the bin still creates the shopper and returns a manual-bind hint (step 10). Passing the multiline `persona` / `userSpec` as JSON dodges shell-arg escaping. The bin is **non-interactive**: it executes an **already-assembled, already-endorsed** spec — it never re-runs the interview and never prompts (the endorsement gate lives upstream in the interview; the bin's own validate-first + singleton pre-flight still protect a direct caller). Creation is **local and offline** — the bin reads **no token**, performs **no** `sil_register` / `sil_whoami`, and makes **no network call**. The `sil` **plugin** and `sil` **skill** are always wired (that is what makes it *sil-wired*). Do **not** present sil registration as a prerequisite — the shopper registers the user later, on first shop, via `sil_register`.
+The bin is **non-interactive**: it executes an **already-assembled, already-endorsed**
+spec — it **never re-runs the interview** and never prompts. The sil **plugin** and sil
+**skill** are always wired — that is what makes it *sil-wired*. It is a standalone
+operator script, **not** the plugin process, so the plugin's "never write host config"
+guarantee holds; the bin legitimately drives `openclaw …` on your behalf.
 
-> The bin is a standalone operator script (the same class as the other shipped `sil-openclaw` operator bins), **not** the plugin process — so the plugin's `noChildProcess` / "never write host config" guarantee is intact; the bin legitimately drives the host `openclaw …` CLI on your behalf.
-
-## The profile spec (input) — the JSON the bin reads
-
-The endorsed draft feeds two stores. The **persona** becomes the host workspace **`SOUL.md`** (its identity / voice / standing rules — via the host CLI, **not** a sil artefact). The **shared user spec** becomes the sil data-dir artefact:
+## The spec (input)
 
 | Field | Meaning | Goes to | Required? |
 |---|---|---|---|
-| **agentId** | Lower-kebab id (e.g. `my-shopper`) → `agents.list[].id`. Unique, never `main`. | host | Required |
+| **agentId** | Lower-kebab id → `agents.list[].id`. Unique, never `main`. | host | Required |
 | **name** | Human-readable name ("My Shopper"). | sil manifest | Required |
-| **persona** | Who this shopper is and how it shops — a generalist, voice/tone, standing rules. | host **`SOUL.md`** (via host CLI — no `persona.md`) | Required (non-empty) |
-| **workspace** | The shopper's workspace directory (e.g. `~/.openclaw/workspace-my-shopper`). | host | Required for the non-interactive add |
-| **userSpec** | The user's **shared, cross-niche** facts + hard constraints (addresses, sizes, allergy/ethics rules, budget psychology). **Seeded partial** by the interview, then augmented per-query. | sil `user_spec.md` | **Required (non-empty)** |
-| **channel** | The communication channel the setup conversation is on (e.g. `telegram`) — bound to the new shopper so the user's next message reaches it. Populate it when you know the channel; the bin also falls back to the host's `OPENCLAW_MCP_MESSAGE_CHANNEL` on a live turn. | host `openclaw.json` `bindings[]` | **Optional (fail-open)** — absent/blank/unresolvable ⇒ manual-bind hint, never `invalid_request` |
+| **persona** | Who the shopper is / how it shops — a generalist, voice, standing rules. | host **`SOUL.md`** (no `persona.md`) | Required |
+| **workspace** | The shopper's workspace directory. | host | Required |
+| **userSpec** | The user's **shared, cross-niche** facts + hard constraints. Seeded partial by the interview. | sil `user_spec.md` | **Required** |
+| **channel** | The channel the setup conversation is on — bound to the new shopper. | host `openclaw.json` bindings | **Optional (fail-open)** |
 
-There is **no** per-niche input at create time. The deep `domainSpec`, the derived `intentSpec` schema, and the niche `playbook` are **not** authored here — they are researched and minted on first shop in each niche.
+There is **no per-niche input at create** — no `domainSpec` / `intentSpec` / `playbook`;
+those are minted lazily on first shop. The shopper reaches the web to mint and refresh
+domains, so the agent needs web/fetch tools (inherited from `agents.defaults`); if
+defaults grant none, the bin reports `created` with a `warnings` entry naming the gap
+(bare `sil_search` still works) — surface it.
 
-## The created shopper needs WEB tools
+## What the bin does atomically (in this exact order)
 
-The shopper **lazily mints a domain on first shop** (its research pass reaches the web) and **web-refreshes each domain spec on every query**. So the created agent must have **web/fetch tools in its tool profile** — inherited from `agents.defaults` when its shell is created. If `agents.defaults` does **not** grant a web tool, the bin reports **`created` with a `warnings` entry** naming the gap (bare `sil_search` still works, so it does **not** hard-fail) — it never silently swallows the gap and never pretends the research happened. Surface that warning to the user.
-
-## What the bin does atomically (the choreography it runs for you, in this exact order)
-
-1. **Validates the spec FIRST — before anything is written.** It checks `agentId` (present, lower-kebab, ≠ `main`), `name`, `persona`, `workspace`, and the **shared `userSpec` — present and non-blank** (the only sil artefact at create; seeded *partial* by the interview, never omitted). There is **no** `domainSpec` / `intentSpec` / `playbook` to validate here. On any failure it stops with **`invalid_request`** naming the field and **writes nothing**. This runs ahead of every host command, so a bad spec never reaches the host.
-
-2. **Singleton check — a user has exactly ONE shopper.** The bin runs `openclaw agents list --json` and reads the sil artefact store (the no-args `sil_profile_get` overview, `ok` empty-is-healthy when no shopper exists) **before** the add; if a sil shopper **already exists**, it stops with **`collision`** — **"a shopper already exists"** — and **does not** run `openclaw agents add`. That steers the user to **shop a new niche** (which lazily mints a domain on the spot) or **refine the existing shopper** — **never mint a second shopper**. An `agentId` that collides with any existing agent is likewise refused (`collision`) — never overwriting an existing agent's persona or wiring. If either read is **inconclusive** (a CLI error, a degraded store), the bin fails closed rather than fabricate a "no shopper" verdict.
-
-3. **Creates the agent shell (host CLI).** It runs:
-   ```
-   openclaw agents add <agentId> --workspace <workspace> --non-interactive --json
-   ```
-   This creates the real `agents.list[]` entry and the workspace bootstrap files (`SOUL.md`, `AGENTS.md`, …), inheriting model and **tool profile** (which must grant **web/fetch** — see above) from `agents.defaults`. `--non-interactive --json` drives it without a prompt.
-
-4. **Writes the persona into the workspace `SOUL.md` (host CLI).** The persona is the shopper's soul / system framing — the host's `SOUL.md`, **not** a sil artefact. The bin writes the endorsed persona text **straight into** the new agent's `SOUL.md`. There is **no** `persona.md` in the sil store and **no copy** step — the persona lives in exactly one place.
-
-5. **Materializes the shared user spec — NO `domain`.** The bin calls **`sil_profile_materialize`** with **`{ name, userSpec }`** — the shared `userSpec` seeded by the interview. The shopper is a singleton, so this takes **no `agentId`**. **With no `domain`** at create, the tool writes the shared **`user_spec.md`** + **`profile.json`** (with an **empty `domains: {}` map**) into the fixed **`$SIL_DATA_DIR/shopper/`**, atomically. There is **no** `domain_spec.md` / `intent_spec.md` / `playbook.md` yet — the first shop in a niche mints that niche's pack (with a `domain` object) lazily. On `invalid_request` it wrote nothing; on `persistence_failed` it left nothing partial.
-
-6. **Wires the sil skill + plugin (host CLI).** Asserted against the pinned host — **`alpine/openclaw:2026.6.9`** — both value-mode sets with `--strict-json` (the only set mode this image accepts):
+1. **Validate the spec FIRST** — `agentId` (present, lower-kebab, ≠ `main`), `name`,
+   `persona`, `workspace`, and the shared **`userSpec`** (present, non-blank — the only
+   sil artefact at create). No `domainSpec` / `intentSpec` / `playbook` to validate. Any
+   failure stops with **`invalid_request`** naming the field and **writes nothing**, ahead
+   of every host command.
+2. **Singleton check.** Run `openclaw agents list --json` and read the sil store (the
+   no-args `sil_profile_get` overview) **before** the add. If a sil shopper already
+   exists, stop with **`collision`** — **"a shopper already exists"** — and do **not** run
+   `openclaw agents add`; steer to shop-a-new-niche (lazy mint) or refine — **never mint a
+   second shopper**. An `agentId` clashing with any existing agent is likewise
+   `collision`. An inconclusive read fails closed.
+3. **Create the agent shell.** `openclaw agents add <agentId> --workspace <workspace>
+   --non-interactive --json` — the real `agents.list[]` entry + workspace bootstrap
+   (`SOUL.md`, `AGENTS.md`, …), inheriting model and tool profile from `agents.defaults`.
+4. **Write the persona straight into the workspace `SOUL.md`** (host CLI). The persona is
+   the shopper's soul — the host's `SOUL.md`, not a sil artefact. There is **no**
+   `persona.md` and **no copy** step.
+5. **Materialize the shared user spec — NO `domain`.** Call `sil_profile_materialize {
+   name, userSpec }` (the singleton takes no `agentId`). With no `domain`, it writes the
+   shared **`user_spec.md`** + **`profile.json`** with an **empty `domains: {}` map** into
+   `$SIL_DATA_DIR/shopper/`, atomically. No `domain_spec.md` / `intent_spec.md` /
+   `playbook.md` yet.
+6. **Wire the sil skill + plugin** (host CLI). Asserted against the pinned host
+   **`alpine/openclaw:2026.6.9`**, both value-mode sets with `--strict-json` (the only set
+   mode this image accepts):
    ```
    openclaw config set 'agents.list[<i>].skills' '["sil"]' --strict-json
    openclaw config set plugins.entries.sil.enabled true --strict-json
    ```
-   The skill **attach** makes the agent **know how** to drive the tools; the plugin **enable** turns the sil plugin **on** — but it does **not** by itself un-filter the `sil_*` tools (see the admission step next). `sil` stays in the agent's skill list and the `sil_*` tools are not denied.
+   The skill **attach** makes the agent know how to drive the tools; the plugin **enable**
+   turns sil on — but does not un-filter the tools by itself (next step).
+7. **Admit sil at the host allow surfaces.** Until sil is admitted at `plugins.allow` +
+   **`tools.alsoAllow`**, the host keeps the `sil_*` tools filtered. The value-mode `config
+   set` above is overwrite-only, so it cannot additively merge those shared arrays without
+   clobbering another admitted plugin (e.g. `klodi`). The bin runs the shipped admission
+   helper — the sibling bin `sil-openclaw-allowlist` (the `openclaw:allowlist` script) —
+   the additive, idempotent, self-validating three-surface merge. **If the helper exits
+   non-zero (a failed admission), the bin reports `persistence_failed` with the path +
+   cause and does NOT declare `created`** — never a green `created` over filtered tools.
+8. **Bind the current channel — FAIL-OPEN.** Resolve the channel (`spec.channel`, else the
+   host's `OPENCLAW_MCP_MESSAGE_CHANNEL`) and, if one resolves, run `openclaw agents bind
+   --agent <agentId> --bind <channel> --json`, then **verify** the route stuck (read-back +
+   `openclaw config validate` still passes). If undetermined, owned by another agent (no
+   `--force`), or unverifiable, revert any partial route and degrade to a manual-bind hint
+   in `warnings` — this step **never fails creation**.
+9. **Validate with the host's own check, THEN declare created.** `openclaw config validate
+   --json` returns `{ valid, path, issues? }` — success keys off **`.valid`**, never an
+   `ok` field. Only when `valid: true` **and** admission (step 7) succeeded does it report
+   **`created`**, carrying `boundChannel` (or `null`). Otherwise it reports
+   **`persistence_failed`** with the failing **path** + **cause**.
+10. **On any failure after writes begin, tear down** — restore the pre-run `openclaw.json`
+    snapshot (reversing the agent entry + skill + plugin + admission + any channel
+    binding), remove the workspace dir (only if it created it) and the singleton shopper
+    dir (only if it did not pre-exist). `persistence_failed` truthfully means **nothing
+    partial** is left. In the rare case teardown cannot fully revert, the bin reports a
+    distinct, louder outcome that **names the residue** — never voiced as "nothing partial".
 
-7. **Admits sil at the host allow surfaces — the shipped helper.** Enabling the plugin is necessary but not sufficient: until `sil` is admitted at the **global** allow surfaces `plugins.allow` + **`tools.alsoAllow`**, the host keeps the `sil_*` tools **filtered**. Admission is **plugin-ID only** — no per-tool key. The value-mode `openclaw config set` above is **overwrite-only** on this image, so it cannot additively merge those shared global arrays without clobbering another already-admitted plugin (e.g. `klodi`). The bin therefore runs the shipped admission helper — the sibling package `bin` `sil-openclaw-allowlist` (same artefact as the `openclaw:allowlist` script) — which performs the **additive, idempotent, atomic, self-validating** three-surface merge (`plugins.allow` + `tools.alsoAllow` + `plugins.entries.sil`). **If the helper exits non-zero (a failed admission), the bin reports `persistence_failed` with the path + cause and does NOT declare `created`** — never a green `created` over still-filtered tools.
+The bin emits **one** `{ status, … }` result and exits 0 **only** on `created`.
 
-8. **Binds the current channel to the new shopper — FAIL-OPEN, never a precondition.** It resolves the channel (`spec.channel`, else the `OPENCLAW_MCP_MESSAGE_CHANNEL` the host sets on the live turn) and, if one resolves, runs `openclaw agents bind --agent <agentId> --bind <channel> --json`, then **verifies** the route actually stuck — the bind verdict shows it applied with **no conflict**, the `openclaw agents bindings --json` read-back shows `<channel> → <agentId>`, **and** `openclaw config validate` still passes. A **verified** route means the user's next message on that channel reaches the new shopper with no manual bind or restart. If the channel is **undetermined**, already owned by **another agent** (there is no `--force` — the prior owner is left in place, never silently stolen), or the bind **cannot be verified**, the bin reverts any partial route and degrades to a **manual-bind hint** in `warnings` — it **NEVER fails creation**. This is the **one step that does not tear the create down**: it is a convenience, not a precondition.
-
-9. **Validates with the host's OWN check, THEN declares created.** The bin runs `openclaw config validate --json`. The verdict is `{ valid, path, issues? }` — success keys off **`.valid`**, never an `ok` field. Only when `valid: true` **and** the admission (step 7) succeeded does it report **`created`**, carrying `boundChannel` — the channel the route was **verified**-bound to, or `null` when nothing was bound. A channel is named **only** once the read-back + validate confirm it; issuing the bind write is not enough. If `valid: false`, the admission helper exited non-zero, or any step failed, it reports **`persistence_failed`** with the failing **path** + **cause** (the `issues?`).
-
-10. **On any failure after writes begin, tears down — leaving nothing partial.** The bin snapshots `openclaw.json` before step 3 and, on any failure, **restores that whole-file snapshot** (reversing the `agents.list` entry + the skill + the plugin + the trust admission **+ any verified channel binding** in one atomic op — the binding lives in `openclaw.json`, so the same snapshot reverses it for free), then removes the workspace dir (only if it created it) and the singleton shopper dir (only if it did not pre-exist). This returns the host to its **exact pre-run state** — a co-installed `klodi` that was trusted pre-run stays trusted — so `persistence_failed` truthfully means **nothing partial** is left.
-
-The bin emits **one** `{ status, … }` JSON result and exits 0 **only** on `created`.
-
-## Status taxonomy (agent-creation engine)
+## Status taxonomy
 
 | `status` | Meaning | What to do |
 |---|---|---|
-| `created` | Shopper added, shared user spec materialized, sil plugin + skill wired, `openclaw config validate` accepted it. Carries `name` + `agentId` + `workspace` + `boundChannel` (the verified-bound channel, or `null`). A manual-bind `warnings` entry rides here when the channel could not be auto-routed. | Tell the user it's ready and how to open it; if `boundChannel` is `null`, relay the manual-bind hint. |
-| `invalid_request` | Spec failed validation (missing/blank field). **Nothing attempted.** | Name the field, fix it, run the command again — nothing reached `openclaw agents add`. |
-| `collision` | A shopper already exists (the singleton), or the `agentId` clashes. **Nothing written.** | Surface it — "a shopper already exists"; steer to shop-a-new-niche (lazy mint) or refine. **Never mint a second shopper.** |
-| `persistence_failed` | A write, the allow-list admission helper (non-zero exit), or `openclaw config validate` step failed. Teardown ran — **nothing partial** left. | Fix the reported path/cause, run the command again (a re-run is safe). |
-
-In the **rare** case teardown itself cannot fully revert (e.g. the agent was added but reverting it fails), the bin reports a **distinct, louder** outcome that **names the residue** — do **not** voice that as `persistence_failed`'s "nothing partial"; tell the user exactly what remains and where.
+| `created` | Shopper added, shared user spec materialized, plugin + skill wired, `openclaw config validate` accepted it. Carries `name` + `agentId` + `workspace` + `boundChannel` (or `null`). | Tell the user it's ready; if `boundChannel` is `null`, relay the manual-bind hint. |
+| `invalid_request` | Spec failed validation. **Nothing attempted.** | Name the field, fix it, run again. |
+| `collision` | A shopper already exists (the singleton), or the `agentId` clashes. **Nothing written.** | Surface "a shopper already exists"; steer to shop-a-new-niche or refine. **Never a second shopper.** |
+| `persistence_failed` | A write, the allow-list helper (non-zero exit), or `openclaw config validate` failed. Teardown ran — **nothing partial** left. | Fix the reported path/cause and re-run (safe). |
 
 ## Runtime — how the shopper loads its behaviour
 
-When you (the sil skill) start a session as the shopper, the host has already injected the persona via the workspace **`SOUL.md`**. Then read `$SIL_DATA_DIR/shopper/profile.json` and load:
-- the **shared `user_spec.md`** — the person's cross-niche facts + hard constraints (seeded partial, augmented per-query), reused across **every** niche;
-- the slug-keyed **`domains`** map — the niches the shopper has already learned. An **empty** map is healthy; the per-domain packs (`domains/<slug>/{domain_spec,intent_spec,playbook}.md`) load **lazily at shop time**, not here.
-
-Loading these is what lets the shopper shop any niche with no further setup. When the user states a shopping intent, shop per [`shop_loop.md`](shop_loop.md) — the loop that classifies the niche, **reuses an existing domain or mints one on the fly**, then on **every query** web-refreshes that domain's spec, decomposes the request along its intent-spec dimensions (the ephemeral per-query intent), and **learns** every query (a fact → the shared `user_spec.md`, a taste → the active domain's `playbook.md`, each via a single `sil_remember` append). Because the `sil_*` tools were admitted at create, the shopper calls **`sil_search`** / **`sil_product_get`** (and `sil_register` / `sil_whoami` as needed) on the user's intent with **no further setup**, minting each niche's domain pack on the fly the first time the user shops it. To sharpen the shopper or one of its domains from observed sessions, see [`refine_shopper.md`](refine_shopper.md).
+When you (the sil skill) start a session as the shopper, the host has already injected the
+persona via **`SOUL.md`**. Then read `$SIL_DATA_DIR/shopper/profile.json` and load the
+shared **`user_spec.md`** (cross-niche facts + hard constraints, reused across every
+niche) and the slug-keyed **`domains`** map — an empty map is healthy; the per-domain
+packs load **lazily at shop time**. Because the `sil_*` tools were admitted at create, the
+shopper calls **`sil_search`** / **`sil_product_get`** (and `sil_register` / `sil_whoami`
+as needed) with **no further setup**, minting each niche on the fly the first time the
+user shops it, per [`shop_loop.md`](shop_loop.md). To sharpen the shopper or a domain, see
+[`refine_shopper.md`](refine_shopper.md).

--- a/sil-shopping/references/brainstorm_interview.md
+++ b/sil-shopping/references/brainstorm_interview.md
@@ -5,72 +5,93 @@ description: The two-touchpoint shopper onboarding — persona + shared user-spe
 
 # Set up your shopper — the onboarding interview
 
-When the user asks to **set up shopping** — "create my shopper", "set up an agent that shops for me", "I want something that shops for me" — do **not** jump to the engine. Run a short, **two-touchpoint** onboarding that shapes the shopper *with* the user — **pre-seeded from what they already said this session** — then **create nothing** until the user endorses the assembled draft. The agent-creation engine ([`agent_creation_engine.md`](agent_creation_engine.md)) only runs **after** that explicit endorsement.
+When the user asks to **set up shopping** — "create my shopper", "set up an agent
+that shops for me" — do **not** jump to the engine. Run a short, **two-touchpoint**
+onboarding that shapes the shopper *with* the user — **pre-seeded from what they
+already said this session** — then create nothing until the user endorses the
+assembled draft. The engine ([`agent_creation_engine.md`](agent_creation_engine.md))
+runs only **after** that explicit endorsement.
 
-This is a **conversation, not a form-fill** — and a **short** one. Because you **pre-seed** from the session, you open by **reflecting a filled draft back**, not with a cold question. The shopper is a **generalist**: it goes deep on whatever the user later buys, **lazily minting a domain on first shop in each niche**. So onboarding does **NOT** research any niche and does **NOT** ask the user to pick one. It touches exactly **two** things: the **persona** (how their shopper should behave) and a **shared user-spec seed** (cross-niche facts + hard constraints). Everything niche-specific — how to shop a niche well, what each request in it should resolve, the niche shopping taste — is **deferred to first shop**, not authored here.
+This is a **conversation, not a form-fill** — and a short one. The shopper is a
+**generalist**: it goes deep on whatever the user later buys, **lazily minting a
+domain on first shop** in each niche. So onboarding does **not** research any niche
+and does **not** ask the user to pick one. It touches exactly **two** things: the
+**persona** (how the shopper behaves) and a **shared user-spec seed** (cross-niche
+facts + hard constraints).
 
-## Session pre-seed — open with a reflected draft, never a cold question
+## Open with a reflected draft, not a cold question
 
-Before you ask anything, assemble a **draft** from what the user has **already said** *this session*: the **persona** (their own words on how the shopper should behave) and the **shared user-spec seed** (any sizes, hard limits, or ethics rules they mentioned in passing). Then **open by reflecting that draft back** — *"from what you've told me, here's the shopper I'd set up…"* — and ask only to **confirm-or-adjust**. That is the **rich** (a filled draft, so the shopper demonstrably listened) + **light** (one confirm) shape.
+Before asking anything, **pre-seed** a draft from what the user already said *this
+session*: the **persona** (their words on how the shopper should behave) and the
+**shared user-spec seed** (any sizes, hard limits, or ethics rules mentioned in
+passing). Then **open by reflecting that draft back** — *"from what you've told me,
+here's the shopper I'd set up…"* — and ask only to confirm-or-adjust. That is the
+rich (a filled draft) + light (one confirm) shape.
 
-- **Pre-seed, don't interrogate.** **Pre-fill** the persona + the shared `user_spec` from the session; ask only to fill genuine gaps, never to re-collect what the user already told you.
-- **Never invent facts you did not hear.** If the session gave little, seed a **minimal honest** draft ("cross-niche facts to be learned as we shop; no hard constraints stated yet") and say so — never fabricate a size or a limit.
-- **Session-only — local + offline.** The seed is assembled **only** from this conversation. It does **NOT** pull `sil_whoami`, reads **no** token, and makes no network call. (The shopper registers the user later, on first shop, via `sil_register` — never a prerequisite here.)
-- **The endorsement gate is untouched.** A rich pre-fill is a **proposal**, never consent — see the gate in §3 below.
+- **Pre-fill, don't interrogate.** Ask only to fill genuine gaps, never to re-collect
+  what the user already told you. If the session gave little, seed a **minimal
+  honest** draft ("cross-niche facts to be learned as we shop; no hard constraints
+  stated yet") and say so — never fabricate a size or a limit.
+- **Session-only — local + offline.** The seed is assembled **only** from this
+  conversation. It reads **no token**, does **not** pull `sil_whoami`, and makes **no
+  network call**. (The shopper registers the user later, on first shop.)
+- **The pre-fill is a proposal, never consent.** The endorsement gate below is
+  untouched.
 
-## The two onboarding touchpoints — persona + shared user spec
+## The two touchpoints
 
-A created shopper runs on a persona (`SOUL.md`) plus the **shared, agent-level `user_spec.md`**, both seeded here. The per-domain packs are minted lazily at shop time, not at onboarding.
+| Artefact | Where | What it holds |
+|---|---|---|
+| **`SOUL.md`** (persona) | host workspace | the shopper's voice / standing rules — a **generalist**, not a niche specialist |
+| **`user_spec.md`** (shared) | sil data dir (**required**) | the user's **cross-niche** facts + hard constraints (addresses, sizes, allergy/ethics rules, budget psychology) |
 
-| Artefact | Where | What it holds | Seeded |
-|---|---|---|---|
-| **`SOUL.md`** (persona) | host workspace (via host CLI) | the shopper's identity / voice / standing rules — a **generalist**, not a niche specialist | pre-seeded from the session (§1 below); refined on persona refine, stable per query |
-| **`user_spec.md`** (shared) | sil data dir (**required**) | the user's **cross-niche** facts + hard constraints (addresses, sizes, allergy/ethics rules, budget psychology) | pre-seeded partial from the session (§2); augmented every query, reused across **every** niche |
+The niche packs — the deep niche know-how, the per-request template, and the niche
+shopping taste — are **not authored here**; they are **minted lazily on first shop**
+in each niche ([`shop_loop.md`](shop_loop.md)). Never research a niche here.
 
-The niche packs — the deep niche know-how, the per-request template a query is resolved against, and the niche shopping taste — are **NOT** authored here; they are minted **on first shop in each niche** ([`shop_loop.md`](shop_loop.md)). The per-query fill (the template filled in for one request) is **ephemeral** — never persisted, never authored here.
+**1. Persona — reflect back, confirm.** Open by reflecting the session-seeded persona
+draft ("from what you've told me, your shopper sounds like…"), then confirm-or-adjust
+its **voice/tone** and any **standing rules**. This surfaces voice, **not a niche** —
+a generalist that shops whatever the user buys. It becomes the host workspace
+**`SOUL.md`** (no `persona.md`).
 
-## Principles for the interview
+**2. Shared user spec — seed the cross-niche facts + hard constraints.** Pre-fill the
+**shared user spec** from the session: **cross-niche** facts and any **hard
+constraints** that should hold in *every* niche — addresses / sizes, an allergy or
+ethics rule ("never leather"), a budget psychology. Reflect the seed back and mark
+each **hard** (inviolable) vs **soft** (bendable). Seed what the user offered; the
+rest is augmented per-query at shop time. This lands in `userSpec` (→ the shared
+`user_spec.md`). **No niche taste, no domain question, no intent dimensions** are
+gathered here.
 
-- **Pre-seed from the session; open with the draft.** Assemble the persona + shared user-spec draft from what the user already said, and lead with it (reflect-back), not a cold questionnaire. The interview is **rich but light** — a filled draft plus one confirm-or-adjust per touchpoint.
-- **Two touchpoints, no niche research.** Touch the persona and the shared user spec — that is the whole onboarding. The shopper is a **generalist**; there is **no narrow-the-niche step** and **no domain interview**. The deep niche expertise is researched **lazily, at first shop**, never interrogated here.
-- **The persona question shapes voice, not a niche.** The persona surfaces the **voice / standing rules** — terse vs. chatty, cautious vs. opinionated, any never-break rules. It does **not** bind the shopper to one niche.
-- **Seed the shared facts, ask little.** The shared user spec holds cross-niche facts + hard constraints that carry across every niche. Seed what the user volunteered — don't run a questionnaire; the rest is **augmented per-query** at shop time.
-- **Converge, don't accumulate.** Reflect a short summary back and get a yes/adjust before advancing. The flow is **collaborative** and **re-entrant** — the user can revise an earlier touchpoint at any point.
-- **Endorsement is a gate, not a formality.** Until the user explicitly says "create it", run **zero** engine steps. The draft lives only in the conversation.
+## Assemble + endorse
 
-## Run the interview in this order — two touchpoints
+- **Identity.** Propose an `agentId` (lower-kebab, `^[a-z0-9][a-z0-9-]*$`, never
+  `main`) and a `name` ("My Shopper" / `my-shopper`). Confirm both.
+- **Assemble + present.** Compose **`{ agentId, name, persona, userSpec }`** and
+  present a readable summary: who the shopper is and the seeded shared user spec
+  (partial, to grow per-query). Self-check the shape — `agentId` lower-kebab & ≠
+  `main`, non-blank `name`/`persona`, non-blank shared `userSpec` (the only sil
+  artefact at create). This writes nothing; the engine's validate-first step is the
+  authoritative gate.
+- **Endorse — the gate.** Ask for an explicit go-ahead ("shall I create your
+  shopper?"). Endorsement is an affirmative act on the assembled draft — "yes, create
+  it". It is **not** inferred from the last answer and **not** from silence. **Only on
+  that explicit endorsement** do you proceed to the engine
+  ([`agent_creation_engine.md`](agent_creation_engine.md)).
 
-### 1. `SOUL.md` — persona + behaviour (a generalist shopper), pre-seeded
+## Invariants (hold on every path)
 
-Open by **reflecting the session-seeded persona draft back** ("from what you've told me, your shopper sounds like…"), then confirm-or-adjust its **voice/tone** (terse vs. chatty, cautious vs. opinionated) and any **standing rules** it should always follow. Only ask the persona/identity question cold if the session gave you nothing to reflect. This is the shopper's **system framing**, a **generalist** that will shop whatever the user buys — **not** a niche choice; the niche is decided later, per query, when the user actually shops. This becomes the host workspace **`SOUL.md`** (the persona is the agent's system framing — **not** a sil artefact, no `persona.md`).
-
-### 2. `user_spec.md` (shared) — seed the cross-niche facts + hard constraints
-
-**Pre-fill** the **shared user spec** from the session: the user's **cross-niche** facts and any **hard constraints** that should hold in *every* niche — addresses / sizes the user volunteered, an allergy or ethics rule ("never leather"), a budget psychology. Reflect the pre-filled seed back and mark each as **hard** (inviolable — an allergy, an ethics rule, an age gate) vs **soft** (a bendable preference). Don't run a questionnaire — seed what the user offered; the rest is **augmented per-query** at shop time, and a niche-specific fact is learned when that niche is first shopped. If the user gave little, seed a minimal honest body (e.g. "cross-niche facts to be learned as we shop; no hard constraints stated yet") — non-blank, but partial. This lands in `userSpec` (→ the shared `user_spec.md`). **No niche taste, no domain question, no intent dimensions are gathered here** — those belong to first-shop lazy mint.
-
-### 3. Derive the identity, assemble, endorse
-
-- **Identity.** Propose an `agentId` (lower-kebab, `^[a-z0-9][a-z0-9-]*$`, never `main`) and a human-readable `name` ("My Shopper" / `my-shopper`). **Confirm both** — never silently invent them.
-- **Assemble + present.** Compose **`{ agentId, name, persona, userSpec }`** and present a **readable summary**: who the shopper is (its persona/voice + standing rules) and the **seeded shared user spec** (cross-niche facts + hard constraints, partial, to grow per-query). Self-check the shape against the engine's contract: `agentId` lower-kebab & ≠ `main` (it keys the host `openclaw agents add`, not the sil tool), non-blank `name`/`persona`, and a non-blank shared `userSpec` — the only sil artefact at create (the engine passes just `name` + `userSpec` to the singleton `sil_profile_materialize`; no niche pack is authored here). This is shape-only — it writes nothing; the engine's validate-first step is the authoritative gate.
-- **Endorse — the gate.** Ask for an explicit go-ahead ("shall I create your shopper?"). Endorsement is an **affirmative user act** on the assembled draft — "yes, create it" / "go ahead". It is **NOT** inferred from the user answering the last question, and **NOT** from silence. **Only on that explicit endorsement** do you proceed to the engine ([`agent_creation_engine.md`](agent_creation_engine.md)) and run the one command.
-
-## Edge cases the interview handles gracefully
-
-- **A shopper already exists (the singleton).** The shopper is a singleton — the engine refuses a second create (its `collision` outcome, "a shopper already exists") and never clobbers the existing one. Surface it and steer the user to **shop a new niche** (which lazily mints a domain on the spot) or **refine the existing shopper** — **never** mint a second shopper, never silently mutate the existing one.
-- **Abandon mid-flow.** Because **no engine step runs before endorsement**, abandonment leaves **nothing created** — no host agent, no artefacts, no wiring, no teardown. Never "save progress" by writing artefacts early.
-- **Creation is local + offline (for the user's identity).** Creating a shopper neither requires nor performs sil registration. Do **NOT** present sil registration or a token as a prerequisite to create the shopper; the session seed does **not** pull `sil_whoami`, reads no token, and never reaches the network. It registers the user later, on first shop, via `sil_register`. (No web access is needed at onboarding either — the niche research that reaches the web happens later, at first shop.)
-
-## Business rules (invariants the interview holds on every path)
-
-1. **No creation without explicit endorsement.** Nothing is written — not the host agent, the `SOUL.md`, the shared user spec, or the wiring — until the user explicitly endorses. The draft lives only in the conversation until then.
-2. **Abandon-mid-flow creates nothing.** No engine step runs pre-endorsement (**zero engine steps** before the explicit "yes"), so an abandoned interview leaves no partial shopper — automatic, not a teardown. Nothing is created, nothing partial.
-3. **Two touchpoints only — persona, then shared user spec.** `SOUL.md` (persona/voice, a generalist, NOT a niche) and the shared `user_spec.md` (cross-niche facts + hard constraints), both **pre-seeded from the session**. **No** niche know-how, no niche shopping taste, and no per-request template work at onboarding — those move to first-shop lazy mint.
-4. **No niche is researched or chosen at onboarding.** The shopper is a generalist; the deep niche know-how, the per-request template, and the niche shopping taste are minted **lazily, on first shop** in each niche ([`shop_loop.md`](shop_loop.md)). Onboarding never interrogates a niche or asks the user to pick one.
-5. **Converge each touchpoint before advancing; stay re-entrant.** Reflect-and-confirm per touchpoint; let the user revise an earlier one.
-6. **Singleton: refuse a second shopper; never clobber.** Defer to the engine's `collision` refusal ("a shopper already exists"); steer to shop-a-new-niche or refine.
-7. **Creation is local + offline for the user's identity.** Never present sil registration / a token as a prerequisite to create, and never pull `sil_whoami` to seed — the seed is session-only.
-8. **The persona is the host `SOUL.md`, not a sil artefact.** No `persona.md` in the sil store. The only sil artefact seeded at create is the **shared** `user_spec.md`; the niche packs (the deep niche know-how, the per-request template, the niche shopping taste) are minted later, per niche.
-
-## After endorsement
-
-Once the user has **explicitly endorsed** the assembled draft, proceed to [`agent_creation_engine.md`](agent_creation_engine.md) and run the **one command**. Until that explicit endorsement, **zero engine steps** have run.
+- **No creation without explicit endorsement.** **Zero engine steps** run before the
+  explicit "yes"; the draft lives only in the conversation. **Nothing is created**
+  until then, so an abandoned interview leaves no partial shopper.
+- **Two touchpoints only** — persona, then shared user spec, both pre-seeded from the
+  session. No niche is researched or chosen here; that is first-shop lazy mint.
+- **Converge each touchpoint before advancing; stay re-entrant** — the user can revise
+  an earlier touchpoint at any point.
+- **Singleton.** If a shopper already exists, the engine refuses a second create (its
+  `collision`, "a shopper already exists") — surface it and steer to shop-a-new-niche
+  or refine; never clobber the existing one.
+- **Local + offline for identity.** Never present sil registration or a token as a
+  prerequisite to create, and never pull `sil_whoami` to seed — the seed is
+  session-only.

--- a/sil-shopping/references/catalog_tools_reference.md
+++ b/sil-shopping/references/catalog_tools_reference.md
@@ -5,35 +5,28 @@ description: Per-tool behaviour of the four core sil tools (register, whoami, se
 
 # sil catalog + identity tools — per-tool behaviour and the shared status taxonomy
 
-Load this reference when driving any of the four core tools — `sil_register`,
-`sil_whoami`, `sil_search`, `sil_product_get`. It holds how each tool behaves and
-the status taxonomy every shopping tool shares. The router in `SKILL.md` names
-which tool an intent maps to; this reference is what that tool actually does.
+Load this when driving any of the four core tools — `sil_register`, `sil_whoami`,
+`sil_search`, `sil_product_get`. The router names which tool an intent maps to; this
+reference is what each does, plus the status taxonomy they all share. All four return a
+single JSON body carrying a `status`; prices are in the currency's ISO 4217 minor unit.
 
-All four return the canonical envelope: a single text content block whose JSON
-body carries a `status`. Prices are in the currency's ISO 4217 minor unit (e.g.
-cents).
+## Per-tool behaviour
 
-## How each tool behaves
-
-- **`sil_register`** starts browser-based registration. It returns promptly with
-  `status: "awaiting_browser"` and an `auth_url` — share that URL with the user.
-  The plugin polls in the background; once the user finishes signing in, call
-  `sil_register` again to confirm (it reports `already_registered`).
-- **`sil_whoami`** returns the registered user's identity (name and addresses).
-  An expired session token is refreshed transparently and the read retried; if the
-  session is fully dead, the result names the recovery (`sil_register`).
+- **`sil_register`** starts browser-based registration: it returns promptly with
+  `status: "awaiting_browser"` and an `auth_url` — share that URL. The plugin polls in
+  the background; once the user signs in, call `sil_register` again to confirm (it
+  reports `already_registered`).
+- **`sil_whoami`** returns the registered user's identity (name + addresses). An expired
+  token is refreshed transparently; a fully-dead session names the recovery
+  (`sil_register`).
 - **`sil_search`** returns a ranked list of purchasable variants (`id`, `title`,
-  `price`, `availability`, `checkout_url`, `source`), best match first — present
-  them in order, do not re-rank. An empty list means nothing matched: a normal
-  `ok` outcome, not an error. Use the returned `cursor` for the next page; its
-  absence means no more results (never infer end-of-results from page size).
-- **`sil_product_get`** is the lookup companion to `sil_search`. Pass ids already
-  held and get the matching products back with fresh detail (description, options,
-  the featured variant). Each variant carries an `inputs` list correlating it back
-  to the id(s) asked about (the response is NOT in request order). Ids that no
-  longer resolve come back in a `not_found` list — a normal partial-success
-  outcome, not an error; the other products are still valid.
+  `price`, `availability`, `checkout_url`, `source`), best match first — present in
+  order, do not re-rank. An empty list is a normal `ok` outcome, not an error. Use the
+  returned `cursor` for the next page; its absence means no more results.
+- **`sil_product_get`** is the lookup companion — pass ids you already hold and get the
+  matching products back with fresh detail. Each variant carries an `inputs` list
+  correlating it to the id(s) asked about (the response is not in request order). Ids
+  that no longer resolve come back in a `not_found` list — a normal partial success.
 
 ## Status taxonomy (shared across the shopping tools)
 
@@ -46,6 +39,6 @@ cents).
 | `invalid_request` | The query/ids were rejected (e.g. empty input). | Fix the input and call again — do NOT re-register. |
 | `retryable` | A transient network/5xx blip. | Try the same call again — do NOT re-register. |
 
-On a non-`ok` status, say what happened and follow the tool's own `recovery`
-hint — never improvise a different one (re-registering can't fix a bad query or a
-transient 5xx, and would derail the user).
+On a non-`ok` status, say what happened and follow the tool's own `recovery` hint —
+never improvise a different one (re-registering can't fix a bad query or a transient
+5xx).

--- a/sil-shopping/references/manage_domains.md
+++ b/sil-shopping/references/manage_domains.md
@@ -5,57 +5,73 @@ description: View or forget the shopper's learned domains — the two sil_profil
 
 # Manage your shopper's domains — view, forget
 
-Load this when the user wants to see what their **shopper** knows or **forget a domain** (a niche) — "what does my shopper know?", "which domains has it learned?", "show me the cycling domain", "forget the grocery niche". The router in `SKILL.md` names which `sil_profile_*` tool each intent maps to; this reference is what those tools do, plus the **two remove granularities** and the confirm-before-remove gate.
+Load this when the user wants to see what their **shopper** knows or **forget a domain**
+(a niche) — "what does my shopper know?", "which domains has it learned?", "show me the
+cycling domain", "forget the grocery niche". The router names which `sil_profile_*` tool
+each intent maps to; this reference is what those tools do, plus the **two remove
+granularities** and the confirm-before-remove gate.
 
-These are pure local-lifecycle operations over the two stores the create-engine established — **host config + workspace `SOUL.md` = wiring + persona; `$SIL_DATA_DIR/shopper/` = the shared user spec + per-domain packs**. No server call, no token read, no identity coupling: a shopper with zero domains still shops generically — the first shop in a niche mints it. The shopper is a **singleton**, scoped to the fixed `$SIL_DATA_DIR/shopper/` path, so these tools take **no caller `agentId`** — only an optional `domainSlug` to address one niche.
-
-**The source of truth for "what the shopper knows" is the sil artefact store, not the host agent list.** The directory `$SIL_DATA_DIR/shopper/` with a readable `profile.json` IS the shopper; its `domains` map is the niche index. A bare host `agents.list[]` entry without a `profile.json` is just a host agent, not ours to view/forget. Always read `profile.json`, **never the host agent list**, to decide what exists.
+These are pure local-lifecycle operations — no server call, no token read. The shopper is
+a **singleton** scoped to the fixed `$SIL_DATA_DIR/shopper/` path, so these tools take
+**no caller `agentId`** — only an optional `domainSlug`. **The source of truth is the sil
+artefact store, not the host agent list:** `$SIL_DATA_DIR/shopper/` with a readable
+`profile.json` IS the shopper; its `domains` map is the niche index. Always read
+`profile.json`, **never the host agent list**, to decide what exists.
 
 ## Match intent to a tool
 
 | Intent | Tool |
 |---|---|
-| "what does my shopper know?" / "which domains has it learned?" / "show me the shopper" (overview) | `sil_profile_get` (no `domainSlug` — the overview absorbs the old listing) |
+| "what does my shopper know?" / "which domains has it learned?" (overview) | `sil_profile_get` (no `domainSlug`) |
 | "show me / tell me about the &lt;niche&gt; domain" | `sil_profile_get` (pass the `domainSlug`) |
 | "forget / remove / delete the &lt;niche&gt; domain" | `sil_profile_remove` (pass the `domainSlug`) |
-| "decommission / tear down my whole shopper" | host CLI `openclaw agents remove <agentId>` **FIRST**, then clear the artefact tree (see the two granularities) |
+| "decommission / tear down my whole shopper" | host CLI `openclaw agents remove <agentId>` **FIRST**, then clear the artefact tree |
 
-## How the read tool behaves
+## How `sil_profile_get` reads the singleton shopper
 
-`sil_profile_get` reads the **singleton** shopper in two modes:
+- **No `domainSlug` (overview):** returns the `name`, the shared `userSpec` (cross-niche
+  facts + hard constraints), the **`domains` index** (each niche's `slug`/`name`/
+  timestamps — no bodies), plus any degraded directory in **`unreadable`**. A shopper
+  with **no domains yet still reads `ok`, empty index — healthy** (the first shop mints
+  one); so does an empty store ("you haven't set up a shopper yet" → point at create —
+  still `ok`, never `not_found`). Render a human summary (shopper, what it knows, domains
+  learned, wiring); a flat-layout leftover from the old one-agent-per-niche model reads
+  as `unreadable` — frame it as an old-model leftover, do not read it as a domain.
+- **With a `domainSlug`:** returns that niche's pack (`domainSpec` + `intentSpec` +
+  `playbook`) plus the shared `userSpec`. An unminted/unloadable domain returns
+  `not_found` (its `recovery` is the no-args `sil_profile_get`) — frame it plainly and
+  list what DOES exist. **Never surface a stack trace or a raw filesystem path.**
 
-- **No `domainSlug` (overview — the folded listing):** returns the shopper's `name`, the **shared `userSpec`** (the person's cross-niche facts + hard constraints), and the **`domains` index** (each niche's `slug`, `name`, `createdAt`, `updatedAt` — no per-domain bodies), plus any degraded directory in **`unreadable`**. A shopper **with no domains yet still reads ok, with an empty domain index — that is healthy, not an error** (the first shop in a niche mints it); so is an empty store ("you haven't set up a shopper yet" → point at create — it returns `ok`, never `not_found`). Render a human summary: the shopper, what it knows about the user (shared facts + hard constraints), the domains it has learned, and a wiring summary (a real host agent, sil plugin enabled, sil skill attached, ready with no further setup). A degraded/legacy directory lands in `unreadable` — mention it inline, but never let it hide the healthy state. (A flat-layout directory left over from the retired one-agent-per-niche model reads as `unreadable` — frame it as an **old-model leftover** and steer the user to re-create their shopper; do not try to read it as a domain.)
-- **With a `domainSlug` (one domain):** returns that niche's pack — `domainSpec` + `intentSpec` + `playbook` (the niche buying taste) **plus** the shared `userSpec`. Render the niche (from the domain spec), its decomposition dimensions, and the buying taste learned for it. An unminted/unloadable domain returns `not_found` (its `recovery` is `sil_profile_get`, the no-args overview) — frame it plainly ("no `<slug>` domain — here's what the shopper has learned") and list what DOES exist. **Never surface a stack trace or a raw filesystem path.**
+## The two remove granularities
 
-## The two remove granularities — forget a domain vs decommission the shopper
+Removal is **destructive and irreversible**, so **confirm before removing**: state
+exactly what will be deleted and proceed only on the user's **explicit go-ahead**. When
+ambiguous, ask.
 
-Removal is **destructive and irreversible**, so **confirm before removing**: state exactly what will be deleted and proceed only on the user's **explicit go-ahead**. There are **two distinct granularities** — pick the one the user means, and when ambiguous, ask:
+**Forget ONE domain (`sil_profile_remove`).** "forget the grocery niche", "remove the
+cycling domain", **"delete the grocery agent"** all mean **forget that one DOMAIN** — the
+niche pack only. The shopper, the shared user spec, and every **sibling domain survive**;
+no host wiring is touched. Call **`sil_profile_remove { domainSlug }`** — `domainSlug` is
+**REQUIRED**. A malformed/traversal/`main`/missing slug returns `invalid_request` and
+deletes nothing; an unregistered slug returns `not_found` (idempotent); a filesystem
+failure returns `persistence_failed`.
 
-### Forget ONE domain (the common case — `sil_profile_remove`)
-
-"forget the grocery niche", "remove the cycling domain", **"delete the grocery agent"** now mean **forget that one DOMAIN** — the niche pack only. The shopper, the **shared user spec**, and **every sibling domain survive**. This is the **artefact half only**, scoped to one niche; **no host wiring is touched** (the shopper agent stays):
-
-- Call **`sil_profile_remove { domainSlug }`** — `domainSlug` is **REQUIRED** (it never deletes the whole shopper). It removes exactly the one `domains/<slug>/` leaf and de-registers it from the manifest. A malformed/traversal/`main`/missing slug returns `invalid_request` and deletes nothing; an unregistered slug returns `not_found` (idempotent — safe to re-run); a filesystem failure returns `persistence_failed`.
-- After it, confirm the domain is gone and the shopper, the shared user spec, and its **sibling domains are untouched**.
-
-### Decommission the WHOLE shopper (the host-CLI-first path)
-
-"tear down my shopper", "decommission the whole thing" means remove the **entire shopper** — host wiring + `SOUL.md` + the whole artefact tree. This is the **host-CLI-first** flow, for the **whole agent** (not a single niche):
-
-1. **Existence check (read).** Run `openclaw agents list --json` and confirm the `agentId` is the sil-wired shopper.
-2. **Remove the host wiring (host CLI) — FIRST.** Run `openclaw agents remove <agentId>`, then `openclaw config validate --json` to confirm the host config is still valid. The plugin cannot write the host config, so this half is the host CLI's and runs ahead of the artefact removal.
-3. **Remove the sil artefacts — SECOND.** Clear the shopper's whole `$SIL_DATA_DIR/shopper/` tree (the shared user spec + every domain pack). `sil_profile_remove` is **per-domain** by design (its `domainSlug` is required), so decommissioning the shopper's full tree is the host-side concern, not a single tool call — remove each domain, or clear the shopper directory as part of the host teardown.
-
-**Never artefacts-first for the whole-shopper path.** The order is a safety decision: a failed artefact step after the host removal leaves only *residual artefacts with no host entry* — harmless disk cruft the no-args `sil_profile_get` still surfaces, so the user retries clean. The **reverse** is unsafe — artefacts gone, then a failed host step, leaves a *host entry whose `profile.json` is gone*: the agent still loads but the sil skill ENOENTs at runtime, a visibly broken shopper. Both halves are individually idempotent, so a re-run from any partial state converges to clean.
-
-Leave `plugins.entries.sil.enabled` alone on any removal — it is shared host state (the shopper depends on it), not per-domain. Even decommissioning the shopper leaves it enabled for a future re-create.
+**Decommission the WHOLE shopper (host-CLI-first).** Remove the entire shopper — host
+wiring + `SOUL.md` + the whole artefact tree: (1) `openclaw agents list --json` to
+confirm the `agentId`; (2) `openclaw agents remove <agentId>` then `openclaw config
+validate --json` — the plugin cannot write host config, so this half runs **first**; (3)
+clear the whole `$SIL_DATA_DIR/shopper/` tree. Host-first is a safety order: a failed
+artefact step after the host removal leaves only harmless residual artefacts, whereas the
+reverse leaves a host entry whose `profile.json` is gone — a visibly broken shopper. Both
+halves are idempotent. Leave `plugins.entries.sil.enabled` alone — it is shared host
+state for a future re-create.
 
 ## Status taxonomy (manage: view / remove)
 
 | `status` | Meaning | What to do |
 |---|---|---|
-| `ok` | A view returned the overview (a shopper's `domains` may be empty — normal; an absent shopper is still `ok`, empty-is-healthy) or one domain's detail. | Relay the data; on an empty domain index, say so plainly and point at "just shop a niche". |
-| `not_found` | No domain matches the `domainSlug` (view or remove). Its `recovery` is `sil_profile_get` (the no-args overview). | Frame it plainly and list what DOES exist; do NOT re-register. For remove, a re-run is safe (idempotent). |
-| `invalid_request` | The `domainSlug` was malformed, `main`, traversal-shaped, or (remove) missing. **Nothing was read or deleted.** | Fix the slug and call again — never a stack trace or raw path to the user. |
+| `ok` | A view returned the overview (a `domains` map may be empty — normal; an absent shopper is still `ok`) or one domain's detail. | Relay the data; on an empty index, point at "just shop a niche". |
+| `not_found` | No domain matches the `domainSlug`. Its `recovery` is the no-args `sil_profile_get`. | Frame it plainly and list what DOES exist; for remove, a re-run is safe. |
+| `invalid_request` | The `domainSlug` was malformed, `main`, traversal-shaped, or (remove) missing. **Nothing read or deleted.** | Fix the slug and call again — never a stack trace or raw path. |
 | `removed` | `sil_profile_remove` deleted exactly one domain pack. | Confirm that niche is gone; the shopper + shared user spec + sibling domains are untouched. |
 | `persistence_failed` | The domain directory could not be removed (the **path** + **cause** name what to fix). | Fix the data directory (writable), then remove again. |

--- a/sil-shopping/references/refine_shopper.md
+++ b/sil-shopping/references/refine_shopper.md
@@ -5,49 +5,93 @@ description: The refinement loop — sharpen the shopper or one domain from obse
 
 # Refine your shopper or one of its domains — the refinement loop
 
-When the user wants to **sharpen their shopper** — "refine my shopper", "the cycling domain keeps surfacing the wrong stuff, let's fix it", "amend what you know about me" — do **not** re-onboard from scratch and do **not** quietly mutate anything. Run this **targeted-amend** loop: load the relevant artefact, propose concrete refinements drawn from what the shopper actually **observed** in real shopping sessions, let the user **confirm a subset**, and persist **only** the confirmed subset by re-running the existing persist step. Nothing changes silently; nothing persists without the user's explicit confirmation.
+When the user wants to **sharpen their shopper** — "refine my shopper", "the cycling
+domain keeps surfacing the wrong stuff", "amend what you know about me" — do **not**
+re-onboard and do **not** quietly mutate anything. Run this **targeted-amend** loop:
+load the relevant artefact, propose refinements drawn from what the shopper actually
+**observed** in real sessions, let the user **confirm a subset**, and persist **only**
+the confirmed subset. Nothing changes silently; nothing persists without confirmation.
 
-Refine has **two targets** — pick the one the user means:
+Refine has **two targets**:
 
-- **The shopper itself** — the **shared `user_spec.md`** (cross-niche facts + hard constraints that carry across every niche), or the **persona** (the host `SOUL.md`).
-- **One domain** — a single niche pack (target it by **slug**): its `domain_spec.md` (niche mechanics), `intent_spec.md` (decomposition dimensions), or `playbook.md` (the niche buying taste).
+- **The shopper itself** — the **shared `user_spec.md`** (cross-niche facts + hard
+  constraints), or the **persona** (the host `SOUL.md`).
+- **One domain** — a single niche **domain pack**, targeted by **slug**: its
+  `domain_spec.md`, `intent_spec.md`, or `playbook.md`.
 
-This is a distinct capability from creating the shopper ([`agent_creation_engine.md`](agent_creation_engine.md), which CREATES) and from the shop-time loop (which SHOPS). The default is a **targeted amend**, not a full cold re-onboard. Run these steps **in order, top to bottom** — the order is the spec.
+This is distinct from creating the shopper
+([`agent_creation_engine.md`](agent_creation_engine.md)) and from the shop loop (which
+SHOPS). Run the steps **in order**.
 
-## The refinement loop (run in this exact order)
+## The refinement loop
 
-1. **Trigger + load the target.** Refinement starts only when the user **explicitly asks** to sharpen the shopper or a **named** domain. At the end of a session you MAY *offer* to refine — but that offer is a prompt only: it loads nothing, proposes nothing, and persists nothing until the user accepts and then clears the explicit confirm gate in step 3. An ambiguous, silent, or off-topic remark is **never** a trigger. Once triggered, load the relevant artefacts with **`sil_profile_get { domainSlug? }`**:
-   - To refine the **shopper**, load the **overview** (no `domainSlug`) — the shared `userSpec` + the domain index.
-   - To refine **one domain**, pass its **`domainSlug`** — its `domainSpec` / `intentSpec` / `playbook` bodies **plus** the shared `userSpec`.
-   The persona is the host workspace **`SOUL.md`**, read separately when a persona refinement is on the table. Everything you propose is grounded in what the shopper already is.
+1. **Trigger + load the target.** Refinement starts only when the user **explicitly
+   asks** to sharpen the shopper or a **named** domain. At session end you MAY *offer*
+   to refine, but that offer loads/proposes/persists nothing until the user accepts and
+   clears the confirm gate (step 3). Load with **`sil_profile_get { domainSlug? }`** —
+   the overview (no slug) for the shopper, or a `domainSlug` for one domain's pack (+
+   the shared `userSpec`). Read the persona from the host **`SOUL.md`** when it is on
+   the table.
+2. **Propose, session-grounded — never a generic template.** Propose a small set of
+   **concrete refinements drawn from the observed session** — what the shopper actually
+   saw. Each proposal names **which artefact element it changes** (a persona rule, a
+   shared `user_spec.md` fact/constraint, or — within one named domain — a
+   `domain_spec.md` mechanic, an `intent_spec.md` dimension, or a `playbook.md` taste)
+   **and the concrete observed evidence** (a param mapping that returned relevant vs
+   irrelevant items, a candidate accepted or rejected, a fact the user volunteered but
+   the spec never captured — "you said 'nothing over 8kg' three times" → a shared hard
+   constraint; "you kept asking about lug depth" → that domain's `domain_spec.md`).
+   Scope each correctly: a cross-niche fact/constraint or persona change targets the
+   **shopper**; a niche-mechanical change targets **one domain's** pack. The per-query
+   intent is ephemeral and never a refine target — only a domain's `intent_spec.md`
+   *schema* is. Every proposal cites its evidence; an ungrounded one is not proposed.
+3. **Confirm — the gate.** Present the proposals and let the user **confirm a subset** —
+   all, some, or none (per-proposal accept/reject). Confirmation is an explicit
+   affirmative act; it is **never inferred from silence**, and never from an
+   **off-topic** reply. Until the user confirms, the proposals live only in the
+   conversation. (This re-applies the create engine's endorsement discipline — see
+   [`brainstorm_interview.md`](brainstorm_interview.md); do not restate it here.)
+4. **Persist ONLY the confirmed subset — scoped to the right target.** Fold **only the
+   confirmed** proposals in and re-run the engine's persist step — refine is a
+   **whole-doc** path, so it uses **`sil_profile_materialize`** (not `sil_remember`):
+   - A **shared user-spec** change → **`sil_profile_materialize { name, userSpec }`**
+     with **no `domain`** — overwrites only the shared `user_spec.md`.
+   - A **domain** change → **`sil_profile_materialize { name, userSpec, domain: { slug,
+     name, domainSpec, intentSpec, playbook } }`** scoped to **that one slug** —
+     re-mints exactly that `domains/<slug>/` pack; siblings + the shared spec untouched.
+   - A **persona** change → refresh the workspace **`SOUL.md`** via the host CLI — a
+     persona refinement is a host-CLI `SOUL.md` re-write, **not** a
+     `sil_profile_materialize` call.
+   The re-materialize is an **atomic in-place re-write** (the store's idiom; do not
+   hand-roll a write). **On a persist failure the prior artefacts are left intact** —
+   never a half-refined shopper — and you tell the user the refinement did not stick.
+5. **Close the loop.** A later session loads the **updated** artefacts and behaves
+   accordingly. Refinement is iterative — a change that did not land is refinable next
+   time.
+6. **Isolation.** A domain refinement touches exactly that one `domains/<slug>/` pack —
+   **siblings and the shared user spec are untouched** unless the shared spec is the
+   target — and the profile-less path is untouched. One target's sharpening never leaks
+   into another.
 
-2. **Propose, session-grounded — concretely, never a generic template.** Propose a small set of **concrete refinements drawn from the observed session** — what the shopper actually saw in the just-completed (or in-progress) session. Each proposal must name **two things**:
-   - **which artefact element it changes** — a **persona** standing rule (the host `SOUL.md`), a **shared user-spec** fact or hard constraint (`user_spec.md` — e.g. a standing measurement, "never leather" as a hard constraint — carries across every niche), or, within **one named domain**, a **domain-spec** mechanic (`domain_spec.md`), an **intent-spec** dimension (`intent_spec.md`), or a **buying-taste** preference (`playbook.md` — a brand the user keeps rejecting in this niche, a tightened budget band); and
-   - **the concrete observed evidence behind it** — a `sil_search` param mapping that returned **relevant** vs **irrelevant** items, a question that turned out to matter (or was noise), a candidate the user **accepted** or **rejected**, or a fact/taste/constraint the user **volunteered but the spec never captured** (e.g. "you said 'nothing over 8kg' three times" → a shared `user_spec.md` hard constraint; "you rejected every leather option" → a shared hard constraint; "you kept asking about lug depth, which the cycling domain spec never covered" → that domain's `domain_spec.md` mechanic; "every cycling request turned on frame size, but its intent schema never decomposed on it" → that domain's `intent_spec.md` dimension).
+## Per-user + local
 
-   **Scope each proposal correctly:** a cross-niche fact/constraint or persona change targets the **shopper** (shared `user_spec.md` / `SOUL.md`); a niche-mechanical change targets **one domain's** pack. The **per-query intent** is ephemeral and is never a refine target — only a domain's `intent_spec.md` *dimension schema* is. Every proposal cites the observed evidence — it is **grounded**, not guesswork; a proposal not tied to anything the session showed is forbidden. (When the observed session is unavailable, do not invent one — see the fallback at the foot of this reference.)
+The improvement is **per-user and local**: written only to this user's sil data
+directory (`$SIL_DATA_DIR/shopper/`), on this machine. No server-side aggregation, no
+cross-user signal, no identity round-trip.
 
-3. **Confirm — the gate, before anything persists.** Present the proposals and let the user **confirm a subset** — all, some, or none (per-proposal accept/reject). Confirmation is an **explicit affirmative act** on specific proposals. It is **never inferred from silence**, and **never** from the user answering an **off-topic** / unrelated question. This is the strongest invariant of the loop, re-applying the create engine's endorsement discipline at refine time — *see [`brainstorm_interview.md`](brainstorm_interview.md) for the endorsement-gate discipline; do not restate it here.* Until the user confirms, the proposals live **only in the conversation**.
+## How a refinement reaches the params
 
-4. **Persist ONLY the confirmed subset — scoped to the right target.** Fold **only the confirmed** proposals into the right artefact, then re-run the engine's persist step over the matching target — refine is a **whole-doc path**, so it uses **`sil_profile_materialize`** (not `sil_remember`):
-   - A **shared user-spec** change (cross-niche fact / hard constraint) → **`sil_profile_materialize { name, userSpec }`** with **NO `domain`** — read the current shared `userSpec`, fold the confirmed change in, pass it back. This overwrites only the shared `user_spec.md`; no domain pack is touched.
-   - A **domain** change (a domain-spec mechanic, an intent-spec dimension, or a buying-taste preference for one niche) → **`sil_profile_materialize { name, userSpec, domain: { slug, name, domainSpec, intentSpec, playbook } }`** scoped to **that one slug** — read the current pack, fold the confirmed change into the relevant body, pass all three domain bodies (+ the unchanged shared `userSpec`) back. This re-mints exactly that one `domains/<slug>/` pack; sibling domains and the shared spec are untouched.
-   - A **persona** change → refresh the agent's workspace **`SOUL.md`** via the host CLI — the persona is the `SOUL.md`, not a sil artefact, so a persona refinement is a host-CLI `SOUL.md` re-write, **NOT** a `sil_profile_materialize` call.
-
-   The unconfirmed proposals are **discarded** with the conversation; nothing else persists. If the user confirms nothing, nothing changes. The re-materialize is an **atomic in-place re-write** of the targeted artefact(s) (the store's existing idiom; do **not** hand-roll a write under the sil data directory). **On a persist failure the prior artefacts are left intact** — the shopper is never served half-refined, and you tell the user the refinement **did not stick**. *Truthful failure-safety note: the re-write is per-file atomic and dir-preserving — a failed re-write never tears the shopper down and never serves a coherent half-refined pack (a broken manifest reads back as not-found, fail-closed). It is **not** a cross-file transaction; the safety property is "fails closed, prior state intact / never half-served", not "all files roll back together".*
-
-5. **Close the loop — the refined shopper reflects the kept changes on re-run.** A later session loads the **updated** artefacts (the same Runtime hook the engine documents) and behaves accordingly — the new shared hard-no, the deeper cycling domain spec, the sharper intent dimensions, the tightened niche taste. The improvement is durable: refinement is **iterative, never one-shot** — a change that did not land well is itself refinable next time.
-
-6. **Isolation — the targeted artefact only.** A domain refinement touches exactly that one `domains/<slug>/` pack — **siblings and the shared user spec are untouched** (unless the shared spec is the target). A shared-spec or persona refinement touches the shopper level and **no domain pack**. And the **generic, profile-less shopping path is untouched** (a plain sil session still shops exactly as today). One target's sharpening never leaks into another.
-
-## Privacy + scope — per-user and local
-
-The improvement is **per-user and local**: written only to this user's sil data directory (`$SIL_DATA_DIR/shopper/`), on this machine. There is **no server-side aggregation, no shared store, no cross-user signal** — the refine path calls **no server endpoint** and performs **no identity round-trip**. The shopper gets sharper for this user alone; nothing is pooled or shared.
-
-## How a refinement reaches the `sil_search` params
-
-A refinement to what the shopper searches on lands in an artefact — a shared fact in `user_spec.md`, or, within a domain, a mechanic in `domain_spec.md`, a dimension in `intent_spec.md`, or a taste in `playbook.md` — and those feed the **shop-time** mapping ([`search_param_mapping.md`](search_param_mapping.md)). The mapping maps **only onto real `sil_search` params** — a refined fact/taste with **no matching param** folds into the `query` text or the recommend-time rubric, **never an invented filter**. The `ship_to` rule is unchanged at refine time too: leave it empty (the server resolves the registered default) — no identity round-trip to populate it. **Do not restate the param table here** — point at [`search_param_mapping.md`](search_param_mapping.md).
+A refined fact / mechanic / dimension / taste lands in an artefact and feeds the
+**shop-time** mapping ([`search_param_mapping.md`](search_param_mapping.md)) — real
+`sil_search` params only; a refinement with no matching param folds into `query` or the
+rubric, never an invented filter. The `ship_to` rule is unchanged (leave it empty; the
+server resolves the registered default). **Do not restate the param table here** — point
+at [`search_param_mapping.md`](search_param_mapping.md).
 
 ## When there is no observed-session signal
 
-If the user asks to refine but **no observed session** is available — a fresh session, or the prior session is out of context — do **not fabricate** session observations to propose against. Fall back to a **guided amend**: ask the user what they want to change (and apply the same confirm-before-persist gate to whatever they describe), or **invite them to shop a session first** so the next refinement has real evidence to ground proposals in. Never invent observations.
+If the user asks to refine but **no observed session** is available (a fresh session, or
+the prior one is out of context), do **not fabricate** observations. Fall back to a
+**guided amend**: ask the user what to change (apply the same confirm-before-persist
+gate), or **invite them to shop a session first** so the next refinement has real
+evidence. Never invent observations.

--- a/sil-shopping/references/search_param_mapping.md
+++ b/sil-shopping/references/search_param_mapping.md
@@ -5,56 +5,75 @@ description: The shop-time answer→sil_search parameter mapping — real params
 
 # Answer→`sil_search`-param mapping (the mapping is real)
 
-Load this at shop time, when the shop loop maps a decomposed request into a `sil_search` call ([`shop_loop.md`](shop_loop.md) Step 4). The mapping must target the **real `sil_search` parameters** (the shopping loop's catalog tool, named in `SKILL.md`) and nothing else — never invent a filter. (Under SDS there is no stored "answer→param mapping" seller artefact — the niche knowledge of *what* to search on lives in the active domain's domain spec; this reference is the generic param table the mapping draws on.)
+Load this at shop time, when the shop loop maps a decomposed request into a
+`sil_search` call ([`shop_loop.md`](shop_loop.md) Beat 5). The mapping targets the
+**real `sil_search` parameters** and nothing else — never invent a filter.
 
-## The parameters available to map onto
+**The param catalog lives in the `sil_search` tool description** — the full list and
+their forms (`query`/`category`; `price_min`/`price_max` in the currency's ISO 4217
+minor unit; `condition` = `["new"]`/`["secondhand"]`; `available`; `local_merchants`;
+`ship_to` as ISO codes). Read it there; do not restate it here. Under SDS there is no
+stored "answer→param" seller artefact — *what* to search on for a niche lives in the
+active domain's `domain_spec.md`; this reference covers only the SDS layers that feed
+the mapping and the two rules the mapping must hold.
 
-| User's stated input | `sil_search` param it maps to |
-|---|---|
-| A budget ("under €1500", "€800–1200") | `price_min` / `price_max` — **in the currency's ISO 4217 minor unit** (cents): €1500 → `price_max: 150000` |
-| "Prefer secondhand" / "used is fine" | `condition: ["secondhand"]` |
-| "New only" | `condition: ["new"]` |
-| The narrowed niche + key descriptors | `query` (free text) and/or `category` |
-| "In stock only" (the default) / "show me out-of-stock too" | `available` (omit for in-stock default; `false` to include unavailable) |
-| "Buy from a local/domestic shop" | `local_merchants: true` (a best-effort ranking *bias*, not a hard filter — and *optionally*, to surface more local shops, issue the `query` in that country's language; a tactic, never an override of a language the user deliberately chose) |
+## What feeds the mapping — the SDS layers
 
-A stated taste with **no matching param** (e.g. "I like bold colours", "prefer eco-friendly brands") does **not** become a new param — fold it into the `query` text or into the recommendation rubric. There is no `color` filter, no `brand` filter; inventing one produces a shopper that emits invalid `sil_search` calls at shop time.
+The mapping reads several layers, not just the user's words for this request:
 
-## SDS mapping inputs — the decomposed intent, the shared user facts, the domain buying taste, the domain mechanics
+- The **decomposed per-query intent** (the active `intent_spec.md` filled for this
+  request — ephemeral) is most specific and wins for *preferences* (precedence
+  **intent > playbook(domain) > user_spec(SHARED) > domain_spec(domain)**).
+- The **shopping taste** (the active `playbook.md`) supplies standing preferences for
+  *this niche* — a budget band → `price_min`/`price_max` exactly like a freshly-stated
+  answer, but **never re-asked**. Taste is per-domain.
+- The **shared user spec** (`user_spec.md`) supplies standing **facts** and the **hard
+  constraints**, reused across **every** niche — a fact maps to a param like any answer.
+- The **domain spec** supplies the niche's decision-mechanics — which attributes are
+  load-bearing here — so the mapping knows what to map and what matters.
 
-Under [Spec-Driven Shopping](shop_loop.md), the mapping reads several layers, not only the user's words for *this* request:
+These layers are inputs to the same params, not new params. A stated taste with **no
+matching param** (a colour, a brand, "eco-friendly") folds into the `query` text or the
+recommendation rubric — **never a new filter**. There is no `color` or `brand` param;
+inventing one emits invalid `sil_search` calls.
 
-- The **decomposed per-query intent** (the active domain's `intent_spec.md` dimensions filled in for this request — ephemeral) is the most specific layer and wins for *preferences* (precedence **intent > playbook(domain) > user_spec(SHARED) > domain_spec(domain)**).
-- The **buying taste** (the active domain's `playbook.md`) supplies the user's standing preferences for *this niche* — budget band, brand likes/dislikes — these map to params (a budget band → `price_min`/`price_max`) exactly like a freshly-stated answer would, but are **never re-asked**. Taste is per-domain — it does not carry to another niche.
-- The **shared user spec** (`user_spec.md`) supplies the user's standing **facts** (a foot profile, a compatibility detail) and the **hard constraints**, reused across **every** niche — facts map to params like any stated answer; the stored value fills the param, never re-asked.
-- The **domain spec** (the active domain's `domain_spec.md`) supplies the niche's **decision-mechanics** — which attributes are load-bearing for *this* niche (last volume, rim depth, gearing range), so the mapping knows what to map and what matters.
+## Hard constraints — a real filter AND a reject-at-recommend rule, NEVER only `query`
 
-The param table itself is **unchanged** — these layers are inputs to the same mapping, not new params. A domain dimension, a standing user fact, or a taste with **no matching param** folds into `query`/rubric per the no-invented-filter rule above, exactly like any other non-param taste.
+A shared user-spec **hard constraint** ("never leather", "nothing over 8 kg", an
+allergy, an age gate) is **inviolable** in every niche. A hard constraint carried
+**only** as soft `query` text leaks — the catalog can still surface a violating item.
+Route each to **two** points, **not merely `query`** (see
+[`shop_loop.md`](shop_loop.md) Beat 5):
 
-## Hard constraints — route to a real filter AND a reject-at-recommend rule, NEVER only `query` text
+1. **A real `sil_search` filter where one exists** — "new/secondhand only" →
+   `condition`; "in stock only" → `available` (omit for the in-stock default). Where a
+   param matches, set it so the catalog never returns the violating item.
+2. **An explicit reject-at-pick rubric rule** for a constraint with no matching param
+   (no `material` filter for "never leather"): the constraint **rejects** any violating
+   candidate outright, never down-weights it. A hard constraint is a reject, not a
+   weight.
 
-A **shared user-spec hard constraint** ("never leather", "nothing over 8 kg", an allergy, an age gate) is **inviolable** in *every* niche — the shopper never recommends a violating item. A hard constraint carried **only** as soft `query` free text leaks: the catalog can still surface a violating product, and recommending it is a defect. So map every hard constraint to **two** enforcement points, **not merely `query`**:
+## `ship_to` stays EMPTY by default
 
-1. **A real `sil_search` filter where one exists.** "New only" / "secondhand only" → `condition`; "in stock only" → `available` (omit for the in-stock default). Where a param matches the constraint, set it so the catalog never returns the violating item at all.
-2. **An explicit reject-at-pick rubric rule** ([`shop_loop.md`](shop_loop.md) Step 6). For a constraint with **no matching param** (no `material` filter for "never leather"), the constraint becomes a rubric rule that **rejects** any violating candidate outright — **never recommend** it — rather than down-weighting it. A hard constraint is a reject, not a weight.
+Do **not** map the user's location onto `ship_to`, and do **not** call `sil_whoami` to
+populate it. When `ship_to` is absent, sil-api resolves the user's **registered default
+address** server-side. Set `ship_to` only to OVERRIDE the default with a *different*
+destination (e.g. "ship this to my office in Germany"). The shopper inherits
+location-aware search by construction — leave `ship_to` out.
 
-A hard constraint that lands **only** in `query` text is **not** enforced — it is a hint, not a filter, and the catalog may ignore it. Route it to a filter and a reject rule; the `query` text is at most an additional nudge, never the sole carrier of an inviolable constraint.
+## Worked example
 
-## `ship_to` stays EMPTY by default — inline rule (do not skip)
-
-Do **not** map the user's location onto `ship_to`, and do **not** instruct the shopper to call `sil_whoami` to populate it. When `ship_to` is absent, sil-api resolves the user's **registered default address** server-side. Set `ship_to` (a `{ country, region?, postal_code? }` object of ISO codes) **only** to OVERRIDE the default with a *different* destination than the registered address (e.g. "ship this to my office in Germany"). The shopper inherits correct location-aware search by construction — leave `ship_to` out, and never round-trip `sil_whoami` to fill it.
-
-## Worked param examples
-
-At shop time the mapping translates the decomposed intent + the stored facts/taste into concrete params. For a shopper's road-cycling domain whose user said (this request, plus a stored €1200 budget taste in that domain) "secondhand is fine, I'm in France and want local shops":
+For a road-cycling domain whose user said (this request + a stored budget taste in that
+domain) "secondhand is fine, I'm in France and want local shops":
 
 ```
-query:           "<niche descriptors from the answer>"   # e.g. "endurance road bike 105 groupset"
+query:           "endurance road bike 105 groupset"   # niche descriptors
 category:        "<the narrowed niche category>"
 price_max:       120000        # €1200 → minor units (cents)
-condition:       ["secondhand"]   # "secondhand is fine"
-local_merchants: true             # "want local shops" → ranking bias; optionally query in the local language (e.g. French) to surface more of them
-# ship_to: OMITTED — server resolves the registered default address; no sil_whoami round-trip
+condition:       ["secondhand"]
+local_merchants: true          # ranking bias; optionally query in French to surface more local shops
+# ship_to: OMITTED — server resolves the registered default address
 ```
 
-Budget → `price_max` (cents), "secondhand is fine" → `condition`, "want local shops" → `local_merchants: true`; `ship_to` left out so the server resolves the registered default. A non-param taste ("understated colours") folds into `query` or the rubric, never a new filter.
+A non-param taste ("understated colours") folds into `query` or the rubric, never a new
+filter.

--- a/sil-shopping/references/setup_onboarding.md
+++ b/sil-shopping/references/setup_onboarding.md
@@ -5,85 +5,64 @@ description: The one-time setup script the router defers to — the five-stage o
 
 # Setting up the shopper — the staged onboarding
 
-SKILL.md (the router) reads the stage from state and defers the **one-time setup
-script** to this file: the full five-stage progression, the after-register offer
-beat, and the per-search pitch. None of it applies once setup is complete — the
-router sheds it and routes straight to usage.
-
-Every stage is **read from state**, never guessed: `sil_whoami` (is there a sil
-identity yet?) plus the no-arg `sil_profile_get` overview (does a shopper exist —
-the `name` field — and does it hold any `domains`?). Present **only the current
-stage's beat and its single next step**, never the whole ladder at once.
+The router defers the **one-time setup script** here: the five-stage **progression**, the
+after-register offer, and the per-search pitch. None of it applies once setup is complete
+— the router sheds it. Read every stage from state, never guess: `sil_whoami` (is there a
+sil identity yet?) plus the no-arg `sil_profile_get` overview (does a shopper exist — the
+`name` field — and does it hold any `domains`?). Present **only the current stage's beat
+and its single next step**.
 
 ## The five-stage progression — present one stage, shed it on completion
 
-1. **Unregistered** — `sil_whoami` finds no sil identity. Guide the user to
-   register. **Before `sil_register` runs**, set the expectation: state plainly
-   what registering does and **how 4GPTs & sil use their data**, grounded strictly
-   in what this plugin does — no invented policy. Registering opens a sign-in link
-   in the default browser and creates their **sil identity** (name + saved
-   addresses, read back by `sil_whoami`), stored **locally** on this device; their
-   shopper's setup and anything it remembers live in a **local profile store**
-   under `$SIL_DATA_DIR`, never leaving the device via the plugin; catalog
-   **search** queries sil's product catalog. Next step: `sil_register`.
-2. **Registered, no shopper** — a sil identity exists, but no shopper yet. Bare
-   `sil_search` works now, though this is not the finished state. Guide the user
-   to **set up their shopper**: name up front, before the onboarding starts, that
-   it takes a **couple of minutes and a few questions**. The after-register offer
-   below owns the gate — it reads the store once and offers only on an empty one;
-   on a yes it runs the create two-step in SKILL.md.
-3. **Shopper, no domain yet** — `name` present, `domains: []` (no niche yet). The
-   first shopping intent **mints the first domain**, announced in the shopper's
-   voice with the inferred niche stated so the user can correct it. Next step:
-   state a shopping intent; the shopper-stage gate runs the forced mint.
-4. **Shopper active** — `name` present, `domains` non-empty. Check off the
-   completion **milestones**: the **first domain created** (the `domains` map is
-   now non-empty) and, softer, the memory tool has begun to be used (`sil_remember`
-   has stored a fact or taste). The memory milestone is a soft self-check, not a
-   shed gate — the overview cannot prove it, so judge it from whether this shopper
-   has ever remembered anything.
-5. **Setup complete** — a shopper with at least one domain. **Shed** every
-   onboarding beat: none of the stages above apply. **Show only how to use** the
-   plugin well — the domain-gated **shop loop** and **Spec-Driven Shopping**
-   ([`shop_loop.md`](shop_loop.md)).
+1. **Unregistered** — `sil_whoami` finds no sil identity. Before `sil_register` runs, set
+   the expectation: state plainly what registering does and **how 4GPTs & SIL use the
+   user's data**, grounded strictly in this plugin — no invented policy. Registering opens
+   a browser sign-in and creates their **sil identity** (name + addresses, read by
+   `sil_whoami`), stored **locally**; their shopper's setup and memory live in a **local
+   profile store** under `$SIL_DATA_DIR`, never leaving the device via the plugin; catalog
+   **search** queries sil's product catalog. Next: `sil_register`.
+2. **Registered, no shopper** — a sil identity exists, no shopper yet. Bare `sil_search`
+   works now, but is not the finished state. Guide the user to **set up their shopper**,
+   naming **up front, before the onboarding starts**, that it takes a **couple of minutes
+   and a few questions**. The after-register offer below owns the gate.
+3. **Shopper, no domain yet** — `name` present, `domains: []`. The first shopping intent
+   **mints the first domain**, announced with the inferred niche stated so the user can
+   correct it. Next: state a shopping intent.
+4. **Shopper active** — `name` present, `domains` non-empty. Check off the completion
+   **milestones**: the **first domain created** (`domains` now non-empty) and, softer, that
+   the memory tool has been used (`sil_remember` stored a fact or taste — a soft self-check
+   judged from whether this shopper has ever remembered anything).
+5. **Setup complete** — a shopper with at least one domain. **Shed** every onboarding beat:
+   none of the stages above apply. **Show only how to use** the plugin well — the
+   **domain-gated shop loop** and **Spec-Driven Shopping** ([`shop_loop.md`](shop_loop.md)).
 
 ## After register — offer to set up the shopper, once (offer_shopper)
 
 `sil_register` returns `already_registered` with `next_step: "offer_shopper"` on a
-confirmed registration (a fresh sign-in this session, or a returning session
-already signed in). That hint is a routing breadcrumb, not a decision — act on it
-by first running a **no-arg `sil_profile_get`** (the overview) to read shopper
-state, then branch:
+confirmed registration. That hint is a breadcrumb: first run a **no-arg `sil_profile_get`**
+(the overview) to read shopper state, then branch:
 
-- **Empty store — no shopper yet:** introduce the shopper in one short beat and
-  offer to set it up — name the value in its own terms: it shops each niche in
-  depth, reuses the sizes and hard limits it already knows so nothing is re-asked,
-  and explains why each pick fits. Only **on a yes**, load
-  [`brainstorm_interview.md`](brainstorm_interview.md) — the two-touchpoint
-  onboarding, never a form. Take no for an answer: bare `sil_search` stays a
-  first-class path, so don't re-offer in the same turn.
-- **A shopper already exists:** **skip this beat** entirely. The shopper is a
-  **singleton** — never offer a second one.
+- **Empty store — no shopper yet:** introduce the shopper in one short beat and offer to
+  set it up — name the value (it shops each niche in depth, reuses the sizes and hard
+  limits it already knows so nothing is re-asked, explains why each pick fits). Load
+  [`brainstorm_interview.md`](brainstorm_interview.md) **only if the user accepts** (a
+  yes). Take no for an answer; bare `sil_search` stays first-class.
+- **A shopper already exists:** **skip this beat** entirely. The shopper is a **singleton**
+  — never offer a second one.
 
 ## After a bare search — the per-search pitch (post-result)
 
-When a plain `sil_search` **completes with status `ok`** in a **profile-less**
-session, present the results best-first exactly as they came back, then append
-**one short trailing line** naming what a shopper would add on top. It is never a
-pre-search question and never a re-rank: bare search stays a legitimate quick
-lookup, and these are the same results a shopper would start from.
+When a plain `sil_search` **completes with status `ok`** in a **profile-less** session,
+present the results best-first **exactly as they came back**, then append **one short
+trailing line** naming what a shopper would add. It is never a pre-search question and
+never a re-rank. Name one or two of the three levers, rotating which you lead with:
 
-Name one or two of the three levers a bare search leaves on the table, and rotate
-which you lead with so the recurring line stays fresh:
-
-- **niche depth** — a shopper weighs these picks against how the niche actually
-  buys, in depth, instead of just listing them;
+- **niche depth** — a shopper weighs these picks against how the niche actually buys;
 - **memory** — it keeps your sizes and hard limits on file, so no search re-asks them;
-- **the why** — it explains which pick fits you and why, instead of a flat list.
+- **the why** — it explains which pick fits you and why.
 
-This line **recurs on every** completed profile-less search — the recurrence is
-the point; there is **no fire-once or seen-it gate, and no cooldown**. Brevity
-plus lever rotation are all that keep it from nagging. Exactly two things suppress
-it: a **shopper already exists** (that session is the shopper's — **drop the
-line**), or the search **did not complete `ok`** (a non-ok status carries its own
-recovery — follow that and add no tip).
+This line **recurs on every** completed profile-less search — the recurrence is the point;
+there is **no fire-once or seen-it gate, and no cooldown**. Brevity plus lever rotation
+keep it from nagging. Two things suppress it: a **shopper already exists** (that session is
+the shopper's — **drop the line**), or the search **did not complete `ok`** (a non-ok
+status carries its own recovery — follow that and add no tip).

--- a/sil-shopping/references/shop_loop.md
+++ b/sil-shopping/references/shop_loop.md
@@ -1,141 +1,164 @@
 ---
 name: shop-loop
-description: The Spec-Driven Shopping loop — the shopper shops any niche, minting domains on the fly, over a five-beat spine. Load when running as the shopper and the user states a shopping intent.
+description: The Spec-Driven Shopping loop — the one shopper shops any niche, reusing or minting a domain on the fly, then decomposing the request and learning from it. Load when running as the shopper and the user states a shopping intent.
 ---
 
-# Shop-time loop — how the one shopper shops any niche, minting domains on the fly
+# Shop-time loop — how the one shopper shops any niche
 
-Load this when you (the sil skill) are running as the user's **shopper** and they state a shopping intent ("find me something for a steak dinner around $40"). There is **ONE shopper** — a generalist that goes deep on whatever the user shops for — and it holds **many domains** (niches it has learned), each **minted lazily on first shop**. The [engine's Runtime hook](agent_creation_engine.md) ends where this loop begins: the host has injected the shopper's persona via the workspace **`SOUL.md`** (voice, standing rules, hard-no's), and the sil skill has read `$SIL_DATA_DIR/shopper/profile.json` — the **shared `user_spec.md`** (the person's cross-niche facts + hard constraints) plus the slug-keyed **`domains`** map. The per-niche packs load lazily, at shop time, per the beats below.
+Load this when you (the sil skill) run as the user's **shopper** and they state a
+shopping intent. There is **one shopper** — a generalist holding **many domains**
+(niches), each **minted lazily on first shop**. The [engine's Runtime
+hook](agent_creation_engine.md) leaves you here: the persona is injected via
+**`SOUL.md`**, and the skill has read the shared **`user_spec.md`** (cross-niche facts +
+hard constraints, reused across every niche) plus the slug-keyed **`domains`** map from
+`$SIL_DATA_DIR/shopper/profile.json`.
 
-This is **shop time**, not create time — behave like a specialist the user trusts, in the persona's voice. Consume the catalog tools **unchanged**; the rubric is applied by you at reasoning time, not by any new tool.
+This is **Spec-Driven Shopping (SDS)**: a fact from niche A is reused in niche B without
+being re-asked, while each domain's **`domain_spec.md`** (deep niche expertise),
+**`intent_spec.md`** (decomposition schema), and **`playbook.md`** (the **shopping
+taste**) stay niche-scoped — taste does not leak, only shared facts carry. Behave like a
+specialist in the persona's voice; apply the rubric at reasoning time, not via a new tool.
 
-This is **Spec-Driven Shopping (SDS)** over **one shopper, many domains**. The **shared `user_spec.md`** carries the person across *every* niche — a fact learned while shopping niche A is reused in niche B **without being re-asked**. Each domain's pack is scoped to that niche: **`domain_spec.md`** (deep researched niche expertise), **`intent_spec.md`** (the decomposition-dimension schema), and **`playbook.md`** (the **shopping taste** for *this* niche). **Taste does not leak across domains** — a price band or brand leaning learned in A lives in A's playbook, never B's; only the shared facts and cross-cutting values carry.
+## The five beats — run every query, in order
 
-The router's three always-on rules still hold (act-don't-narrate, follow the tool's own `recovery`, re-check the chosen item before commit) — this loop layers on top, it does not restate them.
+A beat only **asks** when something is genuinely unresolved; a fully-resolved query asks
+nothing and passes straight through.
 
-**The router owns the entry gate; this file is the procedure it hard-routes into.** A reference binds only once it is loaded, so a shopper-present session's non-skippability is enforced **upstream, at the routing fork** — the stage gate in `SKILL.md` reads `sil_profile_get`, sees a shopper, and routes every `sil_search`-driven intent here before any bare search can run. Beat 1 below is that domain check as the *procedure to execute*, not the mechanism that catches a skip — the skip is already foreclosed by the always-loaded router.
+1. **Domain-exists check** — classify the niche, reuse a matching domain or register a miss.
+2. **Learn on a miss** (or refresh on a hit) — the pack is present and current before you search.
+3. **Gather what's missing before searching** — resolve each dimension, then ask only what's unresolved.
+4. **Persist what surfaced** — a single `sil_remember` per new fact or taste.
+5. **Search → rubric → recommend-with-why → re-fetch before purchase.**
 
-## The five-beat spine — the order IS the spec, non-skippable on every query
+## Beat 1 — Domain-exists check
 
-Every shopping query runs these five beats **in order**; the order is not a suggestion. "Non-skippable" governs your **reasoning**, not the user's inbox — every beat RUNS every query, but a beat only ASKS the user when something is genuinely unresolved (a fully-resolved query asks nothing and passes straight through):
+Name the **shopping niche** this request belongs to ("a waterproof trail shoe for a wet
+ultra" → trail running) — your reasoning, no tool call. Then read `profile.json.domains`
+(via the no-args `sil_profile_get`) and match the niche **semantically, not by exact
+string**. If a domain covers it, **reuse it** and go to the gate. **Reuse-before-mint**
+is the shop loop's job: the store enforces only shape, so without **semantic dedup** the
+shopper fragments into duplicate thin packs (`cycling`, `road-cycling`,
+`bikes` for one niche). Torn between a close existing slug and a new one, prefer the
+existing. No match ⇒ register a **miss** for Beat 2.
 
-1. **Domain-exists check first** — classify the query's niche, read `profile.json.domains` (via the no-args `sil_profile_get`), reuse a semantically-matching domain or register a miss. This precedes search — the shopper never reaches search without first resolving which domain the query belongs to.
-2. **Learn the domain on a miss** — mint the domain on the fly (deep `domain_spec` + derived `intent_spec` + partial `playbook`), or web-refresh it on a hit. Either way the pack is present and current before the gate; the shopper never searches a niche it does not hold.
-3. **Gather what's missing from the user, before searching** — the elicitation gate: decompose the request, resolve each dimension against the request + the shared `user_spec` + the active `playbook` (+ `domain_spec` defaults) FIRST, then ask **only for what is genuinely unresolved**. Runs to completion before any `sil_search`.
-4. **Persist what surfaced** — append each surfaced fact/taste with a single `sil_remember`, fired only when something new surfaced.
-5. **Then search → rubric → recommend-with-why → re-fetch before purchase.**
+## Beat 2 — Learn the domain (mint on a miss, refresh on a hit)
 
-## Beat 1 — Domain-exists check first (every query, non-skippable)
+**On a miss — mint the domain on the fly, announced.** Tell the user, in the shopper's
+voice — **never silently** — that this is a new niche ("I haven't shopped cycling for
+you yet — setting that up"), and **state the inferred niche so the user can correct it**.
+**Research** it (web + knowledge) into a **deep `domainSpec`** (a shallow bullet list a
+layperson could write fails the SDS bar), derive the **`intentSpec`** dimensions, and
+seed a partial **`playbook`**. No web tool? Say so and compose from public knowledge —
+never present a guess as verified research. Persist with the **whole-doc**
+**`sil_profile_materialize { name, userSpec, domain: { slug, name, domainSpec,
+intentSpec, playbook } }`** — the deduped slug from Beat 1, `userSpec` re-persisted
+atomically alongside. One atomic call upserts `domains[slug]`. Never `sil_remember`.
 
-Before anything else, decide *which domain this query belongs to* and make sure the shopper holds it. No agent switch and no re-onboarding ever happens here — the **one** shopper handles every niche in the same session. This check is **non-skippable**: the shopper never reaches search without first resolving the domain.
+**On a hit — web-refresh the active domain's `domain_spec.md`** so it stays current, and
+persist by re-running `sil_profile_materialize` with the `domain` object carrying the
+fresh `domainSpec`. A real web step — no web tool? Say so and proceed on the existing
+spec; never pretend the refresh happened.
 
-### Classify the query's niche (skill reasoning — no tool call)
+## Beat 3 — Gather what's missing before searching
 
-From the user's words, name the **shopping niche** this request belongs to ("a waterproof trail shoe for a wet ultra next month" → trail running; "a first road bike" → road cycling). This is your own reasoning, not a tool call — you need the niche to decide whether the shopper already knows it.
+Runs to completion **before any `sil_search`**. Read the active `intent_spec.md`
+dimensions and fill them for **this** request ("a waterproof trail shoe for a wet ultra,
+around €160" → use-case: trail/ultra; weather: wet; budget: ~€160). This filled
+**per-query intent** is **ephemeral** — it lives only in this conversation and is
+**never persisted**; only the `intent_spec.md` *schema* is stored.
 
-### Reuse an existing domain before minting — semantic slug dedup is YOUR job
-
-Read `profile.json.domains` (via the no-args `sil_profile_get`) and match the classified niche against the slugs the shopper already holds **semantically — not by exact string**. If an existing domain covers this niche, **reuse it**: load that pack and go straight to the gate. The store enforces only *shape* (valid kebab, upsert-by-key) — it will happily mint `cycling`, `road-cycling`, and `bikes` as three thin packs for the **same** niche. **Reuse-before-mint is the shop loop's job**, load-bearing: without it the one shopper fragments into duplicate shallow domains and the "shop deep" promise dies. When torn between a close existing slug and a new one, **prefer the existing slug** — reuse over fragment. When no existing domain matches, register a **miss** — and learn it in Beat 2.
-
-## Beat 2 — On a miss, learn the domain and how SDS decomposes in it
-
-The pack must be present **and current** before the gate. On a **miss**, mint the niche on the fly — the research that used to run at create time runs **here, on first shop in this niche**. On a **hit** (a reused domain), the parallel web-refresh keeps that domain's spec current. Either way the shopper never searches a niche it does not hold-and-currently-know.
-
-### On a miss — mint the domain on the fly, announced
-
-When no existing domain matches, mint the niche **on the spot**:
-
-- **Announce it — never silently.** Tell the user, in the shopper's voice, that this is a new niche ("I haven't shopped cycling for you yet — setting that up"). **State the inferred domain so the user can correct it** before it is used; a mis-inferred niche is the user's to fix.
-- **Research the niche (web + knowledge).** Pull how to shop well in this niche deeply — its decision-attributes and mechanics — into a **deep `domainSpec`** (a shallow bullet list a layperson could write fails the SDS bar). Derive the **`intentSpec`** decomposition dimensions **from** that domain spec (agent-specific, a *schema* not a filled instance). Seed a *partial* **`playbook`** — the niche shopping taste, an honest non-blank "to be learned as we shop" body. If you lack a web tool, say so and compose the domain spec from well-established public shopping knowledge — never present a guess as verified research.
-- **Persist with the whole-doc `sil_profile_materialize` — WITH the `domain` object.** Call **`sil_profile_materialize { name, userSpec, domain: { slug, name, domainSpec, intentSpec, playbook } }`** — the **deduped slug** from Beat 1, the deep `domainSpec`, the derived `intentSpec`, the partial `playbook`; `userSpec` is the current **shared** spec (the call re-persists it atomically alongside). One atomic call upserts `domains[slug]`. This is a **whole-doc path** (see Beat 4 + the cheap/heavy split) — `sil_profile_materialize`, **never** `sil_remember`.
-
-### On a hit — web-refresh the active domain's spec
-
-Before decomposing the request, go to the **web** and **enhance the active domain's `domain_spec.md`** so it stays current (new models, standards, prices, technique). Fold what you learn in and **persist** it by re-running **`sil_profile_materialize`** **with** the `domain` object carrying the updated `domainSpec` for this slug (the in-place re-mint — the same atomic store path the entry-mint and refine use). This is a **real web step** — if the host has no web/fetch tool, say so honestly and proceed on the existing domain spec; never pretend the refresh happened.
-
-## Beat 3 — Gather what's missing from the user, before searching (the elicitation gate)
-
-This is the promoted gate — a first-class, ordered step, **not** a clause folded inside the domain or the persist beat. It runs to completion **before any `sil_search`**: decompose the request, resolve each dimension against everything already known, then ask the user **only for what is genuinely unresolved**. It always RUNS; it asks only when something is missing.
-
-### Decompose the request along the intent-spec dimensions (ephemeral — NEVER persisted)
-
-Read the active domain's `intent_spec.md` — the decomposition **dimensions** a good query must resolve — and **fill them in for *this* request** from the user's words ("a waterproof trail shoe for a wet ultra next month, around €160" → use-case: trail/ultra; weather: wet; budget: ~€160; timeline: next month). State the filled decomposition back so the layering is legible. This filled instance is the **per-query intent** — **ephemeral**: it lives only in this conversation and is **NEVER persisted**. There is no intent artefact file of filled values, and `sil_profile_materialize` is never called to store it. Only the `intent_spec.md` *schema* is persisted; the fill is throwaway.
-
-### Resolve each dimension, then elicit ONLY what is genuinely unresolved
-
-For each decomposition dimension, **resolve it FIRST against — in order — the request's own words, the shared `user_spec` (standing facts + hard constraints, reused across every niche), the active `playbook` (this niche's standing taste), and any defensible `domain_spec` default.** Only then elicit, and elicit **only what is genuinely unresolved**. A dimension is genuinely unresolved, and *only then* asked, when it is **BOTH**:
-
-- **load-bearing** — the active `domain_spec` / `intent_spec` marks it as materially changing the recommendation in this niche (not asked for completeness's sake), **AND**
-- **still unfilled** after the resolve above — the request did not state it, and neither the shared `user_spec` nor the active `playbook` nor a domain default supplies it.
-
-Elicitation is **need-driven**: only a dimension **missing** from BOTH the request AND the stored side is elicited — ask **only for what** a defensible pick actually needs, in the persona's voice, one or a few questions at a time, each tied to *why* the pick needs it — **never a battery**, never a form or questionnaire. An attribute the shared `user_spec` or the active `playbook` **already holds is never re-asked** — the stored value fills it silently; re-asking a known fact or taste is the exact defect this spine kills. When the request plus the stored side already carry every load-bearing dimension, **ask nothing and pass straight through** to Beat 5 — the gate is **bounded**, it does not hold the user hostage for perfect completeness. Elicitation gates search **quality, not access**: if the user skips or can't answer an elicited question, proceed on the **best defensible params**, state what you assumed, and never block shopping — a declined question narrows quality, never a dead-end.
+Resolve each dimension against — in order — the **request**, the shared **`user_spec`**,
+the active **`playbook`**, and any defensible `domain_spec` default. Then **elicit only
+what is genuinely unresolved** — a dimension the `domain_spec`/`intent_spec` marks
+**load-bearing** *and* still unfilled. Ask in the persona's voice, a few at a time, each
+tied to *why* — never a battery. A stored attribute is never re-asked. When everything
+load-bearing is covered, **ask nothing and pass straight through** to Beat 5. If the user
+skips a question, proceed on the best defensible params and state what you assumed — a
+declined question narrows quality, never access.
 
 ## Beat 4 — Persist what surfaced (fact → shared user spec, taste → active domain)
 
-When the gate surfaces a new user **fact** (a measurement, a compatibility detail, a hard constraint) or a new **shopping taste** for this niche (price sensitivity, brand leaning), persist it with a **single `sil_remember` call** — fired **only when something new surfaced** — so a future query fills it from the store instead of re-asking:
+When the interaction surfaces a new user **fact** or **shopping taste**, persist it with
+a **single `sil_remember`** — fired **only when something new surfaced**:
 
-- A **fact / measurement / hard constraint** → **`sil_remember { kind: "fact", text, hard? }`** — the **cheap append** that adds one entry to the **shared** `user_spec.md` *without* re-emitting the whole doc. A fact carries across **every** niche (it never takes a `domain`). Mark a true, never-break rule ("never leather", "nothing over 8 kg", an allergy, an age gate) with **`hard: true`** so it appends as an inviolable constraint the reject-at-pick rule can grep; a bendable fact is a plain **soft** entry.
-- A **shopping-taste preference** (budget band, brand likes/dislikes) → **`sil_remember { kind: "taste", text, domain }`** — one entry appended to **this niche's** `playbook.md`, the **active domain**. Pass the active domain's `domain` slug whenever the shopper holds more than one niche (with 2+ domains, omitting it is ambiguous and rejected). Taste is always **soft** — never `hard` — and is **scoped to this domain**: it shapes this niche's picks only, never another's.
+- A **fact / measurement / hard constraint** → **`sil_remember { kind: "fact", text,
+  hard? }`** — the cheap append to the **shared** `user_spec.md`. A fact carries across
+  every niche (no `domain`). Mark a never-break rule (an allergy, an ethics rule, an age
+  gate) with **`hard: true`**; a bendable fact is a soft entry.
+- A **shopping taste** (budget band, brand leaning) → **`sil_remember { kind: "taste",
+  text, domain }`** — one entry to **this niche's** `playbook.md`, the **active domain**.
+  Pass the active `domain` slug (with 2+ domains, omitting it is rejected). Taste is soft
+  and scoped to this domain.
 
-**`sil_remember` is THE per-query persist verb** for a freshly surfaced fact or taste — the lightweight append the shopper takes *every query*, so rich information from the interaction is never lost under load. Reserve the **whole-doc `sil_profile_materialize`** round-trip for the heavy paths ONLY: the **Beat-2 mint** of a new domain, the Beat-2 domain-spec **web refresh**, a full **refine**/overwrite ([`refine_shopper.md`](refine_shopper.md)), and **contradiction-resolution** — when a new statement *contradicts* a stored soft preference, that visible rewrite is the whole-doc path, because an append is **accretive, never corrective**.
-
-The shared user spec and the active domain's playbook **grow incrementally, per-query** — augmenting what is there, never a big up-front form. Fire this persist **only when something new actually surfaced** — a measurement stated, a brand preference revealed, a hard constraint learned, that the shared user spec / this domain's playbook did **not already hold**. If **nothing surfaced**, make **no `sil_remember` call**: no empty, duplicate, or noise entries. One discrete learning per call — two facts and a taste are three calls. A request that contradicts a stored **soft** preference **updates** it visibly (the whole-doc re-materialize); a **hard constraint** is not overridden (see precedence). Everything is **per-user, per-shopper, and local** — written only to this user's `$SIL_DATA_DIR/shopper/`, no server aggregation, no cross-user signal. Capture is **in the open**: each new fact or taste is elicited **in-context, in the persona's voice, only when a dimension needs it** — never silently harvested — and the user can review everything the shopper has stored with `sil_profile_get` (overview + per-domain) and erase a niche with `sil_profile_remove`.
+Reserve the **whole-doc** `sil_profile_materialize` for the heavy paths only — the Beat-2
+mint, the web refresh, a full **refine** ([`refine_shopper.md`](refine_shopper.md)), and
+**contradiction-resolution** (a new statement contradicting a stored *soft* preference is
+a visible whole-doc rewrite; an append is accretive, never corrective). One learning per
+call; if nothing surfaced, no call. Capture is **in the open** — never silently harvested
+— reviewable with `sil_profile_get`, erasable with `sil_profile_remove`, per-user and
+local under `$SIL_DATA_DIR/shopper/`.
 
 ### Layering — precedence intent > playbook(domain) > user_spec(SHARED) > domain_spec(domain)
 
-- **Intent** (the per-query decomposition) narrows the field — what this request demands.
-- **Playbook** (this domain's shopping taste) shapes preferences — price sensitivity, brand, taste — within what the intent allows. Scoped to the **active domain** only.
-- **User spec** (the **shared**, agent-level spec) fills standing **facts** the request left unsaid (a measurement kept from before, a compatibility constraint) — never re-asked, reused across every niche — and carries the **hard constraints**.
-- **Domain spec** (this domain's) supplies the **decision-mechanics and trade-offs** to reason over (for trail running, last volume and lug depth matter more than weight here) — the substrate, not a tiebreaker over the user's wants.
+- **Intent** narrows the field. **Playbook** shapes preferences within it. **User spec**
+  (the **shared** spec) fills standing **facts** the request left unsaid and carries the
+  **hard constraints**. **Domain spec** supplies the decision-mechanics — the substrate.
 
-**Precedence resolves conflicts: intent > playbook > user_spec > domain_spec — for *preferences*.** A specific request overrides a standing taste, which overrides a soft fact-preference, which overrides a domain default. **Exception — hard constraints are inviolable:** a shared `user_spec.md` **hard constraint** is **never** overridden by intent, taste, the domain, or the catalog. Intent can override a soft preference; it can **never** override a hard constraint. A weight bends; a hard constraint does not.
-
-**Route every hard constraint to a real enforcement point, never only soft `query` text.** A hard constraint must hold at **search-param time** (map it to a real `sil_search` filter where one exists — `condition`, `available` — per [`search_param_mapping.md`](search_param_mapping.md)), **in the rubric** (an explicit **reject-at-pick** rule: a violating candidate is rejected outright, not down-weighted), and **in the final pick**. A constraint carried only as free-text `query` is NOT enforced — the catalog can still surface a violating item, and picking it is a **defect**.
-
-> **Terminology — "reject-at-pick" here = the "reject-at-…-rule" phrasing in [`search_param_mapping.md`](search_param_mapping.md) (same rule, one mechanism)** — the one rubric rule that discards a hard-constraint-violating candidate outright (a reject, never a down-weight).
+A specific request overrides a standing taste, over a soft fact-preference, over a domain
+default. **Hard constraints are inviolable:** a shared `user_spec.md` **hard constraint**
+is **never overridden** by intent, taste, the domain, or the catalog. Route each to a
+real enforcement point — a `sil_search` filter where one exists (`condition`,
+`available`, per [`search_param_mapping.md`](search_param_mapping.md)) **and** a
+reject-at-pick rubric rule (rejected outright, not down-weighted). A constraint carried
+only as free-text `query` is not enforced.
 
 ## Beat 5 — Search → rubric → recommend-with-why → re-fetch before purchase
 
-With the domain present, the gate run to completion, and anything surfaced persisted, run the search tail. This tail is **re-ordered, not re-designed** — best-first, never re-rank, reject-at-pick for hard constraints, re-fetch before purchase.
+Best-first, never re-rank, reject-at-pick for hard constraints, re-fetch before purchase.
 
-### Map the answers to well-formed `sil_search` params
+**Map the answers to `sil_search` params.** Translate each filled dimension — plus the
+shared facts, this domain's taste, and the domain-spec mechanics — to real params per
+[`search_param_mapping.md`](search_param_mapping.md) (that reference owns the table; do
+not re-carry it). A taste with no matching param folds into `query` or the rubric —
+**never invent a filter**. Leave **`ship_to` empty** so the server resolves the
+registered default; do not call `sil_whoami` to populate it.
 
-Translate each filled intent dimension — **plus the shared user-spec facts, this domain's shopping taste, and the domain-spec mechanics** the layering brought in — to a **real `sil_search` param** per [`search_param_mapping.md`](search_param_mapping.md). That reference owns the full answer→param table and worked examples; **load it, do not re-carry it here.** The load-bearing rules that govern this step:
+**Search.** Call `sil_search` with the mapped params. It returns purchasable variants
+best-first.
 
-- A stated taste with **no matching param** (a colour, a brand) folds into the `query` text or the rubric — you **never invent a filter**. There is no `color` param, no `brand` param.
-- A user-spec **hard constraint** maps to a **real filter where one exists** (`condition`, `available`) so the catalog never returns a violating item; where no param matches, it does NOT collapse to `query` text — it becomes an explicit **reject-at-pick** rubric rule (the compare step).
-- Leave **`ship_to` empty** by default so the server resolves the registered default address. Do **not** call `sil_whoami` to populate it.
+**Compare on the rubric — reject hard-constraint violators outright.** Build the rubric
+from the active domain-spec dimensions, weighted by this domain's taste, the shared user
+facts, and the per-query intent. A hard constraint is a **reject-at-pick** rule: a
+violating candidate is removed from contention, never the pick. Present results
+**best-first** as returned — **never re-rank** — but a violator is never the pick.
 
-### Search
+**Recommend — always with the "why" that cites the layers.** The "why" must cite the
+per-query intent, at least one stored shared fact or this-domain taste you did **not**
+re-ask ("you're a wide D-width, kept from before"), and at least one researched
+domain-spec dimension ("for trail running, last volume and lug depth matter more than
+weight here"). A "why" naming no researched dimension and reusing no stored attribute is
+generic attribute matching and **fails the SDS bar** even if the product is fine. Never
+hand back a bare list.
 
-Call `sil_search` with the mapped params. It returns purchasable variants **best-first**.
+**Re-fetch with `sil_product_get` before any buy.** Price, availability, and
+`checkout_url` from `sil_search` are **point-in-time**. Before any buy / checkout,
+re-fetch the chosen item with `sil_product_get`. Never commit a buy off the stale
+`sil_search` snapshot.
 
-### Compare the candidates on the rubric — reject hard-constraint violators outright
+**After every recommendation, before the turn ends,** persist anything the interaction
+newly surfaced that Beat 4 did not capture — each via a single `sil_remember` (a fact
+`kind: "fact"` → shared user spec; a taste `kind: "taste"` + the active `domain` → this
+domain's playbook) — and **only when something surfaced** (no empty, duplicate, or noise
+entries).
 
-The **rubric emerges here, at pick time** — not a stored seller artefact. Build it from the active **domain-spec dimensions and trade-offs** (last volume vs. weight, rim depth vs. crosswind — the mechanics the domain spec named) **weighted by this domain's shopping taste** (`playbook.md`), the **shared user facts** (`user_spec.md`), and the **per-query intent**. A user-spec **hard constraint** is a **reject-at-pick** rule, not a weight: any candidate that violates it is **removed from contention outright** — never the pick, even if it scores well elsewhere. (A soft preference only down-weights.) The rubric informs your *reasoning*, not list order: present results **best-first** as `sil_search` returned them — **never re-rank** — but a hard-constraint violator is never the pick.
+## Empty, unservable, and non-`ok` results
 
-### Recommend — always with the "why" that cites the layers
-
-Recommend with **domain-relevant rationale** in the shopper's voice — the **"why"** must make the layering **legible**: cite the **per-query intent** (what this request demanded), at least one **stored shared-user fact or this-domain taste you did NOT re-ask** ("you're a wide D-width, kept from before"), and at least one **researched domain-spec dimension** ("for trail running, last volume and lug depth matter more than weight here") — tied to the user's priorities. The **visible layering is the product**: a "why" that names no researched domain dimension and reuses no stored user attribute is generic attribute matching and **fails the SDS bar even if the picked product is fine**. Never hand back a bare list.
-
-### Re-fetch with `sil_product_get` before any buy
-
-Price, availability, and `checkout_url` from `sil_search` are **point-in-time**. Before any **buy / checkout**, **re-fetch** the chosen item with `sil_product_get` for fresh price / availability / `checkout_url`. **Never commit a buy off the stale `sil_search` snapshot.**
-
-### After the recommendation — capture what surfaced via `sil_remember`
-
-**After every recommendation, before the turn ends**, persist anything new the interaction surfaced that Beat 4 did not already capture — each via its **own single `sil_remember`** call (a person fact with `kind: "fact"` → the shared user spec, a niche buying taste with `kind: "taste"` + the active `domain` → this domain's playbook). This is the safety net that makes "every query is a learning step" hold under load: the whole-doc round-trip is the path the shopper skips, so this **cheap append** is the one that actually runs, and a measurement or brand preference voiced in the session is never lost to the conversation.
-
-Fire this capture **only when something new actually surfaced** — a measurement stated, a brand preference revealed, a hard constraint learned, that the shared user spec / this domain's playbook did **not already hold**. If **nothing surfaced**, make **no `sil_remember` call**: no empty, duplicate, or noise entries. One discrete learning per call — two facts and a taste are three calls — and never silently; capture only what the interaction surfaced in the open. A **fact** carries to every niche (shared user spec); a **taste** stays in this domain.
-
-## When `sil_search` returns `ok` with `products: []` — relax and explain
-
-An empty result on `status: ok` is a normal, servable outcome — **never a silent dead-end**. **Relax or re-frame** the params (loosen a constraint, broaden the `query`) and **explain what you changed and why** ("I dropped the secondhand-only filter because nothing matched — here's what's in stock"). Never just stop silently.
-
-## When the domain is genuinely unservable — an honest "no", never junk
-
-When the catalog **cannot serve** the niche — out of scope, **not shippable**, **age-gated**, or persistently empty after a reasonable relax — say so **honestly**. This is a **different outcome** from the empty-but-servable relax case: there is no constraint to loosen, so you give an honest "no". **Never fabricate** options and **never pad with junk** — handing back unbuyable results destroys trust.
-
-## When `sil_search` / `sil_product_get` returns a non-`ok` status
-
-A non-`ok` status is **not an empty match** — do **not** treat a `retryable` or an auth failure like `products: []` and relax the params. **Follow the tool's own `recovery` hint** exactly and **never improvise**. The full taxonomy and per-status recovery live in [`catalog_tools_reference.md`](catalog_tools_reference.md) — **load it, do not re-carry the taxonomy here.**
+- **`ok` with `products: []`** — a normal, servable outcome. **Relax or re-frame** the
+  params and **explain** the change ("I dropped the secondhand-only filter — here's
+  what's in stock"). Never stop silently.
+- **Genuinely unservable** (out of scope, not shippable, age-gated, or persistently
+  empty after a reasonable relax) — say so **honestly**. Never fabricate options and
+  never pad with junk.
+- **A non-`ok` status** is not an empty match — do not relax the params. **Follow the
+  tool's own `recovery`** exactly and never improvise. The taxonomy lives in
+  [`catalog_tools_reference.md`](catalog_tools_reference.md); load it, don't re-carry it.

--- a/src/__tests__/skill-content.test.ts
+++ b/src/__tests__/skill-content.test.ts
@@ -2208,12 +2208,11 @@ describe("references/shop_loop.md — the elicit-missing gate is a first-class s
 // so it is the RED driver. The card's fuller OR-group is not used as the anchor because
 // "every query"/"on every"/"first" already live at L43 and would false-GREEN.
 const SKILL_SKIP_REINFORCE_ANCHORS = [
-  "non-skippable",
-  "non skippable",
-  "cannot be skipped",
-  "never skip",
-  "do not skip",
   "before any search",
+  "before searching",
+  "before any sil_search",
+  "before recommending",
+  "reuse a learned domain or mint",
 ] as const;
 const SKILL_DOMAIN_CHECK_TOKENS = [
   "domain-exists",
@@ -2244,7 +2243,7 @@ describe("sil-shopping/SKILL.md — one reinforcement line makes the on-every-qu
     const body = skillBody(readFileSync(SKILL_PATH, "utf8")).toLowerCase();
     const idx = firstIndexOfAny(body, SKILL_SKIP_REINFORCE_ANCHORS);
     // NET-NEW anchor → RED today; GREEN once the reinforcement line lands.
-    expect(idx, "SKILL.md must add a non-skippable / before-any-search domain-exists reinforcement").toBeGreaterThanOrEqual(0);
+    expect(idx, "SKILL.md must add a domain-exists reinforcement (resolve the domain before searching), scoped as the shopper").toBeGreaterThanOrEqual(0);
     // The reinforcement is ABOUT the domain-exists / classify / reuse-or-mint check.
     const win = body.slice(Math.max(0, idx - 450), idx + 450);
     const namesDomainCheck = SKILL_DOMAIN_CHECK_TOKENS.some((t) => win.includes(t));
@@ -2570,36 +2569,33 @@ describe("references/brainstorm_interview.md — session-seeded pre-fill, still 
 });
 
 /* ===========================================================================
- * STAGE-AWARE ROUTING THAT GATES SEARCH ON A DOMAIN
- * card: stage-aware-skill-md-that-gates-search-on-a-domain (BR1–BR7 / AC1–AC8)
+ * STAGE-AWARE ROUTING — the shopper shops through a domain (de-rigidified)
+ * cards: stage-aware-skill-md-that-gates-search-on-a-domain, then
+ *        derigidify-sil-shopping-skill (scolding → guidance).
  *
- * The `## Routing` slice is rewritten DELETE-FIRST so it OPENS with a stage gate
- * keyed on the no-arg `sil_profile_get` `name`-presence, then branches:
+ * The `## Routing` slice OPENS with a stage read keyed on the no-arg
+ * `sil_profile_get` `name`-presence, then branches:
  *   - name ABSENT  ⇒ profile-less: the bare "find X" → sil_search lane, unchanged.
- *   - name PRESENT ⇒ shopper: the domain-gated spine runs BEFORE any sil_search;
- *     the bare lane is not reachable; `domains: []` forces an announced/correctable
- *     mint; a sil_search reached without an active domain is a LOUD process-failure
- *     that self-corrects (never bare results passed off as the shopper's work).
- * A per-query FIVE-BEAT self-check rides the shopper branch as PROSE (no new tool).
+ *   - name PRESENT ⇒ shopper: shop through what you know — classify the niche and
+ *     reuse-or-mint its domain BEFORE recommending; an empty `domains` map mints
+ *     the first domain, announced with the inferred niche stated so the user can
+ *     correct it. Identity / a direct id re-check / management route normally.
+ * A lightweight per-query self-check rides the shopper branch as PROSE — an
+ * in-context orientation aid, no new tool/table/telemetry.
  *
- * ADD-ONLY. Every describe ABOVE stays UNEDITED + green — including the spine-order
- * pin (:2055), the Lane-1-stays-bare pins (:2226), and the buy-window rail (:1287).
- * Disavowal discipline (docs/knowledge/skill-prose-drift-guard-disavowal-discipline.md):
- * positive NET-NEW anchors, section-scoped, negation-aware negatives, `.toEqual([])`.
+ * These pins assert PRESERVED BEHAVIOUR, not the retired scolding vocabulary. The
+ * de-rigidify removed "the bare lane is not reachable", "process failure", "warn
+ * visibly", the "non-skippable" framing, and the rote five-verb self-check recital
+ * (`profile_loaded → domain_classified → …`) — so this block pins the
+ * domain-before-recommend behaviour, the announced/correctable mint, the no-friction
+ * pass-through, the ungated non-shopping intents, and a labelled (but un-recited)
+ * self-check — never the deleted tokens. Behaviour anchors are OR-grouped intent
+ * substrings, section/heading-scoped, negation-aware where negative, `.toEqual([])`.
  *
- * RED-capability (proven against the card base HEAD 8d163ea via `git show`): every
- * NET-NEW anchor below — "stage"/"read the stage", the `name`-discriminator, "not
- * reachable", "domains: []"/"force a mint", "process failure"/"warn"/"self-correct",
- * the five self-check verbs, "quality, {not|never} access"/"governs … reasoning",
- * "ungated", the `### Profile-less stage` H3 — is grepped to ZERO in HEAD:SKILL.md,
- * so each positive anchor fails against the pristine base (RED). The recurring
- * `sil_profile_get` / `sil_search` / "shopper" / "profile-less" tokens are
- * DELIBERATELY not used as RED anchors (they already appear → would false-GREEN);
- * they are only asserted WITHIN a net-new-anchored, heading-scoped window.
- *
- * The `[e2e]` behavioural ACs (the agent actually OBEYS the gate at runtime) are
- * DEFERRED — no host-load gate exists in this repo — and are NOT faked here: these
- * pins assert only that the ROUTER PROSE ships the instruction, never a runtime claim.
+ * ADD-ONLY over the blocks ABOVE (all stay green). The `[e2e]` behavioural ACs (the
+ * agent OBEYS the gate at runtime) stay DEFERRED — no host-load gate in this repo —
+ * and are NOT faked: these pins assert only that the ROUTER PROSE ships the
+ * instruction, never a runtime claim.
  * ========================================================================= */
 
 /** The `## Routing` H2 region — from the `## Routing` heading to the next `## ` (or
@@ -2631,32 +2627,24 @@ function headingScopedSection(body: string, anchor: number): string {
   return body.slice(start, end);
 }
 
-// ---- NET-NEW positive anchors (all 0 in HEAD:SKILL.md — the RED drivers) ----
+// ---- Behaviour anchors for the shopper stage (preserved behaviour, de-rigidified) ----
 const NAME_DISCRIMINATOR_RE =
   /`?name`?\s*(?:field\b|absent|present|is present|is absent|-?presence)|carries a `?name`?|(?:the )?(?:whole|single) discriminator|presence of (?:a |the )?`?name`?/i;
 const STAGE_READ_RE =
   /read the stage|settles which stage|reads? the stage|derive[sd]? the stage|keyed (?:on|off)|(?:the )?(?:whole|single) discriminator/i;
-const BARE_LANE_CLOSED_RE =
-  /not reachable|unreachable|not (?:presented|offered|available|a legitimate)|no bare lane/i;
 const EMPTY_DOMAINS_RE =
   /domains?\s*:?\s*\[\s*\]|domains?\s*==\s*\[\s*\]|no niche yet|empty domains/i;
-const FORCE_MINT_RE =
-  /force[sd]?\s+(?:a |the |one )?mint|forces? a mint|mint (?:the domain|a domain|one)[^.]{0,20}(?:first|before)|mints? the domain before/i;
-const PROCESS_FAILURE_RE = /process[- ]failure|warn (?:visibly|loudly)|\bwarn\b/i;
-const SELF_CORRECT_RE = /self-correct|self correct|run(?:ning|s)? the skipped|corrects? itself/i;
-const ZERO_FRICTION_RE =
-  /quality,?\s*(?:not|never)\s*access|governs[^.]{0,40}reasoning|not the user'?s inbox|ask(?:s|ing)? nothing|passes? straight through|zero questions?/i;
+// No-friction: a reused domain + fully-resolved query asks nothing / passes straight
+// through. The retired defensive framing ("quality, not access" / "governs … reasoning")
+// is NOT required — only the behaviour that a resolved query adds no friction.
+const NO_FRICTION_RE =
+  /ask(?:s|ing)? nothing|passes? straight through|zero questions?|no (?:further )?questions?/i;
+// The non-shopping intents route normally (not subject to the domain-resolve step).
+// Anchored on the scope STATEMENT's own phrasing ("route normally" / "ungated"); a bare
+// "no domain check" is deliberately NOT an alternative — it also names the profile-less
+// arm's bare lane, which precedes this statement and would mis-anchor the window scan.
 const UNGATED_RE =
-  /ungated|no domain gate|not gated|without (?:a |the |any )?domain gate|no (?:domain )?gate (?:is )?imposed/i;
-
-// The five self-check beats — the most distinctive NET-NEW anchor (all 0 in HEAD).
-const SELF_CHECK_VERBS = [
-  "profile_loaded",
-  "domain_classified",
-  "domain_reused_or_minted",
-  "intent_decomposed",
-  "facts_remembered",
-] as const;
+  /ungated|route[s]? normally|not (?:subject to|gated)|without (?:a |the |any )?domain (?:check|gate)/i;
 
 /** AFFIRMATIVE domain-gate STEP instructions (a real gate, not a disavowal of one).
  * Bare "domain gate" / "domain" are DELIBERATELY excluded — a legit profile-less
@@ -2697,62 +2685,33 @@ describe("sil-shopping/SKILL.md — Routing opens with a stage gate read from si
   });
 });
 
-describe("sil-shopping/SKILL.md — shopper stage: domain resolved BEFORE any search; the bare lane is not reachable (BR4/AC1; add-only)", () => {
-  it("routes every shopper-stage sil_search intent through sil_profile_get → reuse-or-mint a domain before any sil_search", () => {
+describe("sil-shopping/SKILL.md — shopper stage: the domain is resolved BEFORE recommending; scoped 'as the shopper' (BR4/AC1; add-only)", () => {
+  it("routes every shopper-stage sil_search intent through sil_profile_get → reuse-or-mint a domain before searching, scoped 'as the shopper'", () => {
     const lower = routingLower();
-    // Precondition prose present in the shopper branch (scoped by the net-new anchors).
     expect(lower).toContain("sil_profile_get");
     expect(lower).toContain("sil_search");
     const reuseOrMint =
       /reuse[^.]{0,20}(?:or )?mint|reuse a learned domain or mint|reuse-or-mint|reuse or mint/i.test(lower);
     expect(reuseOrMint, "the shopper branch must reuse-or-mint a domain").toBe(true);
-    const beforeSearch = /before any (?:sil_search|search)/i.test(lower);
-    expect(beforeSearch, "the domain must resolve BEFORE any sil_search").toBe(true);
+    const beforeSearch = /before (?:any )?(?:sil_search|search|searching|recommend)/i.test(lower);
+    expect(beforeSearch, "the domain must resolve BEFORE searching / recommending").toBe(true);
     // The precondition is scoped to the shopper (Lane 2), never the general router.
     expect(lower).toContain("as the shopper");
   });
-
-  it("closes the bare 'find X' lane in the shopper-present path — it is NOT reachable once a shopper exists (NET-NEW)", () => {
-    const lower = routingLower();
-    // NET-NEW RED driver: "not reachable" / "unreachable" (0 in HEAD).
-    const m = BARE_LANE_CLOSED_RE.exec(lower);
-    expect(m, "the shopper path must state the bare 'find X' lane is not reachable (NET-NEW — 0 in HEAD)").not.toBeNull();
-    // The closure is ABOUT the bare / Lane-1 / 'find X' lane, in a shopper-scoped window.
-    const at = m!.index;
-    const win = lower.slice(Math.max(0, at - 220), at + 60);
-    const namesBareLane = win.includes("bare") || win.includes('"find x"') || win.includes("find x") || win.includes("lane");
-    expect(namesBareLane, "the not-reachable statement must be about the bare 'find X' lane").toBe(true);
-    const scopedShopper = win.includes("shopper") || win.includes("name` present") || win.includes("name present");
-    expect(scopedShopper, "the closure must be scoped to the shopper stage").toBe(true);
-  });
 });
 
-describe("sil-shopping/SKILL.md — `domains: []` forces an announced, correctable mint before search (BR5/AC2; add-only)", () => {
-  it("a shopper with an empty domains map forces a mint FIRST, announced with the inferred niche stated so the user can correct it", () => {
+describe("sil-shopping/SKILL.md — an empty domains map mints the first domain before search, announced + correctable (BR5/AC2; add-only)", () => {
+  it("a shopper with no niche yet mints the domain before searching, announced with the inferred niche stated so the user can correct it", () => {
     const lower = routingLower();
-    // NET-NEW RED drivers: the empty-domains condition + the forced mint (0 in HEAD).
     expect(EMPTY_DOMAINS_RE.test(lower), "the empty-domains condition (`domains: []` / no niche yet) must be named").toBe(true);
-    expect(FORCE_MINT_RE.test(lower), "an empty domains map must FORCE a mint before searching (NET-NEW)").toBe(true);
-    // Announced + correctable (the mint is never silent).
+    const mints = /\bmint/i.test(lower);
+    expect(mints, "an empty domains map must mint the first domain").toBe(true);
     const announced = /announce[sd]?/i.test(lower);
-    expect(announced, "the forced mint must be announced").toBe(true);
+    expect(announced, "the mint must be announced (never silent)").toBe(true);
     const correctable = /correct it|can correct|so the user can correct|user can correct/i.test(lower);
     expect(correctable, "the inferred niche must be stated so the user can correct it").toBe(true);
     const beforeSearch = /before (?:searching|any (?:sil_search|search))/i.test(lower);
-    expect(beforeSearch, "the forced mint must precede search").toBe(true);
-  });
-});
-
-describe("sil-shopping/SKILL.md — a domain-less sil_search is a loud process-failure that self-corrects, never bare results (BR1/AC3; add-only)", () => {
-  it("directs a visible warn + self-correct when sil_search is reached without an active domain — never silently returns bare catalog results", () => {
-    const lower = routingLower();
-    // NET-NEW RED drivers: the process-failure framing + the self-correct step (0 in HEAD).
-    expect(PROCESS_FAILURE_RE.test(lower), "a domain-less sil_search must be framed a loud process-failure / warn visibly (NET-NEW)").toBe(true);
-    expect(SELF_CORRECT_RE.test(lower), "the backstop must self-correct (run the skipped domain check) (NET-NEW)").toBe(true);
-    // The honesty rail (BR1): never silently pass bare results off as the shopper's work.
-    const neverSilentBare =
-      /(?:never|not) silently[^.]{0,60}bare|bare catalog results[^.]{0,40}(?:never|not)|never[^.]{0,40}bare catalog/i.test(lower);
-    expect(neverSilentBare, "the backstop must never silently return bare catalog results as the shopper's work").toBe(true);
+    expect(beforeSearch, "the mint must precede search").toBe(true);
   });
 });
 
@@ -2776,21 +2735,21 @@ describe("sil-shopping/SKILL.md — the profile-less stage keeps the bare lane b
   });
 });
 
-describe("sil-shopping/SKILL.md — the per-query five-beat self-check ships as PROSE, no new tool/table/telemetry (BR6/AC6; add-only)", () => {
-  it("carries the five self-check beats in one in-context guardrail line, disavowing any new machinery", () => {
+describe("sil-shopping/SKILL.md — the per-query self-check is a lightweight PROSE orientation aid, no new tool/table/telemetry (BR6/AC6; §3a — de-rigidified)", () => {
+  it("carries a labelled per-query self-check that keeps the shopper oriented (which beat / domain resolved before searching), disavowing any new machinery", () => {
     const lower = routingLower();
-    // NET-NEW RED driver: the five verb tokens (all 0 in HEAD).
-    const missing = SELF_CHECK_VERBS.filter((v) => !lower.includes(v));
-    expect(missing, `self-check beats missing from SKILL.md: ${missing.join(", ")}`).toEqual([]);
-    // The five beats co-locate as ONE self-check line (not scattered).
-    const first = lower.indexOf(SELF_CHECK_VERBS[0]!);
-    const win = lower.slice(Math.max(0, first - 200), first + 500);
-    const allInWindow = SELF_CHECK_VERBS.every((v) => win.includes(v));
-    expect(allInWindow, "the five self-check beats must appear together as one self-check line").toBe(true);
-    const labelledSelfCheck = /self-check/i.test(win) || win.includes("guardrail") || win.includes("self-report");
-    expect(labelledSelfCheck, "the beat line must be labelled an in-context self-check / guardrail").toBe(true);
-    // No new machinery — POSITIVELY pin the disavowal (avoids the negation-lookback trap
-    // of a bare offender scan across "not a new tool, table, or telemetry surface").
+    // A labelled self-check / guardrail line exists (the rote profile_loaded → … recital
+    // is retired; a lightweight "know where you are in the flow" aid stays).
+    const at = lower.search(/self-check|self-report|guardrail/);
+    expect(at, "SKILL.md must keep a labelled per-query self-check / guardrail line").toBeGreaterThanOrEqual(0);
+    const win = lower.slice(Math.max(0, at - 200), at + 500);
+    // It is about knowing where you are in the flow — the beat/stage, and that the domain
+    // was resolved before searching — NOT a fixed five-verb recital.
+    const orients =
+      win.includes("beat") || win.includes("stage") || win.includes("where you are") ||
+      win.includes("which step") || (win.includes("domain") && win.includes("before"));
+    expect(orients, "the self-check must orient the shopper (which beat/stage; domain resolved before searching)").toBe(true);
+    // No new machinery — POSITIVELY pin the disavowal.
     const disavowsNewMachinery =
       /not (?:a )?(?:new )?tool/i.test(win) && /telemetry|table/i.test(win);
     expect(disavowsNewMachinery, "the self-check must disavow being a new tool / table / telemetry surface").toBe(true);
@@ -2803,26 +2762,21 @@ describe("sil-shopping/SKILL.md — the per-query five-beat self-check ships as 
   });
 });
 
-describe("sil-shopping/SKILL.md — the gate governs reasoning, not access: a reused domain + resolved query passes straight through (AC7; add-only)", () => {
-  it("states the non-skippable gate asks nothing on a resolved reused-domain query — quality, not access", () => {
+describe("sil-shopping/SKILL.md — a reused domain + fully-resolved query passes straight through, asking nothing (AC7; add-only)", () => {
+  it("states the shopper stage adds no friction on a resolved reused-domain query — it asks nothing and passes straight through", () => {
     const lower = routingLower();
-    // NET-NEW RED driver: "quality, {not|never} access" / "governs … reasoning" / "not the
-    // user's inbox" / "asks nothing" / "straight through" (all 0 in HEAD).
-    expect(ZERO_FRICTION_RE.test(lower), "the gate must be framed quality-not-access / asks-nothing on a resolved query (NET-NEW)").toBe(true);
-    // The zero-friction claim is anchored to a reused domain + resolved query passing through.
+    expect(NO_FRICTION_RE.test(lower), "a resolved query must ask nothing / pass straight through (no added friction)").toBe(true);
     const reusedResolved =
       /reused domain[^.]{0,80}(?:straight through|asks? nothing|no question|zero question)|passes? straight through|ask(?:s|ing)? nothing/i.test(lower);
     expect(reusedResolved, "a reused domain + fully-resolved query must pass straight through with no questions").toBe(true);
   });
 });
 
-describe("sil-shopping/SKILL.md — the domain gate scopes to sil_search discovery only; identity / id re-check / management stay ungated (BR4/AC8; add-only)", () => {
+describe("sil-shopping/SKILL.md — the domain step scopes to sil_search shopping only; identity / id re-check / management route normally (BR4/AC8; add-only)", () => {
   it("leaves identity, direct sil_product_get id re-checks, and shopper-management intents ungated", () => {
     const lower = routingLower();
-    // NET-NEW RED driver: the "ungated" scoping statement (0 in HEAD).
     const m = UNGATED_RE.exec(lower);
-    expect(m, "Routing must state the non-shopping intents stay ungated (NET-NEW — 0 in HEAD)").not.toBeNull();
-    // The ungated scope names identity, a direct sil_product_get id re-check, and management.
+    expect(m, "Routing must state the non-shopping intents route normally / ungated").not.toBeNull();
     const at = m!.index;
     const win = lower.slice(Math.max(0, at - 320), at + 60);
     const namesIdentity = win.includes("sil_register") || win.includes("sil_whoami") || win.includes("identity");
@@ -2831,9 +2785,8 @@ describe("sil-shopping/SKILL.md — the domain gate scopes to sil_search discove
     expect(namesIdRecheck, "the ungated scope must name a direct sil_product_get id re-check").toBe(true);
     const namesManagement = win.includes("management") || win.includes("forget") || win.includes("view");
     expect(namesManagement, "the ungated scope must name shopper-management intents").toBe(true);
-    // The gate is positively scoped to sil_search-driven product discovery.
-    const scopedToDiscovery = /scopes? to [^.]{0,30}sil_search|sil_search-driven (?:product )?discovery|product discovery only/i.test(lower);
-    expect(scopedToDiscovery, "the gate must be scoped to sil_search-driven product discovery only").toBe(true);
+    const scopedToDiscovery = /scopes? (?:to|only to)[^.]{0,40}sil_search|sil_search-driven (?:product )?(?:discovery|shopping)|(?:product )?discovery only/i.test(lower);
+    expect(scopedToDiscovery, "the domain step must be scoped to sil_search-driven shopping only").toBe(true);
   });
 });
 


### PR DESCRIPTION
## Why

Anthropic's authoring guidance: **match the degree of freedom to the task.** Shopping is high-freedom — an *open field*, not a *narrow bridge* — but the `sil-shopping` skill applied narrow-bridge scolding (`non-skippable`, `forbidden`, `process failure`, `warn visibly`, "the order **IS** the spec") across the whole surface. This keeps firm language only at the genuine cliffs and loosens everything else to heuristics.

**The Spec-Driven Shopping state machine and the file-creation flow are unchanged.** This changes *how the flow is written*, never *what the flow is*.

## What changed

**Test first (the unblock).** `skill-content.test.ts` opened with *"THESE ASSERTIONS ARE THE SPEC"* and pinned the exact scolding tokens — that's what welded the rigidity in place. Retargeted the `STAGE-AWARE ROUTING` assertions from prose-token pins (`process failure` / `warn visibly` / `not reachable` / `non-skippable` / the rote `profile_loaded → domain_classified → …` recital) to token-robust **behaviour** pins, deleted the one describe whose behaviour is removed, and dropped six now-dead consts. Landed green against the *current* prose first, so the rewrite couldn't trip CI. (Test file changes made by the `qa-developer` agent, per repo ownership.)

**Firm language now lives only at the cliffs** — endorsement gate, singleton refusal, confirm-before-remove/persist, hard-constraint reject-at-pick, re-fetch-before-buy, follow-the-tool's-`recovery`. Each stated once, in one place.

**Duplication killed / jargon reduced / lean on the tool descriptions.** The `sil_search` param-catalog **table** is dropped from `search_param_mapping.md` (the tool description owns it — the mapping points there). Cross-file restatements collapsed to single sources.

**Orientation preserved and made *more* legible** (not what "de-rigidify" removes): the stage read, the single next step, a lightweight per-query self-check, and the user-facing registration "why" (what registering does, the browser flow, local-on-device storage).

## Size

| | before | after |
|---|---:|---:|
| `shop_loop.md` (biggest scolding target) | 3529 | 1541 (−56%) |
| whole bundle | 15,644 | **9,101 (−41%)** |
| `SKILL.md` | 1138 | 960 · **118 lines** |

> Note: the bundle cut is 41%, short of the ~50% target. The floor is set by content the plan mandates keeping — the engine's 10-step choreography, three *distinct* status-taxonomy tables, the routing table, and the ~40 behaviour anchors the tests hold. Reaching 50% would mean deleting pinned contract detail and relaxing the matching drift tests; I stopped rather than trade drift protection for the number.

## Verification

- `skill-content.test.ts` **158/158 green**; full suite green except the known `repo-scaffold` worktree failure (gitignored `docs/` not checked out — pre-existing, unchanged).
- `tsc --noEmit` clean.
- Scolding tokens grep to **zero**; no whole-word `expert`; no `sil_search` param-catalog table restated in the skill.
- `code-quality-guardian` → **PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)