### PR TITLE
feature: forward specs contract — sil_search.specs + observable specs_status (pure transport)

### DIFF
--- a/src/__tests__/catalog-search.integration.test.ts
+++ b/src/__tests__/catalog-search.integration.test.ts
@@ -3030,7 +3030,9 @@ describe("sil_search — the enriched projection is read-side only: request body
  * PLUGIN contract against that boundary:
  *   - the request forwards the predicates under ONE namespaced `filters.specs` key
  *     (the predicates ride the already-open SearchFilters, exactly as `ships_to` did);
- *   - the products still move (via the query fold) even at `applied:false`;
+ *   - the tool is PURE TRANSPORT — it forwards the agent's free-text `query` unchanged
+ *     and does NOT fold predicates into it; results move via the agent's authored
+ *     free-text (here, the mocked sil-api simply returns a matching product);
  *   - `specs_status` surfaces on the `ok` payload FAITHFULLY, per-predicate, all
  *     `applied:false` — never collapsed to a boolean, never dropped — INCLUDING on an
  *     empty match.
@@ -3040,10 +3042,6 @@ describe("sil_search — the enriched projection is read-side only: request body
  * non-empty `checkout_url`) PLUS a top-level `specs_status`. Nothing here asserts the
  * backend FILTERS on any `ns.key`, and nothing asserts a stubbed tool — it asserts the
  * client BUILDS the contract and READS the honest status.
- *
- * EXPECT RED today: `readSearchParams`/`buildSearchBody` ignore `specs` (no
- * `filters.specs` reaches the wire) and `classifySearchResponse` never reads
- * `specs_status` (the `ok` payload omits it) — so both halves fail.
  */
 describe("sil_search — all-applied:false is a NORMAL success with an OBSERVABLE per-predicate specs_status (AC-P3)", () => {
   const SPECS = [
@@ -3088,7 +3086,8 @@ describe("sil_search — all-applied:false is a NORMAL success with an OBSERVABL
     expect(body).not.toHaveProperty("specs");
     expect(filters).not.toHaveProperty("waterproof_rating");
 
-    // (2) A NORMAL success — products moved (via the query fold) even at applied:false.
+    // (2) A NORMAL success — products present even at applied:false (the mocked
+    //     sil-api returns a match; the tool does not fold specs into the query).
     expect(payload["status"]).toBe("ok");
     expect((payload["products"] as unknown[]).length).toBeGreaterThan(0);
 

--- a/src/__tests__/catalog-search.integration.test.ts
+++ b/src/__tests__/catalog-search.integration.test.ts
@@ -3017,3 +3017,135 @@ describe("sil_search — the enriched projection is read-side only: request body
     expect(sourceFailStatus).toBe("retryable");
   });
 });
+
+/**
+ * CARD `sds-forward-specs-contract` (epic `spec-driven-shopping-redesign`, Phase 2)
+ * — the HEADLINE integration proof (AC-P3): all-`applied:false` is a NORMAL
+ * `status:"ok"` success, and the per-predicate `specs_status` is OBSERVABLE to the
+ * agent, end-to-end through the REAL tool + real sil-client.
+ *
+ * The registry that would filter on a `ns.key` and set `applied:true` has NOT landed
+ * (the sil-services `spec-registry-backend` epic), so the mocked sil-api returns EVERY
+ * predicate `applied:false` — the honest not-indexed-yet shape. This suite proves the
+ * PLUGIN contract against that boundary:
+ *   - the request forwards the predicates under ONE namespaced `filters.specs` key
+ *     (the predicates ride the already-open SearchFilters, exactly as `ships_to` did);
+ *   - the products still move (via the query fold) even at `applied:false`;
+ *   - `specs_status` surfaces on the `ok` payload FAITHFULLY, per-predicate, all
+ *     `applied:false` — never collapsed to a boolean, never dropped — INCLUDING on an
+ *     empty match.
+ *
+ * STUB-FREE (complete-work-is-stub-free): the only mock is `fetch`; the response is
+ * the REAL flat sil-api envelope (products with a required `source`, variants with a
+ * non-empty `checkout_url`) PLUS a top-level `specs_status`. Nothing here asserts the
+ * backend FILTERS on any `ns.key`, and nothing asserts a stubbed tool — it asserts the
+ * client BUILDS the contract and READS the honest status.
+ *
+ * EXPECT RED today: `readSearchParams`/`buildSearchBody` ignore `specs` (no
+ * `filters.specs` reaches the wire) and `classifySearchResponse` never reads
+ * `specs_status` (the `ok` payload omits it) — so both halves fail.
+ */
+describe("sil_search — all-applied:false is a NORMAL success with an OBSERVABLE per-predicate specs_status (AC-P3)", () => {
+  const SPECS = [
+    { ns: "product", key: "waterproof_rating", op: "gte", value: 10000, unit: "mm", hard: true },
+    { ns: "seller", key: "rating_average", op: "gte", value: 4.5 },
+  ];
+  /** Every predicate `applied:false` — the honest not-indexed-yet shape. */
+  const SPECS_STATUS_ALL_FALSE = [
+    { ns: "product", key: "waterproof_rating", applied: false },
+    { ns: "seller", key: "rating_average", applied: false },
+  ];
+  /** The REAL flat sil-api envelope + a top-level `specs_status` sibling of `products`. */
+  function envelopeWithSpecsStatus(products: unknown[], specs_status: unknown): unknown {
+    return {
+      ucp: { version: "0.1", status: "success" },
+      products,
+      pagination: { has_next_page: false },
+      specs_status,
+    };
+  }
+
+  it("forwards the predicates under ONE `filters.specs` key AND surfaces the all-false specs_status verbatim on the ok payload", async () => {
+    seedTokens("the-access-token", "the-refresh-token");
+    const rec = installRouter((kind) =>
+      kind === "search"
+        ? { status: 200, body: envelopeWithSpecsStatus([PRODUCT_A], SPECS_STATUS_ALL_FALSE) }
+        : { status: 500, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", { query: "waterproof gloves", specs: SPECS }),
+    );
+
+    // (1) The request forwarded the predicates under the ONE namespaced key — not
+    //     spread per-predicate, not top-level (the ships_to fail-green defense).
+    expect(rec.search.length).toBe(1);
+    const body = rec.search[0]!.body as Record<string, unknown>;
+    const filters = (body["filters"] ?? {}) as Record<string, unknown>;
+    expect(filters["specs"]).toEqual(SPECS);
+    expect(body).not.toHaveProperty("specs");
+    expect(filters).not.toHaveProperty("waterproof_rating");
+
+    // (2) A NORMAL success — products moved (via the query fold) even at applied:false.
+    expect(payload["status"]).toBe("ok");
+    expect((payload["products"] as unknown[]).length).toBeGreaterThan(0);
+
+    // (3) specs_status is OBSERVABLE, per-predicate, all applied:false — never
+    //     collapsed to a boolean, never dropped.
+    expect(payload["specs_status"]).toEqual(SPECS_STATUS_ALL_FALSE);
+    expect(typeof payload["specs_status"]).not.toBe("boolean");
+    for (const s of payload["specs_status"] as Array<{ applied: unknown }>) {
+      expect(s.applied).toBe(false);
+    }
+  });
+
+  it("an EMPTY match still surfaces the all-false specs_status (sibling of products) — the honesty pass runs even at zero results", async () => {
+    seedTokens("at", "rt");
+    installRouter((kind) =>
+      kind === "search"
+        ? { status: 200, body: envelopeWithSpecsStatus([], SPECS_STATUS_ALL_FALSE) }
+        : { status: 500, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", { query: "waterproof gloves", specs: SPECS }),
+    );
+
+    expect(payload["status"]).toBe("ok");
+    expect(payload["products"]).toEqual([]);
+    // specs_status still present on the empty match — it is a sibling of products.
+    expect(payload["specs_status"]).toEqual(SPECS_STATUS_ALL_FALSE);
+  });
+
+  it("NEVER asserts the backend filtered — a hard:true predicate STILL comes back applied:false (the observable fail-green reflection polices)", async () => {
+    // The exact product requirement: a `hard:true` predicate returning `applied:false`
+    // means the backend did NOT enforce it. The tool must surface that truthfully — it
+    // is what lets Beat 5 reject-at-pick instead of silently presenting an unenforced
+    // hard constraint as met. Nothing here claims the backend filtered on the ns.key.
+    seedTokens("at", "rt");
+    installRouter((kind) =>
+      kind === "search"
+        ? { status: 200, body: envelopeWithSpecsStatus([PRODUCT_A], SPECS_STATUS_ALL_FALSE) }
+        : { status: 500, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", {
+        query: "waterproof gloves",
+        specs: [{ ns: "product", key: "waterproof_rating", op: "gte", value: 10000, unit: "mm", hard: true }],
+      }),
+    );
+
+    expect(payload["status"]).toBe("ok");
+    const status = payload["specs_status"] as Array<{ ns: string; key: string; applied: boolean }>;
+    const hardEntry = status.find((s) => s.ns === "product" && s.key === "waterproof_rating");
+    expect(hardEntry).toBeDefined();
+    expect(hardEntry!.applied).toBe(false);
+  });
+});

--- a/src/__tests__/lib/search-classify.test.ts
+++ b/src/__tests__/lib/search-classify.test.ts
@@ -922,3 +922,167 @@ describe("classifySearchResponse — cursor hoist (end-of-results is the ABSENT 
     }
   });
 });
+
+/**
+ * CARD `sds-forward-specs-contract` (epic `spec-driven-shopping-redesign`, Phase 2)
+ * — the RED unit floor for the OBSERVABLE `specs_status` read on the `ok` outcome
+ * (AC-P2, AC-A4).
+ *
+ * The response half of the `specs` contract. sil-api emits a per-predicate
+ * `specs_status:[{ ns, key, applied }]` at the TOP LEVEL of its FLAT envelope
+ * (sibling of `products`, so it surfaces on an EMPTY match too). `classifySearchResponse`
+ * must thread it onto the `ok` outcome FAITHFULLY, per-predicate:
+ *
+ *   - NEVER collapsed to a single boolean, NEVER dropped, NEVER summarized — it IS
+ *     the machine-readable input to Beat 5's hard-constraint honesty pass. Until the
+ *     sil-services registry lands, EVERY entry is `applied:false` (the honest
+ *     not-indexed-yet shape) and that exact set is what reflection polices; a lost or
+ *     collapsed `specs_status` silently breaks the honesty rail.
+ *   - NO FABRICATION: an absent `specs_status` is OMITTED (never a fabricated default);
+ *     malformed entries (missing `ns`/`key`, non-boolean `applied`) are DROPPED, never
+ *     coerced and never invented as `applied:true`; a non-array `specs_status` is
+ *     omitted. The `products` anti-false-green gate is UNCHANGED — `specs_status` is
+ *     informational, never a purchasability gate.
+ *
+ * Contract this file pins for the implementation (expert-developer),
+ * `src/lib/sil-client.ts`:
+ *   interface SpecStatus { ns: string; key: string; applied: boolean }
+ *   SearchOutcome ok gains `specs_status?: SpecStatus[]`
+ *   `extractSpecsStatus` reads the FLAT envelope's top-level `specs_status`, narrows
+ *   each entry to `{ns:string,key:string,applied:boolean}`, drops malformed entries,
+ *   and the `ok` outcome OMITS the key when the wire carried none.
+ *
+ * EXPECT RED today: `classifySearchResponse` returns `{ kind:"ok", products, cursor? }`
+ * — it never reads `specs_status`, so `out.specs_status` is `undefined`; every faithful-
+ * surfacing assertion below fails.
+ */
+describe("classifySearchResponse — specs_status surfaces FAITHFULLY, per-predicate, on the ok outcome (AC-P2)", () => {
+  it("a 200 carrying specs_status:[{ns,key,applied}] → ok with specs_status VERBATIM, in order, per-predicate", () => {
+    const specs_status = [
+      { ns: "product", key: "waterproof_rating", applied: false },
+      { ns: "seller", key: "rating_average", applied: false },
+      { ns: "shipping", key: "delivery_max_days", applied: false },
+    ];
+    const out = classifySearchResponse(200, envelope({ products: [PRODUCT_A], specs_status }));
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      // Faithful, per-predicate, order-preserving — NOT collapsed, NOT dropped.
+      expect(out.specs_status).toEqual(specs_status);
+    }
+  });
+
+  it("all-`applied:false` (the honest not-indexed-yet shape) surfaces with EVERY flag still false — none flipped to true", () => {
+    // The exact set reflection's honesty check polices. A registry that has not
+    // landed returns every predicate unenforced; the classifier must surface that
+    // truthfully, never optimistically flipping a flag.
+    const specs_status = [
+      { ns: "product", key: "a", applied: false },
+      { ns: "product", key: "b", applied: false },
+    ];
+    const out = classifySearchResponse(200, envelope({ products: [PRODUCT_A], specs_status }));
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      expect(Array.isArray(out.specs_status)).toBe(true);
+      expect(out.specs_status).toHaveLength(2);
+      for (const s of out.specs_status!) expect(s.applied).toBe(false);
+    }
+  });
+
+  it("is NEVER collapsed to a boolean — a MIXED applied set keeps each per-predicate flag distinct", () => {
+    // The anti-collapse guard: one applied:true, one applied:false. If the impl
+    // reduced specs_status to a single boolean (or dropped it), this distinct-flag
+    // assertion fails. reflection needs to know WHICH predicate was unenforced.
+    const specs_status = [
+      { ns: "product", key: "enforced", applied: true },
+      { ns: "product", key: "unenforced", applied: false },
+    ];
+    const out = classifySearchResponse(200, envelope({ products: [PRODUCT_A], specs_status }));
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      expect(out.specs_status).toEqual(specs_status);
+      expect(typeof out.specs_status).not.toBe("boolean");
+    }
+  });
+
+  it("surfaces specs_status even on an EMPTY match (products:[]) — it is a sibling of `products`, not nested in a result", () => {
+    // A zero-match search still reports which predicates were applied — the sibling
+    // placement is what makes that possible. The honesty pass runs regardless of
+    // whether anything matched.
+    const specs_status = [{ ns: "product", key: "waterproof_rating", applied: false }];
+    const out = classifySearchResponse(
+      200,
+      envelope({ products: [], pagination: { has_next_page: false }, specs_status }),
+    );
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      expect(out.products).toEqual([]);
+      expect(out.specs_status).toEqual(specs_status);
+    }
+  });
+});
+
+describe("classifySearchResponse — specs_status narrowing: no fabrication, drop malformed, never a false-green (AC-A4)", () => {
+  it("a 200 whose body OMITS specs_status → ok WITHOUT specs_status (no fabricated default)", () => {
+    // Absence is reflection's to interpret (a backend predating the registry sends
+    // none). The classifier must NOT invent an empty/`applied:true` default.
+    const out = classifySearchResponse(200, envelope({ products: [PRODUCT_A] }));
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      expect(out.specs_status).toBeUndefined();
+      // The products gate is unchanged — specs_status absence is not a fault.
+      expect(out.products).toHaveLength(1);
+    }
+  });
+
+  it("drops MALFORMED entries but keeps the valid ones — never fabricates applied:true from garbage", () => {
+    // The discriminating narrowing case: one clean entry among garbage. The clean one
+    // surfaces; the malformed ones (missing applied, non-string ns, non-boolean
+    // applied, a bare non-object) are DROPPED — never coerced, never invented as
+    // applied:true. RED today (specs_status is undefined, so the valid entry is lost).
+    const specs_status = [
+      { ns: "product", key: "clean", applied: false },
+      { ns: "product", key: "no_applied" }, // missing applied → drop
+      { ns: 42, key: "bad_ns", applied: false }, // non-string ns → drop
+      { ns: "product", key: "coerced", applied: "false" }, // non-boolean applied → drop
+      "not-an-object", // → drop
+      null, // → drop
+    ];
+    const out = classifySearchResponse(200, envelope({ products: [PRODUCT_A], specs_status }));
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      // Only the one well-formed entry survives, verbatim.
+      expect(out.specs_status).toEqual([{ ns: "product", key: "clean", applied: false }]);
+      // The anti-fabrication invariant, stated directly: no surfaced entry was
+      // conjured to applied:true from a malformed/absent one.
+      for (const s of out.specs_status!) {
+        expect(typeof s.applied).toBe("boolean");
+        expect(s.key).not.toBe("no_applied");
+        expect(s.key).not.toBe("coerced");
+      }
+    }
+  });
+
+  it("a NON-ARRAY specs_status (string / object / null) → omitted, never crash, never false-green", () => {
+    for (const bad of ["garbage", { applied: false }, null, 7]) {
+      const out = classifySearchResponse(200, envelope({ products: [PRODUCT_A], specs_status: bad }));
+      // The 200 is still a valid ok on the products gate; specs_status is simply omitted.
+      expect(out.kind).toBe("ok");
+      if (out.kind === "ok") {
+        expect(out.specs_status).toBeUndefined();
+        expect(out.products).toHaveLength(1);
+      }
+    }
+  });
+
+  it("specs_status NEVER affects the products anti-false-green gate — a stub 200 carrying a specs_status is still NOT ok", () => {
+    // specs_status is informational only. A 200 with no usable `products` array must
+    // stay `retryable` even if it carries a well-formed specs_status — the honesty
+    // signal can never manufacture a false empty-match success.
+    const out = classifySearchResponse(
+      200,
+      { ucp: { version: "0.1", status: "success" }, specs_status: [{ ns: "p", key: "k", applied: false }] },
+    );
+    expect(out.kind).not.toBe("ok");
+    expect(out.kind).toBe("retryable");
+  });
+});

--- a/src/__tests__/lib/search-client.test.ts
+++ b/src/__tests__/lib/search-client.test.ts
@@ -579,3 +579,263 @@ describe("searchCatalog — transport failure maps to retryable without leaking 
     expect(JSON.stringify(thrown)).not.toContain(SECRET);
   });
 });
+
+/**
+ * CARD `sds-forward-specs-contract` (epic `spec-driven-shopping-redesign`, Phase 2)
+ * — the RED unit floor for the `specs` DUAL PROJECTION in `buildSearchBody`
+ * (AC-P1, AC-P5, AC-A2 wire-half, AC-A3 wire-half).
+ *
+ * `SearchParams` gains `specs?: SpecPredicate[]` — a closed-shape / OPEN-vocabulary
+ * structured requirement `{ ns, key, op, value?, unit?, hard? }`. `buildSearchBody`
+ * has TWO effects on it, both pinned here:
+ *
+ *   (1) filters.specs — the narrowed predicate array rides under ONE namespaced
+ *       well-known key `filters.specs`, NEVER spread per-predicate as
+ *       `filters.<key>`/`filters.<ns>` and NEVER at the top level. This is the exact
+ *       fail-green hazard the `ships_to` rename defends against (the OPEN
+ *       `SearchFilters`, `additionalProperties:true`, silently accepts a wrong key →
+ *       a no-op that a presence-only test would miss). So the defense is WHOLE-BODY
+ *       equality asserting the precise `filters.specs` array, never "a specs key
+ *       exists". `hard` is forwarded VERBATIM (true kept, false kept-not-dropped,
+ *       absent stays absent) so the backend can enforce once it lands and reflection
+ *       can correlate the `applied:false` hard set.
+ *
+ *   (2) the query fold — every POSITIVE predicate (`eq`/`gte`/`lte`/`in`) folds its
+ *       value (+`unit`) into `body.query`, deduped case-insensitively against the
+ *       existing tokens, with the agent's own phrasing kept PRIMARY/un-mangled. A
+ *       `neq`/`nin`/`exists` predicate and a BOOLEAN value render NOTHING — a negation
+ *       surfaced as a bare positive token would surface exactly what it EXCLUDES
+ *       (fail-WORSE than silent). When only negation/boolean/exists predicates are
+ *       present and there is no agent `query`, the `query` key is OMITTED.
+ *
+ * The backend does not filter on any `ns.key` yet (the sil-services
+ * `spec-registry-backend` epic) — NOTHING here asserts filtering; the fold is the
+ * degrade-gracefully backstop that moves results at `applied:false`.
+ *
+ * Contract this file pins for the implementation (expert-developer),
+ * `src/lib/sil-client.ts`:
+ *   type SpecOp = "eq"|"neq"|"gte"|"lte"|"in"|"nin"|"exists";
+ *   interface SpecPredicate { ns: string; key: string; op: SpecOp;
+ *     value?: number|string|boolean|(string|number)[]; unit?: string; hard?: boolean }
+ *   SearchParams.specs?: SpecPredicate[]
+ *   buildSearchBody sets ONE `filters.specs` = the predicate array (verbatim, `hard`
+ *   kept) AND folds positive values(+unit) into `body.query` deduped; negations/
+ *   booleans/exists render nothing. The exact mappings below ARE the immutable spec.
+ *
+ * EXPECT RED today: `buildSearchBody` ignores `specs` entirely — no `filters.specs`
+ * is emitted and `body.query` is untouched, so every fold + placement assertion below
+ * fails.
+ */
+describe("searchCatalog — specs ride ONE namespaced filters.specs key (whole-body equality, never spread)", () => {
+  let cap: Captured[];
+  beforeEach(() => {
+    cap = [];
+    spyFetch(cap);
+  });
+
+  it("a NEGATION-only spec beside typed filters → whole body EXACT: filters.specs is one key beside categories/price, query untouched", async () => {
+    // The strongest placement assertion — a byte-exact whole-body equality. A neq
+    // predicate renders NOTHING into the query (so the query stays exactly the
+    // agent's), which lets us pin the ENTIRE body: `filters.specs` sits beside
+    // `categories`/`price` under the ONE `filters` object, carrying the predicate
+    // verbatim. If the impl spread it as `filters.color`/`filters.product`, or hoisted
+    // it top-level, or folded the negation into the query, this equality FAILS.
+    await searchCatalog(SIL_API, "tok", {
+      query: "gloves",
+      category: "Apparel",
+      price_max: 5000,
+      specs: [{ ns: "product", key: "color", op: "neq", value: "red" }],
+    });
+    expect(cap[0]!.body).toEqual({
+      query: "gloves",
+      filters: {
+        categories: ["Apparel"],
+        price: { max: 5000 },
+        specs: [{ ns: "product", key: "color", op: "neq", value: "red" }],
+      },
+    });
+  });
+
+  it("filters.specs carries the predicate array VERBATIM and NEVER spreads a predicate as filters.<name> or top-level `specs`", async () => {
+    await searchCatalog(SIL_API, "tok", {
+      query: "gloves",
+      specs: [
+        { ns: "product", key: "waterproof_rating", op: "gte", value: 10000, unit: "mm" },
+        { ns: "seller", key: "rating_average", op: "gte", value: 4.5 },
+        { ns: "product", key: "size", op: "in", value: ["medium", "large"] },
+      ],
+    });
+    const body = cap[0]!.body as Record<string, unknown>;
+    const filters = (body["filters"] ?? {}) as Record<string, unknown>;
+    // The ONE namespaced key holds every predicate, unchanged (no reshaping).
+    expect(filters["specs"]).toEqual([
+      { ns: "product", key: "waterproof_rating", op: "gte", value: 10000, unit: "mm" },
+      { ns: "seller", key: "rating_average", op: "gte", value: 4.5 },
+      { ns: "product", key: "size", op: "in", value: ["medium", "large"] },
+    ]);
+    // NEVER spread per-predicate onto the open SearchFilters (the silent-no-op / typed-
+    // filter-collision hazard) — not by key, not by ns.
+    for (const wrong of ["waterproof_rating", "rating_average", "size", "product", "seller"]) {
+      expect(filters).not.toHaveProperty(wrong);
+    }
+    // NEVER at the top level — `specs` is a backend-bound filter, unlike sil-private
+    // `local_merchants`.
+    expect(body).not.toHaveProperty("specs");
+  });
+
+  it("forwards `hard` VERBATIM on each entry — true kept, false kept (not dropped as falsy), absent stays absent", async () => {
+    // The backend can only enforce a hard constraint, and reflection can only
+    // correlate the `applied:false` hard set, if `hard` survives the wire unchanged.
+    // A truthiness drop of `hard:false`, or a fabricated default on an absent `hard`,
+    // would break the honesty rail. `toEqual` pins all three: true, false, and the
+    // ABSENCE of a `hard` key on the third entry.
+    await searchCatalog(SIL_API, "tok", {
+      query: "gloves",
+      specs: [
+        { ns: "a", key: "b", op: "eq", value: 1, hard: true },
+        { ns: "a", key: "c", op: "eq", value: 2, hard: false },
+        { ns: "a", key: "d", op: "eq", value: 3 },
+      ],
+    });
+    const filters = ((cap[0]!.body as Record<string, unknown>)["filters"] ?? {}) as Record<string, unknown>;
+    expect(filters["specs"]).toEqual([
+      { ns: "a", key: "b", op: "eq", value: 1, hard: true },
+      { ns: "a", key: "c", op: "eq", value: 2, hard: false },
+      { ns: "a", key: "d", op: "eq", value: 3 },
+    ]);
+  });
+
+  it("an EMPTY specs:[] is a no-op — no filters.specs, query unchanged (whole body exact)", async () => {
+    await searchCatalog(SIL_API, "tok", { query: "gloves", specs: [] });
+    // An empty predicate list adds nothing: no `filters` skeleton conjured to hold a
+    // `specs`, and the query is byte-exactly the agent's. (Symmetry with the
+    // omit-when-absent discipline every other filter follows.)
+    expect(cap[0]!.body).toEqual({ query: "gloves" });
+  });
+});
+
+describe("searchCatalog — the specs → query fold (positive ops render; negations/booleans render NOTHING)", () => {
+  let cap: Captured[];
+  beforeEach(() => {
+    cap = [];
+    spyFetch(cap);
+  });
+
+  /** The final `body.query` string (or undefined when the key is omitted). */
+  function foldedQuery(): string | undefined {
+    const q = (cap[0]!.body as Record<string, unknown>)["query"];
+    return typeof q === "string" ? q : undefined;
+  }
+
+  it("a POSITIVE predicate folds its value into the query (a structured requirement still MOVES results at applied:false)", async () => {
+    await searchCatalog(SIL_API, "tok", {
+      query: "external drive",
+      specs: [{ ns: "product", key: "capacity_gb", op: "eq", value: 512 }],
+    });
+    const q = foldedQuery();
+    expect(q, "query key must be present").toBeTypeOf("string");
+    // The agent's phrasing stays PRIMARY (verbatim substring) …
+    expect(q!.toLowerCase()).toContain("external drive");
+    // … and the predicate value is folded in as a token (RED today — the fold does
+    // not exist, so "512" is absent).
+    expect(q!).toContain("512");
+  });
+
+  it("folds the `unit` alongside the value for a gte predicate (value AND unit both surface)", async () => {
+    await searchCatalog(SIL_API, "tok", {
+      query: "hiking gloves",
+      specs: [{ ns: "product", key: "waterproof_rating", op: "gte", value: 10000, unit: "mm" }],
+    });
+    const q = foldedQuery()!.toLowerCase();
+    expect(q).toContain("hiking gloves");
+    expect(q).toContain("10000");
+    expect(q).toContain("mm");
+  });
+
+  it("folds EACH element of an `in` array value", async () => {
+    await searchCatalog(SIL_API, "tok", {
+      query: "jacket",
+      specs: [{ ns: "product", key: "size", op: "in", value: ["medium", "large"] }],
+    });
+    const q = foldedQuery()!.toLowerCase();
+    expect(q).toContain("jacket");
+    expect(q).toContain("medium");
+    expect(q).toContain("large");
+  });
+
+  it("DEDUPES case-insensitively against existing query tokens — a value already present is not doubled, a new one is added", async () => {
+    // Two predicates: `leather` already appears in the query (case-differently), `512`
+    // does not. The fold must ADD "512" (proving it ran — RED today) and must NOT
+    // append a second "leather" (the case-insensitive dedup — a naive append would
+    // make it appear twice).
+    await searchCatalog(SIL_API, "tok", {
+      query: "Leather bag",
+      specs: [
+        { ns: "product", key: "material", op: "eq", value: "leather" },
+        { ns: "product", key: "capacity_gb", op: "eq", value: 512 },
+      ],
+    });
+    const q = foldedQuery()!.toLowerCase();
+    expect(q).toContain("512"); // the new value was folded (RED today)
+    // "leather" appears exactly ONCE — the case-insensitive dedup held.
+    expect((q.match(/leather/g) ?? []).length).toBe(1);
+  });
+
+  it("a NEGATION renders NOTHING into the query and NEVER surfaces the excluded value (fail-worse guard)", async () => {
+    // The cardinal query-fold hazard: rendering a `neq`/`nin` value as a bare positive
+    // token would surface exactly what the buyer wants EXCLUDED — worse than silent.
+    // The query must stay byte-exactly the agent's, and the excluded value must appear
+    // NOWHERE in it. (The predicate still rides filters.specs — asserted separately.)
+    await searchCatalog(SIL_API, "tok", {
+      query: "running shoes",
+      specs: [
+        { ns: "product", key: "color", op: "neq", value: "pink" },
+        { ns: "product", key: "brand", op: "nin", value: ["accaltd"] },
+      ],
+    });
+    expect(foldedQuery()).toBe("running shoes");
+    const q = foldedQuery()!.toLowerCase();
+    expect(q).not.toContain("pink");
+    expect(q).not.toContain("accaltd");
+  });
+
+  it("an `exists` predicate renders NOTHING into the query (it carries no value to fold) but still rides filters.specs", async () => {
+    await searchCatalog(SIL_API, "tok", {
+      query: "tent",
+      specs: [{ ns: "product", key: "waterproof_rating", op: "exists" }],
+    });
+    expect(foldedQuery()).toBe("tent");
+    const filters = ((cap[0]!.body as Record<string, unknown>)["filters"] ?? {}) as Record<string, unknown>;
+    expect(filters["specs"]).toEqual([{ ns: "product", key: "waterproof_rating", op: "exists" }]);
+  });
+
+  it("a BOOLEAN value renders NOTHING into the query even for a positive op (a bare `true` token is meaningless noise)", async () => {
+    await searchCatalog(SIL_API, "tok", {
+      query: "laptop",
+      specs: [{ ns: "product", key: "backlit_keyboard", op: "eq", value: true }],
+    });
+    expect(foldedQuery()).toBe("laptop");
+    const filters = ((cap[0]!.body as Record<string, unknown>)["filters"] ?? {}) as Record<string, unknown>;
+    // The predicate still forwards (the backend may index the boolean) — only the
+    // QUERY fold skips it.
+    expect(filters["specs"]).toEqual([{ ns: "product", key: "backlit_keyboard", op: "eq", value: true }]);
+  });
+
+  it("when ONLY negation/exists/boolean predicates are present and there is NO agent query, the `query` key is OMITTED", async () => {
+    // Nothing renders → no query text exists → no empty `query` key conjured. The
+    // predicates still ride filters.specs so the constraint is not lost.
+    await searchCatalog(SIL_API, "tok", {
+      specs: [
+        { ns: "product", key: "color", op: "neq", value: "red" },
+        { ns: "product", key: "waterproof_rating", op: "exists" },
+      ],
+    });
+    const body = cap[0]!.body as Record<string, unknown>;
+    expect(body).not.toHaveProperty("query");
+    const filters = (body["filters"] ?? {}) as Record<string, unknown>;
+    expect(filters["specs"]).toEqual([
+      { ns: "product", key: "color", op: "neq", value: "red" },
+      { ns: "product", key: "waterproof_rating", op: "exists" },
+    ]);
+  });
+});

--- a/src/__tests__/lib/search-client.test.ts
+++ b/src/__tests__/lib/search-client.test.ts
@@ -44,6 +44,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 import { searchCatalog } from "../../lib/sil-client.js";
+import type { SpecPredicate } from "../../lib/sil-client.js";
 
 const SIL_API = "https://sil-api.test.example.com";
 
@@ -581,36 +582,37 @@ describe("searchCatalog — transport failure maps to retryable without leaking 
 });
 
 /**
- * CARD `sds-forward-specs-contract` (epic `spec-driven-shopping-redesign`, Phase 2)
- * — the RED unit floor for the `specs` DUAL PROJECTION in `buildSearchBody`
- * (AC-P1, AC-P5, AC-A2 wire-half, AC-A3 wire-half).
+ * CARD `sds-forward-specs-contract` (epic `spec-driven-shopping-redesign`, Phase 2
+ * — founder scope revision 2026-07-13: THE PLUGIN IS PURE TRANSPORT). The unit floor
+ * for the `specs` contract in `buildSearchBody` (AC-P1, AC-P5, AC-A2 wire-half,
+ * AC-A3 wire-half).
  *
  * `SearchParams` gains `specs?: SpecPredicate[]` — a closed-shape / OPEN-vocabulary
  * structured requirement `{ ns, key, op, value?, unit?, hard? }`. `buildSearchBody`
- * has TWO effects on it, both pinned here:
+ * has exactly ONE effect on it:
  *
- *   (1) filters.specs — the narrowed predicate array rides under ONE namespaced
- *       well-known key `filters.specs`, NEVER spread per-predicate as
- *       `filters.<key>`/`filters.<ns>` and NEVER at the top level. This is the exact
- *       fail-green hazard the `ships_to` rename defends against (the OPEN
- *       `SearchFilters`, `additionalProperties:true`, silently accepts a wrong key →
- *       a no-op that a presence-only test would miss). So the defense is WHOLE-BODY
- *       equality asserting the precise `filters.specs` array, never "a specs key
- *       exists". `hard` is forwarded VERBATIM (true kept, false kept-not-dropped,
- *       absent stays absent) so the backend can enforce once it lands and reflection
- *       can correlate the `applied:false` hard set.
+ *   filters.specs — the predicate array rides under ONE namespaced well-known key
+ *   `filters.specs`, forwarded VERBATIM (the whole array, all seven ops, `hard`
+ *   unchanged), NEVER spread per-predicate as `filters.<key>`/`filters.<ns>` and
+ *   NEVER at the top level. This is the exact fail-green hazard the `ships_to` rename
+ *   defends against (the OPEN `SearchFilters`, `additionalProperties:true`, silently
+ *   accepts a wrong key → a no-op that a presence-only test would miss). So the
+ *   defense is WHOLE-BODY equality asserting the precise `filters.specs` array, never
+ *   "a specs key exists". `hard` is forwarded VERBATIM (true kept, false
+ *   kept-not-dropped, absent stays absent) so the backend can enforce once it lands
+ *   and reflection can correlate the `applied:false` hard set.
  *
- *   (2) the query fold — every POSITIVE predicate (`eq`/`gte`/`lte`/`in`) folds its
- *       value (+`unit`) into `body.query`, deduped case-insensitively against the
- *       existing tokens, with the agent's own phrasing kept PRIMARY/un-mangled. A
- *       `neq`/`nin`/`exists` predicate and a BOOLEAN value render NOTHING — a negation
- *       surfaced as a bare positive token would surface exactly what it EXCLUDES
- *       (fail-WORSE than silent). When only negation/boolean/exists predicates are
- *       present and there is no agent `query`, the `query` key is OMITTED.
+ * THE PLUGIN DOES NOT FOLD PREDICATES INTO `query`. Authoring free-text from the
+ * requirements is the AGENT's job (the sil-shopping loop, Beat 4) and reframing on
+ * `applied:false` is Beat 5 — a mechanical plugin fold was lossy (a range renders as
+ * a bare numeric token — noise) and unsafe (a negation folded as a bare positive
+ * token inverts intent). So `body.query` is left EXACTLY the agent's `params.query`,
+ * byte-for-byte, regardless of `specs` — a predicate never adds, removes, or reorders
+ * a query token, and `specs` alone never SYNTHESIZES a `query` (absent stays absent).
  *
  * The backend does not filter on any `ns.key` yet (the sil-services
- * `spec-registry-backend` epic) — NOTHING here asserts filtering; the fold is the
- * degrade-gracefully backstop that moves results at `applied:false`.
+ * `spec-registry-backend` epic) — NOTHING here asserts filtering. Results move today
+ * via the agent's free-text authoring, not a plugin-side fold.
  *
  * Contract this file pins for the implementation (expert-developer),
  * `src/lib/sil-client.ts`:
@@ -619,12 +621,14 @@ describe("searchCatalog — transport failure maps to retryable without leaking 
  *     value?: number|string|boolean|(string|number)[]; unit?: string; hard?: boolean }
  *   SearchParams.specs?: SpecPredicate[]
  *   buildSearchBody sets ONE `filters.specs` = the predicate array (verbatim, `hard`
- *   kept) AND folds positive values(+unit) into `body.query` deduped; negations/
- *   booleans/exists render nothing. The exact mappings below ARE the immutable spec.
+ *   kept) and forwards `body.query` = `params.query` UNCHANGED. The exact mappings
+ *   below ARE the immutable spec.
  *
- * EXPECT RED today: `buildSearchBody` ignores `specs` entirely — no `filters.specs`
- * is emitted and `body.query` is untouched, so every fold + placement assertion below
- * fails.
+ * EXPECT RED today: the current impl still FOLDS positive predicate values into
+ * `body.query` (`renderSpecQuery`/`renderSpecTokens`/`POSITIVE_SPEC_OPS`). Every
+ * "query untouched by specs" assertion below fails until that fold is deleted; the
+ * `filters.specs` placement/verbatim/hard assertions already pass and stay as forward
+ * guards.
  */
 describe("searchCatalog — specs ride ONE namespaced filters.specs key (whole-body equality, never spread)", () => {
   let cap: Captured[];
@@ -633,25 +637,35 @@ describe("searchCatalog — specs ride ONE namespaced filters.specs key (whole-b
     spyFetch(cap);
   });
 
-  it("a NEGATION-only spec beside typed filters → whole body EXACT: filters.specs is one key beside categories/price, query untouched", async () => {
-    // The strongest placement assertion — a byte-exact whole-body equality. A neq
-    // predicate renders NOTHING into the query (so the query stays exactly the
-    // agent's), which lets us pin the ENTIRE body: `filters.specs` sits beside
-    // `categories`/`price` under the ONE `filters` object, carrying the predicate
-    // verbatim. If the impl spread it as `filters.color`/`filters.product`, or hoisted
-    // it top-level, or folded the negation into the query, this equality FAILS.
+  it("whole body EXACT: filters.specs carries ALL SEVEN ops verbatim beside typed filters, and the query is left UNTOUCHED", async () => {
+    // The strongest single assertion — a byte-exact whole-body equality carrying every
+    // op (eq/neq/gte/lte/in/nin/exists) plus a `hard:true` entry. `filters.specs` is
+    // the ONE namespaced key beside `categories`/`price` under the ONE `filters`
+    // object, holding the predicate array VERBATIM. The agent's `query` ("gloves")
+    // survives byte-for-byte: a plugin that folded the positive ops (eq/gte/lte/in)
+    // would append "black"/"10000mm"/"500"/"leather"/"suede" and this equality would
+    // FAIL — which is exactly the RED that the pure-transport rewrite must green.
+    const specs: SpecPredicate[] = [
+      { ns: "product", key: "color", op: "eq", value: "black", hard: true },
+      { ns: "product", key: "size", op: "neq", value: "xs" },
+      { ns: "product", key: "waterproof_rating", op: "gte", value: 10000, unit: "mm" },
+      { ns: "product", key: "weight_g", op: "lte", value: 500 },
+      { ns: "product", key: "material", op: "in", value: ["leather", "suede"] },
+      { ns: "seller", key: "name", op: "nin", value: ["acme"] },
+      { ns: "product", key: "insulation", op: "exists" },
+    ];
     await searchCatalog(SIL_API, "tok", {
       query: "gloves",
       category: "Apparel",
       price_max: 5000,
-      specs: [{ ns: "product", key: "color", op: "neq", value: "red" }],
+      specs,
     });
     expect(cap[0]!.body).toEqual({
       query: "gloves",
       filters: {
         categories: ["Apparel"],
         price: { max: 5000 },
-        specs: [{ ns: "product", key: "color", op: "neq", value: "red" }],
+        specs,
       },
     });
   });
@@ -714,116 +728,99 @@ describe("searchCatalog — specs ride ONE namespaced filters.specs key (whole-b
   });
 });
 
-describe("searchCatalog — the specs → query fold (positive ops render; negations/booleans render NOTHING)", () => {
+/**
+ * PURE TRANSPORT (founder scope revision 2026-07-13): `specs` NEVER touch `body.query`.
+ * The plugin forwards the agent's free-text VERBATIM; folding requirements into search
+ * text is the agent's job (sil-shopping loop, Beat 4). These assertions are the RED
+ * floor against the current fold implementation — each one fails while
+ * `renderSpecQuery` still appends positive predicate values, and greens once the fold
+ * is deleted and `body.query` reverts to forwarding `params.query` unchanged.
+ */
+describe("searchCatalog — specs are PURE TRANSPORT: body.query is the agent's query VERBATIM, untouched by any predicate", () => {
   let cap: Captured[];
   beforeEach(() => {
     cap = [];
     spyFetch(cap);
   });
 
-  /** The final `body.query` string (or undefined when the key is omitted). */
-  function foldedQuery(): string | undefined {
+  /** The outbound `body.query` (or undefined when the key is omitted). */
+  function outboundQuery(): string | undefined {
     const q = (cap[0]!.body as Record<string, unknown>)["query"];
     return typeof q === "string" ? q : undefined;
   }
 
-  it("a POSITIVE predicate folds its value into the query (a structured requirement still MOVES results at applied:false)", async () => {
+  it("a POSITIVE eq predicate leaves body.query EXACTLY the agent's query — the value appears NOWHERE in it (RED against the fold)", async () => {
     await searchCatalog(SIL_API, "tok", {
       query: "external drive",
       specs: [{ ns: "product", key: "capacity_gb", op: "eq", value: 512 }],
     });
-    const q = foldedQuery();
-    expect(q, "query key must be present").toBeTypeOf("string");
-    // The agent's phrasing stays PRIMARY (verbatim substring) …
-    expect(q!.toLowerCase()).toContain("external drive");
-    // … and the predicate value is folded in as a token (RED today — the fold does
-    // not exist, so "512" is absent).
-    expect(q!).toContain("512");
+    // Byte-exact: no token added, removed, or reordered by the predicate.
+    expect(outboundQuery()).toBe("external drive");
+    expect(outboundQuery()).not.toContain("512");
   });
 
-  it("folds the `unit` alongside the value for a gte predicate (value AND unit both surface)", async () => {
+  it("a gte predicate's value AND unit are NOT folded into the query (query stays byte-exact)", async () => {
     await searchCatalog(SIL_API, "tok", {
       query: "hiking gloves",
       specs: [{ ns: "product", key: "waterproof_rating", op: "gte", value: 10000, unit: "mm" }],
     });
-    const q = foldedQuery()!.toLowerCase();
-    expect(q).toContain("hiking gloves");
-    expect(q).toContain("10000");
-    expect(q).toContain("mm");
+    expect(outboundQuery()).toBe("hiking gloves");
+    const q = outboundQuery()!.toLowerCase();
+    expect(q).not.toContain("10000");
+    expect(q).not.toContain("mm");
   });
 
-  it("folds EACH element of an `in` array value", async () => {
+  it("an `in` array value is NOT folded — no element enters the query", async () => {
     await searchCatalog(SIL_API, "tok", {
       query: "jacket",
       specs: [{ ns: "product", key: "size", op: "in", value: ["medium", "large"] }],
     });
-    const q = foldedQuery()!.toLowerCase();
-    expect(q).toContain("jacket");
-    expect(q).toContain("medium");
-    expect(q).toContain("large");
+    expect(outboundQuery()).toBe("jacket");
+    const q = outboundQuery()!.toLowerCase();
+    expect(q).not.toContain("medium");
+    expect(q).not.toContain("large");
   });
 
-  it("DEDUPES case-insensitively against existing query tokens — a value already present is not doubled, a new one is added", async () => {
-    // Two predicates: `leather` already appears in the query (case-differently), `512`
-    // does not. The fold must ADD "512" (proving it ran — RED today) and must NOT
-    // append a second "leather" (the case-insensitive dedup — a naive append would
-    // make it appear twice).
+  it("a MIX of positive and negation predicates leaves the query byte-exactly the agent's — no token added, removed, or reordered", async () => {
+    // The general invariant in one shot: positive ops (which the old fold appended)
+    // and negations (which it excluded) both leave `body.query` identical to
+    // `params.query`. Byte-exact equality catches an add, a drop, and a reorder alike.
     await searchCatalog(SIL_API, "tok", {
-      query: "Leather bag",
+      query: "waterproof running shoes",
       specs: [
-        { ns: "product", key: "material", op: "eq", value: "leather" },
         { ns: "product", key: "capacity_gb", op: "eq", value: 512 },
-      ],
-    });
-    const q = foldedQuery()!.toLowerCase();
-    expect(q).toContain("512"); // the new value was folded (RED today)
-    // "leather" appears exactly ONCE — the case-insensitive dedup held.
-    expect((q.match(/leather/g) ?? []).length).toBe(1);
-  });
-
-  it("a NEGATION renders NOTHING into the query and NEVER surfaces the excluded value (fail-worse guard)", async () => {
-    // The cardinal query-fold hazard: rendering a `neq`/`nin` value as a bare positive
-    // token would surface exactly what the buyer wants EXCLUDED — worse than silent.
-    // The query must stay byte-exactly the agent's, and the excluded value must appear
-    // NOWHERE in it. (The predicate still rides filters.specs — asserted separately.)
-    await searchCatalog(SIL_API, "tok", {
-      query: "running shoes",
-      specs: [
         { ns: "product", key: "color", op: "neq", value: "pink" },
         { ns: "product", key: "brand", op: "nin", value: ["accaltd"] },
+        { ns: "product", key: "waterproof_rating", op: "gte", value: 10000, unit: "mm" },
       ],
     });
-    expect(foldedQuery()).toBe("running shoes");
-    const q = foldedQuery()!.toLowerCase();
+    expect(outboundQuery()).toBe("waterproof running shoes");
+    const q = outboundQuery()!.toLowerCase();
+    // The excluded values were never surfaced (the old fail-worse hazard) …
     expect(q).not.toContain("pink");
     expect(q).not.toContain("accaltd");
+    // … and no positive value was appended either — pure transport.
+    expect(q).not.toContain("512");
+    expect(q).not.toContain("10000");
   });
 
-  it("an `exists` predicate renders NOTHING into the query (it carries no value to fold) but still rides filters.specs", async () => {
+  it("query ABSENT + only a POSITIVE spec → the `query` key is OMITTED — specs NEVER synthesize a query", async () => {
+    // The critical case the pure-transport rewrite must green: the old fold synthesized
+    // a `query` string ("512") from a specs-only request. The plugin must NOT — with no
+    // agent free-text there is no query to forward, so the key is absent. The predicate
+    // still rides filters.specs, so the constraint is not lost.
     await searchCatalog(SIL_API, "tok", {
-      query: "tent",
-      specs: [{ ns: "product", key: "waterproof_rating", op: "exists" }],
+      specs: [{ ns: "product", key: "capacity_gb", op: "eq", value: 512 }],
     });
-    expect(foldedQuery()).toBe("tent");
-    const filters = ((cap[0]!.body as Record<string, unknown>)["filters"] ?? {}) as Record<string, unknown>;
-    expect(filters["specs"]).toEqual([{ ns: "product", key: "waterproof_rating", op: "exists" }]);
+    const body = cap[0]!.body as Record<string, unknown>;
+    expect(body).not.toHaveProperty("query");
+    const filters = (body["filters"] ?? {}) as Record<string, unknown>;
+    expect(filters["specs"]).toEqual([{ ns: "product", key: "capacity_gb", op: "eq", value: 512 }]);
   });
 
-  it("a BOOLEAN value renders NOTHING into the query even for a positive op (a bare `true` token is meaningless noise)", async () => {
-    await searchCatalog(SIL_API, "tok", {
-      query: "laptop",
-      specs: [{ ns: "product", key: "backlit_keyboard", op: "eq", value: true }],
-    });
-    expect(foldedQuery()).toBe("laptop");
-    const filters = ((cap[0]!.body as Record<string, unknown>)["filters"] ?? {}) as Record<string, unknown>;
-    // The predicate still forwards (the backend may index the boolean) — only the
-    // QUERY fold skips it.
-    expect(filters["specs"]).toEqual([{ ns: "product", key: "backlit_keyboard", op: "eq", value: true }]);
-  });
-
-  it("when ONLY negation/exists/boolean predicates are present and there is NO agent query, the `query` key is OMITTED", async () => {
-    // Nothing renders → no query text exists → no empty `query` key conjured. The
-    // predicates still ride filters.specs so the constraint is not lost.
+  it("query ABSENT + only negation/exists predicates → the `query` key is OMITTED, predicates still ride filters.specs", async () => {
+    // Forward guard (green today, must stay green): no agent free-text and nothing a
+    // fold would ever have rendered → no `query` key conjured, predicates preserved.
     await searchCatalog(SIL_API, "tok", {
       specs: [
         { ns: "product", key: "color", op: "neq", value: "red" },

--- a/src/__tests__/lib/search-client.test.ts
+++ b/src/__tests__/lib/search-client.test.ts
@@ -623,12 +623,6 @@ describe("searchCatalog — transport failure maps to retryable without leaking 
  *   buildSearchBody sets ONE `filters.specs` = the predicate array (verbatim, `hard`
  *   kept) and forwards `body.query` = `params.query` UNCHANGED. The exact mappings
  *   below ARE the immutable spec.
- *
- * EXPECT RED today: the current impl still FOLDS positive predicate values into
- * `body.query` (`renderSpecQuery`/`renderSpecTokens`/`POSITIVE_SPEC_OPS`). Every
- * "query untouched by specs" assertion below fails until that fold is deleted; the
- * `filters.specs` placement/verbatim/hard assertions already pass and stay as forward
- * guards.
  */
 describe("searchCatalog — specs ride ONE namespaced filters.specs key (whole-body equality, never spread)", () => {
   let cap: Captured[];
@@ -644,7 +638,7 @@ describe("searchCatalog — specs ride ONE namespaced filters.specs key (whole-b
     // object, holding the predicate array VERBATIM. The agent's `query` ("gloves")
     // survives byte-for-byte: a plugin that folded the positive ops (eq/gte/lte/in)
     // would append "black"/"10000mm"/"500"/"leather"/"suede" and this equality would
-    // FAIL — which is exactly the RED that the pure-transport rewrite must green.
+    // FAIL — the guard against any future re-introduction of a fold.
     const specs: SpecPredicate[] = [
       { ns: "product", key: "color", op: "eq", value: "black", hard: true },
       { ns: "product", key: "size", op: "neq", value: "xs" },
@@ -730,11 +724,10 @@ describe("searchCatalog — specs ride ONE namespaced filters.specs key (whole-b
 
 /**
  * PURE TRANSPORT (founder scope revision 2026-07-13): `specs` NEVER touch `body.query`.
- * The plugin forwards the agent's free-text VERBATIM; folding requirements into search
- * text is the agent's job (sil-shopping loop, Beat 4). These assertions are the RED
- * floor against the current fold implementation — each one fails while
- * `renderSpecQuery` still appends positive predicate values, and greens once the fold
- * is deleted and `body.query` reverts to forwarding `params.query` unchanged.
+ * The plugin forwards the agent's free-text VERBATIM; authoring search text from the
+ * requirements is the agent's job (sil-shopping loop, Beat 4). Every assertion below
+ * pins that invariant: `body.query` is byte-exactly `params.query`, and a specs-only
+ * request synthesizes no `query` key.
  */
 describe("searchCatalog — specs are PURE TRANSPORT: body.query is the agent's query VERBATIM, untouched by any predicate", () => {
   let cap: Captured[];
@@ -782,9 +775,9 @@ describe("searchCatalog — specs are PURE TRANSPORT: body.query is the agent's 
   });
 
   it("a MIX of positive and negation predicates leaves the query byte-exactly the agent's — no token added, removed, or reordered", async () => {
-    // The general invariant in one shot: positive ops (which the old fold appended)
-    // and negations (which it excluded) both leave `body.query` identical to
-    // `params.query`. Byte-exact equality catches an add, a drop, and a reorder alike.
+    // The general invariant in one shot: positive ops and negations alike leave
+    // `body.query` identical to `params.query`. Byte-exact equality catches an add,
+    // a drop, and a reorder alike.
     await searchCatalog(SIL_API, "tok", {
       query: "waterproof running shoes",
       specs: [
@@ -796,19 +789,18 @@ describe("searchCatalog — specs are PURE TRANSPORT: body.query is the agent's 
     });
     expect(outboundQuery()).toBe("waterproof running shoes");
     const q = outboundQuery()!.toLowerCase();
-    // The excluded values were never surfaced (the old fail-worse hazard) …
+    // Negation values never enter the query …
     expect(q).not.toContain("pink");
     expect(q).not.toContain("accaltd");
-    // … and no positive value was appended either — pure transport.
+    // … and no positive value either — pure transport.
     expect(q).not.toContain("512");
     expect(q).not.toContain("10000");
   });
 
   it("query ABSENT + only a POSITIVE spec → the `query` key is OMITTED — specs NEVER synthesize a query", async () => {
-    // The critical case the pure-transport rewrite must green: the old fold synthesized
-    // a `query` string ("512") from a specs-only request. The plugin must NOT — with no
-    // agent free-text there is no query to forward, so the key is absent. The predicate
-    // still rides filters.specs, so the constraint is not lost.
+    // With no agent free-text there is no query to forward, so the `query` key is
+    // absent — a specs-only request never synthesizes one. The predicate still rides
+    // filters.specs, so the constraint is not lost.
     await searchCatalog(SIL_API, "tok", {
       specs: [{ ns: "product", key: "capacity_gb", op: "eq", value: 512 }],
     });
@@ -819,8 +811,8 @@ describe("searchCatalog — specs are PURE TRANSPORT: body.query is the agent's 
   });
 
   it("query ABSENT + only negation/exists predicates → the `query` key is OMITTED, predicates still ride filters.specs", async () => {
-    // Forward guard (green today, must stay green): no agent free-text and nothing a
-    // fold would ever have rendered → no `query` key conjured, predicates preserved.
+    // No agent free-text → no `query` key conjured; the predicates still ride
+    // filters.specs, preserved.
     await searchCatalog(SIL_API, "tok", {
       specs: [
         { ns: "product", key: "color", op: "neq", value: "red" },

--- a/src/__tests__/tools/search.test.ts
+++ b/src/__tests__/tools/search.test.ts
@@ -984,3 +984,316 @@ describe("sil_search — token never logged (leak-canary)", () => {
     expect(blob).not.toMatch(/authorization/i);
   });
 });
+
+/**
+ * CARD `sds-forward-specs-contract` (epic `spec-driven-shopping-redesign`, Phase 2)
+ * — the RED unit floor for the `specs` param at the TOOL boundary: the SCHEMA shape
+ * (AC-A1), the description steer (AC-A1), the `invalid_spec` client-side rejection
+ * (AC-P4), the empty-vs-malformed split + `exists` validity (AC-A2), and specs-as-
+ * usable-input (AC-A3).
+ *
+ * `sil_search` gains an OPTIONAL `specs: SpecPredicate[]` — a CLOSED shape over an
+ * OPEN vocabulary: `{ ns, key, op, value?, unit?, hard? }`. `ns`/`key` carry NO enum
+ * and NO pattern (enumerating a `ns.key` is the central schema the design FORBIDS —
+ * [[sds-specs-vocabulary-is-bottom-up]]); `op` is exactly the seven literals; `value`
+ * is optional in the SCHEMA (an `exists` carries none) — the op↔value validity is a
+ * READ-SITE rule (`readSpecs`), the established flat-schema + read-site-enforcement
+ * idiom (`readSearchParams`/`ship_to`, NOT a new pattern). A malformed predicate
+ * rejects the WHOLE request client-side with code `invalid_spec`, ZERO network — the
+ * `invalid_filter`/`ship_to` twin.
+ *
+ * EXPECT RED today: the schema has no `specs` property, the description names no
+ * `specs` steer, and the tool neither validates nor forwards `specs` — so a malformed
+ * predicate is silently ignored (no `invalid_spec`) and a specs-only request is
+ * rejected as `empty_search_input` (not counted as usable input).
+ */
+describe("sil_search — schema exposes `specs` as an optional closed-shape / open-vocabulary array (AC-A1)", () => {
+  function searchProps(): Record<string, Record<string, unknown>> {
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+    const params = getTool(api, TOOL).parameters as {
+      properties?: Record<string, Record<string, unknown>>;
+    };
+    return params.properties ?? {};
+  }
+  /** The `specs` array's per-item object schema node. */
+  function specItemProps(): Record<string, Record<string, unknown>> {
+    const specs = searchProps()["specs"];
+    expect(specs, "specs must be a registered param").toBeDefined();
+    const items = (specs!["items"] ?? {}) as Record<string, unknown>;
+    return (items["properties"] ?? {}) as Record<string, Record<string, unknown>>;
+  }
+  /** Collect the literal values `op` allows, from whichever JSON-schema encoding
+   * TypeBox emits for a union-of-literals (`enum`, or `anyOf`/`oneOf` of `const`). */
+  function opLiterals(): string[] {
+    const op = specItemProps()["op"];
+    expect(op, "spec item must have an `op`").toBeDefined();
+    if (Array.isArray(op!["enum"])) return (op!["enum"] as unknown[]).map(String);
+    const union = (op!["anyOf"] ?? op!["oneOf"]) as Array<Record<string, unknown>> | undefined;
+    if (Array.isArray(union)) {
+      return union
+        .map((m) => (m["const"] !== undefined ? m["const"] : Array.isArray(m["enum"]) ? (m["enum"] as unknown[])[0] : undefined))
+        .filter((v): v is unknown => v !== undefined)
+        .map(String);
+    }
+    return [];
+  }
+
+  it("declares `specs` as an optional array of objects (NOT in the required set)", () => {
+    const specs = searchProps()["specs"];
+    expect(specs).toBeDefined();
+    expect(specs!["type"]).toBe("array");
+    const items = (specs!["items"] ?? {}) as Record<string, unknown>;
+    expect(items["type"]).toBe("object");
+
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+    const params = getTool(api, TOOL).parameters as { required?: unknown };
+    const required = Array.isArray(params.required) ? (params.required as string[]) : [];
+    expect(required).not.toContain("specs");
+  });
+
+  it("each predicate has props ns / key / op / value / unit / hard", () => {
+    const keys = Object.keys(specItemProps());
+    for (const k of ["ns", "key", "op", "value", "unit", "hard"]) {
+      expect(keys).toContain(k);
+    }
+  });
+
+  it("ns and key are OPEN strings — NO enum, NO pattern (enumerating a ns.key is the schema the design forbids)", () => {
+    // The load-bearing open-vocabulary guard: a `ns`/`key` enum or pattern would be
+    // the central spec registry the bottom-up design deliberately refuses. They are
+    // two SEPARATE plain-string wire fields, never a dotted string, never constrained.
+    for (const field of ["ns", "key"]) {
+      const node = specItemProps()[field];
+      expect(node, `${field} must exist`).toBeDefined();
+      expect(node!["type"]).toBe("string");
+      expect(node!["enum"]).toBeUndefined();
+      expect(node!["pattern"]).toBeUndefined();
+    }
+  });
+
+  it("op is a union of EXACTLY the seven operators {eq,neq,gte,lte,in,nin,exists}", () => {
+    expect(new Set(opLiterals())).toEqual(
+      new Set(["eq", "neq", "gte", "lte", "in", "nin", "exists"]),
+    );
+  });
+
+  it("unit is an optional string and hard is an optional boolean", () => {
+    expect(specItemProps()["unit"]!["type"]).toBe("string");
+    expect(specItemProps()["hard"]!["type"]).toBe("boolean");
+  });
+
+  it("value is present but NOT required within a predicate (an `exists` carries none — op↔value is a read-site rule)", () => {
+    const specs = searchProps()["specs"];
+    const items = (specs!["items"] ?? {}) as Record<string, unknown>;
+    const req = Array.isArray(items["required"]) ? (items["required"] as string[]) : [];
+    // `value` is schema-optional (validity is enforced at readSpecs, not the schema).
+    expect(req).not.toContain("value");
+    expect(req).not.toContain("unit");
+    expect(req).not.toContain("hard");
+  });
+});
+
+describe("sil_search — description steers `specs` as the open long-tail channel + prefer-a-dedicated-param (AC-A1)", () => {
+  function description(): string {
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+    return getTool(api, TOOL).description;
+  }
+
+  it("names `specs` as the structured channel for the OPEN long-tail (attributes with no dedicated param)", () => {
+    const d = description();
+    expect(d).toMatch(/specs/);
+    const dl = d.toLowerCase();
+    // It is the channel for structured requirements that have no dedicated param —
+    // the additive long-tail (capacity, rating, delivery days, …).
+    expect(dl).toMatch(/structured|requirement|attribute|long.tail|no dedicated/);
+  });
+
+  it("states PREFER A DEDICATED PARAM over a `specs` predicate for the same attribute, listing the reserved attributes", () => {
+    // Business rule 1 as a description steer (NOT a tool guard — the open-vocabulary
+    // design forbids a hardcoded ns.key→param map). The prose must tell the agent to
+    // route price/category/condition/availability/destination to their dedicated
+    // params and NOT double-constrain via a specs predicate.
+    const d = description();
+    const dl = d.toLowerCase();
+    expect(dl).toMatch(/prefer|instead of|rather than|do not use.*specs|not.*specs.*dedicated/);
+    // The reserved attributes with dedicated params are named so the agent knows the gap.
+    expect(dl).toMatch(/price/);
+    expect(dl).toMatch(/categor/);
+    expect(dl).toMatch(/condition/);
+    expect(dl).toMatch(/availab/);
+    expect(dl).toMatch(/ship_to|destination|deliver/);
+  });
+});
+
+describe("sil_search — a MALFORMED predicate rejects the whole request client-side with `invalid_spec`, ZERO network (AC-P4)", () => {
+  let api: MockPluginAPI;
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // A token IS present, so the read-site validation (not the not-registered path)
+    // is what rejects; fetch fails loudly if a malformed spec slips to the wire.
+    seedTokens();
+    fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(new Error("a malformed spec must not hit the network"));
+    api = createMockPluginApi();
+    registerCatalogTools(api);
+  });
+
+  /** Each entry: a label + the malformed predicate. A real `query` rides alongside so
+   * the request would ITSELF be valid — proving the malformed predicate rejects the
+   * WHOLE request (mirrors invalid_filter / ship_to), not merely an empty one. */
+  const MALFORMED: Array<[string, Record<string, unknown>]> = [
+    ["op outside the seven", { ns: "product", key: "x", op: "contains", value: "y" }],
+    ["blank ns", { ns: "", key: "x", op: "eq", value: 1 }],
+    ["blank key", { ns: "product", key: "", op: "eq", value: 1 }],
+    ["missing ns", { key: "x", op: "eq", value: 1 }],
+    ["value-op with NO value (eq)", { ns: "product", key: "x", op: "eq" }],
+    ["in with a NON-array value", { ns: "product", key: "x", op: "in", value: "medium" }],
+    ["nin with a NON-array value", { ns: "product", key: "x", op: "nin", value: "medium" }],
+    ["gte with a NON-number value", { ns: "product", key: "x", op: "gte", value: "big" }],
+    ["lte with a NON-number value", { ns: "product", key: "x", op: "lte", value: "small" }],
+    ["exists CARRYING a value", { ns: "product", key: "x", op: "exists", value: 5 }],
+  ];
+
+  for (const [label, predicate] of MALFORMED) {
+    it(`rejects (${label}) → invalid_request/invalid_spec, ZERO network`, async () => {
+      const payload = payloadOf(
+        await getTool(api, TOOL).execute("c1", { query: "gloves", specs: [predicate] }),
+      );
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(payload["status"]).toBe("invalid_request");
+      expect(payload["error"]).toBe("invalid_spec");
+    });
+  }
+
+  it("rejects even when the malformed predicate is the SECOND entry (validates the whole list, names the offender)", async () => {
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", {
+        query: "gloves",
+        specs: [
+          { ns: "product", key: "waterproof_rating", op: "gte", value: 10000 },
+          { ns: "product", key: "color", op: "in", value: "red" }, // in ⇒ array; malformed
+        ],
+      }),
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(payload["status"]).toBe("invalid_request");
+    expect(payload["error"]).toBe("invalid_spec");
+    // The message must name the offending predicate so the agent can fix it (mirrors
+    // invalid_filter naming `ship_to.country`). The offender is index 1 / its key.
+    expect(JSON.stringify(payload)).toMatch(/color|1|spec/i);
+  });
+
+  it("is DISTINCT from invalid_filter — a malformed spec is `invalid_spec`, not the ship_to `invalid_filter` code", async () => {
+    // The read arm carries a `code` so the right envelope fires. A malformed spec must
+    // never be mislabelled as a location-filter problem.
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", { query: "gloves", specs: [{ ns: "product", key: "x", op: "eq" }] }),
+    );
+    expect(payload["error"]).toBe("invalid_spec");
+    expect(payload["error"]).not.toBe("invalid_filter");
+  });
+});
+
+describe("sil_search — empty vs malformed specs split; `exists`-without-value is VALID; non-array dropped (AC-A2)", () => {
+  it("a benign `specs: []` alongside a real query is NOT invalid_spec — it PROCEEDS and forwards NO filters.specs", async () => {
+    seedTokens();
+    const bodies: unknown[] = [];
+    const fetchSpy = captureBodyFetch(bodies);
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { query: "gloves", specs: [] }));
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1); // proceeded, not rejected
+    expect(payload["status"]).toBe("ok");
+    const filters = ((bodies[0] as Record<string, unknown>)["filters"] ?? {}) as Record<string, unknown>;
+    expect(filters).not.toHaveProperty("specs"); // empty ⇒ no-op omit
+  });
+
+  it("`specs: []` as the request's ONLY content falls to `empty_search_input` (empty specs are no usable input), ZERO network", async () => {
+    seedTokens();
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(new Error("empty specs is no usable input — must not hit the network"));
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { specs: [] }));
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    // NOT invalid_spec (nothing is malformed) — it is the existing empty-input guard.
+    expect(payload["status"]).toBe("invalid_request");
+    expect(payload["error"]).toBe("empty_search_input");
+  });
+
+  it("an `exists` predicate with NO value is VALID (not invalid_spec) — it proceeds and rides filters.specs", async () => {
+    seedTokens();
+    const bodies: unknown[] = [];
+    const fetchSpy = captureBodyFetch(bodies);
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", {
+        query: "tent",
+        specs: [{ ns: "product", key: "waterproof_rating", op: "exists" }],
+      }),
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(payload["status"]).toBe("ok");
+    const filters = ((bodies[0] as Record<string, unknown>)["filters"] ?? {}) as Record<string, unknown>;
+    expect(filters["specs"]).toEqual([{ ns: "product", key: "waterproof_rating", op: "exists" }]);
+  });
+
+  it("a `specs` that is NOT an array is DROPPED (treated absent), not coerced — with a query it proceeds and forwards no filters.specs", async () => {
+    seedTokens();
+    const bodies: unknown[] = [];
+    const fetchSpy = captureBodyFetch(bodies);
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    // A drifted on-disk call passes a non-array `specs`; the read site drops it (the
+    // `readIds` discipline), never rejecting as invalid_spec and never coercing.
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", { query: "gloves", specs: "not-an-array" }),
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(payload["status"]).toBe("ok");
+    expect(payload["error"]).not.toBe("invalid_spec");
+    const filters = ((bodies[0] as Record<string, unknown>)["filters"] ?? {}) as Record<string, unknown>;
+    expect(filters).not.toHaveProperty("specs");
+  });
+});
+
+describe("sil_search — a non-empty well-formed `specs` COUNTS as usable input (AC-A3)", () => {
+  it("a specs-only request (no query, no dedicated filter) PROCEEDS to the network — a spec is a real constraint, not a refinement", async () => {
+    // The counterpart to the `local_merchants`/`cursor`/`limit` refinements (which do
+    // NOT constitute a search): a well-formed spec renders + filters, so it is a real
+    // input. `hasUsableInput` must count it — RED today (specs is ignored, so a
+    // specs-only request is rejected as empty_search_input and never reaches fetch).
+    seedTokens();
+    const bodies: unknown[] = [];
+    const fetchSpy = captureBodyFetch(bodies);
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", {
+        specs: [{ ns: "product", key: "capacity_gb", op: "gte", value: 512 }],
+      }),
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(payload["status"]).toBe("ok");
+    // And the predicate rode the wire under the one namespaced key.
+    const filters = ((bodies[0] as Record<string, unknown>)["filters"] ?? {}) as Record<string, unknown>;
+    expect(filters["specs"]).toEqual([{ ns: "product", key: "capacity_gb", op: "gte", value: 512 }]);
+  });
+});

--- a/src/lib/sil-client.ts
+++ b/src/lib/sil-client.ts
@@ -220,6 +220,48 @@ export interface ShipTo {
   postal_code?: string;
 }
 
+/** The comparison operator on a spec predicate. The seven split by their effect
+ * on the query FOLD (see {@link buildSearchBody}): the POSITIVE ops (`eq`/`gte`/
+ * `lte`/`in`) render their value into `query` text as a backstop; the negation +
+ * existence ops (`neq`/`nin`/`exists`) render NOTHING (a negation as a bare
+ * positive token would surface exactly what it excludes — fail-worse). All seven
+ * forward unchanged on the wire `filters.specs`; only the fold is op-aware. */
+export type SpecOp = "eq" | "neq" | "gte" | "lte" | "in" | "nin" | "exists";
+
+/** The value a spec predicate carries. A scalar for `eq`/`neq`, a number for
+ * `gte`/`lte`, an array for `in`/`nin`; `exists` carries NONE. Value is OPTIONAL
+ * in the shape (so `exists` fits) — the op→value validity is a READ-SITE rule
+ * (`readSpecs` in catalog.ts), not a schema one. */
+export type SpecValue = number | string | boolean | (string | number)[];
+
+/** One structured requirement projected from a filled PRD — the THIRD search
+ * channel beside free-text `query` and the dedicated params. Closed SHAPE, open
+ * `ns.key` VOCABULARY: `ns`/`key` are two free wire strings (the method coins them
+ * bottom-up; the TypeBox schema enumerates zero keys — [[sds-specs-vocabulary-is-
+ * bottom-up]]), never a dotted string. `hard` mirrors the PRD inviolability flag
+ * and is forwarded UNCHANGED so the backend can enforce once it lands and
+ * reflection can correlate the `applied:false` hard set. */
+export interface SpecPredicate {
+  ns: string;
+  key: string;
+  op: SpecOp;
+  value?: SpecValue;
+  unit?: string;
+  hard?: boolean;
+}
+
+/** The per-predicate applied-status the backend reports on the `ok` response —
+ * the OBSERVABLE fail-green signal. `applied:true` = the backend indexed it and
+ * truly filtered; `applied:false` = not indexed yet (it moved results only via the
+ * query fold), and that `applied:false` set is EXACTLY what reflection's
+ * hard-constraint honesty check polices. Surfaced verbatim, per-predicate — never
+ * collapsed to one boolean, never dropped. */
+export interface SpecStatus {
+  ns: string;
+  key: string;
+  applied: boolean;
+}
+
 /** The simplified search query an agent sends — a free-text `query` plus
  * optional filters and pagination. Maps 1:1 into the sil-api `CatalogSearchRequest`
  * body (`searchCatalog` builds the nested shape). All fields optional at this
@@ -250,6 +292,13 @@ export interface SearchParams {
   condition?: string[];
   available?: boolean;
   local_merchants?: boolean;
+  /** The structured requirement predicates ({@link SpecPredicate}) projected from a
+   * filled PRD — the open long-tail channel with no dedicated param. Each is
+   * DUAL-projected in `buildSearchBody`: it rides a single namespaced `filters.specs`
+   * key AND folds its value into `query` (positive ops only). Present-but-empty `[]`
+   * is a benign no-op (omits `filters.specs`, does not count as usable input); the
+   * per-predicate validity is enforced at the read site (`readSpecs`). */
+  specs?: SpecPredicate[];
 }
 
 /** A currency-tagged price, passed through OPAQUE from sil-api's UCP `Price`
@@ -338,6 +387,11 @@ export interface ProductDescription {
 export interface SearchResult {
   products: SearchProduct[];
   cursor?: string;
+  /** The per-predicate applied-status ({@link SpecStatus}[]) read off the flat
+   * envelope's top-level `specs_status` — a SIBLING of `products`, so it surfaces on
+   * an empty match too. OMITTED entirely when the wire carries none (no fabricated
+   * default — interpreting absence as unconfirmed is reflection's job). */
+  specs_status?: SpecStatus[];
 }
 
 /**
@@ -370,7 +424,7 @@ export interface SearchResult {
  * whether to clear the dead token (only on `user_not_provisioned`).
  */
 export type SearchOutcome =
-  | { kind: "ok"; products: SearchProduct[]; cursor?: string }
+  | { kind: "ok"; products: SearchProduct[]; cursor?: string; specs_status?: SpecStatus[] }
   | { kind: "unauthorized" }
   | { kind: "forbidden"; reason: string }
   | { kind: "invalid_request"; error: string; message: string }
@@ -1060,7 +1114,12 @@ function extractForbiddenReason(body: unknown): string {
  */
 function buildSearchBody(params: SearchParams): Record<string, unknown> {
   const body: Record<string, unknown> = {};
-  if (typeof params.query === "string") body["query"] = params.query;
+  // The agent's free-text `query` is PRIMARY; each POSITIVE spec predicate folds
+  // its value(+unit) in as a backstop (deduped case-insensitively) so a structured
+  // requirement still moves results at `applied:false`. `renderSpecQuery` returns
+  // the base query verbatim when there are no specs (behaviour-preserving).
+  const query = renderSpecQuery(params.query, params.specs ?? []);
+  if (query !== undefined) body["query"] = query;
 
   const filters: Record<string, unknown> = {};
   if (typeof params.category === "string") {
@@ -1078,6 +1137,14 @@ function buildSearchBody(params: SearchParams): Record<string, unknown> {
   if (params.condition !== undefined) filters["condition"] = params.condition;
   if (typeof params.available === "boolean") filters["available"] = params.available;
 
+  // The structured requirement predicates ride ONE namespaced well-known key —
+  // `filters.specs` holds the WHOLE array (never spread as `filters.<key>`, which
+  // would collide with a typed filter and fail-green on the open `SearchFilters`;
+  // never top-level — unlike the sil-private `local_merchants`, `specs` is a
+  // backend-bound filter). `hard` rides each entry UNCHANGED. A present-but-empty
+  // `[]` emits nothing (the query is unchanged, `filters.specs` omitted).
+  if (Array.isArray(params.specs) && params.specs.length > 0) filters["specs"] = params.specs;
+
   if (Object.keys(filters).length > 0) body["filters"] = filters;
 
   // `local_merchants` is a sil-PRIVATE ranking bias — it rides at the TOP LEVEL of
@@ -1094,6 +1161,69 @@ function buildSearchBody(params: SearchParams): Record<string, unknown> {
   if (Object.keys(pagination).length > 0) body["pagination"] = pagination;
 
   return body;
+}
+
+/** The POSITIVE spec ops whose value folds into the free-text query. The rest
+ * (`neq`/`nin`/`exists`) render NOTHING — a negation as a bare positive token
+ * would surface exactly what it EXCLUDES, failing worse than a silent no-op. */
+const POSITIVE_SPEC_OPS: ReadonlySet<SpecOp> = new Set(["eq", "gte", "lte", "in"]);
+
+/**
+ * Fold the POSITIVE spec predicates into the agent's free-text `query` as a
+ * backstop so a structured requirement still moves results while the backend
+ * reports it `applied:false`. The agent's phrasing stays PRIMARY and un-mangled:
+ * its tokens are kept, and each spec token is appended ONLY when not already
+ * present (case-insensitive, whitespace-tokenized) so the fold never duplicates
+ * what the agent already wrote nor what an earlier predicate rendered.
+ *
+ * A predicate renders `value` immediately followed by `unit` (`16` + `GB` →
+ * `16GB`, matching the design's rendered-form example — NO separating space); an
+ * `in` array renders one token per element. Negation/existence ops and BOOLEAN
+ * values render nothing (see {@link POSITIVE_SPEC_OPS}).
+ *
+ * Behaviour-preserving when `specs` is empty: returns the base `query` verbatim
+ * (including an empty string, kept present), or `undefined` when there is no base
+ * query and nothing to fold (so `buildSearchBody` omits the key).
+ */
+function renderSpecQuery(query: string | undefined, specs: SpecPredicate[]): string | undefined {
+  const hasBase = typeof query === "string";
+  const base = hasBase ? query : "";
+  const seen = new Set(tokenizeQuery(base));
+  const additions: string[] = [];
+  for (const spec of specs) {
+    for (const token of renderSpecTokens(spec)) {
+      const lower = token.toLowerCase();
+      if (seen.has(lower)) continue;
+      seen.add(lower);
+      additions.push(token);
+    }
+  }
+  if (additions.length === 0) return hasBase ? base : undefined;
+  return [base, ...additions].filter((token) => token.length > 0).join(" ");
+}
+
+/** The free-text query as lower-cased, whitespace-split tokens — the dedup set the
+ * spec fold checks each rendered token against. */
+function tokenizeQuery(query: string): string[] {
+  return query
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((token) => token.length > 0);
+}
+
+/** Render one predicate to its query token(s), or none. Only POSITIVE ops render;
+ * `value` is stringified with `unit` appended (no space), an array value yields one
+ * token per element, and a boolean/absent value renders nothing. */
+function renderSpecTokens(spec: SpecPredicate): string[] {
+  if (!POSITIVE_SPEC_OPS.has(spec.op)) return [];
+  const unit = typeof spec.unit === "string" ? spec.unit : "";
+  const values = Array.isArray(spec.value) ? spec.value : [spec.value];
+  const tokens: string[] = [];
+  for (const value of values) {
+    if (typeof value !== "string" && typeof value !== "number") continue;
+    tokens.push(`${value}${unit}`);
+  }
+  return tokens;
 }
 
 /** Emit a ship-to object with its alpha-2 `country` UPPERCASED on the wire
@@ -1127,6 +1257,11 @@ function withUppercaseCountry<T extends { country: string }>(value: T): T {
  * The opaque cursor is hoisted from `pagination.cursor` and surfaced ONLY when
  * `pagination.has_next_page` is true (end-of-results is the absent cursor — never
  * derived from `products.length`).
+ *
+ * `specs_status` is read off the SAME flat envelope as a sibling of `products`
+ * (via {@link extractSpecsStatus}), so the observable per-predicate applied-status
+ * surfaces even on an empty match. It is informational — NEVER a purchasability
+ * gate; the `Array.isArray(products)` anti-false-green guard is unchanged.
  */
 function extractSearchResult(body: unknown): SearchResult | null {
   const envelope = asRecord(body);
@@ -1139,8 +1274,37 @@ function extractSearchResult(body: unknown): SearchResult | null {
     .map(projectProduct)
     .filter((p): p is SearchProduct => p !== null);
 
+  const result: SearchResult = { products };
   const cursor = extractCursor(envelope["pagination"]);
-  return cursor === null ? { products } : { products, cursor };
+  if (cursor !== null) result.cursor = cursor;
+  const specsStatus = extractSpecsStatus(envelope["specs_status"]);
+  if (specsStatus !== null) result.specs_status = specsStatus;
+  return result;
+}
+
+/** Narrow the wire `specs_status` to {@link SpecStatus}[], or null to OMIT the
+ * key. Each usable entry needs a non-empty string `ns`, a non-empty string `key`,
+ * and a BOOLEAN `applied`; a malformed entry is DROPPED (never fabricated
+ * `applied:true`, never a crash). Returns null when the field is absent/non-array
+ * OR when no entry survives — the no-fabrication discipline: interpreting the
+ * ABSENCE of a status is reflection's job, not the tool's. A fully-`applied:false`
+ * array is the honest "not indexed yet" shape and passes through whole. */
+function extractSpecsStatus(raw: unknown): SpecStatus[] | null {
+  if (!Array.isArray(raw)) return null;
+  const statuses = raw
+    .map((entry): SpecStatus | null => {
+      const obj = asRecord(entry);
+      if (obj === null) return null;
+      const ns = obj["ns"];
+      const key = obj["key"];
+      const applied = obj["applied"];
+      if (typeof ns !== "string" || ns.length === 0) return null;
+      if (typeof key !== "string" || key.length === 0) return null;
+      if (typeof applied !== "boolean") return null;
+      return { ns, key, applied };
+    })
+    .filter((s): s is SpecStatus => s !== null);
+  return statuses.length === 0 ? null : statuses;
 }
 
 /**

--- a/src/lib/sil-client.ts
+++ b/src/lib/sil-client.ts
@@ -220,12 +220,10 @@ export interface ShipTo {
   postal_code?: string;
 }
 
-/** The comparison operator on a spec predicate. The seven split by their effect
- * on the query FOLD (see {@link buildSearchBody}): the POSITIVE ops (`eq`/`gte`/
- * `lte`/`in`) render their value into `query` text as a backstop; the negation +
- * existence ops (`neq`/`nin`/`exists`) render NOTHING (a negation as a bare
- * positive token would surface exactly what it excludes — fail-worse). All seven
- * forward unchanged on the wire `filters.specs`; only the fold is op-aware. */
+/** The comparison operator on a spec predicate. All seven forward UNCHANGED on the
+ * wire `filters.specs` — the plugin is pure transport and never interprets an op.
+ * The op→value shape validity is a READ-SITE rule (`readSpecs` in catalog.ts), not
+ * a wire concern. */
 export type SpecOp = "eq" | "neq" | "gte" | "lte" | "in" | "nin" | "exists";
 
 /** The value a spec predicate carries. A scalar for `eq`/`neq`, a number for
@@ -252,10 +250,9 @@ export interface SpecPredicate {
 
 /** The per-predicate applied-status the backend reports on the `ok` response —
  * the OBSERVABLE fail-green signal. `applied:true` = the backend indexed it and
- * truly filtered; `applied:false` = not indexed yet (it moved results only via the
- * query fold), and that `applied:false` set is EXACTLY what reflection's
- * hard-constraint honesty check polices. Surfaced verbatim, per-predicate — never
- * collapsed to one boolean, never dropped. */
+ * truly filtered; `applied:false` = not indexed yet, and that `applied:false` set
+ * is EXACTLY what reflection's hard-constraint honesty check polices. Surfaced
+ * verbatim, per-predicate — never collapsed to one boolean, never dropped. */
 export interface SpecStatus {
   ns: string;
   key: string;
@@ -293,10 +290,11 @@ export interface SearchParams {
   available?: boolean;
   local_merchants?: boolean;
   /** The structured requirement predicates ({@link SpecPredicate}) projected from a
-   * filled PRD — the open long-tail channel with no dedicated param. Each is
-   * DUAL-projected in `buildSearchBody`: it rides a single namespaced `filters.specs`
-   * key AND folds its value into `query` (positive ops only). Present-but-empty `[]`
-   * is a benign no-op (omits `filters.specs`, does not count as usable input); the
+   * filled PRD — the open long-tail channel with no dedicated param. Each rides a
+   * single namespaced `filters.specs` key in `buildSearchBody`, forwarded VERBATIM:
+   * the plugin is pure transport and NEVER folds a predicate into `query` (the agent
+   * authors free-text from the requirements itself). Present-but-empty `[]` is a
+   * benign no-op (omits `filters.specs`, does not count as usable input); the
    * per-predicate validity is enforced at the read site (`readSpecs`). */
   specs?: SpecPredicate[];
 }
@@ -1114,12 +1112,10 @@ function extractForbiddenReason(body: unknown): string {
  */
 function buildSearchBody(params: SearchParams): Record<string, unknown> {
   const body: Record<string, unknown> = {};
-  // The agent's free-text `query` is PRIMARY; each POSITIVE spec predicate folds
-  // its value(+unit) in as a backstop (deduped case-insensitively) so a structured
-  // requirement still moves results at `applied:false`. `renderSpecQuery` returns
-  // the base query verbatim when there are no specs (behaviour-preserving).
-  const query = renderSpecQuery(params.query, params.specs ?? []);
-  if (query !== undefined) body["query"] = query;
+  // The agent's free-text `query` is forwarded VERBATIM. The plugin is pure
+  // transport — a `specs` predicate NEVER folds into `query` (that lossy/unsafe job
+  // belongs to the agent, which authors the free-text from the requirements).
+  if (typeof params.query === "string") body["query"] = params.query;
 
   const filters: Record<string, unknown> = {};
   if (typeof params.category === "string") {
@@ -1161,69 +1157,6 @@ function buildSearchBody(params: SearchParams): Record<string, unknown> {
   if (Object.keys(pagination).length > 0) body["pagination"] = pagination;
 
   return body;
-}
-
-/** The POSITIVE spec ops whose value folds into the free-text query. The rest
- * (`neq`/`nin`/`exists`) render NOTHING — a negation as a bare positive token
- * would surface exactly what it EXCLUDES, failing worse than a silent no-op. */
-const POSITIVE_SPEC_OPS: ReadonlySet<SpecOp> = new Set(["eq", "gte", "lte", "in"]);
-
-/**
- * Fold the POSITIVE spec predicates into the agent's free-text `query` as a
- * backstop so a structured requirement still moves results while the backend
- * reports it `applied:false`. The agent's phrasing stays PRIMARY and un-mangled:
- * its tokens are kept, and each spec token is appended ONLY when not already
- * present (case-insensitive, whitespace-tokenized) so the fold never duplicates
- * what the agent already wrote nor what an earlier predicate rendered.
- *
- * A predicate renders `value` immediately followed by `unit` (`16` + `GB` →
- * `16GB`, matching the design's rendered-form example — NO separating space); an
- * `in` array renders one token per element. Negation/existence ops and BOOLEAN
- * values render nothing (see {@link POSITIVE_SPEC_OPS}).
- *
- * Behaviour-preserving when `specs` is empty: returns the base `query` verbatim
- * (including an empty string, kept present), or `undefined` when there is no base
- * query and nothing to fold (so `buildSearchBody` omits the key).
- */
-function renderSpecQuery(query: string | undefined, specs: SpecPredicate[]): string | undefined {
-  const hasBase = typeof query === "string";
-  const base = hasBase ? query : "";
-  const seen = new Set(tokenizeQuery(base));
-  const additions: string[] = [];
-  for (const spec of specs) {
-    for (const token of renderSpecTokens(spec)) {
-      const lower = token.toLowerCase();
-      if (seen.has(lower)) continue;
-      seen.add(lower);
-      additions.push(token);
-    }
-  }
-  if (additions.length === 0) return hasBase ? base : undefined;
-  return [base, ...additions].filter((token) => token.length > 0).join(" ");
-}
-
-/** The free-text query as lower-cased, whitespace-split tokens — the dedup set the
- * spec fold checks each rendered token against. */
-function tokenizeQuery(query: string): string[] {
-  return query
-    .toLowerCase()
-    .split(/\s+/)
-    .filter((token) => token.length > 0);
-}
-
-/** Render one predicate to its query token(s), or none. Only POSITIVE ops render;
- * `value` is stringified with `unit` appended (no space), an array value yields one
- * token per element, and a boolean/absent value renders nothing. */
-function renderSpecTokens(spec: SpecPredicate): string[] {
-  if (!POSITIVE_SPEC_OPS.has(spec.op)) return [];
-  const unit = typeof spec.unit === "string" ? spec.unit : "";
-  const values = Array.isArray(spec.value) ? spec.value : [spec.value];
-  const tokens: string[] = [];
-  for (const value of values) {
-    if (typeof value !== "string" && typeof value !== "number") continue;
-    tokens.push(`${value}${unit}`);
-  }
-  return tokens;
 }
 
 /** Emit a ship-to object with its alpha-2 `country` UPPERCASED on the wire

--- a/src/tools/catalog.ts
+++ b/src/tools/catalog.ts
@@ -314,7 +314,7 @@ function registerSearch(api: PluginAPI): void {
               Type.String({
                 description:
                   "The value's unit (e.g. \"mm\", \"GB\", \"days\") — optional context"
-                  + " carried on the wire and folded into the query text.",
+                  + " carried on the wire.",
               }),
             ),
             hard: Type.Optional(
@@ -330,7 +330,7 @@ function registerSearch(api: PluginAPI): void {
               "Structured requirement predicates for the OPEN LONG-TAIL of attributes"
               + " with no dedicated param (product.capacity_gb, seller.rating_average,"
               + " shipping.delivery_max_days). Each { ns, key, op, value, unit?, hard? }"
-              + " both rides the request AND folds into the query text. PREFER a"
+              + " rides the request under one namespaced `filters.specs` key. PREFER a"
               + " dedicated param (price_min/price_max, category, condition, available,"
               + " ship_to) over a `specs` predicate for the SAME attribute — never send"
               + " both. Omit when there are no structured requirements.",

--- a/src/tools/catalog.ts
+++ b/src/tools/catalog.ts
@@ -61,6 +61,9 @@ import {
   type SearchOutcome,
   type SearchParams,
   type ShipTo,
+  type SpecOp,
+  type SpecPredicate,
+  type SpecValue,
 } from "../lib/sil-client.js";
 import { jsonResult } from "../lib/tool-result.js";
 
@@ -143,7 +146,17 @@ function registerSearch(api: PluginAPI): void {
       + " results are all local. To surface MORE local shops you MAY also issue the"
       + " `query` in that country's language (a Greek-language query surfaces Greek"
       + " shops) — optional, and never an override of a language the user deliberately"
-      + " chose; pass NO country — sil resolves it server-side. Requires registration (run"
+      + " chose; pass NO country — sil resolves it server-side. `specs` is the"
+      + " STRUCTURED requirement channel — a list of typed predicates ({ ns, key, op,"
+      + " value, unit?, hard? }) for the OPEN LONG-TAIL of attributes that have no"
+      + " dedicated param (e.g. product.capacity_gb, seller.rating_average,"
+      + " shipping.delivery_max_days). PREFER A DEDICATED PARAM OVER A `specs`"
+      + " PREDICATE FOR THE SAME ATTRIBUTE: route price to price_min/price_max,"
+      + " category to category, condition to condition, availability to available,"
+      + " and the delivery destination to ship_to — never send both a dedicated"
+      + " param and a `specs` predicate for the one attribute (that risks an"
+      + " over-narrow or divergent result). Mark a predicate `hard: true` when the"
+      + " requirement is inviolable. Requires registration (run"
       + " sil_register first).",
     parameters: Type.Object({
       query: Type.Optional(
@@ -253,6 +266,77 @@ function registerSearch(api: PluginAPI): void {
             + " to keep the default (available only).",
         }),
       ),
+      specs: Type.Optional(
+        Type.Array(
+          Type.Object({
+            ns: Type.String({
+              description:
+                "The predicate NAMESPACE (e.g. \"product\", \"seller\", \"shipping\")"
+                + " — a free string, coined bottom-up; NOT dotted with the key.",
+            }),
+            key: Type.String({
+              description:
+                "The predicate KEY within the namespace (e.g. \"capacity_gb\","
+                + " \"rating_average\") — a free string, coined bottom-up.",
+            }),
+            op: Type.Union(
+              [
+                Type.Literal("eq"),
+                Type.Literal("neq"),
+                Type.Literal("gte"),
+                Type.Literal("lte"),
+                Type.Literal("in"),
+                Type.Literal("nin"),
+                Type.Literal("exists"),
+              ],
+              {
+                description:
+                  "The comparison operator. `gte`/`lte` need a number `value`;"
+                  + " `in`/`nin` need an array `value`; `eq`/`neq` need a scalar"
+                  + " `value`; `exists` takes NO `value`.",
+              },
+            ),
+            value: Type.Optional(
+              Type.Union(
+                [
+                  Type.Number(),
+                  Type.String(),
+                  Type.Boolean(),
+                  Type.Array(Type.Union([Type.String(), Type.Number()])),
+                ],
+                {
+                  description:
+                    "The compared value, matching the op (omit it for `exists`).",
+                },
+              ),
+            ),
+            unit: Type.Optional(
+              Type.String({
+                description:
+                  "The value's unit (e.g. \"mm\", \"GB\", \"days\") — optional context"
+                  + " carried on the wire and folded into the query text.",
+              }),
+            ),
+            hard: Type.Optional(
+              Type.Boolean({
+                description:
+                  "Set true when the requirement is INVIOLABLE (a hard constraint the"
+                  + " result must satisfy), false/omit for a soft preference.",
+              }),
+            ),
+          }),
+          {
+            description:
+              "Structured requirement predicates for the OPEN LONG-TAIL of attributes"
+              + " with no dedicated param (product.capacity_gb, seller.rating_average,"
+              + " shipping.delivery_max_days). Each { ns, key, op, value, unit?, hard? }"
+              + " both rides the request AND folds into the query text. PREFER a"
+              + " dedicated param (price_min/price_max, category, condition, available,"
+              + " ship_to) over a `specs` predicate for the SAME attribute — never send"
+              + " both. Omit when there are no structured requirements.",
+          },
+        ),
+      ),
     }),
     async execute(_callId, params) {
       // 1 — not registered: terminal, zero network calls.
@@ -269,6 +353,10 @@ function registerSearch(api: PluginAPI): void {
       // `invalid_filter` beats an opaque, fail-late sil-api 400 (re-spec).
       const read = readSearchParams(params);
       if (read.kind === "invalid") {
+        if (read.code === "invalid_spec") {
+          api.logger.info("sil_search_invalid_spec", { field: read.field });
+          return invalidSpec(read.field);
+        }
         api.logger.info("sil_search_invalid_filter", { field: read.field });
         return invalidFilter(read.field);
       }
@@ -561,12 +649,14 @@ type FilterRead<T> =
   | { kind: "invalid"; field: string };
 
 /** The outcome of narrowing the whole param object: either the typed
- * {@link SearchParams} to forward, or the FIRST bad-format field that rejects the
- * request client-side (the read site owns FORMAT rejection; the wire owns
- * country-case normalization). */
+ * {@link SearchParams} to forward, or the FIRST bad field that rejects the request
+ * client-side. `code` names WHICH reject envelope the tool emits — a bad-FORMAT
+ * location filter (`invalid_filter`) or a malformed spec predicate
+ * (`invalid_spec`) — so the two client-side rejects stay distinguishable (the read
+ * site owns FORMAT + op→value rejection; the wire owns country-case normalization). */
 type SearchParamsRead =
   | { kind: "ok"; params: SearchParams }
-  | { kind: "invalid"; field: string };
+  | { kind: "invalid"; field: string; code: "invalid_filter" | "invalid_spec" };
 
 /** Narrow the untrusted `params` to the simplified {@link SearchParams}, or report
  * the first bad-FORMAT filter field. A field of the wrong type is dropped (treated
@@ -605,7 +695,9 @@ function readSearchParams(params: Record<string, unknown>): SearchParamsRead {
   if (typeof limit === "number") result.limit = limit;
 
   const shipTo = readShipTo(params["ship_to"]);
-  if (shipTo.kind === "invalid") return { kind: "invalid", field: shipTo.field };
+  if (shipTo.kind === "invalid") {
+    return { kind: "invalid", field: shipTo.field, code: "invalid_filter" };
+  }
   if (shipTo.kind === "ok") result.ship_to = shipTo.value;
 
   const condition = readCondition(params["condition"]);
@@ -619,6 +711,16 @@ function readSearchParams(params: Record<string, unknown>): SearchParamsRead {
   // unlike `available:false`, a false bias carries no ranking signal.
   const localMerchants = params["local_merchants"];
   if (typeof localMerchants === "boolean") result.local_merchants = localMerchants;
+
+  // `specs` is a THIRD input class (a real constraint, not a refinement): a
+  // malformed predicate rejects the whole request client-side (`invalid_spec`,
+  // zero network — the `invalid_filter` twin); a non-array is DROPPED (the
+  // `readIds` discipline); a benign empty `[]` reads `ok` and no-ops downstream.
+  const specs = readSpecs(params["specs"]);
+  if (specs.kind === "invalid") {
+    return { kind: "invalid", field: specs.field, code: "invalid_spec" };
+  }
+  if (specs.kind === "ok") result.specs = specs.value;
 
   return { kind: "ok", params: result };
 }
@@ -682,9 +784,111 @@ function readCondition(raw: unknown): string[] | null {
   return values.length === 0 ? null : values;
 }
 
+/** The seven spec ops, the ONLY closed part of the predicate contract (the `ns`/
+ * `key` vocabulary is deliberately open — [[sds-specs-vocabulary-is-bottom-up]]). */
+const SPEC_OPS: readonly SpecOp[] = ["eq", "neq", "gte", "lte", "in", "nin", "exists"];
+
+function isSpecOp(op: string): op is SpecOp {
+  return (SPEC_OPS as readonly string[]).includes(op);
+}
+
+/** The op→value validity rule, enforced at the READ SITE (the flat-schema +
+ * read-site idiom — the schema keeps `value` optional so `exists` fits; the
+ * per-op requirement lives here, not in TypeBox):
+ *   - `exists` carries NO value;
+ *   - `in`/`nin` need a NON-EMPTY array of string|number;
+ *   - `gte`/`lte` need a number;
+ *   - `eq`/`neq` need a scalar (string|number|boolean).
+ * Exhaustive over {@link SpecOp} — a new op forces a case here. */
+function specValueMatchesOp(op: SpecOp, value: unknown): boolean {
+  switch (op) {
+    case "exists":
+      return value === undefined;
+    case "in":
+    case "nin":
+      return (
+        Array.isArray(value)
+        && value.length > 0
+        && value.every((v) => typeof v === "string" || typeof v === "number")
+      );
+    case "gte":
+    case "lte":
+      return typeof value === "number";
+    case "eq":
+    case "neq":
+      return typeof value === "string" || typeof value === "number" || typeof value === "boolean";
+  }
+}
+
+/** The outcome of narrowing ONE untrusted predicate: the typed {@link SpecPredicate}
+ * to forward, or the offending index/field that rejects the whole request. */
+type SpecRead =
+  | { kind: "ok"; value: SpecPredicate }
+  | { kind: "invalid"; field: string };
+
+/** The outcome of narrowing the whole `specs` arg. `absent` covers both a missing
+ * arg AND a non-array (DROPPED — the `readIds` discipline); an empty array reads
+ * `ok` with an empty value (a benign no-op downstream). The FIRST malformed
+ * predicate wins the `invalid`. */
+type SpecsRead =
+  | { kind: "ok"; value: SpecPredicate[] }
+  | { kind: "absent" }
+  | { kind: "invalid"; field: string };
+
+/** Narrow the untrusted `specs` arg to {@link SpecPredicate}[], or report the FIRST
+ * malformed predicate. A non-array is DROPPED (treated absent — the `readIds`
+ * discipline; a drifted on-disk call must not slip a non-array through). Each entry
+ * must be an object with a non-blank `ns` and `key`, an `op` in the seven, and a
+ * `value` matching the op ({@link specValueMatchesOp}) — else the WHOLE request is
+ * rejected client-side (`invalid_spec`, zero network — the `invalid_filter` twin),
+ * because a malformed hard predicate silently dropped would be a fail-worse honesty
+ * hole. `unit`/`hard` are carried when the right type, dropped otherwise. No `any`,
+ * no unchecked `as` (the one cast is gated by {@link specValueMatchesOp}). */
+function readSpecs(raw: unknown): SpecsRead {
+  if (!Array.isArray(raw)) return { kind: "absent" };
+  const specs: SpecPredicate[] = [];
+  for (let index = 0; index < raw.length; index++) {
+    const read = readSpec(raw[index], index);
+    if (read.kind === "invalid") return read;
+    specs.push(read.value);
+  }
+  return { kind: "ok", value: specs };
+}
+
+/** Narrow ONE untrusted predicate to {@link SpecPredicate}, or report the offending
+ * field (`specs[i]`, `specs[i].ns`, `specs[i].op`, `specs[i].value`, …) for a clear
+ * client-side reject. */
+function readSpec(raw: unknown, index: number): SpecRead {
+  const at = (suffix: string): string => `specs[${index}]${suffix}`;
+  const obj = asRecord(raw);
+  if (obj === null) return { kind: "invalid", field: at("") };
+
+  const ns = obj["ns"];
+  if (typeof ns !== "string" || ns.trim().length === 0) return { kind: "invalid", field: at(".ns") };
+  const key = obj["key"];
+  if (typeof key !== "string" || key.trim().length === 0) return { kind: "invalid", field: at(".key") };
+
+  const op = obj["op"];
+  if (typeof op !== "string" || !isSpecOp(op)) return { kind: "invalid", field: at(".op") };
+
+  const value = obj["value"];
+  if (!specValueMatchesOp(op, value)) return { kind: "invalid", field: at(".value") };
+
+  const spec: SpecPredicate = { ns, key, op };
+  // `exists` carries no value (validated above); the others carry the op-checked value.
+  if (op !== "exists") spec.value = value as SpecValue;
+  const unit = obj["unit"];
+  if (typeof unit === "string") spec.unit = unit;
+  const hard = obj["hard"];
+  if (typeof hard === "boolean") spec.hard = hard;
+  return { kind: "ok", value: spec };
+}
+
 /** The one client-side invariant the tool owns: at least one recognized input.
- * A non-whitespace `query` OR any filter (`category` / `price_min` / `price_max`)
- * suffices. A bare `{}` or a whitespace-only `query` with no filter is rejected;
+ * A non-whitespace `query`, any filter (`category` / `price_min` / `price_max`),
+ * OR a non-empty well-formed `specs` list suffices — a spec is a real constraint
+ * (it renders + filters), not a refinement. A bare `{}`, a whitespace-only `query`
+ * with no filter, or a present-but-EMPTY `specs: []` with nothing else is rejected;
  * pagination params alone (`cursor`/`limit`) are NOT inputs — they refine an
  * existing search, they do not constitute one. */
 function hasUsableInput(params: SearchParams): boolean {
@@ -693,7 +897,8 @@ function hasUsableInput(params: SearchParams): boolean {
     typeof params.category === "string"
     || typeof params.price_min === "number"
     || typeof params.price_max === "number";
-  return hasQuery || hasFilter;
+  const hasSpecs = Array.isArray(params.specs) && params.specs.length > 0;
+  return hasQuery || hasFilter || hasSpecs;
 }
 
 /** Success: the ranked products + optional cursor — no token, no Bearer header.
@@ -746,6 +951,23 @@ function invalidFilter(field: string) {
       + " free-text names: country as a 2-letter ISO 3166-1 alpha-2 code (e.g."
       + " \"US\"), region as an ISO 3166-2 subdivision code (e.g. \"CA\"), and"
       + " postal_code as a destination postal/ZIP code.",
+  });
+}
+
+/** Client-side validation: a `specs` predicate is malformed (blank `ns`/`key`, an
+ * `op` outside the seven, or a value shape contradicting the op) — rejected BEFORE
+ * any network call, the twin of {@link invalidFilter} for `ship_to`. Distinct
+ * machine code `invalid_spec`; `field` names the offending predicate index/field.
+ * No `recovery: sil_register` — auth is fine; the predicate is the problem. */
+function invalidSpec(field: string) {
+  return jsonResult({
+    status: "invalid_request",
+    error: "invalid_spec",
+    message:
+      `The \`${field}\` spec predicate is malformed. Each predicate needs a`
+      + " non-empty `ns` and `key`, an `op` of eq/neq/gte/lte/in/nin/exists, and a"
+      + " `value` matching the op: a number for gte/lte, a non-empty array for"
+      + " in/nin, a scalar for eq/neq, and NO value for exists.",
   });
 }
 


### PR DESCRIPTION
Re-opens the work from #53, which was squash-merged by mistake and then reverted by #54. This restores the same branch's **pure-transport** `sil_search.specs` contract onto the reverted `main` (the branch's real commits were never in `main`'s history because #53 was squash-merged, and the revert restored the touched files to base — so this diff applies cleanly).

## What this ships — plugin-only, schema change, not a new tool
- `sil_search` gains `specs: SpecPredicate[]` — closed shape, open `ns.key` vocabulary.
- `buildSearchBody` forwards the whole predicate array under one namespaced `filters.specs` key (all seven ops, `hard` unchanged; never spread as `filters.<name>`, never top-level). **Pure transport: `body.query` is the agent's free-text verbatim — no fold, no op-split.**
- `extractSpecsStatus` reads per-predicate `specs_status` off the `ok` response verbatim (omitted when absent, present on empty match) — the observable fail-green the sil-shopping loop's honesty pass polices.
- Malformed predicate → `invalid_spec`, client-side, zero network (op→value validity enforced at the read site).
- `openclaw.plugin.json#contracts.tools`, `SKILL.md`, the exact-set mirrors, and sil-api are untouched.

The query-fold was removed by founder scope decision: folding requirements into free-text is the agent's job (sil-shopping Beats 4/5), not the plugin's — a mechanical fold was lossy (bare numeric tokens) and unsafe (a negation as a bare token inverts intent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
