### PR TITLE
feature: sil_specs client tool — coin/dedupe/register canonicalization (floor 9→10)

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -17,6 +17,7 @@
       "sil_profile_search",
       "sil_register",
       "sil_search",
+      "sil_specs",
       "sil_whoami"
     ]
   },

--- a/sil-shopping/SKILL.md
+++ b/sil-shopping/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sil-shopping
-description: 'Use for any sil shopping, identity, or shopper-setup intent: register or sign in, check the account, search the sil catalog for purchasable products, or look up products by id — plus the single-shopper lifecycle: create the shopper (a short two-touchpoint onboarding), search what it knows or which domains (niches) it has learned, view or forget a domain or one of its PRDs, refine it — or, as the shopper, run the six-beat Spec-Driven Shopping loop on any niche and learn a fact or buying taste it surfaces. Drives sil_register, sil_whoami, sil_search, sil_product_get, sil_profile_materialize, sil_profile_search, sil_profile_get, sil_profile_remove, and sil_learn.'
+description: 'Use for any sil shopping, identity, or shopper-setup intent: register or sign in, check the account, search the sil catalog for purchasable products, or look up products by id — plus the single-shopper lifecycle: create the shopper (a short two-touchpoint onboarding), search what it knows or which domains (niches) it has learned, view or forget a domain or one of its PRDs, refine it — or, as the shopper, run the six-beat Spec-Driven Shopping loop on any niche and learn a fact or buying taste it surfaces. Drives sil_register, sil_whoami, sil_search, sil_product_get, sil_specs, sil_profile_materialize, sil_profile_search, sil_profile_get, sil_profile_remove, and sil_learn.'
 metadata:
   openclaw:
     emoji: "\U0001F6D2"

--- a/sil-shopping/references/method_and_prds.md
+++ b/sil-shopping/references/method_and_prds.md
@@ -29,9 +29,18 @@ create`**, never the **setup-only** `sil_profile_materialize` (which writes only
 shared `user_spec.md` and mints no domain). Then **announce** the inferred domain so
 the buyer can correct it.
 
-The coined vocabulary is canonicalized via `sil_specs` only where that endpoint
-exists (Phase 3). Until then it is **coined-and-used raw** — every predicate reads
-`applied:false`, so `sil_specs` is **not** called and nothing is stubbed.
+The coined vocabulary is **canonicalized before persist**. Submit the coined spec
+definitions to **`sil_specs`** (dedupe-or-create) and adopt the returned **canonical**
+`ns.key` for every spec: a **`matched`** result means an equivalent canonical spec
+already exists — **drop your coined synonym and adopt the canonical name**; a
+**`created`** result means yours is novel and is canonical going forward (keep it).
+Rewrite the method's `## Search vocabulary` and any PRD `specs` predicates to those
+canonical names, then persist — the method is **born canonical**, never
+write-then-amend. This convergence is what makes `filters.specs` actually filter
+across methods. If `sil_specs` is **not `ok`** (a registry blip), **do not block the
+mint**: persist with the **raw coined names** (every predicate reads `applied:false`)
+and shop on — convergence retries on the next mint/refresh. Canonicalization is
+**silent to the buyer**: never surface `ns.key` plumbing.
 
 ## REFRESH — signal-driven (HIT, stale)
 
@@ -47,6 +56,10 @@ re-emit the whole body via `sil_learn create` (overwrite), and announce the delt
 The merge **preserves** every **buyer** `sil_learn` edit — it rewrites stale
 *research* claims and **never clobbers** a buyer edit. The method is fully
 buyer-mutable at any time via `sil_learn` append/amend/retract.
+
+Canonicalize any **newly-coined** specs via `sil_specs` before persisting the
+refreshed method — resubmit **only** the specs not yet carrying a canonical name
+(already-canonical names are stable; do not resubmit them).
 
 ## Intent-keyed PRDs
 

--- a/src/__tests__/catalog-specs.integration.test.ts
+++ b/src/__tests__/catalog-specs.integration.test.ts
@@ -1,0 +1,710 @@
+/**
+ * INTEGRATION — sil_specs canonicalization against sil-api (tier: integration).
+ *
+ * CARD `sds-specs-client-tool` (epic `spec-driven-shopping-redesign`, Phase 3). The
+ * real `sil_specs` tool wired through the real sil-client (`specsCatalog` +
+ * `classifySpecsResponse` + `extractSpecsResult`) and the real credentials module.
+ * The ONLY thing mocked is `fetch` — the host/network boundary. There is no live
+ * sil-api or Postgres in this repo; the true cross-service guarantee (a real registry
+ * dedupe over the wire) is sil-stage's deferred eval. Here we prove the whole
+ * PLUGIN-SIDE contract — param→request mapping, the outcome taxonomy, the matched/
+ * created resolution surfacing, the shared 401 choreography, and token privacy —
+ * against a mocked boundary, exactly as `catalog-search.integration.test.ts` proves
+ * search.
+ *
+ * TWO ORIGINS: the canonicalization targets the resolved **sil-api** origin
+ * (`getApiUrl`), at the BARE path `/catalog/specs` — NOT `/api/v1`. On a 401 the tool
+ * refreshes transparently against the **sil-web** origin (`getWebUrl`, via the real
+ * `refreshStoredTokens`) and retries the canonicalization ONCE — the SAME
+ * refresh-and-retry-once choreography `sil_search` / `sil_product_get` / `sil_whoami`
+ * perform (`sil_specs` is the 4th sil-api tool on the shared seam). Both origins are
+ * pinned to distinct known hosts so the origin + path assertions are exact.
+ *
+ * Wire shapes verified against the LIVE handler (sil-services
+ * `services/sil-api/src/handlers/specs.ts` + `@sil/schemas` `specs.ts`):
+ *   request body (SpecsRequest): { query: string, specs: SpecDefinition[] } — bare,
+ *     NO filters/context/envelope (pure transport).
+ *   response (200): the BARE `{ resolved: SpecResolution[] }` — `resolved` TOP-LEVEL,
+ *     NO `ucp` meta, NO `result` wrapper (#56's bare-envelope decision; the design
+ *     doc's `{ ucp, resolved }` is STALE).
+ *   400 { error, message }                        → invalid_request envelope
+ *   401                                           → refresh-and-retry-once (see below)
+ *   403 { error: user_not_provisioned|principal_mismatch } → forbidden envelope
+ *   5xx / network / timeout                       → retryable envelope (BARE — no source)
+ *
+ *   refresh (sil-web):  POST <sil-web>/api/v1/auth/refresh { refresh_token }
+ *     200 { access_token, refresh_token }         → rotate tokens.json, retry once
+ *     401 { error: "invalid_grant" }              → terminal re-register, tokens cleared
+ *     5xx / network                               → transient retryable, NO retry
+ *
+ * THE anti-false-green (complete-work-is-stub-free): the happy-path mock returns the
+ * REAL `{ resolved: SpecResolution[] }` shape (each entry a matched/created resolution
+ * carrying a usable `canonical` ref). The suite asserts the tool surfaces the resolved
+ * verdict — so it is UNABLE to go green against a `{ stub: true }` echo.
+ *
+ * EXPECT RED today: `sil_specs` is not registered and `specsCatalog` /
+ * `classifySpecsResponse` do not exist — every `getTool(api, "sil_specs")` throws.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { registerCatalogTools } from "../tools/catalog.js";
+// The AC7 end-to-end recovery proof drives sil_register (after a sil_specs 403 clears
+// the dead token) on the SAME api + data dir — so identity tools register alongside.
+import { registerIdentityTools } from "../tools/identity.js";
+import { setWebUrl, setApiUrl, getWebUrl, getApiUrl } from "../lib/config.js";
+import { getDataDir, getTokensPath } from "../lib/credentials.js";
+import {
+  createMockPluginApi,
+  getTool,
+  type MockPluginAPI,
+} from "./helpers/mock-plugin-api.js";
+
+const TOOL = "sil_specs";
+const SIL_WEB = "https://sil-web.test.example.com"; // auth origin
+const SIL_API = "https://sil-api.test.example.com"; // canonicalization origin
+
+/** Two coined spec definitions the method submits (the request half). */
+const SPEC_WATERPROOFING = {
+  namespace: "product",
+  key: "waterproofing",
+  display_name: "Waterproofing",
+  data_type: "number",
+  unit: "mm",
+};
+const SPEC_HANDMADE = {
+  namespace: "seller",
+  key: "handmade",
+  display_name: "Handmade",
+  data_type: "boolean",
+};
+
+/** A `matched` resolution — the coined "waterproofing" deduped to the EXISTING
+ * canonical "waterproof_rating" (submitted ≠ canonical: adopt the canonical). */
+const RES_MATCHED = {
+  namespace: "product",
+  key: "waterproof_rating",
+  display_name: "Waterproof Rating",
+  data_type: "number",
+  unit: "mm",
+  is_filterable: true,
+  is_comparable: true,
+  submitted: { namespace: "product", key: "waterproofing" },
+  canonical: { namespace: "product", key: "waterproof_rating" },
+  status: "matched",
+};
+
+/** A `created` resolution — the novel "handmade" registered as canonical
+ * (submitted === canonical: keep your own). */
+const RES_CREATED = {
+  namespace: "seller",
+  key: "handmade",
+  display_name: "Handmade",
+  data_type: "boolean",
+  is_filterable: true,
+  is_comparable: false,
+  submitted: { namespace: "seller", key: "handmade" },
+  canonical: { namespace: "seller", key: "handmade" },
+  status: "created",
+};
+
+/** The REAL bare sil-api specs body — `resolved` at the TOP LEVEL, no `ucp`/`result`
+ * wrapper. A `{ stub: true }` echo carries no `resolved`, so the assertions below
+ * cannot pass against the skeleton stub. */
+function specsEnvelope(resolved: unknown[]): unknown {
+  return { resolved };
+}
+
+let dataDir: string;
+let priorSilDataDir: string | undefined;
+
+/** One recorded outbound request. */
+interface Recorded {
+  url: string;
+  method: string;
+  bearer: string | null;
+  body: unknown;
+  hasBody: boolean;
+}
+
+type Reply = { status: number; body: unknown } | "network-error";
+
+/**
+ * A URL-routing fetch double cloned from catalog-search.integration.test.ts.
+ * `reply(kind, nthOfKind, req)` decides each response given whether the request is a
+ * `specs` (sil-api /catalog/specs), a `refresh` (sil-web /auth/refresh — the
+ * transparent 401 recovery leg, reached via the real `refreshStoredTokens`), or
+ * `other`. Records every request so origin, path, the Bearer header, the mapped body,
+ * and call COUNTS (including "exactly one refresh") are all assertable.
+ */
+function installRouter(
+  reply: (
+    kind: "specs" | "refresh" | "other",
+    nthOfKind: number,
+    req: Recorded,
+  ) => Reply,
+): { all: Recorded[]; specs: Recorded[]; refresh: Recorded[] } {
+  const all: Recorded[] = [];
+  const specs: Recorded[] = [];
+  const refresh: Recorded[] = [];
+
+  vi.spyOn(globalThis, "fetch").mockImplementation(
+    (input: unknown, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : String(input);
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      const bearer = headers["Authorization"] ?? headers["authorization"] ?? null;
+      const method = (init?.method ?? "GET").toUpperCase();
+      const hasBody = init?.body !== undefined && init?.body !== null;
+      let body: unknown = null;
+      if (typeof init?.body === "string") {
+        try {
+          body = JSON.parse(init.body);
+        } catch {
+          body = init.body;
+        }
+      }
+      const req: Recorded = { url, method, bearer, body, hasBody };
+      all.push(req);
+
+      // Order matters: /auth/refresh is the sil-web leg; /catalog/specs the sil-api
+      // leg. Check refresh first so a future shared path can't be misrouted.
+      let kind: "specs" | "refresh" | "other";
+      if (url.includes("/auth/refresh")) kind = "refresh";
+      else if (url.includes("/catalog/specs")) kind = "specs";
+      else kind = "other";
+
+      let nthOfKind: number;
+      if (kind === "specs") {
+        specs.push(req);
+        nthOfKind = specs.length - 1;
+      } else if (kind === "refresh") {
+        refresh.push(req);
+        nthOfKind = refresh.length - 1;
+      } else {
+        nthOfKind = all.length - 1;
+      }
+
+      const r = reply(kind, nthOfKind, req);
+      if (r === "network-error") {
+        return Promise.reject(new Error("simulated network failure"));
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify(r.body), {
+          status: r.status,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    },
+  );
+
+  return { all, specs, refresh };
+}
+
+/** Parse a ToolResult payload. */
+function payloadOf(result: { content: { text?: string }[] }): Record<string, unknown> {
+  const text = result.content[0]?.text;
+  if (typeof text !== "string") throw new Error("no tool payload");
+  return JSON.parse(text) as Record<string, unknown>;
+}
+
+/** Seed a stored token pair so the canonicalization proceeds to the read. */
+function seedTokens(access: string, refresh: string): void {
+  const dir = getDataDir();
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    getTokensPath(),
+    JSON.stringify({ access_token: access, refresh_token: refresh }),
+    { mode: 0o600 },
+  );
+}
+
+/** The Bearer token value carried on a recorded request (stripped of scheme). */
+function bearerToken(req: Recorded): string | null {
+  if (req.bearer === null) return null;
+  return req.bearer.replace(/^Bearer\s+/i, "");
+}
+
+/** Collect every argument to every logger level, serialized. */
+function logBlob(api: MockPluginAPI): string {
+  return [api.logger.info, api.logger.warn, api.logger.error, api.logger.debug]
+    .flatMap((fn) => vi.mocked(fn).mock.calls.map((c) => JSON.stringify(c)))
+    .join("\n");
+}
+
+/** Count `api.logger.info(marker, …)` calls whose first positional arg is `marker`. */
+function infoMarkerCount(api: MockPluginAPI, marker: string): number {
+  return vi
+    .mocked(api.logger.info)
+    .mock.calls.filter((c) => c[0] === marker).length;
+}
+
+/** The standard two-spec request the happy-path scenarios submit. */
+const REQUEST = { query: "hiking gloves", specs: [SPEC_WATERPROOFING, SPEC_HANDMADE] };
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), "sil-specs-int-"));
+  priorSilDataDir = process.env["SIL_DATA_DIR"];
+  process.env["SIL_DATA_DIR"] = dataDir;
+  setWebUrl(SIL_WEB);
+  setApiUrl(SIL_API);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  setWebUrl("");
+  setApiUrl("");
+  delete process.env["SIL_WEB_URL"];
+  delete process.env["SIL_API_URL"];
+  if (priorSilDataDir === undefined) delete process.env["SIL_DATA_DIR"];
+  else process.env["SIL_DATA_DIR"] = priorSilDataDir;
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe("sil_specs — param → request mapping (bare path, sil-api origin, Bearer)", () => {
+  it("POSTs the BARE /catalog/specs path on the sil-api origin (NOT /api/v1, NOT sil-web)", async () => {
+    seedTokens("the-access-token", "the-refresh-token");
+    const rec = installRouter((kind) =>
+      kind === "specs"
+        ? { status: 200, body: specsEnvelope([RES_MATCHED, RES_CREATED]) }
+        : { status: 500, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    await getTool(api, TOOL).execute("c1", REQUEST);
+
+    expect(rec.specs.length).toBe(1);
+    const req = rec.specs[0]!;
+    const u = new URL(req.url);
+    expect(u.pathname).toBe("/catalog/specs");
+    expect(req.url).not.toContain("/api/v1");
+    expect(u.origin).toBe(new URL(getApiUrl()).origin);
+    expect(u.origin).not.toBe(new URL(getWebUrl()).origin);
+    expect(req.method).toBe("POST");
+    expect(req.hasBody).toBe(true);
+    expect(bearerToken(req)).toBe("the-access-token");
+  });
+
+  it("sends the body EXACTLY { query, specs } — the definitions forwarded VERBATIM (no envelope, no filters)", async () => {
+    seedTokens("at", "rt");
+    const rec = installRouter((kind) =>
+      kind === "specs"
+        ? { status: 200, body: specsEnvelope([RES_MATCHED, RES_CREATED]) }
+        : { status: 500, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    await getTool(api, TOOL).execute("c1", REQUEST);
+
+    expect(rec.specs.length).toBe(1);
+    const body = rec.specs[0]!.body as Record<string, unknown>;
+    expect(body).toEqual({ query: "hiking gloves", specs: [SPEC_WATERPROOFING, SPEC_HANDMADE] });
+    // Belt-and-braces: NO client-built envelope / filters / context.
+    for (const forbidden of ["filters", "context", "protocol", "domain", "enrichment", "pagination"]) {
+      expect(body[forbidden]).toBeUndefined();
+    }
+  });
+});
+
+describe("sil_specs — AC1/AC2/AC3: happy path surfaces the resolved verdict faithfully (matched + created)", () => {
+  it("returns status ok with ONE resolution per submitted spec, each matched or created (no partial)", async () => {
+    seedTokens("at", "rt");
+    installRouter((kind) =>
+      kind === "specs"
+        ? { status: 200, body: specsEnvelope([RES_MATCHED, RES_CREATED]) }
+        : { status: 500, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", REQUEST));
+
+    // The product promise — surfaced from the REAL bare envelope. A `{ stub: true }`
+    // echo carries no `resolved`, so this can't go green on a stub.
+    expect(JSON.stringify(payload)).not.toContain('"stub"');
+    expect(payload["status"]).toBe("ok");
+    const resolved = payload["resolved"] as Array<Record<string, unknown>>;
+    expect(Array.isArray(resolved)).toBe(true);
+    // One resolution per submitted spec — no partial adopt.
+    expect(resolved).toHaveLength(2);
+    const statuses = resolved.map((r) => r["status"]);
+    expect(statuses).toEqual(["matched", "created"]);
+  });
+
+  it("AC2 — a `matched` surfaces the EXISTING canonical name (canonical ≠ submitted) for the method to adopt", async () => {
+    seedTokens("at", "rt");
+    installRouter((kind) =>
+      kind === "specs" ? { status: 200, body: specsEnvelope([RES_MATCHED]) } : { status: 500, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", { query: "gloves", specs: [SPEC_WATERPROOFING] }),
+    );
+
+    const r = (payload["resolved"] as Array<Record<string, unknown>>)[0]!;
+    expect(r["status"]).toBe("matched");
+    expect(r["canonical"]).toEqual({ namespace: "product", key: "waterproof_rating" });
+    expect(r["submitted"]).toEqual({ namespace: "product", key: "waterproofing" });
+    expect(r["canonical"]).not.toEqual(r["submitted"]);
+  });
+
+  it("AC3 — a `created` echoes the submitted name (canonical === submitted)", async () => {
+    seedTokens("at", "rt");
+    installRouter((kind) =>
+      kind === "specs" ? { status: 200, body: specsEnvelope([RES_CREATED]) } : { status: 500, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", { query: "gloves", specs: [SPEC_HANDMADE] }),
+    );
+
+    const r = (payload["resolved"] as Array<Record<string, unknown>>)[0]!;
+    expect(r["status"]).toBe("created");
+    expect(r["canonical"]).toEqual(r["submitted"]);
+  });
+
+  it("surfaces the canonical DEFINITION verbatim (display_name/data_type/is_filterable) — the method persists it whole", async () => {
+    seedTokens("at", "rt");
+    installRouter((kind) =>
+      kind === "specs" ? { status: 200, body: specsEnvelope([RES_MATCHED, RES_CREATED]) } : { status: 500, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", REQUEST));
+
+    // Faithful pass-through: the resolved array equals the wire array verbatim (the
+    // client trusts the backend's dedupe authority; it does not narrow the def the
+    // method must persist).
+    expect(payload["resolved"]).toEqual([RES_MATCHED, RES_CREATED]);
+    // A first-try success is NOT a silent recovery — the refreshed marker must NOT fire.
+    expect(infoMarkerCount(api, "sil_specs_refreshed")).toBe(0);
+  });
+});
+
+describe("sil_specs — AC5: not registered (no tokens.json) short-circuit", () => {
+  it("makes NO sil-api call and names sil_register as the recovery", async () => {
+    // No tokens seeded.
+    const rec = installRouter(() => ({ status: 200, body: specsEnvelope([RES_MATCHED]) }));
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", REQUEST));
+
+    expect(rec.all.length).toBe(0); // zero network
+    expect(payload["status"]).toBe("not_registered");
+    expect(payload["resolved"]).toBeUndefined();
+    expect(JSON.stringify(payload)).toContain("sil_register");
+  });
+});
+
+describe("sil_specs — AC6: 401 refresh-and-retry-once (uniform with sil_search / sil_product_get / sil_whoami)", () => {
+  it("recovered 401: refresh once, retry once with the ROTATED token (same body), return ok — invisible to the agent", async () => {
+    seedTokens("expired-at", "valid-rt");
+    const rec = installRouter((kind, nth) => {
+      if (kind === "specs") {
+        return nth === 0
+          ? { status: 401, body: { error: "unauthorized" } }
+          : { status: 200, body: specsEnvelope([RES_MATCHED, RES_CREATED]) };
+      }
+      if (kind === "refresh") {
+        return { status: 200, body: { access_token: "rotated-at", refresh_token: "rotated-rt" } };
+      }
+      return { status: 500, body: {} };
+    });
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", REQUEST));
+
+    expect(payload["status"]).toBe("ok");
+    expect(rec.specs.length).toBe(2); // failed read + one retry
+    expect(rec.refresh.length).toBe(1); // exactly one refresh
+    // The retry carried the ROTATED token and the SAME body.
+    expect(bearerToken(rec.specs[1]!)).toBe("rotated-at");
+    expect(rec.specs[1]!.body).toEqual({ query: "hiking gloves", specs: [SPEC_WATERPROOFING, SPEC_HANDMADE] });
+    // The silent-recovery operator marker fires EXACTLY ONCE (logs-only; NOT a payload field).
+    expect(infoMarkerCount(api, "sil_specs_refreshed")).toBe(1);
+    expect(JSON.stringify(payload)).not.toContain("refreshed"); // never leaks to the agent
+  });
+
+  it("second-401: a freshly-rotated token STILL rejected → must_reregister (exactly one refresh, NO storm), tokens cleared", async () => {
+    seedTokens("expired-at", "valid-rt");
+    const rec = installRouter((kind) => {
+      if (kind === "specs") return { status: 401, body: { error: "unauthorized" } }; // ALWAYS 401
+      if (kind === "refresh") return { status: 200, body: { access_token: "rotated-at", refresh_token: "rotated-rt" } };
+      return { status: 500, body: {} };
+    });
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", REQUEST));
+
+    expect(payload["status"]).toBe("must_reregister");
+    expect(payload["recovery"]).toBe("sil_register");
+    expect(rec.refresh.length).toBe(1); // exactly one refresh, NEVER a second
+    expect(rec.specs.length).toBe(2); // initial + exactly one retry
+    expect(existsSync(getTokensPath())).toBe(false); // rotated pair is structurally dead → cleared
+  });
+
+  it("invalid_grant: a dead refresh token → must_reregister, NO retry, tokens cleared", async () => {
+    seedTokens("expired-at", "dead-rt");
+    const rec = installRouter((kind) => {
+      if (kind === "specs") return { status: 401, body: { error: "unauthorized" } };
+      if (kind === "refresh") return { status: 401, body: { error: "invalid_grant" } };
+      return { status: 500, body: {} };
+    });
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", REQUEST));
+
+    expect(payload["status"]).toBe("must_reregister");
+    expect(payload["recovery"]).toBe("sil_register");
+    expect(rec.refresh.length).toBe(1);
+    expect(rec.specs.length).toBe(1); // the original 401 only — NO retry without a rotated token
+    expect(existsSync(getTokensPath())).toBe(false);
+  });
+
+  it("refresh-5xx: a refresh-leg blip → retryable (NO re-register hint), NO retry, tokens KEPT", async () => {
+    seedTokens("expired-at", "valid-rt");
+    const rec = installRouter((kind) => {
+      if (kind === "specs") return { status: 401, body: { error: "unauthorized" } };
+      if (kind === "refresh") return { status: 503, body: { error: "unavailable" } };
+      return { status: 500, body: {} };
+    });
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", REQUEST));
+
+    expect(payload["status"]).toBe("retryable");
+    expect(payload["recovery"]).not.toBe("sil_register"); // a refresh blip is NOT a dead session
+    expect(rec.refresh.length).toBe(1);
+    expect(rec.specs.length).toBe(1); // NO retry — no rotated token
+    expect(existsSync(getTokensPath())).toBe(true); // the pair may be fine — kept
+  });
+});
+
+describe("sil_specs — AC7: 403 forbidden (shared envelope; user_not_provisioned clears the dead token)", () => {
+  it("403 user_not_provisioned → forbidden envelope, the dead token is CLEARED at the call site", async () => {
+    seedTokens("at", "rt");
+    const rec = installRouter((kind) =>
+      kind === "specs"
+        ? { status: 403, body: { error: "user_not_provisioned" } }
+        : { status: 500, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", REQUEST));
+
+    expect(payload["status"]).toBe("forbidden");
+    expect(payload["reason"]).toBe("user_not_provisioned");
+    // NOT refreshed — a 403 is terminal-but-recoverable, no refresh leg fires.
+    expect(rec.refresh.length).toBe(0);
+    // user_not_provisioned clears the structurally-dead token so the next sil_register
+    // re-onboards (parity with sil_search / sil_whoami).
+    expect(existsSync(getTokensPath())).toBe(false);
+  });
+
+  it("403 principal_mismatch → forbidden envelope carrying the reason, but the token is KEPT (recoverable)", async () => {
+    seedTokens("at", "rt");
+    installRouter((kind) =>
+      kind === "specs"
+        ? { status: 403, body: { error: "principal_mismatch" } }
+        : { status: 500, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", REQUEST));
+
+    expect(payload["status"]).toBe("forbidden");
+    expect(payload["reason"]).toBe("principal_mismatch");
+    // The exact-equality clear gate: only user_not_provisioned clears — a
+    // principal_mismatch is recoverable and MUST keep its token.
+    expect(existsSync(getTokensPath())).toBe(true);
+  });
+});
+
+describe("sil_specs — AC8: 5xx / network → retryable (NO re-register hint, BARE — never names a source)", () => {
+  it("5xx → retryable, NO recovery:sil_register", async () => {
+    seedTokens("at", "rt");
+    installRouter((kind) =>
+      kind === "specs"
+        ? { status: 500, body: { error: "internal_error", message: "registry DB unavailable" } }
+        : { status: 200, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", REQUEST));
+
+    expect(payload["status"]).toBe("retryable");
+    expect(payload["recovery"]).not.toBe("sil_register");
+    expect(JSON.stringify(payload).toLowerCase()).not.toMatch(/sil_register/);
+  });
+
+  it("a 5xx carrying a `source` field STILL surfaces a BARE retryable — NO source named (registry has no external source)", async () => {
+    // The taxonomy-over-copy guard at the wired tier: search's source-named retryable
+    // (outcome b) must NOT be copied to specs. Even if a spurious `source` rides a
+    // specs 5xx, the agent-facing envelope names no source and no detail.
+    seedTokens("at", "rt");
+    installRouter((kind) =>
+      kind === "specs"
+        ? { status: 500, body: { error: "source_unavailable", message: "x", source: "shopify" } }
+        : { status: 200, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", REQUEST));
+
+    expect(payload["status"]).toBe("retryable");
+    expect(payload).not.toHaveProperty("detail");
+    expect(JSON.stringify(payload)).not.toContain("shopify");
+  });
+
+  it("network error / timeout (thrown fetch) → retryable", async () => {
+    seedTokens("at", "rt");
+    const rec = installRouter((kind) => (kind === "specs" ? "network-error" : { status: 200, body: {} }));
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", REQUEST));
+
+    expect(rec.specs.length).toBe(1); // exactly one round-trip — no storm
+    expect(payload["status"]).toBe("retryable");
+  });
+});
+
+describe("sil_specs — 400 → invalid_request (surfaces the server's { error, message })", () => {
+  it("400 → invalid_request carrying { error, message }, NOT retryable and NOT re-register", async () => {
+    seedTokens("at", "rt");
+    installRouter((kind) =>
+      kind === "specs"
+        ? { status: 400, body: { error: "invalid_request", message: "specs[0].display_name is required." } }
+        : { status: 200, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", REQUEST));
+
+    expect(payload["status"]).toBe("invalid_request");
+    expect(payload["status"]).not.toBe("retryable");
+    expect(payload["recovery"]).not.toBe("sil_register");
+  });
+});
+
+describe("sil_specs — AC9: anti-false-green (a 200 with no usable resolved array → retryable, never a false ok)", () => {
+  it("a stub 200 ({stub, tool, echo}) → retryable, NEVER ok", async () => {
+    seedTokens("at", "rt");
+    installRouter((kind) =>
+      kind === "specs"
+        ? { status: 200, body: { stub: true, tool: "sil_specs", echo: REQUEST } }
+        : { status: 500, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", REQUEST));
+
+    expect(payload["status"]).not.toBe("ok");
+    expect(payload["status"]).toBe("retryable");
+  });
+
+  it("an EMPTY resolved:[] → retryable (STRICTER than search — a 1:1 request owes ≥1 resolution, no empty-match success)", async () => {
+    seedTokens("at", "rt");
+    installRouter((kind) =>
+      kind === "specs" ? { status: 200, body: specsEnvelope([]) } : { status: 500, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", REQUEST));
+
+    expect(payload["status"]).not.toBe("ok");
+    expect(payload["status"]).toBe("retryable");
+  });
+
+  it("a resolved entry with no usable canonical ref → whole 200 falls to retryable (reject-whole, no partial adopt)", async () => {
+    seedTokens("at", "rt");
+    installRouter((kind) =>
+      kind === "specs"
+        ? { status: 200, body: specsEnvelope([RES_MATCHED, { namespace: "x", key: "y", status: "created" }]) }
+        : { status: 500, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", REQUEST));
+
+    expect(payload["status"]).not.toBe("ok");
+    expect(payload["status"]).toBe("retryable");
+  });
+});
+
+describe("sil_specs — the outcomes map to distinct agent-facing status strings (taxonomy)", () => {
+  it("ok / invalid_request / retryable / forbidden are FOUR distinct statuses", async () => {
+    async function statusFor(reply: Reply): Promise<unknown> {
+      seedTokens("at", "rt");
+      installRouter((kind) => (kind === "specs" ? reply : { status: 500, body: {} }));
+      const api = createMockPluginApi();
+      registerCatalogTools(api);
+      const payload = payloadOf(await getTool(api, TOOL).execute("c1", REQUEST));
+      vi.restoreAllMocks();
+      return payload["status"];
+    }
+
+    const ok = await statusFor({ status: 200, body: specsEnvelope([RES_MATCHED, RES_CREATED]) });
+    const invalid = await statusFor({ status: 400, body: { error: "invalid_request", message: "x" } });
+    const retry = await statusFor({ status: 500, body: {} });
+    const forbid = await statusFor({ status: 403, body: { error: "user_not_provisioned" } });
+
+    expect(ok).toBe("ok");
+    expect(invalid).toBe("invalid_request");
+    expect(retry).toBe("retryable");
+    expect(forbid).toBe("forbidden");
+    expect(new Set([ok, invalid, retry, forbid]).size).toBe(4);
+  });
+});
+
+describe("sil_specs — token privacy (never logged, never echoed)", () => {
+  it("on the SUCCESS path, no logger call and no result carries the access token or a Bearer header", async () => {
+    seedTokens("secret-specs-access", "secret-specs-refresh");
+    installRouter((kind) =>
+      kind === "specs" ? { status: 200, body: specsEnvelope([RES_MATCHED]) } : { status: 500, body: {} },
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", { query: "gloves", specs: [SPEC_WATERPROOFING] }),
+    );
+
+    const logs = logBlob(api);
+    const result = JSON.stringify(payload);
+    for (const blob of [logs, result]) {
+      expect(blob).not.toContain("secret-specs-access");
+      expect(blob).not.toContain("secret-specs-refresh");
+      expect(blob).not.toMatch(/Bearer/i);
+    }
+  });
+});

--- a/src/__tests__/cross-tool-401-parity.integration.test.ts
+++ b/src/__tests__/cross-tool-401-parity.integration.test.ts
@@ -2,18 +2,19 @@
  * INTEGRATION — cross-tool 401 parity (tier: integration).
  *
  * THE structural guard against FLAG-10 re-entry. The card's deliverable is that
- * `sil_search`, `sil_product_get`, and `sil_whoami` present the IDENTICAL 401
- * choreography — one transparent refresh via `refreshStoredTokens()`, one retry of
+ * `sil_search`, `sil_product_get`, `sil_whoami`, AND `sil_specs` present the IDENTICAL
+ * 401 choreography — one transparent refresh via `refreshStoredTokens()`, one retry of
  * the original read, and the same terminal/transient/ok envelope CLASS for each of
  * the four refresh sub-outcomes (retry-ok, second-401, invalid_grant, refresh-5xx).
- * The divergence the goal forbids re-enters the moment a fourth tool copies
- * catalog's OLD terminal branch instead of the shared path — so parity is enforced
- * here by a real shared-behaviour assertion that FAILS if any one tool drifts, not
- * left to reviewer vigilance.
+ * The divergence the goal forbids re-enters the moment a NEW tool copies catalog's OLD
+ * terminal branch instead of the shared path — so parity is enforced here by a real
+ * shared-behaviour assertion that FAILS if any one tool drifts, not left to reviewer
+ * vigilance. `sil_specs` (card sds-specs-client-tool) is the 4th sil-api tool folded
+ * into this guard so the shared seam cannot drift for the new tool.
  *
  * This is deliberately NOT three independent per-tool suites (those live in
  * whoami / catalog-search / catalog-lookup integration). Here we drive the SAME
- * scenario through all three tools in one test and assert their observable 401
+ * scenario through all four tools in one test and assert their observable 401
  * behaviour is the same — the equality IS the assertion. A tool whose 401 stayed
  * terminal (no refresh) shows refresh.length 0 where the others show 1, or maps a
  * recovered 401 to a re-register where the others map to ok — and the parity check
@@ -21,15 +22,15 @@
  *
  * The ONLY thing mocked is `fetch`. Real `sil-client` + `credentials` +
  * `refreshStoredTokens`, real `SIL_DATA_DIR` token seeding — stub-free, exactly as
- * the per-tool suites. The fetch double routes the THREE sil-api read endpoints
- * (`/identity` GET, `/catalog/search`, `/catalog/lookup`) plus the sil-web
- * `/auth/refresh` leg, and exposes per-tool read + refresh call counts.
+ * the per-tool suites. The fetch double routes the FOUR sil-api read endpoints
+ * (`/identity` GET, `/catalog/search`, `/catalog/lookup`, `/catalog/specs`) plus the
+ * sil-web `/auth/refresh` leg, and exposes per-tool read + refresh call counts.
  *
- * EXPECT RED until all three tools route 401 through the shared
- * `refreshAndRetryOnce` helper: against current code `sil_whoami` already
- * refreshes (refresh.length 1, recovered-ok) but the two catalog tools are
- * terminal (refresh.length 0, re-register) — so the per-sub-outcome parity sets
- * have size > 1 and these tests fail. GREEN only once catalog 401 matches whoami.
+ * EXPECT RED until every tool routes 401 through the shared `refreshAndRetryOnce`
+ * helper. For the sds-specs-client-tool card specifically: `sil_specs` is not
+ * registered yet, so `setupTool("specs")` throws "Tool not registered" — every parity
+ * `it` observes all FOUR tools, so the specs slot fails until the tool exists and
+ * adopts the shared path. GREEN only once sil_specs' 401 matches the other three.
  */
 
 import {
@@ -55,7 +56,7 @@ import {
 } from "./helpers/mock-plugin-api.js";
 
 const SIL_WEB = "https://sil-web.test.example.com"; // refresh origin
-const SIL_API = "https://sil-api.test.example.com"; // read origin (all three reads)
+const SIL_API = "https://sil-api.test.example.com"; // read origin (all four reads)
 
 /** A real identity envelope (sil_whoami's ok shape). */
 function identityEnvelope(): unknown {
@@ -92,6 +93,29 @@ function searchEnvelope(): unknown {
       },
     ],
     pagination: { has_next_page: false },
+  };
+}
+
+/** A real specs body with one resolution (sil_specs's ok shape). BARE shape
+ * (`{ resolved }` — top level, no `ucp`/`result` wrapper), the only shape sil-api
+ * emits for `/catalog/specs`. The `matched` entry carries a usable canonical ref so
+ * `extractSpecsResult` accepts it (anti-false-green). */
+function specsEnvelope(): unknown {
+  return {
+    resolved: [
+      {
+        namespace: "product",
+        key: "waterproof_rating",
+        display_name: "Waterproof Rating",
+        data_type: "number",
+        unit: "mm",
+        is_filterable: true,
+        is_comparable: true,
+        submitted: { namespace: "product", key: "waterproofing" },
+        canonical: { namespace: "product", key: "waterproof_rating" },
+        status: "matched",
+      },
+    ],
   };
 }
 
@@ -133,18 +157,18 @@ interface Recorded {
 }
 
 type Reply = { status: number; body: unknown } | "network-error";
-type ReadKind = "identity" | "search" | "lookup";
+type ReadKind = "identity" | "search" | "lookup" | "specs";
 type Kind = ReadKind | "refresh" | "other";
 
 /** What a recording double returns to the caller. */
 interface Buckets {
   all: Recorded[];
-  read: Recorded[]; // the tool's sil-api read endpoint (identity|search|lookup)
+  read: Recorded[]; // the tool's sil-api read endpoint (identity|search|lookup|specs)
   refresh: Recorded[]; // the sil-web /auth/refresh leg
 }
 
 /**
- * A URL-routing fetch double covering all three sil-api read endpoints + the
+ * A URL-routing fetch double covering all four sil-api read endpoints + the
  * sil-web refresh leg. `readKind` selects which read endpoint THIS tool uses, so
  * the `read` bucket counts only that tool's reads (the parity assertion compares
  * read + refresh counts across tools). `replyRead(nthRead)` and
@@ -180,6 +204,7 @@ function installRouter(
       if (url.includes("/auth/refresh")) kind = "refresh";
       else if (url.includes("/catalog/search")) kind = "search";
       else if (url.includes("/catalog/lookup")) kind = "lookup";
+      else if (url.includes("/catalog/specs")) kind = "specs";
       else if (url.includes("/identity")) kind = "identity";
       else kind = "other";
 
@@ -235,6 +260,7 @@ function seedTokens(access: string, refresh: string): void {
 function okEnvelopeFor(readKind: ReadKind): unknown {
   if (readKind === "identity") return identityEnvelope();
   if (readKind === "search") return searchEnvelope();
+  if (readKind === "specs") return specsEnvelope();
   return lookupEnvelope();
 }
 
@@ -246,13 +272,23 @@ function setupTool(readKind: ReadKind): { api: MockPluginAPI; tool: string } {
     return { api, tool: "sil_whoami" };
   }
   registerCatalogTools(api);
-  return { api, tool: readKind === "search" ? "sil_search" : "sil_product_get" };
+  if (readKind === "search") return { api, tool: "sil_search" };
+  if (readKind === "specs") return { api, tool: "sil_specs" };
+  return { api, tool: "sil_product_get" };
 }
 
 /** Invoke a tool with the call args its schema requires. */
 function callArgs(readKind: ReadKind): Record<string, unknown> {
   if (readKind === "search") return { query: "chair" };
   if (readKind === "lookup") return { ids: ["gid://product/a"] };
+  if (readKind === "specs") {
+    return {
+      query: "hiking gloves",
+      specs: [
+        { namespace: "product", key: "waterproofing", display_name: "Waterproofing", data_type: "number" },
+      ],
+    };
+  }
   return {}; // whoami takes no params
 }
 
@@ -263,6 +299,7 @@ function callArgs(readKind: ReadKind): Record<string, unknown> {
 function refreshedMarkerFor(readKind: ReadKind): string {
   if (readKind === "search") return "sil_search_refreshed";
   if (readKind === "lookup") return "sil_product_get_refreshed";
+  if (readKind === "specs") return "sil_specs_refreshed";
   return "sil_whoami_refreshed";
 }
 
@@ -288,7 +325,7 @@ interface Observation {
 }
 
 /**
- * Drive a SINGLE refresh-leg scenario through ALL THREE tools and return one
+ * Drive a SINGLE refresh-leg scenario through ALL FOUR tools and return one
  * Observation per tool. `replyRead(readKind, nthRead)` makes the first read 401
  * and lets the caller return each tool's OWN ok envelope on the retry; `replyRefresh`
  * decides the refresh-leg outcome. Each tool runs in its own fresh token seed +
@@ -298,7 +335,7 @@ async function observeAllTools(
   replyRead: (readKind: ReadKind, nthRead: number) => Reply,
   replyRefresh: (nthRefresh: number) => Reply,
 ): Promise<Observation[]> {
-  const kinds: ReadKind[] = ["identity", "search", "lookup"];
+  const kinds: ReadKind[] = ["identity", "search", "lookup", "specs"];
   const out: Observation[] = [];
   for (const readKind of kinds) {
     // Fresh seed per tool (the prior tool's run may have cleared tokens).
@@ -340,10 +377,10 @@ afterEach(() => {
   rmSync(dataDir, { recursive: true, force: true });
 });
 
-describe("cross-tool 401 parity — all three tools share ONE refresh-and-retry-once choreography", () => {
+describe("cross-tool 401 parity — all four tools share ONE refresh-and-retry-once choreography", () => {
   it("sub-outcome retry-ok: every tool refreshes once, retries once, and returns a NORMAL ok result (no tool dead-ends)", async () => {
     // AC[integration]: identical scenario (expired token → 401 → good refresh →
-    // retry ok) through search / product_get / whoami. All three must look the
+    // retry ok) through search / product_get / whoami / specs. All four must look the
     // same: exactly 1 refresh, exactly 2 reads, status ok, NO recovery hint. The
     // retry returns each tool's OWN ok envelope (via okEnvelopeFor).
     const observed = await observeAllTools(
@@ -362,10 +399,10 @@ describe("cross-tool 401 parity — all three tools share ONE refresh-and-retry-
       expect(o.readCount).toBe(2); // failed read + one retry
       // OBSERVABILITY-SEAM PARITY (review-round-1 fix; card line 161): every tool
       // emits its own `<tool>_refreshed` operator marker EXACTLY ONCE on this
-      // silent-recovery path — the seam restored uniformly across all three. Folded
+      // silent-recovery path — the seam restored uniformly across all four. Folded
       // into THIS anti-divergence guard so the marker cannot drift/disappear
       // per-tool again (the same FLAG-10 failure mode, applied to logging). RED
-      // until all three tools emit the marker via the helper's `refreshed:true`.
+      // until all four tools emit the marker via the helper's `refreshed:true`.
       expect(o.refreshedMarkerCount).toBe(1);
     }
     // The equality across tools IS the guard: collapse each dimension to a set.
@@ -379,7 +416,7 @@ describe("cross-tool 401 parity — all three tools share ONE refresh-and-retry-
   });
 
   it("sub-outcome second-401: every tool refreshes EXACTLY once, retries once, then terminates re-register (no tool storms)", async () => {
-    // AC[integration]: a freshly-rotated token still 401 is terminal for ALL three
+    // AC[integration]: a freshly-rotated token still 401 is terminal for ALL four
     // — exactly 1 refresh, exactly 2 reads, status must_reregister with the hint.
     const observed = await observeAllTools(
       () => ({ status: 401, body: { error: "unauthorized" } }), // read ALWAYS 401
@@ -398,7 +435,7 @@ describe("cross-tool 401 parity — all three tools share ONE refresh-and-retry-
   });
 
   it("sub-outcome invalid_grant: every tool refreshes once, does NOT retry, terminates re-register, and clears tokens", async () => {
-    // AC[integration]: a dead refresh token. ALL three: 1 refresh, NO retry (1
+    // AC[integration]: a dead refresh token. ALL four: 1 refresh, NO retry (1
     // read), status must_reregister + hint, tokens.json cleared.
     const observed = await observeAllTools(
       () => ({ status: 401, body: { error: "unauthorized" } }),
@@ -419,7 +456,7 @@ describe("cross-tool 401 parity — all three tools share ONE refresh-and-retry-
 
   it("sub-outcome refresh-5xx: every tool surfaces TRANSIENT retryable with NO re-register hint, does NOT retry, keeps tokens", async () => {
     // AC[integration]: a refresh-leg 5xx is a blip, not a dead session, for ALL
-    // three — status retryable, NO hint, 1 refresh, NO retry (1 read), tokens kept.
+    // four — status retryable, NO hint, 1 refresh, NO retry (1 read), tokens kept.
     const observed = await observeAllTools(
       () => ({ status: 401, body: { error: "unauthorized" } }),
       () => ({ status: 503, body: { error: "unavailable" } }),
@@ -441,7 +478,7 @@ describe("cross-tool 401 parity — all three tools share ONE refresh-and-retry-
     // This is the explicit anti-divergence assertion the card requires: if any one
     // tool does NOT refresh on a 401 (the old terminal catalog branch), its
     // refreshCount is 0 while the refreshing tools' is 1 — so the cross-tool set
-    // has size 2 and this fails. With all three on the shared helper, the set
+    // has size 2 and this fails. With all four on the shared helper, the set
     // collapses to {1}. (Against current code, the two catalog tools are terminal
     // and whoami refreshes — so this is RED until catalog adopts the shared path.)
     const observed = await observeAllTools(

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -128,9 +128,8 @@ describe("plugin entry — registration contract", () => {
     // register() runs the real tool groups (no mock), so it populates the
     // api with exactly the real tools and NO example stub. This pins the
     // wiring AND the card's "absence" goal: sil_ping / sil_echo gone.
-    // The spec-driven-shopping-redesign card renames sil_remember → sil_learn
-    // and ADDS sil_profile_search (frontmatter-as-truth query) → 8 → 9,
-    // add-only; sil_remember is gone (deleted, not aliased).
+    // The sds-specs-client-tool card ADDS sil_specs (the coin/dedupe/register
+    // canonicalization primitive) to the catalog group → 9 → 10, add-only.
     const api = createMockPluginApi();
     capturedRegisterFn!(api);
     expect([...api._tools.keys()].sort()).toEqual([
@@ -142,6 +141,7 @@ describe("plugin entry — registration contract", () => {
       "sil_profile_search",
       "sil_register",
       "sil_search",
+      "sil_specs",
       "sil_whoami",
     ]);
   });

--- a/src/__tests__/lib/openclaw-allowlist.test.ts
+++ b/src/__tests__/lib/openclaw-allowlist.test.ts
@@ -54,10 +54,9 @@ import {
 // unit core takes them as an argument so the test pins behaviour, not wiring).
 const SIL: SilAllowlistFacts = {
   id: "sil",
-  // The real 9-tool floor after spec-driven-shopping-redesign renamed
-  // sil_remember → sil_learn and added sil_profile_search — the five profile
-  // verbs sil_profile_get / sil_profile_materialize / sil_profile_remove /
-  // sil_profile_search / sil_learn plus the four core tools. (This carrier is
+  // The real 10-tool floor after the sds-specs-client-tool card added sil_specs
+  // (the coin/dedupe/register canonicalization primitive) to the catalog group,
+  // beside the five profile verbs and the four other core tools. (This carrier is
   // the SILENT 7th — a stale entry stays GREEN here, so it is bumped for hygiene
   // in lockstep with the six that bite.)
   tools: [
@@ -69,6 +68,7 @@ const SIL: SilAllowlistFacts = {
     "sil_profile_search",
     "sil_register",
     "sil_search",
+    "sil_specs",
     "sil_whoami",
   ],
   skill: "./sil-shopping",
@@ -131,7 +131,7 @@ describe("AC1 (core) — fresh merge trusts sil at all three real surfaces", () 
     expect(changed).toBe(true);
   });
 
-  it("does NOT enumerate the 8 tool NAMES into config — admission is by plugin id only", () => {
+  it("does NOT enumerate the 10 tool NAMES into config — admission is by plugin id only", () => {
     const { config } = mergeSilAllowlist({}, SIL);
     const serialized = JSON.stringify(config);
     // The mechanism is plugin-id admission; tool names must never leak into the

--- a/src/__tests__/lib/specs-classify.test.ts
+++ b/src/__tests__/lib/specs-classify.test.ts
@@ -1,0 +1,389 @@
+/**
+ * UNIT — sil-api catalog SPECS response classifier + the pure specs-resolution
+ * gate (tier: unit, no network).
+ *
+ * CARD `sds-specs-client-tool` (epic `spec-driven-shopping-redesign`, Phase 3 —
+ * the plugin side). The pure, highest-risk core of `sil_specs`, pinned in isolation
+ * exactly like `classifySearchResponse` / `classifyIdentityResponse`. `sil_specs`
+ * is a STRUCTURAL CLONE of `sil_search` — same origin (sil-api, bare path), same
+ * bearer + 401 refresh-and-retry-once, same outcome taxonomy — BUT over a new wire
+ * shape and with two DELIBERATE deletions from search's classifier that this file
+ * pins as hard adversarial guards:
+ *
+ *   1. NO 422 arm. The specs registry is sil's OWN Postgres (specs.ts:15-17), not an
+ *      external catalog source, so there is no `source_rejected` 422 to special-case.
+ *      A 422 MUST fall through to `retryable` — the OPPOSITE of `classifySearchResponse`,
+ *      where 422 → invalid_request. Copying search's 422 arm here is the taxonomy lie
+ *      in reverse (telling the agent "give up / fix the request" on a transient blip).
+ *   2. NO `source` attribution on `retryable`. The registry has no external source, so
+ *      `SpecsOutcome`'s retryable is ALWAYS bare `{ kind: "retryable" }` — even when a
+ *      5xx body carries a `source` field. Surfacing a source on a specs 5xx is wrong
+ *      attribution (search's `retryableFromBody` source arm is dropped for specs).
+ *
+ * The wire contract, verified against the LIVE handler
+ * (`../../sil-services/services/sil-api/src/handlers/specs.ts`) + `@sil/schemas`
+ * `packages/schemas/src/specs.ts` (authoritative over any design doc — the doc's
+ * `200 { ucp, resolved }` is STALE; the live response is the BARE `{ resolved }`):
+ *   - Request  `{ query: string, specs: SpecDefinition[] }`.
+ *   - Response 200 — the BARE `{ resolved: SpecResolution[] }`, `resolved` TOP-LEVEL,
+ *     NO `ucp` meta, NO `result` wrapper. Read `resolved` straight off the body.
+ *   - SpecResolution = ...SpecDefinition (flat canonical def) + submitted:{namespace,key}
+ *     + canonical:{namespace,key} + status:"matched"|"created" + is_filterable + is_comparable.
+ *   - Error arms: 400 (TypeBox boundary), 401, 403, 5xx/DB fault. NO 422, NO source.
+ *
+ * The anti-false-green gate is `Array.isArray(resolved)` — AND, STRICTER than search:
+ * because a well-formed request (specs `minItems:1`) owes a 1:1 resolution, an EMPTY
+ * `resolved: []` cannot occur → an empty array is itself a malformed 200 → `retryable`
+ * (there is NO valid empty-match success here, UNLIKE `sil_search` where `products:[]`
+ * is a genuine ok). And per the reject-WHOLE decision (card handoff, confirmed): a
+ * structurally-present but MALFORMED entry (no usable `canonical` ref / bad `status`)
+ * falls the WHOLE 200 to `retryable` — never drop-and-continue (the method cannot adopt
+ * a canonical name it never got back; a half-canonical vocabulary forks silently).
+ *
+ * Contract this file pins for the implementation (expert-developer),
+ * `src/lib/sil-client.ts` — model on `SearchOutcome`, dropping the 422 arm + source:
+ *   classifySpecsResponse(status: number, body: unknown): SpecsOutcome
+ *   where SpecsOutcome is a discriminated union on `kind`:
+ *     | { kind: "ok"; resolved: SpecResolution[] }
+ *     | { kind: "unauthorized" }
+ *     | { kind: "forbidden"; reason: string }
+ *     | { kind: "invalid_request"; error: string; message: string }
+ *     | { kind: "retryable" }                 // BARE — no source, no detail
+ *   The classifier branches on `status` (and, for 200, the body shape) — NEVER on
+ *   `res.ok`. `extractSpecsResult(body)` reads `resolved` off the FLAT top-level body
+ *   and returns null (→ retryable) on any non-usable shape. The `resolved` array is
+ *   surfaced FAITHFULLY (the client trusts the backend's dedupe authority — it does
+ *   not second-guess a `matched`).
+ *
+ * EXPECT RED today: `classifySpecsResponse` / `extractSpecsResult` do not exist yet,
+ * so every call throws "is not a function".
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { classifySpecsResponse } from "../../lib/sil-client.js";
+
+/** A coined spec that dedupes to an EXISTING canonical name — `submitted` (the
+ * method's private synonym) DIFFERS from `canonical` (the adopted name). This is the
+ * anti-fragmentation case: the method drops "waterproofing" and adopts the canonical
+ * "waterproof_rating". The flat def fields ARE the canonical definition. */
+const MATCHED = {
+  namespace: "product",
+  key: "waterproof_rating",
+  display_name: "Waterproof Rating",
+  data_type: "number",
+  unit: "mm",
+  is_filterable: true,
+  is_comparable: true,
+  submitted: { namespace: "product", key: "waterproofing" },
+  canonical: { namespace: "product", key: "waterproof_rating" },
+  status: "matched",
+};
+
+/** A NOVEL coined spec registered as canonical — `canonical === submitted` (you were
+ * first, your coined name IS canonical going forward). */
+const CREATED = {
+  namespace: "seller",
+  key: "handmade",
+  display_name: "Handmade",
+  data_type: "boolean",
+  is_filterable: true,
+  is_comparable: false,
+  submitted: { namespace: "seller", key: "handmade" },
+  canonical: { namespace: "seller", key: "handmade" },
+  status: "created",
+};
+
+/** A stub-shaped 200 (`{ stub, tool, echo }`). Such a body must NEVER read as a clean
+ * resolution (complete-work-is-stub-free). */
+const STUB_BODY = { stub: true, tool: "sil_specs", echo: { query: "hiking gloves" } };
+
+describe("classifySpecsResponse — the status taxonomy is a STRICT SUBSET of search's (no 422, no source)", () => {
+  it("200 with a populated resolved → ok (carries the resolutions)", () => {
+    const out = classifySpecsResponse(200, { resolved: [MATCHED, CREATED] });
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      expect(out.resolved).toHaveLength(2);
+    }
+  });
+
+  it("400 → invalid_request, surfacing sil-api's { error, message } (the TypeBox boundary reject)", () => {
+    const out = classifySpecsResponse(400, {
+      error: "invalid_request",
+      message: "specs must contain at least one definition.",
+    });
+    expect(out.kind).toBe("invalid_request");
+    if (out.kind === "invalid_request") {
+      expect(out.error).toBe("invalid_request");
+      expect(out.message).toBe("specs must contain at least one definition.");
+    }
+  });
+
+  it("401 → unauthorized (the refresh trigger, NOT terminal for this tool)", () => {
+    const out = classifySpecsResponse(401, { error: "unauthorized" });
+    expect(out.kind).toBe("unauthorized");
+  });
+
+  it("403 → forbidden carrying its reason (parity with search/identity)", () => {
+    const out = classifySpecsResponse(403, { error: "user_not_provisioned" });
+    expect(out.kind).toBe("forbidden");
+    if (out.kind === "forbidden") {
+      expect(out.reason).toBe("user_not_provisioned");
+    }
+  });
+
+  it("5xx (registry / DB fault) → retryable (transient try-again)", () => {
+    const out = classifySpecsResponse(500, { error: "internal_error", message: "DB unavailable." });
+    expect(out.kind).toBe("retryable");
+  });
+
+  it("keeps the five outcome kinds DISTINCT (ok / invalid_request / unauthorized / forbidden / retryable)", () => {
+    const kinds = new Set([
+      classifySpecsResponse(200, { resolved: [MATCHED] }).kind,
+      classifySpecsResponse(400, { error: "invalid_request" }).kind,
+      classifySpecsResponse(401, {}).kind,
+      classifySpecsResponse(403, { error: "user_not_provisioned" }).kind,
+      classifySpecsResponse(500, {}).kind,
+    ]);
+    expect(kinds.size).toBe(5);
+  });
+
+  it("does NOT flatten 400 / 403 / 5xx into the ok path", () => {
+    expect(classifySpecsResponse(400, { error: "invalid_request" }).kind).not.toBe("ok");
+    expect(classifySpecsResponse(403, { error: "user_not_provisioned" }).kind).not.toBe("ok");
+    expect(classifySpecsResponse(500, {}).kind).not.toBe("ok");
+  });
+});
+
+describe("classifySpecsResponse — a 403 is FORBIDDEN carrying its reason, NEVER retryable (parity with search's forbidden arm)", () => {
+  it("403 principal_mismatch → forbidden carrying reason:'principal_mismatch' (passes through; NEVER retryable)", () => {
+    const out = classifySpecsResponse(403, { error: "principal_mismatch" });
+    expect(out.kind).toBe("forbidden");
+    expect(out.kind).not.toBe("retryable");
+    if (out.kind === "forbidden") {
+      expect(out.reason).toBe("principal_mismatch");
+    }
+  });
+
+  it("403 with an unknown / absent reason → forbidden with the default 'forbidden' marker, NEVER retryable", () => {
+    for (const body of [{}, { error: "" }, { error: 42 }, null, "boom", []]) {
+      const out = classifySpecsResponse(403, body);
+      expect(out.kind).toBe("forbidden");
+      expect(out.kind).not.toBe("retryable");
+      if (out.kind === "forbidden") {
+        expect(out.reason).toBe("forbidden");
+        // Never the provisioning reason on a garbage body — the exact-equality clear
+        // gate downstream therefore cannot mis-fire a destructive token wipe.
+        expect(out.reason).not.toBe("user_not_provisioned");
+      }
+    }
+  });
+
+  it("a 403 is DISTINCT from unauthorized (401, refreshable) and retryable (5xx, transient) — three landings", () => {
+    const forbidden403 = classifySpecsResponse(403, { error: "user_not_provisioned" }).kind;
+    const unauthorized401 = classifySpecsResponse(401, {}).kind;
+    const retryable5xx = classifySpecsResponse(500, {}).kind;
+    expect(forbidden403).toBe("forbidden");
+    expect(unauthorized401).toBe("unauthorized");
+    expect(retryable5xx).toBe("retryable");
+    expect(new Set([forbidden403, unauthorized401, retryable5xx]).size).toBe(3);
+  });
+});
+
+describe("classifySpecsResponse — NO 422 arm (specs registry is sil's OWN Postgres, not an external source)", () => {
+  it("422 → retryable, NEVER invalid_request (the OPPOSITE of classifySearchResponse — copying search's 422 arm is the bug)", () => {
+    // The load-bearing DELETE-FIRST guard: search classifies 422 source_rejected →
+    // invalid_request because an external catalog source refused the request. The
+    // specs registry has NO external source and emits no 422 SourceError — so a 422
+    // reaching this classifier is an UNMAPPED non-200 that must stay `retryable`
+    // (fix-nothing, retry). A dev who copy-pastes search's 422 → invalid_request arm
+    // trips this: it turns a transient blip into a false "give up / fix the request".
+    const out = classifySpecsResponse(422, {
+      error: "source_rejected",
+      message: "should not be treated as a specs invalid_request",
+      source: "shopify",
+    });
+    expect(out.kind).toBe("retryable");
+    expect(out.kind).not.toBe("invalid_request");
+  });
+
+  it("a 422 NEVER surfaces error/message as invalid_request — it is a bare retryable (no source arm either)", () => {
+    const out = classifySpecsResponse(422, { error: "source_rejected", message: "x", source: "etsy" });
+    expect(out.kind).toBe("retryable");
+    expect(out).not.toHaveProperty("error");
+    expect(out).not.toHaveProperty("message");
+    expect(out).not.toHaveProperty("source");
+  });
+});
+
+describe("classifySpecsResponse — retryable is ALWAYS BARE (no source attribution — the registry has no external source)", () => {
+  it("a 5xx that CARRIES a `source` field STILL yields a bare retryable — NO source surfaced (drop search's source arm)", () => {
+    // search's `retryableFromBody` attaches `source`/`detail` when a 5xx body names a
+    // catalog source (outcome b). For specs there IS no external source: the registry
+    // is sil's own Postgres. A `source` on a specs 5xx is spurious and MUST NOT be
+    // surfaced — a fabricated source on a sil-internal fault is wrong attribution.
+    const out = classifySpecsResponse(500, {
+      error: "source_unavailable",
+      message: "Catalog source 'shopify' is temporarily unavailable.",
+      source: "shopify",
+    });
+    expect(out.kind).toBe("retryable");
+    expect(out).not.toHaveProperty("source");
+    expect(out).not.toHaveProperty("detail");
+  });
+
+  it("502/503/504 → bare retryable, no source", () => {
+    for (const code of [502, 503, 504]) {
+      const out = classifySpecsResponse(code, { error: "source_unavailable", source: "etsy" });
+      expect(out.kind).toBe("retryable");
+      expect(out).not.toHaveProperty("source");
+    }
+  });
+
+  it("an unmapped 4xx other than 400/401/403/422 (404/409/429) → retryable, never a silent ok", () => {
+    for (const code of [404, 409, 429]) {
+      expect(classifySpecsResponse(code, {}).kind).toBe("retryable");
+      expect(classifySpecsResponse(code, {}).kind).not.toBe("ok");
+    }
+  });
+});
+
+describe("classifySpecsResponse — the anti-false-green body gate on 200 (STRICTER than search: no empty-match success)", () => {
+  it("200 carrying the STUB body ({stub,tool,echo}) is NOT ok — it is retryable", () => {
+    const out = classifySpecsResponse(200, STUB_BODY);
+    expect(out.kind).not.toBe("ok");
+    expect(out.kind).toBe("retryable");
+  });
+
+  it("200 whose body has NO `resolved` key → retryable, NEVER ok", () => {
+    const out = classifySpecsResponse(200, { note: "no resolved here" });
+    expect(out.kind).toBe("retryable");
+    expect(out.kind).not.toBe("ok");
+  });
+
+  it("200 whose `resolved` is a NON-ARRAY (null / object / string) → retryable, never ok", () => {
+    for (const bad of [null, {}, "nope", 7]) {
+      const out = classifySpecsResponse(200, { resolved: bad });
+      expect(out.kind).not.toBe("ok");
+      expect(out.kind).toBe("retryable");
+    }
+  });
+
+  it("200 with an EMPTY `resolved: []` → retryable, NEVER ok (STRICTER than search — a 1:1 request owes ≥1 resolution)", () => {
+    // THE deliberate divergence from `sil_search`, where `products: []` is a genuine
+    // empty-match SUCCESS. Here the request carries `specs` (minItems:1) and the server
+    // owes one resolution per submitted spec — so an empty `resolved` cannot happen for
+    // a well-formed request. An empty array is a malformed 200, not a valid empty match
+    // → `retryable`. A dev who reuses search's `Array.isArray` gate verbatim (which
+    // accepts `[]`) trips this.
+    const out = classifySpecsResponse(200, { resolved: [] });
+    expect(out.kind).not.toBe("ok");
+    expect(out.kind).toBe("retryable");
+  });
+
+  it("200 with an empty / null / non-object body → retryable, never ok (defensive)", () => {
+    expect(classifySpecsResponse(200, {}).kind).not.toBe("ok");
+    expect(classifySpecsResponse(200, null).kind).not.toBe("ok");
+    expect(classifySpecsResponse(200, "not-an-object").kind).not.toBe("ok");
+  });
+
+  it("does NOT branch on res.ok — a 200 stub and a 200 real resolution differ only by body", () => {
+    expect(classifySpecsResponse(200, { resolved: [MATCHED] }).kind).toBe("ok");
+    expect(classifySpecsResponse(200, STUB_BODY).kind).not.toBe("ok");
+  });
+});
+
+describe("classifySpecsResponse — reject-WHOLE on a malformed entry (no partial adopt; the method needs a usable canonical for EVERY spec)", () => {
+  it("a resolved array with one GOOD entry and one MALFORMED entry (no canonical) → retryable, NOT a partial ok", () => {
+    // The reject-WHOLE decision (card handoff, confirmed with product-owner): unlike
+    // search dropping ONE unusable product from a best-effort list, specs owes a 1:1
+    // resolution — a single unusable entry (no `canonical` ref the method can adopt)
+    // falls the WHOLE 200 to `retryable`. Dropping it would hand back a HALF-canonical
+    // vocabulary that forks silently (the anti-convergence failure this card exists to
+    // prevent). NEVER a partial `ok` carrying only the good entry.
+    const out = classifySpecsResponse(200, {
+      resolved: [MATCHED, { namespace: "x", key: "y", status: "created" /* no canonical ref */ }],
+    });
+    expect(out.kind).not.toBe("ok");
+    expect(out.kind).toBe("retryable");
+  });
+
+  it("a resolved entry with a bad `status` (not matched/created) → whole 200 falls to retryable", () => {
+    const out = classifySpecsResponse(200, {
+      resolved: [{ ...CREATED, status: "maybe" }],
+    });
+    expect(out.kind).not.toBe("ok");
+    expect(out.kind).toBe("retryable");
+  });
+
+  it("a resolved entry that is a bare non-object (string / null) → whole 200 falls to retryable", () => {
+    for (const bad of ["not-an-object", null, 42]) {
+      const out = classifySpecsResponse(200, { resolved: [MATCHED, bad] });
+      expect(out.kind).not.toBe("ok");
+      expect(out.kind).toBe("retryable");
+    }
+  });
+});
+
+describe("classifySpecsResponse — resolution surfacing (faithful: matched adopts the canonical, created echoes the submitted)", () => {
+  it("surfaces the resolved array FAITHFULLY, in order, verbatim — the client does not second-guess the backend's verdict", () => {
+    // The client trusts the registry's dedupe authority (card scope boundary): it
+    // surfaces `resolved` whole, per-entry, in order — never reshaping or dropping a
+    // field the method needs to persist the canonical def (display_name, data_type,
+    // unit, is_filterable, is_comparable). A `{ submitted, canonical, status }` narrow
+    // would strand the method with no canonical DEFINITION to write.
+    const resolved = [MATCHED, CREATED];
+    const out = classifySpecsResponse(200, { resolved });
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      expect(out.resolved).toEqual(resolved);
+    }
+  });
+
+  it("MATCHED: status is 'matched' and canonical (the existing name) DIFFERS from submitted (the coined synonym)", () => {
+    const out = classifySpecsResponse(200, { resolved: [MATCHED] });
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      const r = out.resolved[0]! as Record<string, unknown>;
+      expect(r["status"]).toBe("matched");
+      // The adopt target: canonical is the EXISTING canonical name, ≠ the submitted synonym.
+      expect(r["canonical"]).toEqual({ namespace: "product", key: "waterproof_rating" });
+      expect(r["submitted"]).toEqual({ namespace: "product", key: "waterproofing" });
+      expect(r["canonical"]).not.toEqual(r["submitted"]);
+    }
+  });
+
+  it("CREATED: status is 'created' and canonical EQUALS submitted (you were first; your coined name IS canonical)", () => {
+    const out = classifySpecsResponse(200, { resolved: [CREATED] });
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      const r = out.resolved[0]! as Record<string, unknown>;
+      expect(r["status"]).toBe("created");
+      expect(r["canonical"]).toEqual(r["submitted"]);
+      expect(r["canonical"]).toEqual({ namespace: "seller", key: "handmade" });
+    }
+  });
+
+  it("a MIXED resolution (one matched, one created) surfaces BOTH per-entry — no partial, no collapse", () => {
+    const out = classifySpecsResponse(200, { resolved: [MATCHED, CREATED] });
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      expect(out.resolved).toHaveLength(2);
+      const statuses = out.resolved.map((r) => (r as Record<string, unknown>)["status"]);
+      expect(statuses).toEqual(["matched", "created"]);
+    }
+  });
+
+  it("preserves the canonical DEFINITION fields the method must persist (display_name, data_type, is_filterable, is_comparable)", () => {
+    const out = classifySpecsResponse(200, { resolved: [MATCHED] });
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      const r = out.resolved[0]! as Record<string, unknown>;
+      expect(r["display_name"]).toBe("Waterproof Rating");
+      expect(r["data_type"]).toBe("number");
+      expect(r["unit"]).toBe("mm");
+      expect(r["is_filterable"]).toBe(true);
+      expect(r["is_comparable"]).toBe(true);
+    }
+  });
+});

--- a/src/__tests__/lib/specs-client.test.ts
+++ b/src/__tests__/lib/specs-client.test.ts
@@ -1,0 +1,234 @@
+/**
+ * UNIT — `specsCatalog` HTTP wrapper param→request mapping (tier: unit, `fetch`
+ * spied so nothing reaches the network).
+ *
+ * CARD `sds-specs-client-tool`. Pins the request-construction half of the specs
+ * client in isolation (the classifier — the response half — is
+ * `specs-classify.test.ts`). `specsCatalog(silApiUrl, token, params)` is the seam
+ * where the agent's `{ query, specs }` become the sil-api `SpecsRequest` body and the
+ * stored Bearer token becomes the `Authorization` header — the twin of
+ * `searchCatalog`, but with NO filter mapping: the body is EXACTLY `{ query, specs }`,
+ * forwarded verbatim (the plugin is pure transport for specs).
+ *
+ * What this file locks down (the request side):
+ *   - the URL is the BARE `${silApiUrl}/catalog/specs` — no `/api/v1`, trailing slash
+ *     on the base tolerated;
+ *   - the method is POST with a JSON content-type and an `Authorization: Bearer
+ *     <token>` header;
+ *   - the body is EXACTLY `{ query, specs }` — the whole SpecDefinition array forwarded
+ *     VERBATIM (all fields: namespace/key/display_name/data_type + optional
+ *     description/unit/allowed_values), NEVER reshaped, NEVER spread, NEVER wrapped in
+ *     a `filters`/`context`/UCP envelope;
+ *   - on a thrown fetch (network/timeout) the wrapper returns `retryable` and the token
+ *     never appears in the returned union (the never-leak invariant at the wrapper
+ *     boundary; the tool-level log canary is in `tools/specs.test.ts`).
+ *
+ * Contract this file pins for the implementation (expert-developer),
+ * `src/lib/sil-client.ts`:
+ *   specsCatalog(
+ *     silApiUrl: string,
+ *     token: string,
+ *     params: { query: string; specs: SpecDefinition[] },
+ *   ): Promise<SpecsOutcome>
+ *   It POSTs the body `{ query, specs }` to the bare `/catalog/specs` with the Bearer
+ *   header, then returns `classifySpecsResponse(status, body)`. A thrown fetch →
+ *   `{ kind: "retryable" }`. The exact param mapping below IS the immutable spec.
+ *
+ * EXPECT RED today: `specsCatalog` does not exist yet — the import binding is
+ * undefined and every call throws "is not a function".
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { specsCatalog } from "../../lib/sil-client.js";
+import type { SpecDefinition } from "../../lib/sil-client.js";
+
+const SIL_API = "https://sil-api.test.example.com";
+
+// `satisfies SpecDefinition` pins each fixture to the closed request contract without
+// widening `data_type` to `string` — a type-only anchor (erased at runtime; no
+// assertion changes) that keeps `pnpm typecheck` honest against the real SpecDefinition.
+
+/** One coined spec definition (the request half). All required fields present so the
+ * wrapper forwards it verbatim without any read-site drop. */
+const SPEC_A = {
+  namespace: "product",
+  key: "waterproofing",
+  display_name: "Waterproofing",
+  data_type: "number",
+  unit: "mm",
+} satisfies SpecDefinition;
+
+const SPEC_B = {
+  namespace: "seller",
+  key: "handmade",
+  display_name: "Handmade",
+  data_type: "boolean",
+} satisfies SpecDefinition;
+
+const SPEC_C = {
+  namespace: "product",
+  key: "closure_type",
+  display_name: "Closure Type",
+  data_type: "enum",
+  description: "How the item fastens.",
+  allowed_values: ["zip", "velcro", "buckle"],
+} satisfies SpecDefinition;
+
+interface Captured {
+  url: string;
+  method: string;
+  bearer: string | null;
+  contentType: string | null;
+  body: unknown;
+}
+
+/** Spy `fetch` and capture the single outbound request, replying 200 with a real
+ * (single-resolution) body so the wrapper resolves cleanly. The reply is the BARE
+ * sil-api body (`{ resolved }` — top level, no `ucp`/`result` wrapper), the only shape
+ * sil-api emits. */
+function spyFetch(captured: Captured[]): void {
+  vi.spyOn(globalThis, "fetch").mockImplementation(
+    (input: unknown, init?: RequestInit) => {
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      let body: unknown = null;
+      if (typeof init?.body === "string") {
+        try {
+          body = JSON.parse(init.body);
+        } catch {
+          body = init.body;
+        }
+      }
+      captured.push({
+        url: typeof input === "string" ? input : String(input),
+        method: (init?.method ?? "GET").toUpperCase(),
+        bearer: headers["Authorization"] ?? headers["authorization"] ?? null,
+        contentType: headers["content-type"] ?? headers["Content-Type"] ?? null,
+        body,
+      });
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            resolved: [
+              {
+                namespace: "product",
+                key: "waterproof_rating",
+                display_name: "Waterproof Rating",
+                data_type: "number",
+                unit: "mm",
+                is_filterable: true,
+                is_comparable: true,
+                submitted: { namespace: "product", key: "waterproofing" },
+                canonical: { namespace: "product", key: "waterproof_rating" },
+                status: "matched",
+              },
+            ],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+    },
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("specsCatalog — endpoint, method, and auth header", () => {
+  let cap: Captured[];
+  beforeEach(() => {
+    cap = [];
+    spyFetch(cap);
+  });
+
+  it("POSTs the BARE /catalog/specs path (no /api/v1 anywhere)", async () => {
+    await specsCatalog(SIL_API, "tok", { query: "hiking gloves", specs: [SPEC_A] });
+    expect(cap).toHaveLength(1);
+    expect(new URL(cap[0]!.url).pathname).toBe("/catalog/specs");
+    expect(cap[0]!.url).not.toContain("/api/v1");
+    expect(cap[0]!.url).toBe(`${SIL_API}/catalog/specs`);
+  });
+
+  it("tolerates a trailing slash on the base URL (no double slash)", async () => {
+    await specsCatalog(`${SIL_API}/`, "tok", { query: "gloves", specs: [SPEC_A] });
+    expect(cap[0]!.url).toBe(`${SIL_API}/catalog/specs`);
+    expect(cap[0]!.url).not.toContain("//catalog");
+  });
+
+  it("uses POST with a JSON content-type and the stored Bearer token", async () => {
+    await specsCatalog(SIL_API, "the-access-token", { query: "gloves", specs: [SPEC_A] });
+    expect(cap[0]!.method).toBe("POST");
+    expect(cap[0]!.contentType).toMatch(/application\/json/);
+    expect(cap[0]!.bearer).toBe("Bearer the-access-token");
+  });
+});
+
+describe("specsCatalog — body is EXACTLY { query, specs } (pure transport, no filter mapping, no envelope)", () => {
+  let cap: Captured[];
+  beforeEach(() => {
+    cap = [];
+    spyFetch(cap);
+  });
+
+  it("forwards { query, specs } VERBATIM — whole-body exact, the spec array unchanged", async () => {
+    await specsCatalog(SIL_API, "tok", { query: "hiking gloves", specs: [SPEC_A, SPEC_B, SPEC_C] });
+    // The strongest single assertion: byte-exact whole body. NO `filters` wrapper (this
+    // is NOT search — specs ride the top level), NO reshaping of the definitions.
+    expect(cap[0]!.body).toEqual({
+      query: "hiking gloves",
+      specs: [SPEC_A, SPEC_B, SPEC_C],
+    });
+  });
+
+  it("carries every SpecDefinition field verbatim — description / unit / allowed_values survive whole", async () => {
+    // The enriched-def pass-through: a definition carrying the optional
+    // description/unit/allowed_values must reach the wire intact — the backend dedupes
+    // on the FULL definition (a `{ namespace, key }` narrow would strand the richer
+    // fields the registry uses to match). Pins the whole SPEC_C object survives.
+    await specsCatalog(SIL_API, "tok", { query: "gloves", specs: [SPEC_C] });
+    const body = cap[0]!.body as Record<string, unknown>;
+    expect((body["specs"] as unknown[])[0]).toEqual(SPEC_C);
+  });
+
+  it("builds NO UCP envelope and injects NO context (no protocol/version/domain/enrichment/filters)", async () => {
+    await specsCatalog(SIL_API, "tok", { query: "gloves", specs: [SPEC_A] });
+    const body = cap[0]!.body as Record<string, unknown>;
+    for (const forbidden of ["protocol", "version", "domain", "enrichment", "context", "filters", "pagination"]) {
+      expect(body[forbidden]).toBeUndefined();
+    }
+    // The body carries EXACTLY the two keys — nothing else.
+    expect(Object.keys(body).sort()).toEqual(["query", "specs"]);
+  });
+
+  it("forwards the FULL specs array (never truncates / dedups / reorders it)", async () => {
+    await specsCatalog(SIL_API, "tok", { query: "gloves", specs: [SPEC_A, SPEC_B] });
+    const specs = (cap[0]!.body as Record<string, unknown>)["specs"] as unknown[];
+    expect(specs).toHaveLength(2);
+    expect(specs[0]).toEqual(SPEC_A);
+    expect(specs[1]).toEqual(SPEC_B);
+  });
+});
+
+describe("specsCatalog — transport failure maps to retryable without leaking the token", () => {
+  it("a thrown fetch (network/timeout) → retryable", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("simulated network failure"));
+    const out = await specsCatalog(SIL_API, "tok", { query: "gloves", specs: [SPEC_A] });
+    expect(out.kind).toBe("retryable");
+  });
+
+  it("the returned union NEVER carries the access token (privacy at the wrapper boundary)", async () => {
+    const SECRET = "wrapper-secret-token";
+
+    // Success path.
+    spyFetch([]);
+    const ok = await specsCatalog(SIL_API, SECRET, { query: "gloves", specs: [SPEC_A] });
+    expect(JSON.stringify(ok)).not.toContain(SECRET);
+    vi.restoreAllMocks();
+
+    // Thrown path.
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("boom"));
+    const thrown = await specsCatalog(SIL_API, SECRET, { query: "gloves", specs: [SPEC_A] });
+    expect(JSON.stringify(thrown)).not.toContain(SECRET);
+  });
+});

--- a/src/__tests__/manifest-contract.integration.test.ts
+++ b/src/__tests__/manifest-contract.integration.test.ts
@@ -31,9 +31,10 @@
  *     the manifest names exactly the tools they register) — the set on
  *     both sides equals { sil_learn, sil_product_get, sil_profile_get,
  *     sil_profile_materialize, sil_profile_remove, sil_profile_search,
- *     sil_register, sil_search, sil_whoami } (the 9-tool floor after the
- *     spec-driven-shopping-redesign card renamed sil_remember → sil_learn
- *     and ADDED sil_profile_search — the frontmatter-as-truth query tool).
+ *     sil_register, sil_search, sil_specs, sil_whoami } (the 10-tool floor
+ *     after the sds-specs-client-tool card ADDED the sil_specs catalog tool —
+ *     the coin/dedupe/register canonicalization primitive — to the 9-tool set
+ *     the spec-driven-shopping-redesign card left behind).
  */
 
 import { describe, it, expect } from "vitest";
@@ -127,10 +128,9 @@ describe("manifest ↔ code drift guard (set-equality, BOTH directions)", () => 
     // The card's spine: after removing the skeleton examples, the manifest
     // AND the code both name exactly the real tools. Pinned by literal
     // so a re-introduced sil_ping/sil_echo (on either side) flips this RED,
-    // not just the symmetric drift check above. Now 9 tools — the
-    // spec-driven-shopping-redesign card renames sil_remember → sil_learn
-    // (the target+change feedback verb) and ADDS sil_profile_search (the
-    // frontmatter-as-truth discovery/query tool): 8 → 9, add-only.
+    // not just the symmetric drift check above. Now 10 tools — the
+    // sds-specs-client-tool card ADDS sil_specs (the coin/dedupe/register
+    // canonicalization primitive) to the existing 9: 9 → 10, add-only.
     const expected = [
       "sil_learn",
       "sil_product_get",
@@ -140,6 +140,7 @@ describe("manifest ↔ code drift guard (set-equality, BOTH directions)", () => 
       "sil_profile_search",
       "sil_register",
       "sil_search",
+      "sil_specs",
       "sil_whoami",
     ];
     expect(sorted(codeRegisteredNames())).toEqual(expected);
@@ -240,6 +241,18 @@ describe("manifest ↔ code drift guard (set-equality, BOTH directions)", () => 
     // the equal set: registered by the group AND listed in contracts.tools.
     expect(codeRegisteredNames().has("sil_profile_search")).toBe(true);
     expect(manifestToolNames().has("sil_profile_search")).toBe(true);
+  });
+
+  it("sil_specs is BOTH registered by register() and declared in contracts.tools", () => {
+    // The sds-specs-client-tool card's NEW catalog tool — the coin/dedupe/register
+    // canonicalization primitive (Beat-2 born-canonical-before-persist). Added to the
+    // existing registerCatalogTools group beside sil_search / sil_product_get (no new
+    // group, no src/index.ts change), so it is auto-picked-up by codeRegisteredNames.
+    // The load-bearing 3rd "add a tool" step: it MUST also be listed in
+    // openclaw.plugin.json#contracts.tools — a forgotten manifest entry flips the
+    // set-equality RED here, before merge.
+    expect(codeRegisteredNames().has("sil_specs")).toBe(true);
+    expect(manifestToolNames().has("sil_specs")).toBe(true);
   });
 });
 

--- a/src/__tests__/openclaw-allowlist.integration.test.ts
+++ b/src/__tests__/openclaw-allowlist.integration.test.ts
@@ -63,9 +63,9 @@ const SCRIPT = join(REPO_ROOT, "scripts", "allowlist-openclaw.mjs");
 
 // sil's real facts (asserted against, sourced from the manifest the script reads).
 const SIL_ID = "sil";
-// The real 9-tool floor after the spec-driven-shopping-redesign card renamed
-// sil_remember → sil_learn and added sil_profile_search (frontmatter-as-truth
-// query). Drives `tools_added === SIL_TOOLS.length` and the per-tool
+// The real 10-tool floor after the sds-specs-client-tool card added sil_specs
+// (the coin/dedupe/register canonicalization primitive) to the catalog group.
+// Drives `tools_added === SIL_TOOLS.length` and the per-tool
 // not-enumerated-into-config scan below.
 const SIL_TOOLS = [
   "sil_learn",
@@ -76,6 +76,7 @@ const SIL_TOOLS = [
   "sil_profile_search",
   "sil_register",
   "sil_search",
+  "sil_specs",
   "sil_whoami",
 ] as const;
 
@@ -217,7 +218,7 @@ describe("AC1 / AC3 — fresh merge writes sil into all three surfaces (no-warni
     expect(m["plugins_allow_size"] as number).toBeGreaterThan(0);
   });
 
-  it("does NOT enumerate the 9 tool NAMES into the written config (plugin-id admission only)", () => {
+  it("does NOT enumerate the 10 tool NAMES into the written config (plugin-id admission only)", () => {
     writeConfig(freshConfig());
     runHelper({ OPENCLAW_CONFIG_PATH: configPath });
     const raw = readFileSync(configPath, "utf8");

--- a/src/__tests__/plugin-load.integration.test.ts
+++ b/src/__tests__/plugin-load.integration.test.ts
@@ -160,8 +160,8 @@ describe("plugin load — data dir is created by the FULL real register() (card 
       .mock.calls.filter(([marker]) => marker === "sil_plugin_loaded");
     expect(markerCalls).toHaveLength(1);
     // The full real tool set — the data-dir creation does not add/drop a tool.
-    // 9 tools after the spec-driven-shopping-redesign card renamed sil_remember →
-    // sil_learn and added sil_profile_search (frontmatter-as-truth query).
+    // 10 tools after the sds-specs-client-tool card added sil_specs (the
+    // coin/dedupe/register canonicalization primitive) to the catalog group.
     expect([...api._tools.keys()].sort()).toEqual([
       "sil_learn",
       "sil_product_get",
@@ -171,6 +171,7 @@ describe("plugin load — data dir is created by the FULL real register() (card 
       "sil_profile_search",
       "sil_register",
       "sil_search",
+      "sil_specs",
       "sil_whoami",
     ]);
   });

--- a/src/__tests__/skill-content.test.ts
+++ b/src/__tests__/skill-content.test.ts
@@ -153,7 +153,8 @@ function readBody(path: string): string {
 }
 
 /** The names the real register code emits (identity + catalog + profile groups) —
- * the REAL nine-tool surface (Step A: sil_learn + sil_profile_search). */
+ * the REAL ten-tool surface (the sds-specs-client-tool card added sil_specs to the
+ * catalog group, beside sil_learn + sil_profile_search from the prior card). */
 function registeredNames(): Set<string> {
   const api = createMockPluginApi();
   registerIdentityTools(api);
@@ -203,16 +204,18 @@ describe("sil-shopping/SKILL.md — discoverability", () => {
   });
 });
 
-describe("sil-shopping/SKILL.md — frontmatter drives the NINE tools + shopper/domain model, no expert / deleted-tool vocab", () => {
+describe("sil-shopping/SKILL.md — frontmatter drives the TEN tools + shopper/domain model, no expert / deleted-tool vocab", () => {
   it("frontmatter `name` equals the published basename `sil-shopping` (not the plugin id `sil`)", () => {
     const fm = parseFrontmatter(readFileSync(SKILL_PATH, "utf8"));
     expect(fm.fields["name"]).toBe("sil-shopping");
     expect(fm.fields["name"]).not.toBe("sil");
   });
 
-  it("frontmatter `description` enumerates the NINE sil_* tools it drives, and NOT the deleted sil_profile_list / sil_remember", () => {
-    // TOOL-SET MIRROR #6 — add-only, kept exact. Step A renamed sil_remember →
-    // sil_learn and added sil_profile_search (frontmatter-as-truth query).
+  it("frontmatter `description` enumerates the TEN sil_* tools it drives, and NOT the deleted sil_profile_list / sil_remember", () => {
+    // TOOL-SET MIRROR #6 — add-only, kept exact. The sds-specs-client-tool card ADDS
+    // sil_specs (the coin/dedupe/register canonicalization primitive the method drives
+    // at Beat 2), paired with the SKILL.md frontmatter `description` edit — so this
+    // presence pin stays RED until the description names sil_specs.
     const fm = parseFrontmatter(readFileSync(SKILL_PATH, "utf8"));
     const description = fm.fields["description"] ?? "";
     const missing = [
@@ -225,6 +228,7 @@ describe("sil-shopping/SKILL.md — frontmatter drives the NINE tools + shopper/
       "sil_profile_remove",
       "sil_learn",
       "sil_profile_search",
+      "sil_specs",
     ].filter((t) => !description.includes(t));
     expect(missing).toEqual([]);
     expect(description).not.toContain("sil_profile_list");
@@ -271,16 +275,18 @@ describe("skill name-agreement drift guard — one published name across manifes
 });
 
 /* ===========================================================================
- * BUNDLE — the nine-tool surface, deleted-token retirement, canonical file set
+ * BUNDLE — the ten-tool surface, deleted-token retirement, canonical file set
  * ========================================================================= */
 
-describe("skill bundle — source of truth for the nine-tool surface", () => {
-  it("registeredNames() equals NINE (the four core tools + the five sil_profile_* / sil_learn verbs)", () => {
-    // TOOL-SET MIRROR #6 (count). Add-only, kept exact.
+describe("skill bundle — source of truth for the ten-tool surface", () => {
+  it("registeredNames() equals TEN (the four core tools + the five sil_profile_* / sil_learn verbs + sil_specs)", () => {
+    // TOOL-SET MIRROR #6 (count). Add-only, kept exact — the sds-specs-client-tool
+    // card added sil_specs to the catalog group (9 → 10).
     const names = registeredNames();
-    expect(names.size, `registered tools: ${[...names].sort().join(", ")}`).toBe(9);
+    expect(names.size, `registered tools: ${[...names].sort().join(", ")}`).toBe(10);
     expect(names.has("sil_learn")).toBe(true);
     expect(names.has("sil_profile_search")).toBe(true);
+    expect(names.has("sil_specs")).toBe(true);
     expect(names.has("sil_remember")).toBe(false);
     expect(names.has("sil_profile_list")).toBe(false);
   });

--- a/src/__tests__/tools/specs.test.ts
+++ b/src/__tests__/tools/specs.test.ts
@@ -1,0 +1,481 @@
+/**
+ * UNIT — sil_specs tool: registration shape + the SpecDefinition schema + the
+ * client-side guards (empty-specs, not-registered, malformed-entry reject-whole) +
+ * the token-log canary (tier: unit, mock api + temp data dir, `fetch` spied so
+ * nothing reaches the network).
+ *
+ * CARD `sds-specs-client-tool` (epic `spec-driven-shopping-redesign`, Phase 3). At
+ * method mint/refresh (Beat 2) the method submits its coined spec DEFINITIONS;
+ * `sil_specs` canonicalizes them via the sil-services registry (dedupe-or-create) and
+ * returns the canonical `ns.key` to adopt — born canonical, before persist. The tool
+ * is a STRUCTURAL CLONE of `sil_search`, extended into `registerCatalogTools`.
+ *
+ * Covers the unit-tier acceptance criteria that live at the TOOL boundary (the
+ * request-mapping + classifier pure pieces are pinned in `lib/specs-client.test.ts`
+ * and `lib/specs-classify.test.ts`; the full wired pipeline + the outcome taxonomy are
+ * the integration tier's job in `catalog-specs.integration.test.ts`). Here we assert:
+ *
+ *   - the tool-registration shape: a `sil_specs` tool with a typed parameter object —
+ *     `query` (string) + `specs` (array of SpecDefinition objects, `minItems:1`);
+ *   - the SpecDefinition schema: namespace / key / display_name (required strings) +
+ *     data_type (a closed union of EXACTLY number|text|boolean|enum) + optional
+ *     description / unit / allowed_values (string[]). Unlike search's SpecPredicate,
+ *     SpecDefinition is FULLY TypeBox-expressible, so the host validates the shape;
+ *   - AC4 — the empty-specs guard: an empty or absent `specs` → `invalid_request`
+ *     (`empty_specs_input`), ZERO network calls;
+ *   - the malformed-entry REJECT-WHOLE guard (`readSpecsParams`, the request-side twin
+ *     of the response-side fail-whole in specs-classify): a per-definition malformed
+ *     shape rejects the WHOLE request (`invalid_spec`), ZERO network — a silently
+ *     dropped coined spec never canonicalizes → never converges (the honesty rule);
+ *   - AC5 — the not-registered short-circuit: no tokens.json → terminal
+ *     `not_registered` (recovery `sil_register`), ZERO network;
+ *   - the token-log canary: on every path the stored token never appears in any
+ *     logger call at any level.
+ *
+ * Contract this file pins for the implementation (expert-developer):
+ *   - src/tools/catalog.ts#registerCatalogTools(api) ALSO registers a `sil_specs`
+ *     tool (extending the group — NO new group) whose parameters are a Type.Object
+ *     with `query` (string) + `specs` (Type.Array(SpecDefinitionSchema, {minItems:1}));
+ *   - execute() returns a jsonResult; with an empty/absent specs it returns
+ *     `empty_specs_input` and calls no fetch; with a malformed definition it returns
+ *     `invalid_spec` (reject-whole) and calls no fetch; with no tokens.json it returns
+ *     a terminal not_registered hint and calls no fetch.
+ *
+ * EXPECT RED today: `sil_specs` is not registered, so `getTool(api, "sil_specs")`
+ * throws "Tool not registered", and every execute()-path assertion fails.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { registerCatalogTools } from "../../tools/catalog.js";
+import { setWebUrl, setApiUrl } from "../../lib/config.js";
+import { getDataDir, getTokensPath } from "../../lib/credentials.js";
+import {
+  createMockPluginApi,
+  getTool,
+  type MockPluginAPI,
+} from "../helpers/mock-plugin-api.js";
+
+const TOOL = "sil_specs";
+
+/** A well-formed SpecDefinition — the request half (all required fields present). */
+const SPEC_A = {
+  namespace: "product",
+  key: "waterproofing",
+  display_name: "Waterproofing",
+  data_type: "number",
+  unit: "mm",
+};
+
+let dataDir: string;
+let priorSilDataDir: string | undefined;
+
+/** Parse a ToolResult's JSON payload. */
+function payloadOf(result: { content: { text?: string }[] }): Record<string, unknown> {
+  const text = result.content[0]?.text;
+  if (typeof text !== "string") {
+    throw new Error(`tool result has no text payload: ${String(text)}`);
+  }
+  return JSON.parse(text) as Record<string, unknown>;
+}
+
+/** Seed a valid token pair so a call proceeds past the not-registered guard. */
+function seedTokens(access = "stored-at", refresh = "stored-rt"): void {
+  const dir = getDataDir();
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    getTokensPath(),
+    JSON.stringify({ access_token: access, refresh_token: refresh }),
+    { mode: 0o600 },
+  );
+}
+
+/** A 200 real (single-resolution) body so a forwarded request resolves cleanly. The
+ * BARE sil-api shape (`{ resolved }` — top level, no `ucp`/`result` wrapper). */
+function okEnvelopeFetch(): ReturnType<typeof vi.spyOn> {
+  return vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response(
+      JSON.stringify({
+        resolved: [
+          {
+            namespace: "product",
+            key: "waterproof_rating",
+            display_name: "Waterproof Rating",
+            data_type: "number",
+            unit: "mm",
+            is_filterable: true,
+            is_comparable: true,
+            submitted: { namespace: "product", key: "waterproofing" },
+            canonical: { namespace: "product", key: "waterproof_rating" },
+            status: "matched",
+          },
+        ],
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    ),
+  );
+}
+
+/** Collect every argument to every logger level, serialized. */
+function logBlob(api: MockPluginAPI): string {
+  return [api.logger.info, api.logger.warn, api.logger.error, api.logger.debug]
+    .flatMap((fn) => vi.mocked(fn).mock.calls.map((c) => JSON.stringify(c)))
+    .join("\n");
+}
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), "sil-specs-unit-"));
+  priorSilDataDir = process.env["SIL_DATA_DIR"];
+  process.env["SIL_DATA_DIR"] = dataDir;
+  setWebUrl("");
+  setApiUrl("");
+  delete process.env["SIL_WEB_URL"];
+  delete process.env["SIL_API_URL"];
+});
+
+afterEach(() => {
+  if (priorSilDataDir === undefined) delete process.env["SIL_DATA_DIR"];
+  else process.env["SIL_DATA_DIR"] = priorSilDataDir;
+  setWebUrl("");
+  setApiUrl("");
+  delete process.env["SIL_WEB_URL"];
+  delete process.env["SIL_API_URL"];
+  rmSync(dataDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe("sil_specs — tool registration shape", () => {
+  it("registers a sil_specs tool with a typed query + specs param", () => {
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+    const tool = getTool(api, TOOL);
+    expect(tool.name).toBe(TOOL);
+    expect(tool.label.length).toBeGreaterThan(0);
+    expect(tool.description.length).toBeGreaterThan(0);
+    const props = (tool.parameters as { properties?: Record<string, unknown> }).properties ?? {};
+    for (const expected of ["query", "specs"]) {
+      expect(Object.keys(props)).toContain(expected);
+    }
+  });
+
+  it("registering the catalog group does not disturb the sibling catalog tools", () => {
+    // sil_specs is ADDED to registerCatalogTools alongside sil_search / sil_product_get
+    // — the sibling tools must still register (the group extension is additive).
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+    for (const sibling of ["sil_search", "sil_product_get", "sil_specs"]) {
+      expect(api._tools.has(sibling)).toBe(true);
+    }
+  });
+});
+
+describe("sil_specs — the SpecDefinition schema (fully TypeBox-expressible: the host validates the shape)", () => {
+  function specsProps(): Record<string, Record<string, unknown>> {
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+    const params = getTool(api, TOOL).parameters as {
+      properties?: Record<string, Record<string, unknown>>;
+    };
+    return params.properties ?? {};
+  }
+  /** The `specs` array's per-item object-schema node. */
+  function specItemProps(): Record<string, Record<string, unknown>> {
+    const specs = specsProps()["specs"];
+    expect(specs, "specs must be a registered param").toBeDefined();
+    const items = (specs!["items"] ?? {}) as Record<string, unknown>;
+    return (items["properties"] ?? {}) as Record<string, Record<string, unknown>>;
+  }
+  /** Collect the literal values `data_type` allows, from whichever JSON-schema
+   * encoding TypeBox emits for a union-of-literals (`enum`, or `anyOf`/`oneOf` of
+   * `const`). */
+  function dataTypeLiterals(): string[] {
+    const dt = specItemProps()["data_type"];
+    expect(dt, "spec item must have a `data_type`").toBeDefined();
+    if (Array.isArray(dt!["enum"])) return (dt!["enum"] as unknown[]).map(String);
+    const union = (dt!["anyOf"] ?? dt!["oneOf"]) as Array<Record<string, unknown>> | undefined;
+    if (Array.isArray(union)) {
+      return union
+        .map((m) => (m["const"] !== undefined ? m["const"] : Array.isArray(m["enum"]) ? (m["enum"] as unknown[])[0] : undefined))
+        .filter((v): v is unknown => v !== undefined)
+        .map(String);
+    }
+    return [];
+  }
+
+  it("`specs` is an array of objects, with minItems 1 (a canonicalization needs ≥1 definition)", () => {
+    const specs = specsProps()["specs"];
+    expect(specs).toBeDefined();
+    expect(specs!["type"]).toBe("array");
+    expect(specs!["minItems"]).toBe(1);
+    const items = (specs!["items"] ?? {}) as Record<string, unknown>;
+    expect(items["type"]).toBe("object");
+  });
+
+  it("`query` and `specs` are BOTH required (the request needs a search context AND ≥1 definition)", () => {
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+    const params = getTool(api, TOOL).parameters as { required?: unknown };
+    const required = Array.isArray(params.required) ? (params.required as string[]) : [];
+    expect(required).toContain("query");
+    expect(required).toContain("specs");
+  });
+
+  it("a SpecDefinition has props namespace / key / display_name / data_type + optional description / unit / allowed_values", () => {
+    const keys = Object.keys(specItemProps());
+    for (const k of ["namespace", "key", "display_name", "data_type", "description", "unit", "allowed_values"]) {
+      expect(keys).toContain(k);
+    }
+  });
+
+  it("namespace / key / display_name are strings (the two ref fields + the human label)", () => {
+    for (const field of ["namespace", "key", "display_name"]) {
+      const node = specItemProps()[field];
+      expect(node, `${field} must exist`).toBeDefined();
+      expect(node!["type"]).toBe("string");
+    }
+  });
+
+  it("data_type is a union of EXACTLY the four types {number, text, boolean, enum} (closed)", () => {
+    expect(new Set(dataTypeLiterals())).toEqual(
+      new Set(["number", "text", "boolean", "enum"]),
+    );
+  });
+
+  it("allowed_values is an array of strings; unit and description are strings", () => {
+    const allowed = specItemProps()["allowed_values"];
+    expect(allowed!["type"]).toBe("array");
+    expect(((allowed!["items"] ?? {}) as Record<string, unknown>)["type"]).toBe("string");
+    expect(specItemProps()["unit"]!["type"]).toBe("string");
+    expect(specItemProps()["description"]!["type"]).toBe("string");
+  });
+
+  it("namespace / key / display_name are NOT enum-constrained (the ns.key vocabulary is OPEN, coined bottom-up)", () => {
+    // The open-vocabulary guard (mirrors sil_search's SpecPredicate ns/key): a
+    // namespace/key enum or pattern would be the central spec registry the bottom-up
+    // design forbids. display_name is likewise free human text.
+    for (const field of ["namespace", "key", "display_name"]) {
+      const node = specItemProps()[field];
+      expect(node!["enum"]).toBeUndefined();
+      expect(node!["pattern"]).toBeUndefined();
+    }
+  });
+});
+
+describe("sil_specs — AC4: empty-specs guard (reject empty BEFORE any network)", () => {
+  let api: MockPluginAPI;
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // A token IS present (so the guard, not the not-registered path, is what rejects);
+    // fetch fails loudly if the guard lets an empty request through.
+    seedTokens();
+    fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(new Error("empty specs must not hit the network"));
+    api = createMockPluginApi();
+    registerCatalogTools(api);
+  });
+
+  it("an empty specs:[] (with a valid query) → invalid_request / empty_specs_input, ZERO network calls", async () => {
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { query: "hiking gloves", specs: [] }));
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(payload["status"]).toBe("invalid_request");
+    expect(payload["error"]).toBe("empty_specs_input");
+    // A validation problem, not an auth problem — no re-register hint.
+    expect(payload["recovery"]).not.toBe("sil_register");
+  });
+
+  it("an ABSENT specs (with a valid query) → invalid_request / empty_specs_input, ZERO network calls", async () => {
+    const payload = payloadOf(await getTool(api, TOOL).execute("c1", { query: "hiking gloves" }));
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(payload["status"]).toBe("invalid_request");
+    expect(payload["error"]).toBe("empty_specs_input");
+  });
+
+  it("a NON-ARRAY specs (a bare object) is dropped-to-empty → empty_specs_input, ZERO network calls", async () => {
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", { query: "gloves", specs: { namespace: "p" } }),
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(payload["status"]).toBe("invalid_request");
+    expect(payload["error"]).toBe("empty_specs_input");
+  });
+
+  it("a blank (whitespace-only) query WITH valid specs → invalid_request, ZERO network calls", async () => {
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", { query: "   ", specs: [SPEC_A] }),
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(payload["status"]).toBe("invalid_request");
+  });
+});
+
+describe("sil_specs — malformed-entry REJECT-WHOLE (readSpecsParams; a silently-dropped coined spec never converges)", () => {
+  let api: MockPluginAPI;
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    seedTokens();
+    fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(new Error("a malformed spec must not hit the network"));
+    api = createMockPluginApi();
+    registerCatalogTools(api);
+  });
+
+  it("a blank `namespace` on ONE definition → invalid_spec, WHOLE request rejected, ZERO network", async () => {
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", {
+        query: "gloves",
+        specs: [SPEC_A, { ...SPEC_A, namespace: "" }],
+      }),
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(payload["status"]).toBe("invalid_request");
+    expect(payload["error"]).toBe("invalid_spec");
+    // The whole request is rejected — the good SPEC_A is NOT canonicalized in isolation.
+    expect(payload["recovery"]).not.toBe("sil_register");
+  });
+
+  it("a blank `display_name` → invalid_spec, ZERO network (display_name is load-bearing for dedupe quality)", async () => {
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", {
+        query: "gloves",
+        specs: [{ ...SPEC_A, display_name: "" }],
+      }),
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(payload["status"]).toBe("invalid_request");
+    expect(payload["error"]).toBe("invalid_spec");
+  });
+
+  it("an out-of-set `data_type` (not number/text/boolean/enum) → invalid_spec, ZERO network", async () => {
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", {
+        query: "gloves",
+        specs: [{ ...SPEC_A, data_type: "banana" }],
+      }),
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(payload["status"]).toBe("invalid_request");
+    expect(payload["error"]).toBe("invalid_spec");
+  });
+
+  it("a bare non-object entry (string) among valid ones → invalid_spec, WHOLE request rejected, ZERO network", async () => {
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", {
+        query: "gloves",
+        specs: [SPEC_A, "not-a-definition"],
+      }),
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(payload["status"]).toBe("invalid_request");
+    expect(payload["error"]).toBe("invalid_spec");
+  });
+});
+
+describe("sil_specs — the guard does NOT over-reject a valid request", () => {
+  it("a valid { query, specs:[def] } PROCEEDS to the network (canonicalization round-trip)", async () => {
+    seedTokens();
+    const fetchSpy = okEnvelopeFetch();
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", { query: "hiking gloves", specs: [SPEC_A] }),
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(payload["status"]).toBe("ok");
+  });
+});
+
+describe("sil_specs — AC5: not registered (no tokens.json) short-circuit", () => {
+  let api: MockPluginAPI;
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // No tokens seeded. fetch fails loudly if the tool calls it.
+    fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(new Error("not-registered must not hit the network"));
+    api = createMockPluginApi();
+    registerCatalogTools(api);
+  });
+
+  it("makes NO sil-api call and names sil_register as the recovery", async () => {
+    const payload = payloadOf(
+      await getTool(api, TOOL).execute("c1", { query: "gloves", specs: [SPEC_A] }),
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(payload["status"]).toBe("not_registered");
+    expect(payload["resolved"]).toBeUndefined();
+    expect(JSON.stringify(payload)).toContain("sil_register");
+  });
+
+  it("does NOT crash and resolves promptly when not registered", async () => {
+    const result = await getTool(api, TOOL).execute("c1", { query: "gloves", specs: [SPEC_A] });
+    expect(result).toBeTypeOf("object");
+    expect(result.content[0]?.text).toBeTypeOf("string");
+  });
+});
+
+describe("sil_specs — token never logged (leak-canary)", () => {
+  it("on the SUCCESS path, no logger call carries the access token", async () => {
+    seedTokens("leak-canary-access", "leak-canary-refresh");
+    okEnvelopeFetch();
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    await getTool(api, TOOL).execute("c1", { query: "gloves", specs: [SPEC_A] });
+
+    const blob = logBlob(api);
+    expect(blob).not.toContain("leak-canary-access");
+    expect(blob).not.toContain("leak-canary-refresh");
+    expect(blob).not.toMatch(/Bearer/i);
+  });
+
+  it("on a 401 (non-success) path, no logger call carries the access token", async () => {
+    seedTokens("leak-canary-access-2", "leak-canary-refresh-2");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "unauthorized" }), {
+        status: 401,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    await getTool(api, TOOL).execute("c1", { query: "gloves", specs: [SPEC_A] });
+
+    const blob = logBlob(api);
+    expect(blob).not.toContain("leak-canary-access-2");
+    expect(blob).not.toContain("leak-canary-refresh-2");
+    expect(blob).not.toMatch(/Bearer/i);
+  });
+
+  it("the success result does NOT echo the access token or Authorization header", async () => {
+    seedTokens("secret-access-token", "secret-refresh-token");
+    okEnvelopeFetch();
+    const api = createMockPluginApi();
+    registerCatalogTools(api);
+
+    const blob = JSON.stringify(
+      payloadOf(await getTool(api, TOOL).execute("c1", { query: "gloves", specs: [SPEC_A] })),
+    );
+    expect(blob).not.toContain("secret-access-token");
+    expect(blob).not.toContain("secret-refresh-token");
+    expect(blob).not.toMatch(/Bearer/i);
+    expect(blob).not.toMatch(/authorization/i);
+  });
+});

--- a/src/lib/sil-client.ts
+++ b/src/lib/sil-client.ts
@@ -86,6 +86,32 @@
  * `not_found` → `ok` (success: "none of these exist anymore"), the discriminator
  * being array PRESENCE, never length.
  *
+ * Wire contract for the sil-API spec REGISTRY (SAME origin/path style as search —
+ * sil-api, bare `/catalog/specs`, NOT /api/v1; see the sds-specs-client-tool card).
+ * The dedupe-or-create up-flow: at method mint/refresh the method submits its coined
+ * spec DEFINITIONS and gets back the canonical `ns.key` to adopt (born canonical,
+ * BEFORE persist). sil-api owns the dedupe authority; the plugin sends `{ query,
+ * specs }` (NO envelope) and reads the resolutions straight off the body:
+ *
+ *   POST <silApiUrl>/catalog/specs   Authorization: Bearer <access_token>
+ *     body { query, specs: SpecDefinition[] }        (both required; specs ≥1)
+ *     200 { resolved: SpecResolution[] }             → ok
+ *         (BARE `{ resolved }` at the TOP LEVEL — NO `ucp` meta, NO `result`
+ *          wrapper; specs is an INTERNAL agent↔service op, not a UCP message)
+ *     400 (schema: empty specs / blank query)        → invalid_request
+ *     401                                            → unauthorized (→ refresh)
+ *     403 { error }                                  → forbidden (terminal)
+ *     5xx / network / abort                          → retryable
+ *
+ * The error arms are a STRICT SUBSET of search's: there is NO 422 SourceError arm
+ * and NO `source` attribution — the registry is sil's OWN Postgres, not an external
+ * source (handlers/specs.ts), so a specs `retryable` is always BARE. Every
+ * well-formed request resolves EVERY submitted spec 1:1 (`matched`|`created`);
+ * `classifySpecsResponse` gates `ok` on `Array.isArray(resolved)` AND a NON-EMPTY
+ * array of fully-formed resolutions — a partial / garbage / EMPTY-`resolved` 200
+ * falls WHOLE to `retryable` (the method can't adopt a canonical name it never got
+ * back, and there is NO valid empty-match success here, unlike search's empty list).
+ *
  * `SilCatalogProduct` = a UCP product PLUS a required `source`; each variant PLUS
  * a required non-empty `checkout_url` (sil-services `@sil/schemas` catalog.ts —
  * the byte-shape of truth; `@ucp-js/sdk` carries ZERO catalog types). The plugin
@@ -542,6 +568,83 @@ export type LookupOutcome =
   | { kind: "invalid_request"; error: string; message: string }
   | { kind: "retryable"; source?: string; detail?: string };
 
+/** The closed value-type a coined spec declares (mirrors `@sil/schemas`
+ * `SpecDataType` — re-declared locally, the same no-cross-repo-import discipline as
+ * the `Search*` read-subset). A bad value 400s at the sil-api TypeBox boundary. */
+export type SpecDataType = "number" | "text" | "boolean" | "enum";
+
+/** One coined spec DEFINITION the method submits to `/catalog/specs` for
+ * canonicalization. Closed SHAPE, open `namespace`/`key` VOCABULARY (coined
+ * bottom-up). Mirrors `@sil/schemas` `SpecDefinition` — the read-subset the plugin
+ * sends and echoes back. `data_type` is the closed enum; `description`/`unit`/
+ * `allowed_values` are optional context that sharpens the backend's dedupe. */
+export interface SpecDefinition {
+  namespace: string;
+  key: string;
+  display_name: string;
+  description?: string;
+  data_type: SpecDataType;
+  unit?: string;
+  allowed_values?: string[];
+}
+
+/** A `{ namespace, key }` reference — a resolution carries both the `submitted`
+ * echo and the `canonical` name the method adopts. */
+export interface SpecRef {
+  namespace: string;
+  key: string;
+}
+
+/** The two per-spec resolution classes: `matched` = deduped to an existing
+ * canonical row (`canonical` MAY differ from `submitted` — adopt it, drop the
+ * synonym); `created` = newly registered as canonical (`canonical === submitted`).
+ * NOT named `SpecStatus` — that is the search `specs_status` entry above. */
+export type SpecResolutionStatus = "matched" | "created";
+
+/** The canonical resolution of ONE submitted spec (mirrors `@sil/schemas`
+ * `SpecResolution`). Carries the canonical definition FLAT (a {@link SpecDefinition})
+ * plus the `submitted` echo, the `canonical` ref to adopt, the `status`, and the two
+ * capability flags. The method adopts `canonical.namespace`/`canonical.key`.
+ *
+ * Also spreads `Record<string, unknown>` — the wire-read discipline the `Search*`
+ * opaque types follow: a resolution is surfaced FAITHFULLY (the client trusts the
+ * backend's dedupe verdict, never second-guessing it), so callers read it by dynamic
+ * key without a double-`unknown` cast. The real shape is enforced at RUNTIME by
+ * `projectResolution` (the request `SpecDefinition` stays strictly closed). */
+export interface SpecResolution extends SpecDefinition, Record<string, unknown> {
+  submitted: SpecRef;
+  canonical: SpecRef;
+  status: SpecResolutionStatus;
+  is_filterable: boolean;
+  is_comparable: boolean;
+}
+
+/** The spec-registry request an agent sends: the motivating `query`
+ * (governance/dedupe context) + the non-empty coined `specs`. Maps 1:1 to the
+ * sil-api `SpecsRequest` body — the tool builds NO envelope and NO filter mapping;
+ * the wire body is EXACTLY `{ query, specs }`. */
+export interface SpecsParams {
+  query: string;
+  specs: SpecDefinition[];
+}
+
+/**
+ * Outcome of a single `/catalog/specs` canonicalization (classified by status +
+ * body). A STRICT SUBSET of {@link SearchOutcome}: there is NO 422 arm and the
+ * `retryable` variant is BARE — no `source`/`detail`, because the registry is sil's
+ * OWN Postgres, not an external catalog source (so a fabricated `source` on a specs
+ * 5xx would be wrong attribution). `unauthorized` (401) is the refresh trigger
+ * (routed through {@link refreshAndRetryOnce}, parity with search); `forbidden`
+ * (403) is terminal-but-recoverable carrying the actionable `reason`. The `ok`
+ * variant carries the projected `resolved` array DIRECTLY.
+ */
+export type SpecsOutcome =
+  | { kind: "ok"; resolved: SpecResolution[] }
+  | { kind: "unauthorized" }
+  | { kind: "forbidden"; reason: string }
+  | { kind: "invalid_request"; error: string; message: string }
+  | { kind: "retryable" };
+
 /**
  * Classify a claim response from its HTTP status AND body. The discriminant for
  * the two-200s split is the PRESENCE OF BOTH TOKENS in the body — never the
@@ -752,6 +855,42 @@ export function classifyLookupResponse(status: number, body: unknown): LookupOut
 }
 
 /**
+ * Classify a sil-api spec-REGISTRY response from its HTTP status AND body. A STRICT
+ * SUBSET of `classifySearchResponse` — same 400/401/403 arms, but NO 422 arm and a
+ * BARE `retryable` (the registry has no external source to attribute):
+ *   400 → invalid_request (schema reject: empty `specs` / blank `query` — surface
+ *         the server's `{ error, message }`; NOT retryable, NOT re-register)
+ *   401 → unauthorized (the refresh trigger — the caller drives transparent
+ *         refresh-and-retry-once via `refreshAndRetryOnce`, parity with search)
+ *   403 → forbidden (terminal-but-recoverable; carries the actionable reason
+ *         `user_not_provisioned`/`principal_mismatch`, defaulting to `"forbidden"`)
+ *   5xx / other non-200 → retryable (BARE — no `source`/`detail`; the registry is
+ *         sil's own Postgres, so there is nothing external to name)
+ *   200 → read `resolved` off the FLAT body (`{ resolved }` — top level, NO `ucp`
+ *         meta, NO `result` wrapper) and require a NON-EMPTY array of fully-formed
+ *         resolutions via {@link extractSpecsResult}. A 200 with no usable array (a
+ *         partial / garbage / stub / EMPTY-`resolved` body) is `retryable`, NEVER
+ *         `ok` — `Array.isArray(resolved)` is the anti-false-green gate. Unlike
+ *         search there is NO valid empty-match: the server owes a 1:1 resolution, so
+ *         an empty or short `resolved` is a malformed 200, not a success.
+ *
+ * Pure and exported — unit-tested in isolation like `classifySearchResponse`.
+ */
+export function classifySpecsResponse(status: number, body: unknown): SpecsOutcome {
+  if (status === 400) {
+    const { error, message } = extractApiError(body);
+    return { kind: "invalid_request", error, message };
+  }
+  if (status === 401) return { kind: "unauthorized" };
+  if (status === 403) return { kind: "forbidden", reason: extractForbiddenReason(body) };
+  if (status !== 200) return { kind: "retryable" };
+
+  const resolved = extractSpecsResult(body);
+  if (resolved === null) return { kind: "retryable" };
+  return { kind: "ok", resolved };
+}
+
+/**
  * Attempt to claim the token pair for `sessionId` with `verifier`. The verifier
  * is sent in the body; sil-web derives the same challenge server-side and the
  * CAS compares digest-to-digest (the plugin sends the verifier, not the digest).
@@ -883,6 +1022,38 @@ export async function lookupCatalog(
   }
   const body = await readJsonBody(res);
   return classifyLookupResponse(res.status, body);
+}
+
+/**
+ * Canonicalize coined spec definitions against sil-api's registry (the SAME origin
+ * as the identity read / `searchCatalog` / `lookupCatalog` — NOT sil-web; bare
+ * `/catalog/specs`, no `/api/v1`). The method submits `{ query, specs }` at mint/
+ * refresh and gets back the canonical `ns.key` per submitted spec — building NO UCP
+ * envelope and NO filter mapping (the wire body is EXACTLY `{ query, specs }`).
+ *
+ * The Bearer header is built HERE and never logged; the token travels only in the
+ * outbound request, never into the returned union. A network error / timeout maps
+ * to `retryable` (bare) so the method degrades gracefully to raw coined names — a
+ * registry hiccup never blocks the mint.
+ */
+export async function specsCatalog(
+  silApiUrl: string,
+  token: string,
+  params: SpecsParams,
+): Promise<SpecsOutcome> {
+  const url = `${stripTrailingSlash(silApiUrl)}/catalog/specs`;
+  let res: Response;
+  try {
+    res = await postJson(
+      url,
+      { query: params.query, specs: params.specs },
+      { authorization: `Bearer ${token}` },
+    );
+  } catch {
+    return { kind: "retryable" };
+  }
+  const body = await readJsonBody(res);
+  return classifySpecsResponse(res.status, body);
 }
 
 /** Result of the high-level refresh orchestration (read → refresh → rotate). */
@@ -1339,6 +1510,116 @@ function extractLookupResult(body: unknown): LookupResult | null {
 
   const notFound = extractNotFound(envelope["messages"]);
   return notFound.length === 0 ? { products } : { products, not_found: notFound };
+}
+
+/** The closed spec value-types, the anti-false-green enum for a resolution's
+ * `data_type` (the vocabulary `namespace`/`key` stay open). */
+const SPEC_DATA_TYPES: readonly SpecDataType[] = ["number", "text", "boolean", "enum"];
+
+function isSpecDataType(value: unknown): value is SpecDataType {
+  return typeof value === "string" && (SPEC_DATA_TYPES as readonly string[]).includes(value);
+}
+
+/**
+ * Narrow a sil-api spec-registry response body to the typed {@link SpecResolution}[],
+ * or null if it carries no usable resolution array. sil-api emits a FLAT body:
+ * `resolved` sits at the TOP LEVEL, there is NO `ucp` meta and NO `result` wrapper —
+ * read it straight off the body.
+ *
+ * The load-bearing anti-false-green guard is `Array.isArray(resolved)` AND a
+ * NON-EMPTY array. This is STRICTER than search's products gate: the server owes a
+ * 1:1 resolution for every submitted spec, so there is NO valid empty-match — an
+ * empty `resolved: []` is itself a malformed 200 and returns null → `retryable`.
+ *
+ * FAIL-WHOLE (design decision, product-owner AC1/AC9 "no partial adopt"): because
+ * the method cannot adopt a canonical name it never got back, a SINGLE malformed
+ * entry (missing/blank `canonical` ref, bad `status`, bad `data_type`, missing flag)
+ * falls the WHOLE 200 to `retryable` — unlike search, which drops one unusable
+ * product from a best-effort list. Every entry must project cleanly or none do.
+ */
+function extractSpecsResult(body: unknown): SpecResolution[] | null {
+  const envelope = asRecord(body);
+  if (envelope === null) return null;
+
+  const rawResolved = envelope["resolved"];
+  if (!Array.isArray(rawResolved) || rawResolved.length === 0) return null;
+
+  const resolved: SpecResolution[] = [];
+  for (const raw of rawResolved) {
+    const one = projectResolution(raw);
+    if (one === null) return null; // fail-whole: no half-canonical vocabulary
+    resolved.push(one);
+  }
+  return resolved;
+}
+
+/**
+ * Project ONE wire resolution to the typed {@link SpecResolution}, or null if any
+ * required field is malformed (fail-whole, per {@link extractSpecsResult}). Requires
+ * the flat canonical definition (`namespace`/`key`/`display_name` non-empty,
+ * `data_type` in the closed enum), the `submitted`/`canonical` refs, a valid
+ * `status`, and both boolean capability flags. Optional `description`/`unit`/
+ * `allowed_values` pass through when the right type. No `any`, no unchecked `as`.
+ */
+function projectResolution(raw: unknown): SpecResolution | null {
+  const obj = asRecord(raw);
+  if (obj === null) return null;
+
+  const namespace = obj["namespace"];
+  const key = obj["key"];
+  const displayName = obj["display_name"];
+  if (typeof namespace !== "string" || namespace.length === 0) return null;
+  if (typeof key !== "string" || key.length === 0) return null;
+  if (typeof displayName !== "string" || displayName.length === 0) return null;
+
+  const dataType = obj["data_type"];
+  if (!isSpecDataType(dataType)) return null;
+
+  const submitted = extractSpecRef(obj["submitted"]);
+  const canonical = extractSpecRef(obj["canonical"]);
+  if (submitted === null || canonical === null) return null;
+
+  const status = obj["status"];
+  if (status !== "matched" && status !== "created") return null;
+
+  const isFilterable = obj["is_filterable"];
+  const isComparable = obj["is_comparable"];
+  if (typeof isFilterable !== "boolean" || typeof isComparable !== "boolean") return null;
+
+  const result: SpecResolution = {
+    namespace,
+    key,
+    display_name: displayName,
+    data_type: dataType,
+    submitted,
+    canonical,
+    status,
+    is_filterable: isFilterable,
+    is_comparable: isComparable,
+  };
+  const description = obj["description"];
+  if (typeof description === "string") result.description = description;
+  const unit = obj["unit"];
+  if (typeof unit === "string") result.unit = unit;
+  const allowedValues = obj["allowed_values"];
+  if (Array.isArray(allowedValues)) {
+    const values = allowedValues.filter((v): v is string => typeof v === "string");
+    if (values.length > 0) result.allowed_values = values;
+  }
+  return result;
+}
+
+/** Narrow a wire `{ namespace, key }` reference (the `submitted` / `canonical`
+ * fields), or null if either is missing/blank — the load-bearing gate a resolution
+ * needs so the method can adopt the canonical name. */
+function extractSpecRef(raw: unknown): SpecRef | null {
+  const obj = asRecord(raw);
+  if (obj === null) return null;
+  const namespace = obj["namespace"];
+  const key = obj["key"];
+  if (typeof namespace !== "string" || namespace.length === 0) return null;
+  if (typeof key !== "string" || key.length === 0) return null;
+  return { namespace, key };
 }
 
 /**

--- a/src/tools/catalog.ts
+++ b/src/tools/catalog.ts
@@ -44,6 +44,15 @@
  * result; logs carry only non-credential status markers (search params are not
  * credentials, but are not logged either — nothing here needs them).
  *
+ * The group hosts THREE catalog tools sharing this origin, Bearer, and 401
+ * choreography: `sil_search` (discovery), `sil_product_get` (the lookup companion),
+ * and `sil_specs` (the spec-REGISTRY dedupe-or-create up-flow — the method
+ * canonicalizes its coined `ns.key` vocabulary at Beat-2 mint/refresh, so
+ * `filters.specs` converges). The structured-error envelope helpers (`notRegistered`
+ * / `mustReregister` / `transient` / `forbidden` / `invalidRequest`) are
+ * tool-parameterized and shared across all three — a new catalog tool reuses them,
+ * it does not fork them.
+ *
  * `register()` stays synchronous and side-effect-free beyond registering tools —
  * no fetch, no timer, no unawaited promise. All I/O is inside `execute()`.
  */
@@ -57,12 +66,17 @@ import {
   lookupCatalog,
   refreshAndRetryOnce,
   searchCatalog,
+  specsCatalog,
   type LookupOutcome,
   type SearchOutcome,
   type SearchParams,
   type ShipTo,
+  type SpecDataType,
+  type SpecDefinition,
   type SpecOp,
   type SpecPredicate,
+  type SpecsOutcome,
+  type SpecsParams,
   type SpecValue,
 } from "../lib/sil-client.js";
 import { jsonResult } from "../lib/tool-result.js";
@@ -88,9 +102,64 @@ const COUNTRY_PATTERN = "^[A-Za-z]{2}$";
 const REGION_PATTERN = "^[A-Za-z0-9]{1,3}$";
 const POSTAL_PATTERN = "^(?=[A-Za-z0-9 -]{2,12}$)[A-Za-z0-9]+(?:[ -][A-Za-z0-9]+)*$";
 
+/** The `sil_specs` coined-definition schema. Unlike the search predicate's `value`
+ * (an op→value read-site rule the schema can't express), a `SpecDefinition` is
+ * FULLY TypeBox-expressible — a closed `data_type` union of four literals plus
+ * `minLength:1` identity fields and optional context — so the host validates the
+ * shape directly. Mirrors `@sil/schemas` `SpecDefinition` (the frozen wire contract). */
+const SPEC_DEFINITION_SCHEMA = Type.Object({
+  namespace: Type.String({
+    minLength: 1,
+    description:
+      "The spec NAMESPACE (e.g. \"product\", \"seller\", \"shipping\") — a free"
+      + " string coined bottom-up; NOT dotted with the key.",
+  }),
+  key: Type.String({
+    minLength: 1,
+    description:
+      "The spec KEY within the namespace (e.g. \"waterproof_rating\","
+      + " \"rating_average\") — a free string coined bottom-up.",
+  }),
+  display_name: Type.String({
+    minLength: 1,
+    description: "A short human label for the spec (e.g. \"Waterproof rating\").",
+  }),
+  data_type: Type.Union(
+    [
+      Type.Literal("number"),
+      Type.Literal("text"),
+      Type.Literal("boolean"),
+      Type.Literal("enum"),
+    ],
+    {
+      description:
+        "The spec's value type: number, text, boolean, or enum (use enum with"
+        + " allowed_values for a closed set).",
+    },
+  ),
+  description: Type.Optional(
+    Type.String({
+      description:
+        "Optional prose describing what the spec means — sharpens the registry's"
+        + " dedupe (a clearer definition reduces false matches).",
+    }),
+  ),
+  unit: Type.Optional(
+    Type.String({
+      description: "Optional unit for a numeric spec (e.g. \"mm\", \"GB\", \"days\").",
+    }),
+  ),
+  allowed_values: Type.Optional(
+    Type.Array(Type.String(), {
+      description: "For an enum spec, the closed set of permitted values.",
+    }),
+  ),
+});
+
 export function registerCatalogTools(api: PluginAPI): void {
   registerSearch(api);
   registerProductGet(api);
+  registerSpecs(api);
 }
 
 function registerSearch(api: PluginAPI): void {
@@ -603,6 +672,165 @@ function mapLookupOutcome(api: PluginAPI, outcome: LookupOutcome) {
   }
 }
 
+/**
+ * `sil_specs` — the spec-REGISTRY canonicalize-or-create tool. Driven by the
+ * sil-shopping method at Beat 2 (mint/refresh), NOT directly by the buyer: the
+ * method coins its niche `ns.key` vocabulary bottom-up from research, submits the
+ * coined DEFINITIONS here, and gets back the canonical name per spec to adopt BEFORE
+ * it persists — so the method is born speaking canonical names and the whole
+ * catalog's `filters.specs` vocabulary converges (that convergence is what makes
+ * `filters.specs` actually filter). A `matched` spec adopts the existing canonical
+ * name (drop the private synonym); a `created` spec keeps its own (it is canonical
+ * going forward).
+ *
+ * `execute()` flow (ALL I/O here; `register()` opens nothing — a synchronous
+ * request/response, NOT a poll). MIRRORS `sil_search` and shares its taxonomy, minus
+ * search's 422 arm and source attribution (the registry is sil's own Postgres):
+ *   1. Not registered (no stored tokens) → terminal `not_registered` + a
+ *      `recovery: sil_register` hint, ZERO network calls. Mirrors `sil_whoami`.
+ *   2. Client-side guard: a blank/absent `query` OR an empty/all-dropped `specs`
+ *      array → `invalid_request` (`empty_specs_input`), NO network call (sil-api's
+ *      `minLength`/`minItems` schema 400 is the authoritative backstop). A single
+ *      MALFORMED definition rejects the WHOLE request (`invalid_spec`) — a silently
+ *      dropped coined spec would never canonicalize and never converge.
+ *   3. specsCatalog(getApiUrl(), token, params) → map the `SpecsOutcome`:
+ *        ok            → the `resolved` array (one resolution per submitted spec);
+ *        invalid_request (400) → surface sil-api's `{ error, message }`;
+ *        unauthorized  (401)   → refresh-and-retry ONCE via the shared
+ *                                `refreshAndRetryOnce` choreography (parity with
+ *                                `sil_search`/`sil_product_get`/`sil_whoami` — 401
+ *                                recovery is uniform). Recovered 401 is invisible;
+ *                                second 401 / dead refresh is terminal re-register
+ *                                (tokens cleared);
+ *        retryable (5xx/net)   → transient "try again", NO re-register hint (BARE —
+ *                                no source; the method degrades to raw coined names).
+ *
+ * GRACEFUL DEGRADATION is the load-bearing product invariant (AC14): a non-`ok`
+ * outcome never blocks the mint — the method proceeds with the RAW coined names
+ * (every predicate `applied:false`) and converges on the next mint/refresh. The tool
+ * only surfaces the registry's verdict; the method decides to degrade.
+ *
+ * Privacy: the session token and Bearer header never reach a log line or the result.
+ */
+function registerSpecs(api: PluginAPI): void {
+  api.registerTool({
+    name: "sil_specs",
+    label: "Canonicalize coined spec definitions",
+    description:
+      "Canonicalize the coined spec DEFINITIONS a shopping method invents for a"
+      + " niche — the dedupe-or-create registry call at method mint/refresh (Beat 2)."
+      + " Pass the motivating `query` (what the shopper is buying — governance /"
+      + " dedupe context) and `specs`, a list of coined definitions ({ namespace,"
+      + " key, display_name, data_type, description?, unit?, allowed_values? }). Each"
+      + " submitted spec resolves 1:1: a `matched` result means an equivalent"
+      + " canonical spec already exists — ADOPT its `canonical` { namespace, key }"
+      + " and DROP your coined synonym (this convergence is what makes filters.specs"
+      + " actually filter across methods); a `created` result means yours is novel and"
+      + " registered as canonical (`canonical` === `submitted`, keep it). Rewrite the"
+      + " method's `## Search vocabulary` and any PRD `specs` predicates to the"
+      + " returned canonical names BEFORE persisting — the method is born canonical,"
+      + " never write-then-amend. On REFRESH submit ONLY the specs that do not yet"
+      + " carry a canonical name; already-canonical names are stable, do not resubmit"
+      + " them. This is INTERNAL plumbing: never surface `ns.key` names or"
+      + " \"converged your specs\" to the buyer. If the call is not `ok` (retryable /"
+      + " forbidden / must_reregister), do NOT block the mint — persist the method"
+      + " with the raw coined names and shop on; convergence retries on the next"
+      + " mint/refresh. Requires registration (run sil_register first).",
+    parameters: Type.Object({
+      query: Type.String({
+        description:
+          "The motivating shopping query — what the shopper is buying. Governance /"
+          + " dedupe context for the registry; required and non-empty.",
+      }),
+      specs: Type.Array(SPEC_DEFINITION_SCHEMA, {
+        minItems: 1,
+        description:
+          "The coined spec definitions to canonicalize (at least one). Each is a"
+          + " { namespace, key, display_name, data_type, description?, unit?,"
+          + " allowed_values? } the method coined bottom-up from research.",
+      }),
+    }),
+    async execute(_callId, params) {
+      // 1 — not registered: terminal, zero network calls.
+      const stored = readTokens();
+      if (stored === null) {
+        return notRegistered("sil_specs");
+      }
+
+      // 2 — client-side guard (defensive drifted-call backstop; the host validates
+      // the schema, but a blank query / empty specs / malformed definition is
+      // rejected BEFORE any network call). An empty input is `empty_specs_input`; a
+      // present-but-malformed definition rejects the WHOLE request (`invalid_spec`) —
+      // a silently dropped coined spec never canonicalizes → never converges.
+      const read = readSpecsParams(params);
+      if (read.kind === "invalid") {
+        if (read.code === "invalid_spec") {
+          api.logger.info("sil_specs_invalid_spec", { field: read.field });
+          return invalidSpecDefinition(read.field);
+        }
+        api.logger.info("sil_specs_invalid_request", { error: "empty_specs_input" });
+        return invalidSpecsInput();
+      }
+      const specsParams = read.params;
+
+      // 3 — canonicalize; on a 401 refresh-and-retry ONCE via the shared
+      // choreography (the SAME path sil_whoami / sil_search / sil_product_get use).
+      const first = await specsCatalog(getApiUrl(), stored.access_token, specsParams);
+      const recovered = await refreshAndRetryOnce(
+        first,
+        (o): boolean => o.kind === "unauthorized",
+        (accessToken) => specsCatalog(getApiUrl(), accessToken, specsParams),
+      );
+      switch (recovered.kind) {
+        case "result":
+          if (recovered.refreshed) api.logger.info("sil_specs_refreshed", {});
+          return mapSpecsOutcome(api, recovered.outcome);
+        case "must_reregister":
+          if (recovered.reason === "invalid_grant") clearTokens();
+          api.logger.info("sil_specs_must_reregister", { cause: recovered.reason });
+          return mustReregister("sil_specs");
+        case "second_unauthorized":
+          clearTokens();
+          api.logger.info("sil_specs_must_reregister", { cause: "retry_unauthorized" });
+          return mustReregister("sil_specs");
+        case "retryable":
+          api.logger.info("sil_specs_refresh_retryable", {});
+          return transient("sil_specs");
+      }
+    },
+  });
+}
+
+/** Map a specs outcome that has ALREADY cleared the 401-recovery path (never
+ * `unauthorized` — the refresh trigger handled by {@link refreshAndRetryOnce}) to
+ * the agent-facing envelope. Mirrors `mapSearchOutcome`, minus the source-attributed
+ * `retryable` (specs has no external source): a 5xx/network blip is the GENERIC
+ * transient. The `unauthorized` arm is structurally unreachable but kept exhaustive
+ * (falls to the same terminal re-register) so a future refactor can't drop a variant. */
+function mapSpecsOutcome(api: PluginAPI, outcome: SpecsOutcome) {
+  switch (outcome.kind) {
+    case "ok":
+      return specsResult(outcome);
+    case "forbidden":
+      // Symmetric with sil_search/sil_product_get (one vocabulary): a 403 is the
+      // shared forbidden envelope, and `user_not_provisioned` — and ONLY that exact
+      // reason — clears the structurally-dead token at this call site.
+      api.logger.warn("sil_specs_forbidden", { reason: outcome.reason });
+      if (outcome.reason === "user_not_provisioned") clearTokens();
+      return forbidden(outcome.reason);
+    case "invalid_request":
+      api.logger.info("sil_specs_invalid_request", { error: outcome.error });
+      return invalidRequest(outcome.error, outcome.message);
+    case "retryable":
+      // BARE transient — the registry is sil's own Postgres, so there is no external
+      // source to name (unlike sil_search's outcome-b). Generic "try again" copy.
+      api.logger.info("sil_specs_retryable", {});
+      return transient("sil_specs");
+    case "unauthorized":
+      return mustReregister("sil_specs");
+  }
+}
+
 /** Narrow the untrusted `params` to a string[] of ids. A non-string entry is
  * DROPPED (treated as absent), not coerced — the host has already validated
  * against the schema, but a drifted on-disk call must not slip a non-string into
@@ -884,6 +1112,95 @@ function readSpec(raw: unknown, index: number): SpecRead {
   return { kind: "ok", value: spec };
 }
 
+/** The `sil_specs` read-site closed value-types (the defensive backstop for the
+ * host-validated `data_type`; `namespace`/`key` stay open — the coined vocabulary). */
+const SPEC_DATA_TYPES: readonly SpecDataType[] = ["number", "text", "boolean", "enum"];
+
+function isSpecDataType(value: unknown): value is SpecDataType {
+  return typeof value === "string" && (SPEC_DATA_TYPES as readonly string[]).includes(value);
+}
+
+/** The outcome of narrowing the whole `sil_specs` param object: the typed
+ * {@link SpecsParams} to forward, or the reject class. `empty_specs_input` = a blank
+ * `query` OR an empty/all-dropped `specs` (no usable input); `invalid_spec` = a
+ * present-but-malformed definition (fail-whole — `field` names the offender). */
+type SpecsParamsRead =
+  | { kind: "ok"; params: SpecsParams }
+  | { kind: "invalid"; code: "empty_specs_input" }
+  | { kind: "invalid"; code: "invalid_spec"; field: string };
+
+/** The outcome of narrowing ONE untrusted definition: the typed
+ * {@link SpecDefinition} to forward, or the offending index/field. */
+type SpecDefinitionRead =
+  | { kind: "ok"; value: SpecDefinition }
+  | { kind: "invalid"; field: string };
+
+/** Narrow the untrusted `sil_specs` params to the typed {@link SpecsParams}, or
+ * report the reject. A blank `query` or an empty/non-array/all-dropped `specs` is
+ * `empty_specs_input` (no network); the FIRST malformed definition rejects the WHOLE
+ * request `invalid_spec` (a silently-dropped coined spec never canonicalizes → never
+ * converges — the same honesty rule as search's `readSpecs`). No `any`, no unchecked
+ * `as`. The host has already validated the schema; this is a drifted-call backstop. */
+function readSpecsParams(params: Record<string, unknown>): SpecsParamsRead {
+  const query = params["query"];
+  if (typeof query !== "string" || query.trim().length === 0) {
+    return { kind: "invalid", code: "empty_specs_input" };
+  }
+
+  const rawSpecs = params["specs"];
+  if (!Array.isArray(rawSpecs) || rawSpecs.length === 0) {
+    return { kind: "invalid", code: "empty_specs_input" };
+  }
+
+  const specs: SpecDefinition[] = [];
+  for (let index = 0; index < rawSpecs.length; index++) {
+    const read = readSpecDefinition(rawSpecs[index], index);
+    if (read.kind === "invalid") {
+      return { kind: "invalid", code: "invalid_spec", field: read.field };
+    }
+    specs.push(read.value);
+  }
+  return { kind: "ok", params: { query, specs } };
+}
+
+/** Narrow ONE untrusted definition to {@link SpecDefinition}, or report the
+ * offending field (`specs[i]`, `specs[i].namespace`, `specs[i].data_type`, …).
+ * Requires a non-blank `namespace`/`key`/`display_name` and a `data_type` in the
+ * closed set; optional `description`/`unit`/`allowed_values` are carried when the
+ * right type, dropped otherwise. */
+function readSpecDefinition(raw: unknown, index: number): SpecDefinitionRead {
+  const at = (suffix: string): string => `specs[${index}]${suffix}`;
+  const obj = asRecord(raw);
+  if (obj === null) return { kind: "invalid", field: at("") };
+
+  const namespace = obj["namespace"];
+  if (typeof namespace !== "string" || namespace.trim().length === 0) {
+    return { kind: "invalid", field: at(".namespace") };
+  }
+  const key = obj["key"];
+  if (typeof key !== "string" || key.trim().length === 0) {
+    return { kind: "invalid", field: at(".key") };
+  }
+  const displayName = obj["display_name"];
+  if (typeof displayName !== "string" || displayName.trim().length === 0) {
+    return { kind: "invalid", field: at(".display_name") };
+  }
+  const dataType = obj["data_type"];
+  if (!isSpecDataType(dataType)) return { kind: "invalid", field: at(".data_type") };
+
+  const value: SpecDefinition = { namespace, key, display_name: displayName, data_type: dataType };
+  const description = obj["description"];
+  if (typeof description === "string") value.description = description;
+  const unit = obj["unit"];
+  if (typeof unit === "string") value.unit = unit;
+  const allowedValues = obj["allowed_values"];
+  if (Array.isArray(allowedValues)) {
+    const values = allowedValues.filter((v): v is string => typeof v === "string");
+    if (values.length > 0) value.allowed_values = values;
+  }
+  return { kind: "ok", value };
+}
+
 /** The one client-side invariant the tool owns: at least one recognized input.
  * A non-whitespace `query`, any filter (`category` / `price_min` / `price_max`),
  * OR a non-empty well-formed `specs` list suffices — a spec is a real constraint
@@ -968,6 +1285,43 @@ function invalidSpec(field: string) {
       + " non-empty `ns` and `key`, an `op` of eq/neq/gte/lte/in/nin/exists, and a"
       + " `value` matching the op: a number for gte/lte, a non-empty array for"
       + " in/nin, a scalar for eq/neq, and NO value for exists.",
+  });
+}
+
+/** Success: the resolved canonicalizations — no token, no Bearer header. The `ok`
+ * outcome carries `resolved` directly; spread its payload (minus the `kind`
+ * discriminant) onto the agent-facing `{ status: "ok", resolved }` envelope. */
+function specsResult(outcome: Extract<SpecsOutcome, { kind: "ok" }>) {
+  const { kind: _kind, ...payload } = outcome;
+  return jsonResult({ status: "ok", ...payload });
+}
+
+/** Client-side validation: no usable canonicalization input (a blank `query` or an
+ * empty/all-dropped `specs`). Distinct from a sil-api 400 — this never hit the
+ * network. No `recovery: sil_register` (auth is fine; the input is the problem). */
+function invalidSpecsInput() {
+  return jsonResult({
+    status: "invalid_request",
+    error: "empty_specs_input",
+    message:
+      "Provide a non-empty `query` and at least one coined spec definition to"
+      + " canonicalize.",
+  });
+}
+
+/** Client-side validation: a `specs` definition is malformed (blank
+ * `namespace`/`key`/`display_name`, or a `data_type` outside
+ * number/text/boolean/enum) — the WHOLE request is rejected BEFORE any network call,
+ * so no coined spec is silently dropped from canonicalization. Machine code
+ * `invalid_spec`; `field` names the offending definition. No `recovery: sil_register`. */
+function invalidSpecDefinition(field: string) {
+  return jsonResult({
+    status: "invalid_request",
+    error: "invalid_spec",
+    message:
+      `The \`${field}\` spec definition is malformed. Each definition needs a`
+      + " non-empty `namespace`, `key`, and `display_name`, and a `data_type` of"
+      + " number, text, boolean, or enum.",
   });
 }
 


### PR DESCRIPTION
## Card
`cards/sds-specs-client-tool.md` (lives in the `card/sds-specs-client-tool` branch — gitignored, local-only; see its body for the full intent + handoffs). Epic: `spec-driven-shopping-redesign` (Phase 3, plugin side).

## Summary
Adds the **`sil_specs`** client tool — the spec-registry dedupe-or-create up-flow the sil-shopping method drives at Beat-2 mint/refresh so its coined `ns.key` vocabulary is **canonicalized before persist** (born canonical → `filters.specs` converges). Floor **9 → 10**.

- **`src/lib/sil-client.ts`** — `specsCatalog` + `classifySpecsResponse` + `extractSpecsResult` mirroring the search trio, built against the LIVE bare `{ resolved }` handler. STRICT SUBSET of search: **no 422 arm**, **bare `retryable`** (registry is sil's own Postgres, no external source). Anti-false-green gate `Array.isArray(resolved)` **and non-empty**; a single malformed resolution **fails the whole 200** to `retryable` (no partial adopt).
- **`src/tools/catalog.ts`** — `registerSpecs` extends `registerCatalogTools` (no new group, no `index.ts` change); reuses the tool-parameterized envelope helpers verbatim. `register()` stays synchronous.
- **`openclaw.plugin.json`** — `sil_specs` added to `contracts.tools`.
- **Skill** — `SKILL.md` frontmatter enumerates `sil_specs`; `references/method_and_prds.md` Beat-2 gate rewritten to the active canonicalize-before-persist flow (graceful degradation; refresh resubmits only not-yet-canonical).
- The six exact-tool-set mirrors bumped **add-only** (qa).

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean (dist emits)
- [x] `pnpm test` — 995 passed; the only 4 failures are the known `repo-scaffold.integration.test.ts` gitignored-worktree cases (CLAUDE.md not checked out), not a regression
- [x] 4 new specs test files + 7 mirror bumps all green (272 tests); tests mock the `/catalog/specs` boundary (no stubbed-tool assertions)

## Distillation target
Knowledge capture happens **after Review PASS** in the `distilling` stage — `solutions-architect` runs in this same worktree, commits to this same branch, and pushes so the PR ends up containing implementation + tests + distillation in one mergeable unit.