### PR TITLE
bug: close SDS-redesign behavior + correctness gaps

### DIFF
--- a/sil-shopping/references/shop_loop.md
+++ b/sil-shopping/references/shop_loop.md
@@ -61,13 +61,28 @@ call is a round-trip + tokens):
   order, concatenation **never re-ranks** a backend list nor lifts a peripheral
   hit above a core one — the engine owns order *within* each call, the fan-out
   owns order *across* calls.
-- **Project onto existing params + query enrichment now.** Map each requirement
-  onto the **existing** `sil_search` **param** where one fits (`category`,
-  `price_min`/`price_max`, `condition`, `available`, `local_merchants`); a
-  requirement with no param folds into the free-text `query`. Leave **`ship_to`**
-  empty (the server resolves the registered default). **Never invent** a filter
-  that isn't a real param — see
-  [`search_param_mapping.md`](search_param_mapping.md).
+- **Project each requirement onto existing params, then `specs` predicates, then
+  query enrichment — in that order.** Map each requirement onto the tightest real
+  channel:
+  1. an **existing** `sil_search` **param** where one fits (`category`,
+     `price_min`/`price_max`, `condition`, `available`, `local_merchants`);
+  2. else a structured **`filters.specs` predicate**, built from the method's
+     Beat-2 canonical `## Search vocabulary` (the `sil_specs`-coined names) — one
+     `{ns, key, op, value, unit?, hard?}` per annotated requirement, marking an
+     inviolable one `hard:true`. **Prefer a dedicated param over a predicate** for
+     the SAME attribute — never send both (a `price_max` param OR a price spec, not
+     both);
+  3. else — a purely descriptive residue (a colour, a phrasing) — fold it into the
+     free-text `query`, which **you author yourself**. The plugin is **pure
+     transport**: it never folds a predicate into `query`, so a requirement that
+     belongs in `filters.specs` stays a predicate, never `query` prose.
+  Leave **`ship_to`** empty (the server resolves the registered default). **Never
+  invent** a param or a predicate that isn't real — the params live in the
+  `sil_search` description, the predicate vocabulary in the domain method (see
+  [`search_param_mapping.md`](search_param_mapping.md)). Then read the per-predicate
+  **`specs_status`** the response returns (each `{ns, key, applied}`) — it feeds
+  Beat 5's honesty pass, which rejects at pick any `hard` predicate the backend left
+  `applied:false`.
 
 ## Beat 5 — Reflect: honesty pass first, judgment not threshold, propose-and-wait
 

--- a/src/__tests__/skill-content.test.ts
+++ b/src/__tests__/skill-content.test.ts
@@ -489,6 +489,19 @@ function shopLoopLower(): string {
   return readBody(SHOP_LOOP_PATH).toLowerCase();
 }
 
+/** The Beat-4 section ONLY (lowercased) — `## beat 4` up to `## beat 5`. Scoping is
+ * MANDATORY for the specs-projection assertion: `specs_status`, `predicate` and `hard`
+ * all pre-exist in Beat 5 / Beat 1, so a whole-body `includes` would false-green off a
+ * token this beat never actually documents today. */
+function beat4Lower(): string {
+  const body = shopLoopLower();
+  const start = body.indexOf("## beat 4");
+  const end = body.indexOf("## beat 5");
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return body.slice(start, end);
+}
+
 describe("references/shop_loop.md — the six-beat loop state machine (names all six beats, in order)", () => {
   it("exists on disk", () => {
     expect(existsSync(SHOP_LOOP_PATH)).toBe(true);
@@ -601,6 +614,37 @@ describe("references/shop_loop.md — Beat 4: a BOUNDED ≤4 priority-ordered fa
     const neverInvents =
       body.includes("never invent") || body.includes("not invent") || (body.includes("invent") && body.includes("filter"));
     expect(neverInvents).toBe(true);
+  });
+
+  // GAP 2 — the half-wired specs channel: Beat 2 coins the vocabulary (`sil_specs`) and
+  // Beat 5 consumes `specs_status`, but Beat 4 (the only beat positioned to PRODUCE it)
+  // never told the agent to build `filters.specs`. Scoped to the Beat-4 section so a
+  // pre-existing Beat-5 `specs_status` / `predicate` can't false-green it.
+  it("documents the SPECS PROJECTION end-to-end — build filters.specs predicates from the coined vocabulary, prefer a dedicated param over a predicate, author the query itself (pure transport, no fold), mark hard, and read per-predicate specs_status", () => {
+    const beat4 = beat4Lower();
+    // PRODUCE — build filters.specs predicates from the method's coined / canonical vocabulary.
+    expect(beat4).toContain("filters.specs");
+    expect(beat4).toContain("predicate");
+    const fromCoinedVocab =
+      beat4.includes("canonical") || beat4.includes("coined") || beat4.includes("vocabulary");
+    expect(fromCoinedVocab).toBe(true);
+    // PREFER a dedicated param over a predicate for the same attribute (never both).
+    const prefersDedicatedParam =
+      beat4.includes("dedicated") &&
+      (beat4.includes("prefer") || beat4.includes("over a predicate") || beat4.includes("rather than") ||
+        beat4.includes("not both") || beat4.includes("never both"));
+    expect(prefersDedicatedParam).toBe(true);
+    // PURE TRANSPORT — the agent authors the free-text query itself; no predicate is folded in.
+    const authorsQuery = beat4.includes("author") && beat4.includes("query");
+    expect(authorsQuery).toBe(true);
+    const noFold =
+      beat4.includes("pure transport") || beat4.includes("no fold") || beat4.includes("not fold") ||
+      beat4.includes("never fold") || beat4.includes("folded");
+    expect(noFold).toBe(true);
+    // Inviolable predicates are marked hard (backend-enforced, or Beat 5 rejects-at-pick).
+    expect(beat4).toContain("hard");
+    // CONSUME — read the per-predicate specs_status for Beat 5's honesty pass.
+    expect(beat4).toContain("specs_status");
   });
 });
 

--- a/src/__tests__/tools/profile-sds.test.ts
+++ b/src/__tests__/tools/profile-sds.test.ts
@@ -397,6 +397,98 @@ describe("sil_learn append / amend / retract — refine in place, fail-closed", 
 });
 
 /* ===========================================================================
+ * GAP 1 — `hard:true` is REJECTED loudly on EVERY non-append kind (create /
+ * amend / retract / attach-asset), never silently dropped. One top-level guard
+ * in `learnArtefact` (subsuming the deleted method-only `rejectHardMisuse`) fires
+ * BEFORE the kind switch, so `hard` wins error-precedence over per-kind field
+ * checks and a hard-constraint promotion is never a silent no-op.
+ * ========================================================================= */
+describe("sil_learn — hard:true is rejected on EVERY non-append kind (the silent drop is closed)", () => {
+  // A 1x1 transparent PNG (for the attach-asset kind).
+  const PNG_B64 =
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+
+  it("amend + hard:true → invalid_request (field `hard`) and the PRD bullet stays SOFT — not a silent promotion", async () => {
+    await getTool(api, MATERIALIZE).execute("g1m", { name: "sil shopper", userSpec: USER_SPEC });
+    await getTool(api, LEARN).execute("g1a", {
+      target: "method", domain: "ski", kind: "create", name: "Ski", body: "#g",
+    });
+    await getTool(api, LEARN).execute("g1b", {
+      target: "prd", domain: "ski", prd: "gloves-slope", product: "gloves", intent: "slope", title: "G", kind: "create",
+      body: "## Requirements\n- gore-tex preferred\n",
+    });
+    const payload = payloadOf(
+      await getTool(api, LEARN).execute("g1c", {
+        target: "prd", domain: "ski", prd: "gloves-slope", kind: "amend",
+        from: "gore-tex preferred", to: "gore-tex required", hard: true,
+      }),
+    );
+    expect(payload["status"]).toBe("invalid_request");
+    expect(payload["field"]).toBe("hard");
+    // Nothing written: the amend did NOT land and the soft pref was NOT promoted to hard.
+    const raw = readFileSync(join(domainDir("ski"), "prds", "gloves-slope.md"), "utf8");
+    expect(raw).toContain("gore-tex preferred");
+    expect(raw).not.toContain("gore-tex required");
+    expect(raw).not.toContain("[hard]");
+  });
+
+  it("create + hard:true → invalid_request (field `hard`) and NOTHING is minted", async () => {
+    await getTool(api, MATERIALIZE).execute("g1d", { name: "sil shopper", userSpec: USER_SPEC });
+    const payload = payloadOf(
+      await getTool(api, LEARN).execute("g1e", {
+        target: "method", domain: "ski", kind: "create", name: "Ski", body: "# guide", hard: true,
+      }),
+    );
+    expect(payload["status"]).toBe("invalid_request");
+    expect(payload["field"]).toBe("hard");
+    expect(existsSync(join(domainDir("ski"), "method.md"))).toBe(false);
+  });
+
+  it("retract + hard:true → invalid_request (field `hard`) and the bullet is NOT removed", async () => {
+    const methodPath = await seedSkiMethod();
+    const payload = payloadOf(
+      await getTool(api, LEARN).execute("g1f", {
+        target: "method", domain: "ski", kind: "retract", from: "Prefer last-year models.", hard: true,
+      }),
+    );
+    expect(payload["status"]).toBe("invalid_request");
+    expect(payload["field"]).toBe("hard");
+    expect(readFileSync(methodPath, "utf8")).toContain("Prefer last-year models.");
+  });
+
+  it("attach-asset + hard:true → invalid_request (field `hard`) BEFORE any bytes/link write (hard wins error-precedence)", async () => {
+    await seedSkiMethod();
+    const payload = payloadOf(
+      await getTool(api, LEARN).execute("g1g", {
+        target: "method", domain: "ski", kind: "attach-asset", bytes: PNG_B64, mime: "image/png", hard: true,
+      }),
+    );
+    expect(payload["status"]).toBe("invalid_request");
+    expect(payload["field"]).toBe("hard");
+    expect(existsSync(join(domainDir("ski"), "assets"))).toBe(false);
+    expect(readFileSync(join(domainDir("ski"), "method.md"), "utf8")).not.toContain("assets/");
+  });
+
+  it("append + hard:true is STILL honored on prd (the guard keys on kind+target, never over-narrow to user_spec only)", async () => {
+    await getTool(api, MATERIALIZE).execute("g1h", { name: "sil shopper", userSpec: USER_SPEC });
+    await getTool(api, LEARN).execute("g1i", {
+      target: "method", domain: "ski", kind: "create", name: "Ski", body: "#g",
+    });
+    await getTool(api, LEARN).execute("g1j", {
+      target: "prd", domain: "ski", prd: "gloves-slope", product: "gloves", intent: "slope", title: "G", kind: "create",
+      body: "## Requirements\n- baseline\n",
+    });
+    const payload = payloadOf(
+      await getTool(api, LEARN).execute("g1k", {
+        target: "prd", domain: "ski", prd: "gloves-slope", kind: "append", text: "waterproof to IPX7", hard: true,
+      }),
+    );
+    expect(payload["status"]).toBe("ok");
+    expect(readFileSync(join(domainDir("ski"), "prds", "gloves-slope.md"), "utf8")).toContain("[hard]");
+  });
+});
+
+/* ===========================================================================
  * sil_learn attach-asset — bytes in, path-reference out; per-domain only.
  * ========================================================================= */
 describe("sil_learn attach-asset — persists image bytes into domains/<slug>/assets and links by path", () => {
@@ -443,6 +535,52 @@ describe("sil_learn attach-asset — persists image bytes into domains/<slug>/as
       }),
     );
     expect(payload["status"]).toBe("invalid_request");
+  });
+
+  // GAP 4 — the markdown link append is idempotent: bytes dedup by content hash,
+  // and re-attaching the SAME asset path to the SAME target never accretes a second
+  // `![…](assets/…)` line. Idempotence keys on the asset PATH, not the caption.
+  it("re-attaching the SAME bytes to the SAME target adds NO second link line (second call ok + same assetPath)", async () => {
+    await seedSkiMethod();
+    const first = payloadOf(
+      await getTool(api, LEARN).execute("idem1", {
+        target: "method", domain: "ski", kind: "attach-asset", bytes: PNG_B64, mime: "image/png", caption: "boot last",
+      }),
+    );
+    expect(first["status"]).toBe("ok");
+    const second = payloadOf(
+      await getTool(api, LEARN).execute("idem2", {
+        target: "method", domain: "ski", kind: "attach-asset", bytes: PNG_B64, mime: "image/png", caption: "boot last",
+      }),
+    );
+    expect(second["status"]).toBe("ok");
+    expect(second["assetPath"]).toBe(first["assetPath"]);
+
+    const methodRaw = readFileSync(join(domainDir("ski"), "method.md"), "utf8");
+    const linkCount = (methodRaw.match(/\]\(assets\//g) ?? []).length;
+    expect(linkCount).toBe(1);
+    // The bytes were content-hash dedup'd to a single asset file all along.
+    expect(readdirSync(join(domainDir("ski"), "assets")).length).toBe(1);
+  });
+
+  it("re-attaching the same bytes with a DIFFERENT caption is still a body no-op — idempotence keys on the asset PATH, not the caption", async () => {
+    await seedSkiMethod();
+    await getTool(api, LEARN).execute("cap1", {
+      target: "method", domain: "ski", kind: "attach-asset", bytes: PNG_B64, mime: "image/png", caption: "first caption alpha",
+    });
+    const second = payloadOf(
+      await getTool(api, LEARN).execute("cap2", {
+        target: "method", domain: "ski", kind: "attach-asset", bytes: PNG_B64, mime: "image/png", caption: "second caption bravo",
+      }),
+    );
+    expect(second["status"]).toBe("ok");
+
+    const methodRaw = readFileSync(join(domainDir("ski"), "method.md"), "utf8");
+    const linkCount = (methodRaw.match(/\]\(assets\//g) ?? []).length;
+    expect(linkCount).toBe(1);
+    // The first link stays; the second caption is NOT accreted onto the body.
+    expect(methodRaw).toContain("first caption alpha");
+    expect(methodRaw).not.toContain("second caption bravo");
   });
 });
 
@@ -561,6 +699,42 @@ describe("sil_profile_get — reads ONE full body (method or PRD)", () => {
         "invalid_request",
       );
     }
+  });
+
+  // GAP 3 — the rich read distinguishes a PRESENT-but-corrupt artefact (`unreadable`,
+  // fail-closed) from an ABSENT one (`not_found`), matching the scan paths. Conflating
+  // them lets the agent re-mint over a recoverable body — silent data loss.
+  it("a method.md present but with malformed/absent frontmatter → `unreadable` (NOT not_found) so the agent never re-mints over a recoverable artefact", async () => {
+    await getTool(api, MATERIALIZE).execute("u0", { name: "sil shopper", userSpec: USER_SPEC });
+    // A hand-corrupted domain: method.md exists but carries no valid frontmatter fence.
+    const brokenDir = domainDir("broken");
+    mkdirSync(brokenDir, { recursive: true, mode: 0o700 });
+    writeFileSync(join(brokenDir, "method.md"), "no frontmatter here at all\njust prose\n", { mode: 0o600 });
+
+    const payload = payloadOf(await getTool(api, GET).execute("u1", { domainSlug: "broken" }));
+    expect(payload["status"]).toBe("unreadable");
+    expect(payload["status"]).not.toBe("not_found");
+    // Fail-closed recovery that steers AWAY from re-mint (do not overwrite a corrupt-but-recoverable body).
+    expect(payload["recovery"]).toBe("inspect_artefact");
+    expect(String(payload["message"])).toMatch(/corrupt|overwrite|inspect|repair/i);
+  });
+
+  it("a malformed PRD → `unreadable`; a genuinely ABSENT method / PRD still → not_found", async () => {
+    await getTool(api, MATERIALIZE).execute("u2", { name: "sil shopper", userSpec: USER_SPEC });
+    await getTool(api, LEARN).execute("u3", { target: "method", domain: "ski", kind: "create", name: "Ski", body: "#g" });
+    // A corrupt PRD leaf: present but unparseable.
+    const prdsDir = join(domainDir("ski"), "prds");
+    mkdirSync(prdsDir, { recursive: true, mode: 0o700 });
+    writeFileSync(join(prdsDir, "gloves-slope.md"), "not a frontmatter doc\n", { mode: 0o600 });
+
+    expect(payloadOf(await getTool(api, GET).execute("u4", { domainSlug: "ski", prd: "gloves-slope" }))["status"]).toBe(
+      "unreadable",
+    );
+    // Absence is distinct from corruption — a truly missing method/PRD is still not_found.
+    expect(payloadOf(await getTool(api, GET).execute("u5", { domainSlug: "never-minted" }))["status"]).toBe("not_found");
+    expect(payloadOf(await getTool(api, GET).execute("u6", { domainSlug: "ski", prd: "no-such-prd" }))["status"]).toBe(
+      "not_found",
+    );
   });
 });
 

--- a/src/lib/profile-store.ts
+++ b/src/lib/profile-store.ts
@@ -93,6 +93,16 @@ interface NotFound {
   message: string;
 }
 
+/** A file that is PRESENT but parses to null (malformed/absent frontmatter) — the
+ * rich read must NOT conflate this with an absent file (`not_found`), or a corrupt
+ * but recoverable artefact gets silently re-minted over. Fail-closed, matching the
+ * scan paths (`searchProfileFrontmatter`, `readShopperIdentity`). */
+interface Unreadable {
+  ok: false;
+  kind: "unreadable";
+  message: string;
+}
+
 interface PersistenceFailed {
   ok: false;
   kind: "persistence_failed";
@@ -108,6 +118,16 @@ function invalid(field: string, message: string): InvalidRequest {
 
 function notFound(message: string): NotFound {
   return { ok: false, kind: "not_found", message };
+}
+
+function unreadable(path: string): Unreadable {
+  return {
+    ok: false,
+    kind: "unreadable",
+    message:
+      path + ": the artefact is present but corrupt (malformed or absent frontmatter)"
+        + " — inspect / repair, do NOT overwrite (it may still be recoverable).",
+  };
 }
 
 function persistenceFailed(path: string, err: unknown): PersistenceFailed {
@@ -394,6 +414,19 @@ function resolveTarget(spec: LearnSpec): ResolvedTarget | InvalidRequest {
 }
 
 export function learnArtefact(spec: LearnSpec): LearnResult {
+  // `hard` is valid ONLY on append to user_spec / prd. Every other combination —
+  // all four non-append kinds on any target, and append to method — is rejected
+  // LOUDLY, never silently dropped: a buyer who passes `hard:true` expecting to
+  // promote a constraint must learn at once when the promotion does not land.
+  // Hoisted ABOVE the kind switch so a hard misuse wins error-precedence over the
+  // per-kind field checks (this subsumes the old method-only append guard).
+  if (spec.hard === true && !(spec.kind === "append" && spec.target !== "method")) {
+    return invalid(
+      "hard",
+      "hard is valid only on append to user_spec or prd — a method carries no hard"
+        + " constraints, and create/amend/retract/attach-asset take no hard flag.",
+    );
+  }
   switch (spec.kind) {
     case "create":
       return learnCreate(spec);
@@ -466,25 +499,11 @@ function learnCreate(spec: LearnSpec): LearnResult {
   return { ok: true, kind: "create", target: "prd", domain: slug, prd, path };
 }
 
-/** `hard` is valid only on append to user_spec / prd — a method carries no hard
- * constraints (they are the person's, or the job's). */
-function rejectHardMisuse(spec: LearnSpec): InvalidRequest | null {
-  if (spec.hard === true && spec.target === "method") {
-    return invalid(
-      "hard",
-      "hard is valid only on append to user_spec or prd — a method carries no hard"
-        + " constraints (they belong to the person or the job).",
-    );
-  }
-  return null;
-}
-
 /** append — add `- <text>` (or `- [hard] <text>`) under `## <section>` when given
  * (fail-closed if that heading is absent), else at EOF. The target must already
- * exist → not_found (never resurrects a seed-less doc). */
+ * exist → not_found (never resurrects a seed-less doc). `hard` is guarded up-front
+ * in `learnArtefact` (append to method / any non-append kind is rejected there). */
 function learnAppend(spec: LearnSpec): LearnResult {
-  const badHard = rejectHardMisuse(spec);
-  if (badHard) return badHard;
   if (!nonBlank(spec.text)) return invalid("text", "text is required and must be non-empty.");
 
   const target = resolveTarget(spec);
@@ -606,12 +625,36 @@ function learnAttachAsset(spec: LearnSpec): LearnResult {
   } catch (err) {
     return persistenceFailed(assetAbs, err);
   }
-  const caption = nonBlank(spec.caption) ? (spec.caption as string).trim() : "";
-  const link = "![" + caption + "](" + assetRel + ")";
-  const body = existing.body.replace(/\n*$/, "\n") + link + "\n";
-  const res = writeArtefactBody(target, existing.fields, body, "attach-asset");
+
+  // Idempotent link on the asset PATH (not the caption): if `assets/<hash>.<ext>` is
+  // already referenced in the target, skip the body write — no second link line, no
+  // updated_at churn. The bytes were re-written above (identical-hash overwrite, a
+  // benign no-op), so a re-attach under any caption is a body no-op that still
+  // reports ok + assetPath.
+  const res = existing.body.includes("](" + assetRel + ")")
+    ? okAttach(target)
+    : writeArtefactBody(
+        target,
+        existing.fields,
+        existing.body.replace(/\n*$/, "\n")
+          + "![" + (nonBlank(spec.caption) ? (spec.caption as string).trim() : "") + "](" + assetRel + ")\n",
+        "attach-asset",
+      );
   if (!res.ok) return res;
   return { ...res, assetPath: assetRel };
+}
+
+/** The success envelope for an attach-asset that wrote no body (idempotent re-link)
+ * — mirrors `writeArtefactBody`'s ok shape without the re-serialize / timestamp bump. */
+function okAttach(target: ResolvedTarget): LearnResult {
+  return {
+    ok: true,
+    kind: "attach-asset",
+    target: target.label,
+    ...(target.domain !== undefined ? { domain: target.domain } : {}),
+    ...(target.prd !== undefined ? { prd: target.prd } : {}),
+    path: target.path,
+  };
 }
 
 /** Re-serialize a method/PRD with a bumped `updated_at`; user_spec carries no
@@ -815,6 +858,7 @@ export type ReadResult =
       path: string;
     }
   | NotFound
+  | Unreadable
   | InvalidRequest;
 
 export function readArtefactBody(domainSlug: string, prd?: string): ReadResult {
@@ -825,18 +869,20 @@ export function readArtefactBody(domainSlug: string, prd?: string): ReadResult {
     const badPrd = rejectBadSegment(prd, "prd");
     if (badPrd) return badPrd;
     const path = join(getDomainArtefactDir(domainSlug), PRDS_SUBDIR, prd + ".md");
+    // Split absent from corrupt: an absent file is not_found, a present-but-unparseable
+    // one is unreadable (never conflated — the agent must not re-mint over a corrupt PRD).
+    if (!existsSync(path)) return notFound('No PRD "' + prd + '" in domain "' + domainSlug + '".');
     const parsed = readArtefactFile(path);
-    if (parsed === null) {
-      return notFound('No PRD "' + prd + '" in domain "' + domainSlug + '".');
-    }
+    if (parsed === null) return unreadable(path);
     return { ok: true, target: "prd", domain: domainSlug, prd, fields: parsed.fields, body: parsed.body, path };
   }
 
   const path = join(getDomainArtefactDir(domainSlug), METHOD_FILE);
-  const parsed = readArtefactFile(path);
-  if (parsed === null) {
+  if (!existsSync(path)) {
     return notFound('No method for domain "' + domainSlug + '" — mint it with sil_learn create.');
   }
+  const parsed = readArtefactFile(path);
+  if (parsed === null) return unreadable(path);
   return { ok: true, target: "method", domain: domainSlug, fields: parsed.fields, body: parsed.body, path };
 }
 

--- a/src/tools/profile.ts
+++ b/src/tools/profile.ts
@@ -252,8 +252,11 @@ function registerGet(api: PluginAPI): void {
       + " taste + search vocabulary); with `domainSlug` + `prd`, returns that PRD's"
       + " body (its requirements + filled preferences). Use sil_profile_search first"
       + " to discover which domains/PRDs exist (coordinates), then this to read one in"
-      + " full. A missing method/PRD returns not_found; a malformed/traversal/\"main\""
-      + " slug returns invalid_request. Makes no network call and reads no token.",
+      + " full. A missing method/PRD returns not_found; a present-but-corrupt body"
+      + " (malformed/absent frontmatter) returns unreadable (inspect / repair — do NOT"
+      + " overwrite it, it may be recoverable), distinct from not_found; a malformed/"
+      + "traversal/\"main\" slug returns invalid_request. Makes no network call and reads"
+      + " no token.",
     parameters: Type.Object({
       domainSlug: Type.String({
         description: "The domain slug to read (lower-kebab, not \"main\"). REQUIRED.",
@@ -325,6 +328,7 @@ function mapFailure(
   result:
     | { ok: false; kind: "invalid_request"; field: string; message: string }
     | { ok: false; kind: "not_found"; message: string }
+    | { ok: false; kind: "unreadable"; message: string }
     | { ok: false; kind: "persistence_failed"; error: string; message: string; recovery: "fix_data_dir" },
 ) {
   if (result.kind === "invalid_request") {
@@ -334,6 +338,12 @@ function mapFailure(
   if (result.kind === "not_found") {
     api.logger.info(tool + "_not_found", {});
     return jsonResult({ status: "not_found", message: result.message });
+  }
+  if (result.kind === "unreadable") {
+    // A present-but-corrupt artefact — steer the agent to inspect/repair, NEVER re-mint
+    // over it (silent data loss on a recoverable artefact). Distinct from not_found.
+    api.logger.warn(tool + "_unreadable", {});
+    return jsonResult({ status: "unreadable", message: result.message, recovery: "inspect_artefact" });
   }
   api.logger.error(tool + "_persistence_failed", { error: result.error });
   return jsonResult({


### PR DESCRIPTION
## Card
`cards/close-sds-redesign-behavior-correctness-gaps.md` (lives in the card branch — gitignored; see the body for the full intent + handoffs). epic: `sds-redesign-closeout-2026-07`.

Closes four behavioral drifts between the shipped SDS redesign and its design doc — the anchor throughout is **no silent failures**.

## Summary
- **Gap 1 — `sil_learn` no longer silently drops `hard`.** One guard hoisted above the `kind` switch in `learnArtefact` rejects `hard:true` unless `kind==="append" && target!=="method"` → `invalid_request` (field `hard`), writing nothing. The method-only `rejectHardMisuse` helper + its `learnAppend` call are **deleted** (subsumed). A buyer promoting a soft pref with `amend`+`hard:true` now fails loud instead of a silent no-op.
- **Gap 2 — `shop_loop.md` Beat 4 documents the specs projection end-to-end.** Build `filters.specs` predicates from the method's coined (canonical) vocabulary; **prefer a dedicated param over a predicate** for the same attribute (never both); stay **pure transport** (the agent authors `query` — the plugin never folds a predicate in); mark inviolable predicates `hard:true`; read per-predicate `specs_status` for Beat 5. **Skill doc only** — the transport (`sil_search.specs` + `specs_status`) is already live; `catalog.ts`/`sil-client.ts` untouched.
- **Gap 3 — `sil_profile_get` surfaces `unreadable`.** `readArtefactBody` splits absent (`not_found`) from present-but-unparseable (new `Unreadable` variant), matching the scan paths. `mapFailure` maps it to `{ status:"unreadable", message, recovery:"inspect_artefact" }` (message steers away from re-mint); `registerGet` names the outcome. A corrupt-but-recoverable method is no longer re-minted over.
- **Gap 4 — `attach-asset` link append is idempotent.** Keys on the asset **path** (`assets/<hash>.<ext>`): a re-attach of identical bytes to the same target skips the body write (no second link line, no `updated_at` churn) and still returns `ok` + `assetPath`. Caption-only change on identical bytes is intentionally a body no-op.

No tool added or removed — the six-test tool-set drift fan-out does **not** apply and is untouched.

## Test plan
- [x] 10 new `[unit]` cases (qa-developer): 5 gap-1 (each non-append kind + append-to-prd still honored), 2 gap-4 (re-attach + different-caption), 2 gap-3 (malformed method/PRD → unreadable, absent → not_found), 1 gap-2 (Beat-4 specs projection, scoped to the `## Beat 4` section).
- [x] `pnpm typecheck` clean (incl. test files).
- [x] `pnpm build` clean — `dist/index.js` emits.
- [x] Full suite: 1000/1000 prior tests green; the 10 `repo-scaffold` failures are the known worktree-only failures (gitignored `docs/` + `CLAUDE.md` not checked out), not regressions.

## Distillation target
Knowledge capture happens **after Review PASS** in the `distilling` stage — `solutions-architect` runs in this same worktree, commits to this same branch, and pushes here so the PR ends up containing implementation + tests + distillation in one mergeable unit.