### PR TITLE
docs: proactive spec-convergence coining discipline in shopper MINT §

### DIFF
--- a/sil-shopping/references/method_and_prds.md
+++ b/sil-shopping/references/method_and_prds.md
@@ -29,7 +29,22 @@ create`**, never the **setup-only** `sil_profile_materialize` (which writes only
 shared `user_spec.md` and mints no domain). Then **announce** the inferred domain so
 the buyer can correct it.
 
-The coined vocabulary is **canonicalized before persist**. Submit the coined spec
+The coined vocabulary is **coined to converge, then canonicalized before persist**.
+`sil_specs` is **precision-first** — two coined specs converge only when **every field**
+agrees within the same `namespace` and `data_type`, so the name you coin decides whether a
+concept converges or forks: a synonym (`speed_mbps` vs `transfer_speed_mbps`) splits one
+concept into two specs that never match. So coin for the match. **One concept,
+one spelling:** reuse the exact `ns.key`, `display_name`, `data_type`, and `unit` you
+already coined for that concept — verbatim, across every domain (consult a sibling
+method with `sil_profile_get` only when the concept plausibly recurs, never an
+exhaustive scan). For a common, widely-shared attribute you have **not** coined before
+(screen size, weight, RAM, waterproof rating, material…), take its **conventional**
+name over a personal synonym — a Schelling point, since there is no registry to read.
+Coin a fresh name only for a genuinely niche attribute. On each coined spec carry a
+concept-naming **`description`** — the load-bearing **corroborator** the dedupe leans on
+to merge true synonyms and the veto that keeps distinct concepts apart — and get
+**`data_type`** and **`namespace`** right, the hard floors a wrong value forks the
+concept past. Then submit the coined spec
 definitions to **`sil_specs`** (dedupe-or-create) and adopt the returned **canonical**
 `ns.key` for every spec: a **`matched`** result means an equivalent canonical spec
 already exists — **drop your coined synonym and adopt the canonical name**; a
@@ -37,10 +52,11 @@ already exists — **drop your coined synonym and adopt the canonical name**; a
 Rewrite the method's `## Search vocabulary` and any PRD `specs` predicates to those
 canonical names, then persist — the method is **born canonical**, never
 write-then-amend. This convergence is what makes `filters.specs` actually filter
-across methods. If `sil_specs` is **not `ok`** (a registry blip), **do not block the
-mint**: persist with the **raw coined names** (every predicate reads `applied:false`)
-and shop on — convergence retries on the next mint/refresh. Canonicalization is
-**silent to the buyer**: never surface `ns.key` plumbing.
+across methods; good naming is never a gate — a fragmenting name never blocks a
+search, it only costs precision. If `sil_specs` is **not `ok`** (a registry blip),
+**do not block the mint**: persist with the **raw coined names** (every predicate
+reads `applied:false`) and shop on — convergence retries on the next mint/refresh.
+Canonicalization is **silent to the buyer**: never surface `ns.key` plumbing.
 
 ## REFRESH — signal-driven (HIT, stale)
 
@@ -58,8 +74,10 @@ The merge **preserves** every **buyer** `sil_learn` edit — it rewrites stale
 buyer-mutable at any time via `sil_learn` append/amend/retract.
 
 Canonicalize any **newly-coined** specs via `sil_specs` before persisting the
-refreshed method — resubmit **only** the specs not yet carrying a canonical name
-(already-canonical names are stable; do not resubmit them).
+refreshed method — coin them with the same convergence discipline (reuse a name you
+already coined for the concept; take the conventional name for a common attribute)
+and resubmit **only** the specs not yet carrying a canonical name (already-canonical
+names are stable; do not resubmit them).
 
 ## Intent-keyed PRDs
 

--- a/src/__tests__/skill-content.test.ts
+++ b/src/__tests__/skill-content.test.ts
@@ -729,20 +729,26 @@ describe("references/method_and_prds.md — Beat 2: method load (hot path) vs re
       (body.includes("common") || body.includes("widely") || body.includes("shared"));
     expect(conventionalForCommon).toBe(true);
 
-    // AC#2 (the WHY) — convergence keys on ALL spec fields within a `namespace` and is
-    // precision-first, so consistent + conventional naming is the lever that tips a coin
-    // to `matched` instead of a fresh fragment.
+    // AC#2 (the WHY) — convergence keys on EVERY spec field agreeing within a `namespace`
+    // + `data_type` (precision-first), so consistent + conventional naming is the lever
+    // that tips a coin to `matched` instead of a fresh fragment. Determiner-tolerant
+    // (every/each field · all its/their/the fields) so a benign reword survives; the
+    // "all…fields / every field" phrase is net-new (grep-0 in HEAD) → still RED there.
     const allFieldsWhy =
-      (body.includes("all fields") || body.includes("all its fields") ||
-        body.includes("all spec fields") || body.includes("all the fields") ||
-        body.includes("every field")) &&
+      (/(?:every|each) (?:coined |spec )?field/.test(body) ||
+        /all (?:its |their |the |of its |of their )?(?:coined |spec )?fields/.test(body)) &&
       (body.includes("namespace") || body.includes("precision-first") || body.includes("precision first"));
     expect(allFieldsWhy).toBe(true);
 
     // AC#3 — carry a concept-naming `description` as the load-bearing CORROBORATOR (the
-    // signal that tips a borderline coin, and the veto that keeps distinct concepts
-    // apart). `corroborat*` is net-new; bare "description" (11 hits) alone would false-green.
-    const corroboratingDescription = body.includes("corroborat");
+    // signal that merges true synonyms, and the veto that keeps distinct concepts apart).
+    // `corroborat*` is net-new (grep-0 in HEAD); the fallback still requires the
+    // `description` FIELD framed by a merge/veto role, never bare "description".
+    const corroboratingDescription =
+      body.includes("corroborat") ||
+      (body.includes("description") &&
+        (body.includes("veto") || body.includes("merge true synonym") ||
+          body.includes("distinguish") || body.includes("disambiguat")));
     expect(corroboratingDescription).toBe(true);
   });
 

--- a/src/__tests__/skill-content.test.ts
+++ b/src/__tests__/skill-content.test.ts
@@ -696,6 +696,56 @@ describe("references/method_and_prds.md — Beat 2: method load (hot path) vs re
     expect(coinedRawNow).toBe(true);
   });
 
+  it("MINT coins CONVERGENCE-FRIENDLY — reuse-your-own-name (one concept, one spelling), the CONVENTIONAL name for a common concept, framed by the all-fields WHY + the corroborating `description`", () => {
+    // CARD advise-spec-convergence-in-shopper-skill — the PROACTIVE convergence-aid
+    // coining discipline #57 did NOT ship. #57 taught the agent to REACT to `sil_specs`
+    // (adopt the canonical `ns.key` it returns); this pins how to COIN so the
+    // dedupe-or-create returns `matched` (converged) instead of forking a fresh
+    // `created` row. ADD-ONLY on the MISS assertion above — leaves #57's
+    // canonicalize-before-persist + the ten-tool pins byte-for-byte intact.
+    //
+    // Every anchor below is NET-NEW (grep-0 across the whole sil-shopping bundle
+    // today: conventional / "one concept" / display_name / data_type / namespace /
+    // precision-first / "all fields" / corroborat), so this is genuinely RED until the
+    // convergence-aid prose lands — it CANNOT false-green off #57's pre-existing
+    // `matched` / `converge` / `synonym` / `description`(word) mentions.
+    const body = methodPrdsLower();
+
+    // AC#1 — reuse your OWN coined name for a concept across domains (one concept, one
+    // spelling): keep the same coined SpecDefinition fields (display_name + data_type,
+    // the real frozen-wire tokens) rather than re-spelling the concept per domain.
+    const oneConceptOneSpelling =
+      body.includes("one concept") ||
+      body.includes("reuse the same") || body.includes("reuse your") ||
+      (body.includes("consistent") && (body.includes("across") || body.includes("every")));
+    expect(oneConceptOneSpelling).toBe(true);
+    const reusesTheCoinedFields = body.includes("display_name") && body.includes("data_type");
+    expect(reusesTheCoinedFields).toBe(true);
+
+    // AC#2 — a common/widely-shared concept it has NOT coined before takes the
+    // CONVENTIONAL name, not an idiosyncratic personal synonym.
+    const conventionalForCommon =
+      body.includes("conventional") &&
+      (body.includes("common") || body.includes("widely") || body.includes("shared"));
+    expect(conventionalForCommon).toBe(true);
+
+    // AC#2 (the WHY) — convergence keys on ALL spec fields within a `namespace` and is
+    // precision-first, so consistent + conventional naming is the lever that tips a coin
+    // to `matched` instead of a fresh fragment.
+    const allFieldsWhy =
+      (body.includes("all fields") || body.includes("all its fields") ||
+        body.includes("all spec fields") || body.includes("all the fields") ||
+        body.includes("every field")) &&
+      (body.includes("namespace") || body.includes("precision-first") || body.includes("precision first"));
+    expect(allFieldsWhy).toBe(true);
+
+    // AC#3 — carry a concept-naming `description` as the load-bearing CORROBORATOR (the
+    // signal that tips a borderline coin, and the veto that keeps distinct concepts
+    // apart). `corroborat*` is net-new; bare "description" (11 hits) alone would false-green.
+    const corroboratingDescription = body.includes("corroborat");
+    expect(corroboratingDescription).toBe(true);
+  });
+
   it("mints via `sil_learn create` (target method), NOT the setup-only sil_profile_materialize (no domain-mint on materialize)", () => {
     const body = methodPrdsLower();
     // The mint verb is sil_learn create — the old materialize-with-a-domain-object mint is DELETED.


### PR DESCRIPTION
## Card
`cards/advise-spec-convergence-in-shopper-skill.md` (epic `spec-convergence-2026-07`, card ③ — lives in the `card/advise-spec-convergence-in-shopper-skill` branch, gitignored; not in this diff). Depends on #57 (merged), which shipped the `sil_specs` tool and un-barred coining.

## Summary
- #57 taught the shopper to **react** to `sil_specs` (submit → adopt canonical on `matched`, keep on `created`). It did not teach how to **coin** so a borderline concept comes back `matched` rather than forking a fresh `created` row.
- This adds that proactive discipline to the Beat-2 MINT § of `sil-shopping/references/method_and_prds.md` (delete-first rewrite of #57's single paragraph — not a bolt-on):
  - **One concept, one spelling** — reuse the exact coined `ns.key`/`display_name`/`data_type`/`unit` across domains; `sil_profile_get` a sibling only when the concept plausibly recurs.
  - **Conventional name** for a common attribute (screen size, weight, RAM…) as a Schelling point (no registry to read before coining).
  - Coin fresh only for the genuinely niche; carry a corroborating `description`; get `data_type`/`namespace` right.
  - The WHY: `sil_specs` is precision-first — two specs converge only when every field agrees within a `namespace` + `data_type`, so a synonym fragments. Never a gate — a fragmenting name only costs precision.
- One-line REFRESH nod so refresh-coined specs follow the same discipline.
- **Honesty rails:** no `applied:true`-reachable claim (served matcher still unwired); `applied:false` registry-blip fallback and Beat-5 honesty pass untouched.

## Test plan
- [x] `skill-content.test.ts` 79/79 — incl. qa's add-only `MINT coins CONVERGENCE-FRIENDLY …` pin (four net-new anchors)
- [x] Full suite 990 pass; the 10 fails are the known worktree-only `repo-scaffold.integration.test.ts` quirk (gitignored `docs/`+`CLAUDE.md` absent in a worktree), unrelated to this diff
- [x] `tsc --noEmit` clean
- [x] Scope guardrail: no diff under `src/tools/**`, no `openclaw.plugin.json#contracts.tools` change — manifest drift guard green

## Distillation target
Knowledge capture happens **after Review PASS** in the `distilling` stage — `solutions-architect` runs in this same worktree, commits to this same branch, and pushes here so the PR ends up containing implementation + tests + distillation in one mergeable unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)