### PR TITLE
refactor: drop phantom ucp meta from sil-api mocks and docs

### DIFF
--- a/src/__tests__/catalog-lookup.integration.test.ts
+++ b/src/__tests__/catalog-lookup.integration.test.ts
@@ -24,9 +24,9 @@
  * (PR #18; sil-services `@sil/schemas` catalog.ts + envelope.ts) and the UCP
  * catalog-lookup spec:
  *   request body (CatalogLookupRequest): { ids: string[] }  (no envelope, no defaults)
- *   response (200): the FLAT UCP envelope sil-api emits (`withUcpMeta(body) →
- *     { ucp, ...body }`), carrying a CatalogLookupResult at the TOP LEVEL:
- *     { ucp, products: SilCatalogProduct[], messages? } — no `result` wrapper. Each
+ *   response (200): the FLAT body sil-api emits, carrying a CatalogLookupResult at
+ *     the TOP LEVEL: { products: SilCatalogProduct[], messages? } — no `result`
+ *     wrapper. Each
  *     product with a required `source`, each variant with a non-empty `checkout_url`,
  *     an `availability` object, and the REQUIRED lookup `inputs` correlation.
  *     `messages` carries one { type:"info", code:"not_found", content:<id> } per
@@ -154,16 +154,14 @@ const PRODUCT_B = {
   source: "uplift",
 };
 
-/** The REAL sil-api lookup envelope — the FLAT shape sil-api actually emits
- * (`withUcpMeta(body) → { ucp, ...body }`: `products`/`messages` at the TOP LEVEL
- * beside `ucp`, NOT under a `result` wrapper). The presence of a required `source`
- * per product, a non-empty `checkout_url` + an `inputs` correlation per variant is
- * what makes the suite anti-false-green: a `{ stub: true }` echo carries none of
- * these, so the assertions below cannot pass against the skeleton stub. `messages`
- * is included only when there are misses. */
+/** The REAL sil-api lookup body — the FLAT shape sil-api actually emits
+ * (`products`/`messages` at the TOP LEVEL, NOT under a `result` wrapper). The
+ * presence of a required `source` per product, a non-empty `checkout_url` + an
+ * `inputs` correlation per variant is what makes the suite anti-false-green: a
+ * `{ stub: true }` echo carries none of these, so the assertions below cannot pass
+ * against the skeleton stub. `messages` is included only when there are misses. */
 function lookupEnvelope(products: unknown[], messages?: unknown[]): unknown {
   const envelope: Record<string, unknown> = {
-    ucp: { version: "0.1", status: "success" },
     products,
   };
   if (messages !== undefined) envelope["messages"] = messages;
@@ -2013,7 +2011,6 @@ describe("sil_product_get vs sil_search — the SAME wire product surfaces the S
       vi.spyOn(globalThis, "fetch").mockResolvedValue(
         new Response(
           JSON.stringify({
-            ucp: { version: "0.1", status: "success" },
             products: [{ ...sharedProductWire, variants: [sharedVariantWire] }],
             pagination: { has_next_page: false },
           }),

--- a/src/__tests__/catalog-search.integration.test.ts
+++ b/src/__tests__/catalog-search.integration.test.ts
@@ -26,9 +26,9 @@
  *   request body (CatalogSearchRequest, additionalProperties:false):
  *     { query?, filters?: { categories?: string[], price?: { min?, max? } },
  *       pagination?: { cursor?, limit? }, context? }
- *   response (200): the FLAT UCP envelope sil-api emits (`withUcpMeta(body) →
- *     { ucp, ...body }`), carrying a CatalogSearchResult at the TOP LEVEL:
- *     { ucp, products: SilCatalogProduct[], pagination?, messages? } — no `result` wrapper.
+ *   response (200): the FLAT body sil-api emits, carrying a CatalogSearchResult at
+ *     the TOP LEVEL: { products: SilCatalogProduct[], pagination?, messages? } — no
+ *     `result` wrapper.
  *   400 { error: "empty_search_input", message }  → invalid_request envelope
  *   401                                           → refresh-and-retry-once (see below)
  *   500 / network / timeout                       → retryable envelope
@@ -136,18 +136,16 @@ const PRODUCT_B = {
   source: "uplift",
 };
 
-/** The REAL sil-api search envelope — the FLAT shape sil-api actually emits
- * (`withUcpMeta(body) → { ucp, ...body }`: `products`/`pagination` at the TOP LEVEL
- * beside `ucp`, NOT under a `result` wrapper). The presence of a required `source`
- * per product and a non-empty `checkout_url` per variant is what makes the suite
- * anti-false-green: a `{ stub: true }` echo carries none of these, so the assertions
- * below cannot pass against the skeleton stub. */
+/** The REAL sil-api search body — the FLAT shape sil-api actually emits
+ * (`products`/`pagination` at the TOP LEVEL, NOT under a `result` wrapper). The
+ * presence of a required `source` per product and a non-empty `checkout_url` per
+ * variant is what makes the suite anti-false-green: a `{ stub: true }` echo carries
+ * none of these, so the assertions below cannot pass against the skeleton stub. */
 function searchEnvelope(
   products: unknown[],
   pagination: unknown = { has_next_page: false },
 ): unknown {
   return {
-    ucp: { version: "0.1", status: "success" },
     products,
     pagination,
   };
@@ -1284,7 +1282,7 @@ describe("sil_search — happy path normalizes the REAL envelope (anti-false-gre
 });
 
 describe("sil_search — the three distinct sil-api outcomes surface as three distinguishable envelopes", () => {
-  it("empty match: 200 { ucp, products: [] } → status ok, products [], NO cursor, NO recovery hint (NOT an error)", async () => {
+  it("empty match: 200 { products: [] } → status ok, products [], NO cursor, NO recovery hint (NOT an error)", async () => {
     // UCP: an empty search returns an empty array — "this is not an error". This
     // is the SUCCESS arm, distinct from the 400/500 error arms below.
     seedTokens("at", "rt");

--- a/src/__tests__/catalog-search.integration.test.ts
+++ b/src/__tests__/catalog-search.integration.test.ts
@@ -3054,7 +3054,6 @@ describe("sil_search — all-applied:false is a NORMAL success with an OBSERVABL
   /** The REAL flat sil-api envelope + a top-level `specs_status` sibling of `products`. */
   function envelopeWithSpecsStatus(products: unknown[], specs_status: unknown): unknown {
     return {
-      ucp: { version: "0.1", status: "success" },
       products,
       pagination: { has_next_page: false },
       specs_status,

--- a/src/__tests__/cross-tool-401-parity.integration.test.ts
+++ b/src/__tests__/cross-tool-401-parity.integration.test.ts
@@ -70,12 +70,11 @@ function identityEnvelope(): unknown {
   };
 }
 
-/** A real search envelope with one product (sil_search's ok shape). FLAT shape
- * (`{ ucp, products, pagination }` — top level, no `result` wrapper;
- * `withUcpMeta(body)`), the only shape sil-api emits. */
+/** A real search body with one product (sil_search's ok shape). FLAT shape
+ * (`{ products, pagination }` — top level, no `result` wrapper), the only shape
+ * sil-api emits. */
 function searchEnvelope(): unknown {
   return {
-    ucp: { version: "0.1", status: "success" },
     products: [
       {
         id: "gid://product/a",
@@ -96,12 +95,10 @@ function searchEnvelope(): unknown {
   };
 }
 
-/** A real lookup envelope with one product (sil_product_get's ok shape). FLAT shape
- * (`{ ucp, products }` — top level, no `result` wrapper; `withUcpMeta(body)`), the
- * only shape sil-api emits. */
+/** A real lookup body with one product (sil_product_get's ok shape). FLAT shape
+ * (`{ products }` — top level, no `result` wrapper), the only shape sil-api emits. */
 function lookupEnvelope(): unknown {
   return {
-    ucp: { version: "0.1", status: "success" },
     products: [
       {
         id: "gid://product/a",

--- a/src/__tests__/lib/lookup-classify.test.ts
+++ b/src/__tests__/lib/lookup-classify.test.ts
@@ -30,11 +30,11 @@
  *      (the headline lookup risk; UCP §Identifiers Not Found: "return success with
  *      the found products … MAY include informational messages indicating which
  *      identifiers were not found"):
- *        200 { ucp, products:[…found…], messages:[{type:"info",code:"not_found",content:"<id>"}] }
+ *        200 { products:[…found…], messages:[{type:"info",code:"not_found",content:"<id>"}] }
  *                          → ok + found products + not_found:[<the unfound ids>]
- *        200 { ucp, products:[], messages:[…not_found for every id…] }
+ *        200 { products:[], messages:[…not_found for every id…] }
  *                          → ok + products:[] + not_found:[<all ids>]   (all-missed IS a success)
- *        200 { ucp, products:[…all resolved…] } (NO messages key)
+ *        200 { products:[…all resolved…] } (NO messages key)
  *                          → ok + NO not_found key                       (every id resolved)
  *      The `not_found` ids come from the top-level `messages` entries whose
  *      `code === "not_found"`; `content` is the id (sil-api emits exactly this,
@@ -43,7 +43,7 @@
  *
  *   3. The anti-false-green body gate on 200 (mirroring `extractIdentity`'s
  *      `name`-gate / `extractSearchResult`'s array-gate — complete-work-is-stub-free):
- *        200 { ucp, products: [] }             → ok + empty list   (a VALID all-missed,
+ *        200 { products: [] }                  → ok + empty list   (a VALID all-missed,
  *                                                 distinct from the no-array fault)
  *        200 with NO usable top-level `products` array (partial / garbage / `{stub:true}`)
  *                                              → retryable, NEVER ok (the false-green guard:
@@ -170,16 +170,13 @@ const PRODUCT_B = {
   source: "uplift",
 };
 
-/** Wrap a `CatalogLookupResult` in the FLAT UCP envelope sil-api actually emits —
- * `withUcpMeta(body) → { ucp, ...body }` (sil-services `.../sil-api/src/envelope.ts`):
- * the result body's fields (`products`, `messages`) sit at the TOP LEVEL beside `ucp`,
- * NOT under a `result` wrapper. The `result` arg here IS a CatalogLookupResult object
- * whose keys are spread onto the envelope. A non-object `result` is spread as nothing
- * (the flat body then carries only `ucp`) — exactly the malformed/garbage case the
- * anti-false-green gate must still reject. */
+/** Wrap a `CatalogLookupResult` in the FLAT body sil-api actually emits — the result
+ * body's fields (`products`, `messages`) sit at the TOP LEVEL, NOT under a `result`
+ * wrapper. The `result` arg here IS a CatalogLookupResult object whose keys are spread
+ * onto the body. A non-object `result` is spread as nothing (the body is then empty) —
+ * exactly the malformed/garbage case the anti-false-green gate must still reject. */
 function envelope(result: unknown): unknown {
   return {
-    ucp: { version: "0.1", status: "success" },
     ...(result !== null && typeof result === "object" ? (result as Record<string, unknown>) : {}),
   };
 }

--- a/src/__tests__/lib/lookup-client.test.ts
+++ b/src/__tests__/lib/lookup-client.test.ts
@@ -57,13 +57,12 @@ interface Captured {
   body: unknown;
 }
 
-/** The REAL sil-api lookup envelope, one product whose featured variant carries the
+/** The REAL sil-api lookup body, one product whose featured variant carries the
  * required `inputs` correlation — so a forwarded request resolves cleanly through the
- * classifier and the wrapper returns `ok`. FLAT shape (`{ ucp, products }` — top
- * level, no `result` wrapper; `withUcpMeta(body)`), the only shape sil-api emits. */
+ * classifier and the wrapper returns `ok`. FLAT shape (`{ products }` — top level, no
+ * `result` wrapper), the only shape sil-api emits. */
 function lookupEnvelope(): unknown {
   return {
-    ucp: { version: "0.1", status: "success" },
     products: [
       {
         id: "gid://product/a",

--- a/src/__tests__/lib/search-classify.test.ts
+++ b/src/__tests__/lib/search-classify.test.ts
@@ -23,7 +23,7 @@
  *
  *   2. The empty-match-is-SUCCESS vs the anti-false-green guard (the subtlest
  *      pair, mirroring `extractIdentity`'s `name`-gate at sil-client.ts:340-357):
- *        200 { ucp, products: [] }         → ok + empty list   (a VALID empty match,
+ *        200 { products: [] }              → ok + empty list   (a VALID empty match,
  *                                            NOT an error — UCP "this is not an error")
  *        200 with NO usable top-level `products` array (partial / garbage / `{stub:true}`)
  *                                          → retryable, NEVER ok (the false-green guard:
@@ -55,7 +55,7 @@
  *     source: string;
  *   }
  *   The classifier branches on `status` (and, for 200, the body shape) — NEVER on
- *   `res.ok`. It reads `products` off the FLAT sil-api envelope (`{ ucp, products,
+ *   `res.ok`. It reads `products` off the FLAT sil-api body (`{ products,
  *   pagination? }` — top level, no `result` wrapper). The exact field/variant
  *   projection is the dev's to shape, but the FIELD NAMES below and the cursor-hoist
  *   + empty-vs-error split ARE the immutable spec (assert the projected
@@ -130,16 +130,13 @@ const PRODUCT_B = {
   source: "uplift",
 };
 
-/** Wrap a `CatalogSearchResult` in the FLAT UCP envelope sil-api actually emits —
- * `withUcpMeta(body) → { ucp, ...body }` (sil-services `.../sil-api/src/envelope.ts`):
- * the result body's fields (`products`, `pagination`) sit at the TOP LEVEL beside
- * `ucp`, NOT under a `result` wrapper. The `result` arg here IS a CatalogSearchResult
- * object whose keys are spread onto the envelope. A non-object `result` is spread as
- * nothing (the flat body then carries only `ucp`) — exactly the malformed/garbage
- * case the anti-false-green gate must still reject. */
+/** Wrap a `CatalogSearchResult` in the FLAT body sil-api actually emits — the result
+ * body's fields (`products`, `pagination`) sit at the TOP LEVEL, NOT under a `result`
+ * wrapper. The `result` arg here IS a CatalogSearchResult object whose keys are spread
+ * onto the body. A non-object `result` is spread as nothing (the body is then empty) —
+ * exactly the malformed/garbage case the anti-false-green gate must still reject. */
 function envelope(result: unknown): unknown {
   return {
-    ucp: { version: "0.1", status: "success" },
     ...(result !== null && typeof result === "object" ? (result as Record<string, unknown>) : {}),
   };
 }
@@ -620,7 +617,7 @@ describe("classifySearchResponse — a 422 source_rejected is INVALID_REQUEST ca
 });
 
 describe("classifySearchResponse — empty match is SUCCESS, not error", () => {
-  it("200 { ucp, products: [] } → ok with an EMPTY products list and NO cursor", () => {
+  it("200 { products: [] } → ok with an EMPTY products list and NO cursor", () => {
     // UCP: an empty search returns an empty array — "this is not an error". The
     // agent must see status ok + an empty list, never an error branch.
     const out = classifySearchResponse(

--- a/src/__tests__/lib/search-classify.test.ts
+++ b/src/__tests__/lib/search-classify.test.ts
@@ -1077,7 +1077,7 @@ describe("classifySearchResponse — specs_status narrowing: no fabrication, dro
     // signal can never manufacture a false empty-match success.
     const out = classifySearchResponse(
       200,
-      { ucp: { version: "0.1", status: "success" }, specs_status: [{ ns: "p", key: "k", applied: false }] },
+      { specs_status: [{ ns: "p", key: "k", applied: false }] },
     );
     expect(out.kind).not.toBe("ok");
     expect(out.kind).toBe("retryable");

--- a/src/__tests__/lib/search-client.test.ts
+++ b/src/__tests__/lib/search-client.test.ts
@@ -56,9 +56,9 @@ interface Captured {
 }
 
 /** Spy `fetch` and capture the single outbound request, replying 200 with a real
- * (empty-match) envelope so the wrapper resolves cleanly. The reply is the FLAT
- * sil-api envelope (`{ ucp, products, pagination }` — top level, no `result`
- * wrapper; `withUcpMeta(body)`), the only shape sil-api emits. */
+ * (empty-match) body so the wrapper resolves cleanly. The reply is the FLAT sil-api
+ * body (`{ products, pagination }` — top level, no `result` wrapper), the only shape
+ * sil-api emits. */
 function spyFetch(captured: Captured[]): void {
   vi.spyOn(globalThis, "fetch").mockImplementation(
     (input: unknown, init?: RequestInit) => {
@@ -81,7 +81,6 @@ function spyFetch(captured: Captured[]): void {
       return Promise.resolve(
         new Response(
           JSON.stringify({
-            ucp: { version: "0.1", status: "success" },
             products: [],
             pagination: { has_next_page: false },
           }),

--- a/src/__tests__/tools/product-get.test.ts
+++ b/src/__tests__/tools/product-get.test.ts
@@ -79,15 +79,14 @@ function seedTokens(access = "stored-at", refresh = "stored-rt"): void {
   );
 }
 
-/** A 200 real lookup envelope (one product whose featured variant carries the
+/** A 200 real lookup body (one product whose featured variant carries the
  * required `inputs`), so a forwarded request resolves cleanly to `ok`. The FLAT
- * sil-api shape (`{ ucp, products }` — top level, no `result` wrapper;
- * `withUcpMeta(body)`), the only shape sil-api emits. */
+ * sil-api shape (`{ products }` — top level, no `result` wrapper), the only shape
+ * sil-api emits. */
 function okEnvelopeFetch(): ReturnType<typeof vi.spyOn> {
   return vi.spyOn(globalThis, "fetch").mockResolvedValue(
     new Response(
       JSON.stringify({
-        ucp: { version: "0.1", status: "success" },
         products: [
           {
             id: "gid://product/a",

--- a/src/__tests__/tools/search.test.ts
+++ b/src/__tests__/tools/search.test.ts
@@ -82,14 +82,13 @@ function seedTokens(access = "stored-at", refresh = "stored-rt"): void {
   );
 }
 
-/** A 200 real (empty-match) envelope, so a forwarded request resolves cleanly. The
- * FLAT sil-api shape (`{ ucp, products, pagination }` — top level, no `result`
- * wrapper; `withUcpMeta(body)`), the only shape sil-api emits. */
+/** A 200 real (empty-match) body, so a forwarded request resolves cleanly. The
+ * FLAT sil-api shape (`{ products, pagination }` — top level, no `result` wrapper),
+ * the only shape sil-api emits. */
 function okEnvelopeFetch(): ReturnType<typeof vi.spyOn> {
   return vi.spyOn(globalThis, "fetch").mockResolvedValue(
     new Response(
       JSON.stringify({
-        ucp: { version: "0.1", status: "success" },
         products: [],
         pagination: { has_next_page: false },
       }),
@@ -123,7 +122,6 @@ function captureBodyFetch(captured: unknown[]): ReturnType<typeof vi.spyOn> {
     return Promise.resolve(
       new Response(
         JSON.stringify({
-          ucp: { version: "0.1", status: "success" },
           products: [],
           pagination: { has_next_page: false },
         }),

--- a/src/lib/sil-client.ts
+++ b/src/lib/sil-client.ts
@@ -36,23 +36,22 @@
  *
  *   GET <silApiUrl>/identity    Authorization: Bearer <access_token>
  *                               (no body, no content-type)
- *     200 <UCP envelope>{ result: { name, addresses } }  → ok (carries identity)
+ *     200 { name, addresses }                             → ok (carries identity)
  *     401                                                 → unauthorized (→ refresh)
  *     403 { error: user_not_provisioned | principal_mismatch } → forbidden (terminal)
  *     5xx / network / abort                               → retryable
  *
  * Wire contract for the sil-API catalog search (SAME origin as the identity
  * read — sil-api, bare path, NOT /api/v1; see the sil-search card). A simplified
- * structured query in, ranked purchasable products out. sil-api owns the UCP
- * envelope + enrichment; the plugin sends NO envelope and fills NO defaults:
+ * structured query in, ranked purchasable products out. sil-api owns the
+ * enrichment; the plugin sends NO envelope and fills NO defaults:
  *
  *   POST <silApiUrl>/catalog/search   Authorization: Bearer <access_token>
  *     body { query?, filters?:{ categories?, price?:{ min?, max? } },
  *            pagination?:{ cursor?, limit? } }       (no context, no envelope)
- *     200 <FLAT UCP envelope>{ ucp, products: SilCatalogProduct[],
- *                              pagination?:{ has_next_page, cursor? } } → ok
- *         (sil-api's `withUcpMeta(body) → { ucp, ...body }`: `products`/`pagination`
- *          at the TOP LEVEL beside `ucp`, NO `result` wrapper)
+ *     200 { products: SilCatalogProduct[],
+ *           pagination?:{ has_next_page, cursor? } } → ok
+ *         (`products`/`pagination` at the TOP LEVEL, NO `result` wrapper)
  *     400 { error:"empty_search_input", message }    → invalid_request
  *     401                                            → unauthorized (→ refresh)
  *     5xx / network / abort                          → retryable
@@ -61,16 +60,15 @@
  * sil-api, bare `/catalog/lookup`, NOT /api/v1; see the sil-product-get card). The
  * lookup COMPANION to search: an agent passes ids it already holds and gets fresh
  * RICH detail back (search is LEAN). sil-api owns enrichment + the `not_found`
- * messaging + the envelope; the plugin sends just `{ ids }` (NO filters/context,
+ * messaging; the plugin sends just `{ ids }` (NO filters/context,
  * NO envelope). The two structural deltas from search's response: NO `pagination`
  * (a batch resolve, not a list) and a `messages[]` carrying the misses:
  *
  *   POST <silApiUrl>/catalog/lookup   Authorization: Bearer <access_token>
  *     body { ids: string[] }                         (≥1; no filters/context)
- *     200 <FLAT UCP envelope>{ ucp, products: SilCatalogProduct[],
- *            messages?:[{ type:"info", code:"not_found", content:<id> }] } → ok
- *         (same flat `withUcpMeta` shape: `products`/`messages` at the TOP LEVEL
- *          beside `ucp`, NO `result` wrapper)
+ *     200 { products: SilCatalogProduct[],
+ *           messages?:[{ type:"info", code:"not_found", content:<id> }] } → ok
+ *         (`products`/`messages` at the TOP LEVEL, NO `result` wrapper)
  *     400 (schema: empty `ids` / request_too_large)  → invalid_request
  *     401                                            → unauthorized (→ refresh)
  *     5xx / network / abort                          → retryable
@@ -600,11 +598,11 @@ export function classifyIdentityResponse(status: number, body: unknown): Identit
  *         shared forbidden envelope, never the false-transient `retryable`, and a
  *         valid-but-unprovisioned token gains nothing from a refresh.
  *   5xx / other non-200 → retryable
- *   200 → read `products` off sil-api's FLAT envelope (`{ ucp, products,
- *         pagination? }` — top level, no `result` wrapper), normalize, and require
+ *   200 → read `products` off sil-api's FLAT body (`{ products, pagination? }` —
+ *         top level, no `result` wrapper), normalize, and require
  *         `products` to be a real ARRAY. A 200 that yields no usable top-level
- *         products array (a partial / garbage / stub-shaped body, or one carrying
- *         only `ucp` metadata) is `retryable`, NEVER `ok` — the
+ *         products array (a partial / garbage / stub-shaped body) is `retryable`,
+ *         NEVER `ok` — the
  *         `Array.isArray(products)` gate is the anti-false-green guard, the
  *         analogue of the identity `name`-gate. A genuine empty match (200 whose
  *         top-level `products` IS `[]`) is `ok` with an empty product list: a
@@ -659,8 +657,8 @@ export function classifySearchResponse(status: number, body: unknown): SearchOut
  *         envelope, never the false-transient `retryable`; it is NOT a 401, so no
  *         refresh is triggered.
  *   5xx / other non-200 → retryable
- *   200 → read `products` off sil-api's FLAT envelope (`{ ucp, products,
- *         messages? }` — top level, no `result` wrapper), normalize, and require
+ *   200 → read `products` off sil-api's FLAT body (`{ products, messages? }` —
+ *         top level, no `result` wrapper), normalize, and require
  *         `products` to be a real ARRAY. A 200 that yields no usable top-level
  *         products array (a partial / garbage / stub-shaped body) is `retryable`,
  *         NEVER `ok` — the `Array.isArray(products)` gate is the anti-false-green
@@ -747,9 +745,9 @@ export async function refreshSession(
  * Fastify domain service, NOT sil-web). This is a bodyless `GET <silApiUrl>/identity`:
  * sil-api's authenticated self-read derives the principal from the JWT `sub`
  * (the `Authorization: Bearer <token>` header), loads that user's addresses,
- * and returns `{ id, name, addresses }` in the UCP envelope's `result`
- * (sil-api `handlers/identity.ts` GET route — declares only a response schema,
- * takes no request body). The verb is the whole point: POST hits the agent
+ * and returns `{ id, name, addresses }` (sil-api `handlers/identity.ts` GET route —
+ * declares only a response schema, takes no request body). The verb is the whole
+ * point: POST hits the agent
  * enrich-STUB (no name/addresses), GET hits the real self-read. No `agent_id`
  * or `on_behalf_of` is sent — the GET self-read has no body, so the principal
  * is unambiguously the token subject and the `principal_mismatch` 403 path is
@@ -977,9 +975,9 @@ export async function refreshAndRetryOnce<O>(
 /**
  * Unwrap + narrow a sil-api identity response body to a typed `Identity`, or
  * null if it carries no usable identity. Defends against the latent wire shape:
- * the identity may be wrapped in the UCP envelope's `result` OR (if the
- * follow-on returns it bare) at the top level, so we try `result` first and
- * fall back to the body itself.
+ * the identity may be wrapped in a `result` field OR (if the follow-on returns it
+ * bare) at the top level, so we try `result` first and fall back to the body
+ * itself.
  *
  * A usable identity REQUIRES a non-empty `name` string (the authoritative human
  * name) and that `addresses` is an ARRAY — but the array may be EMPTY. sil-api
@@ -1107,9 +1105,8 @@ function withUppercaseCountry<T extends { country: string }>(value: T): T {
 /**
  * Unwrap + narrow a sil-api catalog-search response body to a typed
  * {@link SearchResult}, or null if it carries no usable products array. sil-api
- * emits a FLAT UCP envelope (`withUcpMeta(body) → { ucp, ...body }` —
- * sil-services `.../sil-api/src/envelope.ts`): `products` and `pagination` sit at
- * the TOP LEVEL beside `ucp`, there is NO `result` wrapper. Read them straight
+ * emits a FLAT body: `products` and `pagination` sit at the TOP LEVEL, there is
+ * NO `result` wrapper. Read them straight
  * off the body. (There is no nested-`result` fallback to keep: search has no
  * second route that ever returns one, so a `result`-wrapper expectation would be
  * dead weight and — worse — a latent false-green a stray `result` key could shadow
@@ -1117,7 +1114,7 @@ function withUppercaseCountry<T extends { country: string }>(value: T): T {
  *
  * The load-bearing anti-false-green guard is the `Array.isArray(products)` check:
  * a 200 lacking a real top-level `products` array (a partial / garbage / stub
- * `{ stub: true }` body, or one carrying only `ucp` metadata) returns null →
+ * `{ stub: true }` body) returns null →
  * `retryable`, never a false-green empty match. An EMPTY array is a VALID empty
  * match (a genuine "nothing matched") and returns an empty `products` list —
  * distinct from the no-array guard. Individual products that are unusable (no
@@ -1212,14 +1209,13 @@ function projectVariant(raw: unknown): SearchVariant | null {
 /**
  * Unwrap + narrow a sil-api catalog-LOOKUP response body to a typed
  * {@link LookupResult}, or null if it carries no usable products array. Like
- * `extractSearchResult`, it reads sil-api's FLAT UCP envelope
- * (`withUcpMeta(body) → { ucp, ...body }`): `products` and `messages` sit at the
- * TOP LEVEL beside `ucp`, there is NO `result` wrapper — read them straight off
+ * `extractSearchResult`, it reads sil-api's FLAT body: `products` and `messages`
+ * sit at the TOP LEVEL, there is NO `result` wrapper — read them straight off
  * the body (no nested-`result` fallback; lookup has no route that returns one).
  *
  * It shares search's load-bearing anti-false-green guard — `Array.isArray(products)`
  * on the TOP-LEVEL `products`; a 200 lacking it (partial / garbage / stub
- * `{ stub: true }`, or only `ucp` metadata) returns null → `retryable`. An EMPTY
+ * `{ stub: true }`) returns null → `retryable`. An EMPTY
  * array is a VALID all-missed lookup (the products gate passes; `not_found`
  * carries the ids) — distinct from the no-array guard. The two structural deltas
  * from search:


### PR DESCRIPTION
## Card
`cards/drop-phantom-ucp-meta-from-sil-api-mocks-and-docs.md` (lives in the `card/drop-phantom-ucp-meta-from-sil-api-mocks-and-docs` branch, gitignored — see the card body for full intent + handoffs). Epic `ucp-meta-external-only`.

## Summary
Consumer-side follow-on to sil-services `strip-ucp-meta-from-agent-facing-sil-api-responses`. That card drops the top-level `ucp` meta member from the agent-facing sil-api 200 bodies. Our runtime is already envelope-agnostic (extractors read sibling top-level fields, never `.ucp`), so this is a **behavior-preserving** test-double + doc realignment — **no runtime logic changed**.

- Dropped the phantom `ucp: { version, status }` member from **all 12** catalog (search/lookup) response mock builders across 9 test files, so the doubles mirror the bare production body.
- Rewrote the stale `{ ucp, ...body }` / `withUcpMeta` wire-shape doc-comments in `src/lib/sil-client.ts` (module header, both classifiers, `fetchIdentity`, the three extractors) and the co-located comments/labels in the test files, to the bare no-`ucp` body — delete-first, no "formerly wrapped" caveats.
- **Kept** (per recorded assumptions): `extractIdentity`'s `result ?? envelope` defensive dual-read description, and the request-side "the plugin sends NO envelope" lines.
- **Out of scope, untouched:** the `protocol: "ucp"` claim/identity fixtures (8 sites), the `extra_ucp_metadata` product-DATA keys (4 lines), and all UCP product-DATA field descriptions.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm test` green across all tiers (only the known `repo-scaffold.integration.test.ts` gitignored-worktree cases fail — not a regression; every touched file passes)
- [x] `pnpm build` clean
- [x] `grep 'ucp:\s*\{' src/__tests__/` → 0; `protocol:\s*"ucp"` still 8; `extra_ucp_metadata` still 4
- [x] `git diff` review: zero assertion changes, zero out-of-scope fixtures touched, zero runtime logic changed

## Distillation target
Knowledge capture happens **after Review PASS** in the `distilling` stage — `solutions-architect` runs in this same worktree, commits to this same branch, and pushes here so the PR ends up containing implementation + distillation in one mergeable unit.