### PR TITLE
chore: SDS-redesign terminology + doc-currency cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ release (`clawhub package publish --changelog`). See [README](./README.md#releas
   fill → search-space → reflect → feedback — across new `references/shop_loop.md`,
   `method_and_prds.md`, and `fill_and_feedback.md` (the `manage_domains.md` /
   `refine_shopper.md` references are retired).
+- **`sil_search` forwards an open-vocabulary `specs` predicate list and returns
+  observable `specs_status` (Phase 2, #55).** Pure transport, no client-side
+  matching: the plugin passes typed predicates (`{ ns, key, op, value, unit?,
+  hard? }`) under one namespaced `filters.specs` key and surfaces the backend's
+  per-predicate `specs_status` (`{ ns, key, applied }[]`, a sibling of `products`)
+  for Beat 5's hard-constraint honesty pass. An unindexed key **fails green**
+  (`applied: false`) — never dropped, never a fabricated `applied: true` — and
+  converges as the spec registry populates.
 
 ### Added
 
@@ -43,6 +51,16 @@ release (`clawhub package publish --changelog`). See [README](./README.md#releas
   the reuse-before-mint primitive that replaces the deleted manifest's index role;
   malformed artefacts surface in an observable `unreadable[]`, never silently
   dropped. Tool floor 8 → 9.
+- **`sil_specs` — the spec-registry canonicalize-or-create tool (Phase 3, #57).**
+  The shopping method's Beat-2 mint submits the coined spec DEFINITIONS it invents
+  for a niche (`{ namespace, key, display_name, data_type, unit?, allowed_values?,
+  description? }`); each resolves 1:1 to a canonical name — **matched** an existing
+  spec (adopt its `canonical` `{ namespace, key }`, drop the coined synonym) or
+  **created** as new (yours is canonical going forward) — so the `filters.specs`
+  vocabulary converges across methods. Shares `sil_search`'s taxonomy (401
+  refresh-and-retry-once, `not_registered` / `forbidden` / `invalid_request` /
+  `retryable`) and degrades gracefully: a non-`ok` verdict never blocks the mint,
+  which proceeds with the raw coined names. Tool floor 9 → 10.
 
 ### Removed
 

--- a/sil-shopping/references/search_param_mapping.md
+++ b/sil-shopping/references/search_param_mapping.md
@@ -35,7 +35,7 @@ precedence — see [`fill_and_feedback.md`](fill_and_feedback.md) — is
 
 These layers are inputs to the same params, not new params. A stated taste with **no
 matching param** (a colour, a brand, "eco-friendly") folds into the `query` text or the
-recommendation rubric — **never a new filter**. There is no `color` or `brand` param;
+recommendation reflection — **never a new filter**. There is no `color` or `brand` param;
 inventing one emits invalid `sil_search` calls.
 
 ## Hard constraints — a real filter AND a reject-at-recommend rule, NEVER only `query`
@@ -49,7 +49,7 @@ Route each to **two** points, **not merely `query`** (see
 1. **A real `sil_search` filter where one exists** — "new/secondhand only" →
    `condition`; "in stock only" → `available` (omit for the in-stock default). Where a
    param matches, set it so the catalog never returns the violating item.
-2. **An explicit reject-at-pick rubric rule** for a constraint with no matching param
+2. **An explicit reject-at-pick rule** for a constraint with no matching param
    (no `material` filter for "never leather"): the constraint **rejects** any violating
    candidate outright, never down-weights it. A hard constraint is a reject, not a
    weight.
@@ -76,5 +76,5 @@ local_merchants: true          # ranking bias; optionally query in French to sur
 # ship_to: OMITTED — server resolves the registered default address
 ```
 
-A non-param taste ("understated colours") folds into `query` or the rubric, never a new
-filter.
+A non-param taste ("understated colours") folds into `query` or the recommendation
+reflection, never a new filter.

--- a/src/__tests__/skill-content.test.ts
+++ b/src/__tests__/skill-content.test.ts
@@ -107,6 +107,15 @@ const DELETED_STORE_TOKENS = ["profile.json", "domain_spec", "intent_spec", "pla
 /** Deleted / never-existed tool names — must be absent from the whole bundle. */
 const DELETED_TOOLS = ["sil_remember", "sil_profile_list", "sil_ping", "sil_echo"] as const;
 
+/** Deleted redesign terminology. The redesign DELETED the client-side ranking
+ * "rubric" (shop_loop.md asserts "never re-rank") and renamed the reasoning step
+ * "reflection over fitness". Any lingering `rubric` labels a mechanism that no
+ * longer exists — a stale noun for the reject-at-pick / recommendation behavior.
+ * Scanned CASE-INSENSITIVELY — UNLIKE the two case-sensitive `.includes()` guards
+ * above — so a capitalized reintroduction (`Rubric`/`RUBRIC`) can't slip back in.
+ * Entries here MUST be lower-case: each body is lower-cased before the match. */
+const DELETED_TERMINOLOGY = ["rubric"] as const;
+
 interface Frontmatter {
   raw: string;
   fields: Record<string, string>;
@@ -325,6 +334,21 @@ describe("skill bundle — source of truth for the ten-tool surface", () => {
     for (const [label, path] of BUNDLE_FILES) {
       const body = readBody(path);
       for (const dead of DELETED_STORE_TOKENS) {
+        if (body.includes(dead)) offenders.push(`${label} → ${dead}`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it("NO bundle file names DELETED redesign terminology (case-insensitive `rubric` — the client re-rank is gone)", () => {
+    // The redesign deleted the client-side ranking rubric (no client re-rank —
+    // shop_loop.md asserts "never re-rank"). The noun leaked into search_param_mapping.md
+    // where it now mislabels the reject-at-pick / recommendation behavior. Grepped to
+    // zero bundle-wide, CASE-INSENSITIVELY — a capitalized reintroduction must FAIL too.
+    const offenders: string[] = [];
+    for (const [label, path] of BUNDLE_FILES) {
+      const body = readBody(path).toLowerCase();
+      for (const dead of DELETED_TERMINOLOGY) {
         if (body.includes(dead)) offenders.push(`${label} → ${dead}`);
       }
     }

--- a/src/tools/profile.ts
+++ b/src/tools/profile.ts
@@ -67,8 +67,10 @@ function registerMaterialize(api: PluginAPI): void {
       + " carry across EVERY niche — with the shopper `name` in the file's own"
       + " frontmatter (there is NO manifest; the frontmatter IS the source of truth)."
       + " It does NOT mint any domain method or PRD — that is sil_learn create. `name`"
-      + " and `userSpec` are both REQUIRED; on any augment pass the full updated body"
-      + " (it overwrites atomically). Makes no network call and reads no token. The"
+      + " and `userSpec` are both REQUIRED. Run this ONCE at setup: post-setup user-spec"
+      + " refinement is sil_learn (append/amend), NEVER a re-materialize (a re-run"
+      + " overwrites the whole body, discarding what sil_learn added). Makes no network"
+      + " call and reads no token. The"
       + " persona is NOT written here — it is the host workspace SOUL.md. A blank"
       + " name/userSpec returns invalid_request and writes nothing; a write failure"
       + " returns persistence_failed.",


### PR DESCRIPTION
## Card
`cards/sds-redesign-terminology-and-doc-currency-cleanup.md` (gitignored — lives on the `card/…` branch working tree; body carries the full intent + handoffs). Epic `sds-redesign-closeout-2026-07`.

No runtime behavior change. Post-merge audit of the SDS redesign ([[spec-driven-shopping-redesign]]) found the implementation faithful; this clears the terminology + doc-currency loose ends so the record matches the shipped system.

## Summary (tracked, in this diff)
- **Item 1 (qa) — `rubric` deleted-terminology guard + rename.** The redesign removed the client-side ranking rubric (no client re-rank); the stale noun leaked into three lines of `sil-shopping/references/search_param_mapping.md`, renamed to the live reflection / reject-at-pick vocabulary. A new **case-insensitive** `DELETED_TERMINOLOGY = ["rubric"]` bundle guard in `skill-content.test.ts` mirrors the sibling deleted-identifier guards (lower-cases each body so `Rubric`/`RUBRIC` can't slip back).
- **Item 2 — CHANGELOG `[Unreleased]`.** Added the missing merged phases: a `Changed` entry for Phase 2 (`sil_search` forwards `filters.specs` + observable `specs_status`, pure transport, #55) and an `Added` entry for Phase 3 (`sil_specs` canonicalize-or-create tool, floor 9 → 10, #57).
- **Item 4 — `sil_profile_materialize` description reword.** Dropped the re-materialize "augment pass" clause; states setup-only, with post-setup user-spec refinement via `sil_learn` (a re-materialize overwrites the whole body, discarding what `sil_learn` added). Copy only — behavior was already setup-only (`materializeProfile` unconditionally `atomicWrite`s).

## Off the PR (gitignored docs, by design)
- **Item 3** — deleted the stale `docs/decisions/sil-specs-backend-epic-handoff.md` (`temporary: true`; its epic #68 is filed + done) on the main checkout, and removed its sole backlink in `docs/decisions/spec-driven-shopping-redesign.md` in the worktree (propagates to main at teardown). `docs/` is gitignored + not reviewed here — inherent to gitignored-mode, not a defect.
- **Item 5** — confirm-only no-op: `find cards -xtype l` is empty on main.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm build` — clean (`dist/index.js` emitted)
- [x] `pnpm test` — 992 pass; the only new/changed suite behavior is Item 1's guard + rename. The 9 failing `repo-scaffold.integration.test.ts` assertions are the known worktree-only class (gitignored `CLAUDE.md` / `docs/**` not checked out), not a regression.

## Distillation target
Knowledge capture happens **after Review PASS** in the `distilling` stage — `solutions-architect` runs in this same worktree, commits to this branch, and pushes here.