### PR TITLE
fix: harden shopper tool policy + rebuild the sil_learn artefact model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,45 @@ release (`clawhub package publish --changelog`). See [README](./README.md#releas
 
 ## [Unreleased]
 
+### Changed
+
+- **The shopper no longer sets a per-agent `tools.deny`.** `create-shopper.mjs` used to
+  deny `["exec","write","edit","apply_patch"]`; removed. On the codex runtime the shell is
+  codex-native (surfaced as `bash`) — a tool the deny never named, so it read skill files
+  and could write host files regardless, while the denied OpenClaw `exec` tool was one
+  codex never used. Denying fs-mutators while a shell stays open buys nothing (an open
+  shell writes anyway — documented OpenClaw behaviour). The shopper now inherits the host
+  default toolset; the shell is open by design (trusted single-operator posture) and is how
+  codex reads its progressively-disclosed skill references. Persistence is steered to the
+  sil tools by the skill, not by tool policy.
+- **`SKILL.md`'s always-on contract now pins two behaviours that lived only in read-once
+  references:** the shopper's memory is the sil store (`sil_learn` / `sil_profile_*`),
+  never a workspace `MEMORY.md`; and Beat 4 is bounded to **≤ 4 spec-filtered `sil_search`
+  calls** per request (core first, then widenings — never brand-by-brand). Both went stale
+  in attention when they lived two lazy reference-hops deep.
+- **`sil_learn`'s write model is now document-first: `create` / `write` / `attach-asset`.**
+  The surgical bullet ops (`append` / `amend` / `retract`) are removed. `create` mints a
+  NEW method/PRD (errors if one exists); `write` replaces an existing doc's whole body with
+  a reconciled version the model authors (read it first, carry every buyer line forward). A
+  correction now rewrites the line it changes instead of stacking a contradicting bullet —
+  the self-contradicting PRD (a "prefer transparency" requirement beside a "transparency not
+  valued" correction) becomes structurally impossible. The method now holds only the general
+  buying guide + coined spec **vocabulary** (never this-buyer values); the PRD carries a
+  **`## Search specs`** block — the resolved `{ns,key,op,value,hard?}` predicate set projected
+  verbatim into `sil_search`, so structured filters no longer decay to keyword-only
+  mid-session. Beat 1 pins the domain to the broad, reusable product category (never folding
+  the use-context into the slug), and a "prefer X, Y/Z acceptable" requirement becomes one
+  `op:in` set with the favourite applied as ranking, not an over-hard `eq`.
+
+### Fixed
+
+- **Artefacts no longer serialize two stacked frontmatter blocks.** A model-authored
+  `sil_learn create` body (or `sil_profile_materialize` userSpec) that began with its own
+  `--- … ---` block got the store's canonical frontmatter wrapped around it.
+  `serializeArtefact` now strips a leading frontmatter fence from the body first, so every
+  artefact carries exactly one (the store's — frontmatter-as-truth); existing
+  double-frontmatter files self-heal on their next write.
+
 ## [0.4.1] - 2026-07-14
 
 ### Fixed

--- a/scripts/create-shopper.mjs
+++ b/scripts/create-shopper.mjs
@@ -31,8 +31,7 @@
  *   7. materializeProfile          — REUSED; SETUP-ONLY { name, userSpec } ⇒ shared
  *                                    user_spec.md (its frontmatter carries the name);
  *                                    NO manifest, no domain minted at create
- *   8. attach the sil skill + deny the escape-hatch tools (exec/write/edit/apply_patch,
- *      a per-agent tools.deny that keeps sil + web) + enable the sil plugin (config set)
+ *   8. attach the sil skill + enable the sil plugin (config set)
  *   9. sil-openclaw-allowlist      — REUSED whole; additive/idempotent/atomic three-surface
  *                                    trust merge (plugins.allow + tools.alsoAllow + plugins.entries.sil)
  *  10. bind the current channel    — FAIL-OPEN convenience, NOT fail-closed: resolve the channel
@@ -97,17 +96,6 @@ const MANIFEST_PATH = resolve(ROOT, "openclaw.plugin.json");
 
 /** A shopper id path-segment shape — lower-kebab, never `main` (host-reserved). */
 const AGENT_ID_RE = /^[a-z0-9][a-z0-9-]*$/;
-
-/** The escape-hatch tools the shopper is DENIED at the per-agent level — the shell
- * (`exec`) and the filesystem mutators (`write`/`edit`/`apply_patch`). A shopper shops
- * through the sil tools; it has no business running a shell (which it wasted re-reading
- * its own skill files) or writing host files (which it used to persist shopping memory
- * into the workspace instead of the sil store). `deny` is the SAFE lever: per the host's
- * tool-precedence model it only further-RESTRICTS and cannot re-grant, so it removes
- * exactly these and CANNOT strip the sil tools (a per-agent `tools.profile` override,
- * by contrast, replaces the base set and would risk the sil grant). Web + messaging
- * tools are intentionally kept — web still feeds gap-filling method research. */
-const SHOPPER_TOOL_DENY = ["exec", "write", "edit", "apply_patch"];
 
 /** The sil creed appended to every shopper's SOUL.md after its persona — a soul, not a
  * rulebook. It carries the mantra (explore first), the loop in three lines, and the one
@@ -315,11 +303,6 @@ function agentIndex(config, agentId) {
   const list = Array.isArray(config?.agents?.list) ? config.agents.list : [];
   return list.findIndex((a) => a?.id === agentId);
 }
-
-// The shopper's per-agent escape-hatch deny-list (step 8) is the INTENDED end state, not
-// a degradation — so it rides no `warnings` entry (that rail is for real gaps, and the
-// happy path stays clean). What the shopper keeps (sil tools + web) and drops (the shell
-// + fs mutators) is documented in CHANGELOG.md + agent_creation_engine.md.
 
 /** True iff `openclaw config validate --json` reported `{valid:true}`. The host
  * writes its verdict to stdout even on a non-zero exit, so read stdout, never the
@@ -593,21 +576,12 @@ function main() {
   if (!skillRes.ok) {
     failAndTeardown(configPath, "attaching the sil skill failed: " + (skillRes.stderr || "non-zero exit"));
   }
-  // Deny the shopper the escape-hatch tools at the per-agent level — sibling of the
-  // `.skills` set above. This subtracts the shell + fs mutators from whatever the host's
-  // global profile grants, so the sil tools (admitted via plugin trust, step 9) and web
-  // survive while the shell/file-write hatches are gone. `deny` is chosen over a
-  // per-agent `tools.profile` override precisely because it only further-restricts and
-  // can never strip the sil grant (SHOPPER_TOOL_DENY rationale). `--strict-json` requires
-  // a valid-JSON value, so the array is passed via JSON.stringify (→ '["exec",…]'),
-  // exactly like the `["…"]` / `true` values above; a bare token would exit 0 but no-op.
-  const denyRes = runOpenclaw(
-    ["config", "set", `agents.list[${idx}].tools.deny`, JSON.stringify(SHOPPER_TOOL_DENY), "--strict-json"],
-    configPath,
-  );
-  if (!denyRes.ok) {
-    failAndTeardown(configPath, "setting the shopper tool deny-list failed: " + (denyRes.stderr || "non-zero exit"));
-  }
+  // No per-agent `tools.deny` is set: the shopper inherits the host's default toolset
+  // untouched. A deny of the fs-mutators is inert here — codex brings its OWN shell
+  // (surfaced as `bash`), which the deny cannot name and which reads the shopper's
+  // skill files anyway, and an open shell writes files regardless of any fs-mutator
+  // deny. The shell stays open by design (trusted single-operator posture); persistence
+  // is steered through the sil tools by the skill, not enforced by tool policy.
   const enableRes = runOpenclaw(
     ["config", "set", "plugins.entries.sil.enabled", "true", "--strict-json"],
     configPath,

--- a/sil-shopping/SKILL.md
+++ b/sil-shopping/SKILL.md
@@ -28,6 +28,9 @@ it knows, view or forget a domain, refine it.
   **before** searching; never skip the mint. The picks you return are always sil
   catalog products (`sil_search` → `checkout_url`), **never** open-web results —
   the web only researches the method, it never sources a pick.
+- **Your memory is the sil store, never a `MEMORY.md`.** Persist and recall every
+  shopping fact, taste, and domain method through `sil_learn` / `sil_profile_*` — a
+  workspace `MEMORY.md` is not the shopper's memory; do not read or write it.
 
 ## Session start
 
@@ -87,6 +90,10 @@ feedback** — loaded on demand from the references that own each beat: **1 clas
 **2 method** (load/mint/refresh, intent-keyed PRDs, the frontmatter-as-truth store)
 → [`references/method_and_prds.md`](references/method_and_prds.md); **3 fill, 6
 feedback** → [`references/fill_and_feedback.md`](references/fill_and_feedback.md).
+
+**Beat 4 is bounded: ≤ 4 spec-filtered `sil_search` calls** per request — the tightest
+projection of the PRD's core first, then deliberate widenings; never brand-by-brand
+enumeration.
 
 The loop shapes the shopper's **reasoning, not the user's inbox**: a reused domain
 plus a fully-resolved request **passes straight through, asking nothing**. It gates

--- a/sil-shopping/examples/multi_domain_shopper_walkthrough.md
+++ b/sil-shopping/examples/multi_domain_shopper_walkthrough.md
@@ -1,6 +1,6 @@
 ---
 name: multi-domain-shopper-walkthrough
-description: A worked six-beat run — create one shopper (after endorsement), then shop two unrelated niches in one session, the second minted on the fly, with a shared user_spec fact reused across both. Illustrative, not a spec.
+description: A worked six-beat run — create one shopper (after endorsement), then shop two unrelated niches in one session (the second minted on the fly), with a shared user_spec fact reused across both and a mid-session correction reconciled by a whole-doc write. Illustrative, not a spec.
 ---
 
 # Worked run — one shopper, two niches, six beats
@@ -18,16 +18,31 @@ lives in `user_spec` (true in **every** niche).
 ## Niche A — ski gloves (all six beats)
 
 1. **Classify** — "warm gloves for the slope" → `{ domain: ski, product: gloves, intent:
-   slope }`; `sil_profile_search` finds no ski domain → a MISS.
-2. **Method** — research ski gear, **mint** via `sil_learn create`, **announced** ("I read this
-   as *ski gloves for the slope* — correct me if not").
-3. **Fill** — the method resolves waterproofing + cuff length; the wool allergy is **reused**
+   slope }`. The domain is the **broad category** (`ski`, not `ski-slope-gloves`), so a later
+   "ski goggles" reuses this method. `sil_profile_search` finds no ski domain → a MISS.
+2. **Method** — research ski gear, then **mint the general buying guide** via `sil_learn create`
+   (`target: method`, domain `ski`): a `## How it's bought` section + a coined `## Search
+   vocabulary` (e.g. `product.waterproof_rating`, `product.insulation_g`) — **dimensions, never
+   this buyer's values**. **Announced** ("I read this as *ski gloves for the slope*").
+3. **Fill** — the method's dimensions resolve from stored state; the wool allergy is **reused**
    from the shared `user_spec` **without re-asking**; only the budget is elicited (one question,
-   tied to why).
-4. **Search-space** — a bounded fan-out of ≤ 4 `sil_search` calls, core first.
+   tied to why). The resolved values are authored into the PRD's **`## Search specs`** block —
+   e.g. `{ns:product, key:waterproof_rating, op:gte, value:10000, unit:mm, hard:true}` — and
+   persisted with `sil_learn create` (`target: prd`, `ski/gloves-slope`).
+4. **Search-space** — **project** the PRD's `## Search specs` block **verbatim** into a bounded
+   ≤ 4 `sil_search` fan-out, core first, deliberate widenings after.
 5. **Reflect** — honesty pass, then a **hero + one alternative**, each with a why.
-6. **Feedback** — "I always run Hestra" → confirm, persist a per-domain taste to the method via
-   `sil_learn`.
+6. **Feedback** — "I always run Hestra" → confirm, then **`sil_learn write`** the ski method with
+   a `## Durable taste` line folded in (a whole-doc reconcile, per-domain — not a stray bullet).
+
+### A correction, mid-session — the write-reconcile
+
+The buyer pushes back: "the €120 cap was just for today — my real ceiling is €90, and I don't
+care about touchscreen fingers." That **contradicts** two filled preferences and is a
+**standing** change, so reconcile the PRD with a single **`sil_learn write`**: read the current
+`ski/gloves-slope`, **rewrite** the budget predicate and drop the touchscreen one in place, and
+write the coherent whole back. No second, contradicting bullet is ever added — the PRD stays
+**one truth per dimension**, and the next search projects the corrected block.
 
 ## Niche B — an espresso grinder (same session, minted on the fly)
 
@@ -36,7 +51,8 @@ the one shopper handles it:
 
 1. **Classify** → `{ domain: espresso, product: grinder, intent: general }` (context-free →
    `general`).
-2. **Method** — a MISS again → research + **mint on the fly**, **announced**.
+2. **Method** — a MISS again → research + **mint the general method on the fly** (`create`),
+   **announced**.
 3. **Fill** — "ships to Berlin" is **reused across** niches from the shared `user_spec`, kept
    from the ski session. The Hestra taste, per-domain on the ski method, does **not** leak here.
 
@@ -45,5 +61,5 @@ Shared facts flow to both; per-domain taste stays isolated.
 ## The singleton edge
 
 "Set me up a second shopper" → the engine refuses: **a shopper already exists**. Steer to shop
-a new niche (mints a domain on the spot) or refine with `sil_learn` — never a second shopper.
-</content>
+a new niche (mints a domain on the spot) or refine an existing one with `sil_learn write` — never
+a second shopper.

--- a/sil-shopping/references/agent_creation_engine.md
+++ b/sil-shopping/references/agent_creation_engine.md
@@ -141,14 +141,14 @@ to mint/refresh domains; if defaults grant none, the bin reports `created` with 
 6. **Materialize the shared user spec** — `sil_profile_materialize { name, userSpec }`
    (singleton, no agentId) writes **`user_spec.md`** atomically, name in its
    frontmatter. **Setup-only: no domain, no method, no PRD.**
-7. **Attach skill + enable plugin + harden tools** (value-mode `config set
-   --strict-json`, the only mode the pinned `alpine/openclaw:2026.6.9` accepts):
-   `agents.list[<idx>].skills` ← `["sil"]`; `plugins.entries.sil.enabled` ← `true`;
-   **`agents.list[<idx>].tools.deny`** ← **`["exec","write","edit","apply_patch"]`** — a
-   per-agent **deny-list** removing the shell (`exec`) + filesystem mutators while
-   **keeping the sil tools + web**. A deny (not replacing the base tool set) is used
-   because per OpenClaw precedence it only *further-restricts* and can never strip the
-   sil grant.
+7. **Attach skill + enable plugin** (value-mode `config set --strict-json`, the only
+   mode the pinned `alpine/openclaw:2026.6.9` accepts):
+   `agents.list[<idx>].skills` ← `["sil-shopping"]`; `plugins.entries.sil.enabled` ←
+   `true`. **No per-agent `tools.deny`** — the shopper inherits the host default toolset.
+   An fs-mutator deny is inert while codex's own shell (surfaced as `bash`) stays open by
+   design: it reads the shopper's skill files and can write regardless. The shell stays
+   open (trusted single-operator posture); persistence is steered through the sil tools by
+   the skill, not enforced by tool policy.
 8. **Admit sil (plugin trust)** — the shipped **`sil-openclaw-allowlist`** helper
    additively merges the three trust surfaces (`plugins.allow` + `tools.alsoAllow` +
    `plugins.entries.sil`) — the only way to un-filter `sil_*` without clobbering a

--- a/sil-shopping/references/fill_and_feedback.md
+++ b/sil-shopping/references/fill_and_feedback.md
@@ -1,12 +1,13 @@
 ---
 name: fill-and-feedback
-description: Beat 3 (fill the PRD by precedence, multi-turn, hard-constraint dual-enforce, the persistence split) and Beat 6 (the reaction half — capture-gate, confirm-before-write, route-by-scope), plus sil_learn, the one target+change write verb. Load when eliciting requirements or capturing what a reaction surfaced.
+description: Beat 3 (fill the PRD by precedence, multi-turn, author the Search specs block, hard-constraint dual-enforce, the persistence split) and Beat 6 (the reaction half — capture-gate, confirm-before-write, route-by-scope), plus sil_learn, the one target+change write verb (create | write | attach-asset). Load when eliciting requirements or capturing what a reaction surfaced.
 ---
 
 # Beat 3 (Fill) and Beat 6 (Feedback) — via `sil_learn`
 
 Beats 1–2 hand off the resolved PRD + method body. Beat 3 fills it; Beat 6 captures
-what the reaction surfaces — both persist through **`sil_learn`**.
+what the reaction surfaces — both persist through **`sil_learn write`** (the whole
+reconciled doc, never a stacked bullet).
 
 ## Beat 3 — Fill by precedence
 
@@ -24,27 +25,37 @@ Pursue each until **resolved** or explicitly **declined**, then search. Each tur
 **a few at a time, never a battery**, each tied to **why**, playing the filled
 understanding back.
 
+**Author the `## Search specs` block.** As dimensions resolve, project each into a
+`{ ns, key, op, value, unit?, hard? }` predicate (keys from the method's `## Search
+vocabulary`) — the block Beat 4 sends verbatim. A **preferred-value-with-fallback**
+("prefer ear hooks, fins acceptable") is **one `op:in` set** over the acceptable
+values, **not** a hard `eq` on the favourite; the favourite is a **Beat-5 ranking**
+preference. Mark a predicate **`hard: true`** only when a miss must **reject at pick** —
+loose hard-marking empties result sets.
+
 **Live request vs a stored durable pref — ask, don't guess.** When the request
 contradicts a stored **durable** PRD preference, the request wins **this** search,
 but ask whether it is **one-off** or **standing**. "Just this once" → ephemeral, no
-write. "From now on" → a **standing** change: **amend** the stored preference.
-**Never silently overwrite** a standing preference.
+write. "From now on" → a **standing** change: **`write`** the reconciled PRD (the
+changed line rewritten in place). **Never silently overwrite** a standing preference.
 
-**Hard constraints are inviolable — dual-enforced.** `user_spec [hard]` + PRD hard
-requirements route to a real **filter** where one exists **and** to Beat 5's
-**reject-at-pick** check — because a `specs` predicate can read `applied:false`.
+**Hard constraints are inviolable — dual-enforced.** A `user_spec` `[hard]` line and a
+PRD `## Search specs` `hard:true` predicate route to a real **filter** where one exists
+**and** to Beat 5's **reject-at-pick** check — because a `specs` predicate can read
+`applied:false`.
 
 **The split — persist stated durable answers NOW.** Fill is the **first** of two
 persistence moments: a durable answer the buyer **stated** during elicitation is
-**written** to the PRD's *Filled preferences* **now** via `sil_learn` — so an
-abandoned session still recovers what was settled. What the buyer's **reaction**
-surfaces is **Beat 6's** write (the **reaction half**). One-off direction stays
+**written** into the PRD **now** — a `write` that folds it into `## Search specs` /
+`## Filled preferences` — so an abandoned session still recovers what was settled. What
+the buyer's **reaction** surfaces is **Beat 6's** write. One-off direction stays
 **ephemeral**, **never written** by either.
 
 **Decline never blocks.** A declined question narrows **quality**, never **access**
 — proceed on the best-defensible params and **state the assumption** ("assuming
 waterproofing, since it's for the slope"). Unresolved-and-declined dimensions land
-in the PRD's *Notes / open* so the next session recovers, not re-asks.
+in the PRD's **`## Notes / open`** so the next session recovers, not re-asks — a
+non-answer is a note, never a preference.
 
 ## Beat 6 — Feedback: the reaction half
 
@@ -64,23 +75,28 @@ reactions ask nothing.
 scope where it stays true**:
 
 - a cross-domain **fact** / **hard** constraint → **`user_spec`**;
-- a durable per-domain **taste** → the **method**;
-- a **this-job** preference → the **PRD**;
+- a durable per-domain **taste** → the **method** (`## Durable taste`);
+- a **this-job** preference or spec → the **PRD** (`## Filled preferences` /
+  `## Search specs`);
 - an **image** → **`attach-asset`** (per-domain).
 
-**Pick the kind.** New learning → **append**; a reaction contradicting a stored
-**soft** pref → **amend** (it **supersedes** — **never a stacked second bullet**); a
-withdrawal → **retract**.
+**Every write is a reconciled whole-doc `write`.** Read the target
+(`sil_profile_get`), fold the new signal into the coherent whole, and `sil_learn write`
+it back — a correction **rewrites** the line it changes, so the doc **never stacks a
+contradicting bullet**. There is no append/amend/retract; reconciliation is the only
+update path.
 
-**Re-scope = write-broader-then-retract-narrower.** When a reaction shows a stored
-fact is broader than where it lives, write it to the **broader** target and
-**retract** the narrower copy (two `sil_learn` calls). There is **no promote verb**.
+**Re-scope = write-broader-then-write-narrower.** When a reaction shows a stored fact
+is broader than where it lives, `write` it into the **broader** target and `write` the
+**narrower** one without the moved line (two `sil_learn write` calls). There is **no
+promote verb**.
 
 ## `sil_learn` — the one target + change write verb
 
 `sil_learn` is the single **target + change** verb owning the whole method/PRD
-lifecycle. `target` selects where the change lands (`user_spec` / `method` /
-`prd`); the **kind** selects the change. **Five kinds:** **create** (mint a whole
-method/PRD), **append**, **amend**, **retract**, **attach-asset** (persist image
-bytes, linked by path). Every capture is reviewable via `sil_profile_get` and
-erasable via `sil_profile_remove` — never silently harvested.
+lifecycle. `target` selects where the change lands (`user_spec` / `method` / `prd`);
+the **kind** selects the change. **Three kinds:** **create** (mint a NEW method/PRD —
+errors if one already exists), **write** (replace an existing doc's whole body with the
+reconciled version you author — read it first, carry every buyer line forward),
+**attach-asset** (persist image bytes, linked by path). Every capture is reviewable via
+`sil_profile_get` and erasable via `sil_profile_remove` — never silently harvested.

--- a/sil-shopping/references/method_and_prds.md
+++ b/sil-shopping/references/method_and_prds.md
@@ -1,6 +1,6 @@
 ---
 name: method-and-prds
-description: Beat 2 of the loop — load, mint or signal-refresh a domain's method — plus the intent-keyed PRD model, the frontmatter-as-truth store, and discovery/manage via sil_profile_search / sil_profile_get / sil_profile_remove. Load when resolving a domain's method or managing what the shopper knows.
+description: Beat 2 of the loop — load, mint or signal-refresh a domain's method — plus the intent-keyed PRD model, the method/PRD templates, the frontmatter-as-truth store, and discovery/manage via sil_profile_search / sil_profile_get / sil_profile_remove. Load when resolving a domain's method or managing what the shopper knows.
 ---
 
 # Beat 2 — the domain method, intent-keyed PRDs, and the store
@@ -23,14 +23,27 @@ on the web **freely and often** to learn how it is *really* bought: its load-bea
 attributes, its failure modes, what separates a good buy from a bad one. The one
 boundary — you research the **domain** (how it's bought), you **never source products**
 from the web; every pick comes only from `sil_search` in Beat 4.
-Draft the buying guide + the buyer's durable per-domain taste (seeded from
-`user_spec`) + the whole-domain **spec vocabulary** you **coin** from the research
-(`ns.key` + data type + unit + why-it-matters) + a **volatility marker** (the
-volatile axis + rough cadence). Persist with **`sil_learn create`** (`target:
-"method"`, domain + name + body) — the file **is** the registration. Never the
-**setup-only** `sil_profile_materialize` (which writes only the shared
-`user_spec.md` and mints no domain). Then **announce** the inferred domain so the
-buyer can correct it.
+
+**The method is GENERAL — the whole product category, reusable across every intent.**
+It holds *how the category is bought* and the *dimensions* that decide a buy — **never
+this buyer's values** (those are the PRD). Mint at the **broadest slug whose buying
+guide generalises**: `earbuds` serves gym, commute, and office; the gym specifics live
+in the gym PRD, not a `wireless-gym-earbuds` method. Folding the use-context into the
+domain forks a near-duplicate method per intent and kills reuse.
+
+Persist with **`sil_learn create`** (`target: "method"`, domain + name + body) — the
+file **is** the registration (it errors if the method already exists: a revisit LOADs,
+a stale one REFRESHes with `write`). Never the setup-only `sil_profile_materialize`.
+Then **announce** the inferred domain so the buyer can correct it. The method body
+carries these sections, and only these:
+
+- **`## How it's bought`** — the buying guide: load-bearing attributes, failure modes,
+  what separates a good buy from a bad one — general to the category, not this buyer.
+- **`## Search vocabulary`** — the spec **dimensions** you coin (`ns.key` + `data_type`
+  + unit + `allowed_values` + why-it-matters) — names only, **no values**.
+- **`## Durable taste`** — the buyer's cross-intent per-domain taste, seeded from
+  `user_spec` (omit until something durable is known).
+- **`## Volatility`** — the volatile axis + a rough refresh cadence.
 
 The vocabulary is **canonicalized before persist**. `sil_specs` is
 **precision-first** — two specs converge only when **every field** agrees within the
@@ -54,9 +67,9 @@ specs that never match. So coin for the match:
 Submit the definitions to **`sil_specs`** (dedupe-or-create) and adopt the returned
 **canonical** `ns.key`: **`matched`** → an equivalent exists, **drop your synonym for
 the canonical**; **`created`** → yours is novel and canonical going forward (keep it).
-Rewrite the `## Search vocabulary` and any PRD `specs` predicates to those names
-before persisting — the method is **born canonical**, never write-then-amend. This is
-what makes `filters.specs` filter across methods; naming is never a gate — a
+Rewrite the `## Search vocabulary` and any PRD `## Search specs` predicates to those
+names before persisting — the method is **born canonical**, never write-then-fix. This
+is what makes `filters.specs` filter across methods; naming is never a gate — a
 fragmenting name costs precision, never blocks a search. If `sil_specs` is **not
 `ok`** (a registry blip), **do not block the mint**: persist the **raw coined names**
 (every predicate reads `applied:false`) and shop on — convergence retries next
@@ -70,11 +83,11 @@ every revisit. The three signals: the buyer **contradicts** the guide, the
 **volatility marker** is overdue, or the buyer **explicitly asks**. Signal-driven,
 not a clock.
 
-Refresh is **create-with-merge**: load the current method, re-research **only** the
-stale volatile material, **carry every buyer-authored line forward verbatim**,
-re-emit the whole body via `sil_learn create` (overwrite), announce the delta. The
-merge rewrites stale *research* claims and **never clobbers** a buyer `sil_learn`
-edit. The method stays fully buyer-mutable via `sil_learn` append/amend/retract.
+Refresh is a **reconciled `write`**: load the current method, re-research **only** the
+stale volatile material, **carry every buyer-authored line forward verbatim**, and
+`sil_learn write` (`target: "method"`) the whole reconciled body — announce the delta.
+The rewrite supersedes stale *research* claims and **never clobbers** a buyer line. The
+method stays fully buyer-mutable — every edit is a `write` of the reconciled whole.
 
 Canonicalize any **newly-coined** specs via `sil_specs` before persisting — same
 convergence discipline (reuse a name already coined for the concept; take the
@@ -84,12 +97,30 @@ carrying a canonical name (already-canonical names are stable).
 ## Intent-keyed PRDs
 
 A PRD's identity is the **job-to-be-done**, keyed by three coordinates so it stays
-queryable: `{ domain, product, intent }` → `ski/gloves-slope` (intent always
-present; a context-free request keys `general`). It holds the method's requirements
-**specialized to this job** plus the buyer's **durable** filled preferences (the
-per-job slice; the per-domain durable taste lives in the method). PRDs are
-**durable** and **revisitable** — re-buying the same thing, or resuming an
-unfinished session, **recovers** the PRD, never rebuilds it.
+queryable: `{ domain, product, intent }` → `ski/gloves-slope` (intent always present;
+a context-free request keys `general`). It holds the method's dimensions **resolved to
+this job** — the buyer's actual values — **specialized, never a copy of the method's
+guide**. PRDs are **durable** and **revisitable** — re-buying the same thing, or
+resuming an unfinished session, **recovers** the PRD, never rebuilds it. The PRD body
+carries these sections:
+
+- **`## Search specs`** — the load-bearing block: the **resolved predicate set**, a
+  list of `{ ns, key, op, value, unit?, hard? }` entries **projected verbatim** into
+  `sil_search`'s `filters.specs` at Beat 4 (one entry per decided dimension, keys drawn
+  from the method's `## Search vocabulary`). A *"prefer X, Y/Z acceptable"* requirement
+  is **one `op:in` set** over `{X, Y, Z}` — mark it `hard` only when a miss must
+  reject-at-pick — with the X-preference applied as **Beat-5 ranking**, **never** a hard
+  `eq` on X alone (that rejects the acceptable alternatives and empties the set).
+- **`## Filled preferences`** — the buyer's stated durable answers, reconciled: **one
+  truth per dimension**. A correction **rewrites** the line it changes; it never adds a
+  second, contradicting one.
+- **`## Notes / open`** — declined or unresolved dimensions, so the next session
+  recovers rather than re-asks. A **non-answer** ("no budget stated") lives here,
+  **never** as a preference.
+
+Every PRD write is a whole-body **`sil_learn write`** (or **`create`** for the first
+mint): read the current PRD, reconcile in context, write the coherent whole — so the
+`## Search specs` block and `## Filled preferences` never drift apart or self-contradict.
 
 ## The store — frontmatter-as-truth (no manifest)
 
@@ -105,7 +136,8 @@ skipped and surfaced as `unreadable`, never half-read.
   their PRDs. The frontmatter-as-truth query, **not a manifest** and not a
   filesystem guess. The no-filter call is the "what does my shopper know?" overview.
 - **Read one body** with **`sil_profile_get`** — `domainSlug` for the method body,
-  `+prd` for that PRD's body.
+  `+prd` for that PRD's body. **Read before every `write`** — reconcile from the real
+  current body, never from memory.
 - **Remove** with **`sil_profile_remove`** — `domainSlug` alone removes the **whole
   domain** subtree; `+prd` removes **just that PRD** (method + siblings survive).
   Destructive: **confirm** with the buyer first.

--- a/sil-shopping/references/shop_loop.md
+++ b/sil-shopping/references/shop_loop.md
@@ -24,11 +24,21 @@ This file owns Beats 1, 4 and 5.
 
 ## Beat 1 — Classify: `{domain, product, intent}`, reuse before mint
 
-Resolve the request through **three coordinates, top-down**: the **domain** (the
-niche that owns the method), the **product** type within it, and the **intent**
-(the use-context that reshapes the requirements). **Intent is always present**: a
-**context-free** request keys the `general` intent (`ski/boots-general`), so every
-job carries all three coordinates and stays uniformly queryable.
+Resolve the request through **three coordinates, top-down**:
+
+- **domain** — the **broad product category** that owns the reusable buying guide.
+  Pick the **widest** slug whose method generalises across use-contexts: `earbuds`,
+  not `wireless-gym-earbuds`; `ski`, not `ski-touring`.
+- **product** — the product type within the domain (`earbuds`, `boots`).
+- **intent** — the **use-context** that reshapes the requirements (`gym`, `slope`).
+
+**Never fold the use-context into the domain.** "Earbuds for the gym" is
+`domain: earbuds, product: earbuds, intent: gym` — the gym-ness is the **intent**, so
+next week's "earbuds for the office" reuses the same method and only mints a new PRD. A
+`wireless-gym-earbuds` domain forks a near-duplicate buying guide per use and kills that
+reuse. **Intent is always present**: a **context-free** request keys the `general`
+intent (`ski/boots-general`), so every job carries all three coordinates and stays
+uniformly queryable.
 
 **Reuse-before-mint.** Query existing coordinates with **`sil_profile_search`**
 (the frontmatter-as-truth discovery tool — never a filesystem guess) and
@@ -48,37 +58,32 @@ silent**. A reuse passes through unannounced.
 
 ## Beat 4 — Search-space: a bounded, priority-ordered fan-out (not a re-rank)
 
-Project the filled PRD onto **`sil_search`** as a **bounded ≤ 4 priority-ordered**
-fan-out — not one search, not unbounded (the bound is a production budget: each
-call is a round-trip + tokens):
+The PRD's **`## Search specs`** block is the resolved predicate set — Beat 4 **projects
+it, never re-derives it**. Send those `{ns, key, op, value, unit?, hard?}` predicates
+**verbatim** as `sil_search`'s `filters.specs`; the only per-call work is choosing the
+fan-out and lifting any attribute a **dedicated param** serves better.
 
-- **Call 1 is the tightest projection of the PRD's core** (its load-bearing
-  requirements); **calls 2–4 are deliberate widenings** — relax the least
-  load-bearing requirement, an adjacent phrasing that lifts recall, or an explicit
-  either/or branch. **Core first, widenings after** — the **priority order**.
+Project the filled PRD onto **`sil_search`** as a **bounded ≤ 4 priority-ordered**
+fan-out — not one search, not unbounded (the bound is a production budget: each call is
+a round-trip + tokens):
+
+- **Call 1 is the tightest projection** — the full `## Search specs` set. **Calls 2–4
+  are deliberate widenings**: relax the least load-bearing **soft** predicate, an
+  adjacent phrasing that lifts recall, or an explicit either/or branch. **Never relax a
+  `hard` predicate.** Core first, widenings after — the **priority order**.
 - **Merge = dedup + concatenate in issue order — NOT a re-rank.** Concatenate the
   per-call backend-ranked lists in issue order and **drop** any product already
-  **seen** earlier. Because issue order *is* priority order, this **never
-  re-ranks** — the engine owns order *within* a call, the fan-out *across* calls.
-- **Project each requirement onto the tightest real channel, in this order:**
-  1. an **existing** `sil_search` **param** where one fits (`category`,
-     `price_min`/`price_max`, `condition`, `available`, `local_merchants`);
-  2. else a **`filters.specs` predicate**, built from the method's Beat-2 canonical
-     `## Search vocabulary` (the `sil_specs`-coined names) — one `{ns, key, op,
-     value, unit?, hard?}` per annotated requirement, marking an inviolable one
-     `hard:true`. **Prefer a dedicated param over a predicate** for the SAME
-     attribute — never both (a `price_max` param OR a price spec);
-  3. else a purely descriptive residue (a colour, a phrasing) — fold it into the
-     free-text `query`, which **you author yourself**. The plugin is **pure
-     transport**: it never folds a predicate into `query`, so a requirement that
-     belongs in `filters.specs` stays a predicate, never `query` prose.
-  Leave **`ship_to`** empty (the server resolves the registered default). **Never
-  invent** a param or predicate that isn't real — the real `sil_search` params live in
-  its tool description, the predicate vocabulary in the domain method. Then read the
-  per-predicate **`specs_status`** the response returns (each `{ns, key, applied}`) — it
-  feeds
-  Beat 5's honesty pass, which rejects at pick any `hard` predicate the backend left
-  `applied:false`.
+  **seen** earlier. Because issue order *is* priority order, this **never re-ranks** —
+  the engine owns order *within* a call, the fan-out *across* calls.
+- **Prefer a dedicated param over a predicate** for the SAME attribute — a `price_max`
+  param OR a price spec, never both; likewise `category`, `condition`, `available`,
+  `local_merchants`. A purely descriptive residue (a colour, a phrasing) folds into the
+  free-text `query`, which **you author** — the plugin is **pure transport** and never
+  folds a predicate into `query`. Leave **`ship_to`** empty (the server resolves the
+  registered default); **never invent** a param or predicate that isn't real. Then read
+  the per-predicate **`specs_status`** the response returns (each `{ns, key, applied}`) —
+  it feeds Beat 5's honesty pass, which rejects at pick any `hard` predicate the backend
+  left `applied:false`.
 
 ## Beat 5 — Reflect: honesty pass first, judgment not threshold, propose-and-wait
 

--- a/src/__tests__/create-shopper.integration.test.ts
+++ b/src/__tests__/create-shopper.integration.test.ts
@@ -97,14 +97,6 @@ const SIL_SKILL = basename(
     ) as { skills: string[] }
   ).skills[0]!,
 );
-/** The escape-hatch tools the shopper is DENIED at the per-agent level — the shell
- * (`exec`) + the filesystem mutators (`write`/`edit`/`apply_patch`). `deny` is the
- * SAFE subtractive lever: per the host's tool-precedence it only further-restricts and
- * can never re-grant, so it removes exactly these and CANNOT strip the sil grant —
- * unlike a `tools.profile` override, which replaces the base set and would risk it.
- * This is the SPEC: the create bin MUST pin the created agent to exactly this deny list
- * and set NO `tools.profile` override. */
-const SHOPPER_TOOL_DENY = ["exec", "write", "edit", "apply_patch"];
 /** Running as root bypasses filesystem permission bits, so the chmod-based
  * "unwritable $SIL_DATA_DIR" fault-injection cannot fire — skip it there. */
 const AS_ROOT = typeof process.getuid === "function" && process.getuid() === 0;
@@ -579,31 +571,28 @@ describe("created — one valid run wires every surface and returns the identity
     expect(agent.skills).toEqual([SIL_SKILL]);
   });
 
-  it("denies the created agent the escape-hatch tools via a per-agent tools.deny (subtractive), with NO tools.profile override", () => {
+  it("sets NO per-agent tools policy on the shopper — it inherits the host defaults (no deny, no profile override)", () => {
     writeConfig(freshConfig());
     const spec = validSpec();
     const r = runBin({ spec });
     expect(r.status).toBe(0);
 
     const c = readConfig();
-    // The shopper is leaned down SUBTRACTIVELY — a per-agent tools.deny removes the
-    // shell + filesystem mutators. Because deny only further-restricts (never re-grants),
-    // it can never strip the sil grant. Locate the agent by id (mirrors the skills
-    // read-back above).
+    // The shopper inherits the host's default toolset untouched. There is NO per-agent
+    // tools.deny (an fs-mutator deny is inert while codex's own shell stays open, by
+    // design — it reads the shopper's skill files and writes regardless) and NO
+    // tools.profile override — only the sil skill is attached to the agent entry.
     const idx = c.agents.list.findIndex((a: any) => a.id === spec.agentId);
     expect(idx).toBeGreaterThanOrEqual(0);
-    expect(c.agents.list[idx].tools.deny).toEqual(SHOPPER_TOOL_DENY);
-    // NO profile override — a tools.profile would REPLACE the base set and risk the sil
-    // grant, so the safe subtractive path must set the deny lever and nothing else.
-    expect(c.agents.list[idx].tools.profile).toBeUndefined();
-    // The global default is untouched (freshConfig ships `coding`) — only the shopper
-    // agent is leaned down, subtractively, not the whole host.
+    expect(c.agents.list[idx].tools?.deny).toBeUndefined();
+    expect(c.agents.list[idx].tools?.profile).toBeUndefined();
+    // The global default is untouched (freshConfig ships `coding`).
     expect(c.tools.profile).toBe("coding");
   });
 
   it("carries an EMPTY warnings array when the channel binds cleanly (no manual-bind hint)", () => {
     // With a resolvable channel that binds + verifies, the manual-bind hint is absent —
-    // the subtractive tools.deny is the intended end state, so it rides no warning.
+    // a clean bind is the happy path, so it rides no warning.
     writeConfig(freshConfig());
     const r = runBin({ spec: validSpec({ channel: "telegram" }) });
     expect(r.status).toBe(0);

--- a/src/__tests__/manifest-contract.integration.test.ts
+++ b/src/__tests__/manifest-contract.integration.test.ts
@@ -223,8 +223,8 @@ describe("manifest ↔ code drift guard (set-equality, BOTH directions)", () => 
 
   it("sil_learn is BOTH registered by register() and declared in contracts.tools", () => {
     // The spec-driven-shopping-redesign card's target+change feedback verb — the
-    // single write tool for the whole method/PRD lifecycle (create + append/amend/
-    // retract/attach-asset), replacing sil_remember. Added to the existing
+    // single write tool for the whole method/PRD lifecycle (create + write +
+    // attach-asset), replacing sil_remember. Added to the existing
     // registerProfileTools group (no new group, no src/index.ts change), so it is
     // auto-picked-up by codeRegisteredNames. The load-bearing 3rd "add a tool"
     // step: it MUST also be listed in openclaw.plugin.json#contracts.tools — a

--- a/src/__tests__/tools/profile-sds.test.ts
+++ b/src/__tests__/tools/profile-sds.test.ts
@@ -15,8 +15,8 @@
  *     does NOT write a manifest.
  *   - `sil_learn { target, domain?, prd?, kind, … }` — the single target+change verb
  *     owning the whole method/PRD lifecycle: `create` mints a whole method/PRD;
- *     `append`/`amend`/`retract` refine in place; `attach-asset` persists image bytes.
- *     REPLACES the deleted `sil_remember` (delete, not alias).
+ *     `write` replaces an EXISTING doc's whole body (reconciled, never stacked);
+ *     `attach-asset` persists image bytes. REPLACES the deleted `sil_remember`.
  *   - `sil_profile_search { domain?, product?, intent?, query? }` — NEW: query artefact
  *     FRONTMATTER (coordinates only, no bodies) — the discovery / reuse-before-mint
  *     primitive that replaces the manifest's index role. Malformed frontmatter is
@@ -90,6 +90,20 @@ function modeBits(path: string): number {
 function walkShopper(): string[] {
   if (!existsSync(shopperDir())) return [];
   return readdirSync(shopperDir(), { recursive: true }) as string[];
+}
+
+/** A sentinel `updated_at`/`created_at` older than any real `new Date()` — so a
+ * subsequent `write`'s timestamp bump (and `created_at` preservation) is
+ * DETERMINISTIC, never a wall-clock race between two sub-millisecond tool calls. */
+const OLD_TS = "2000-01-01T00:00:00.000Z";
+
+/** Backdate an on-disk artefact's timestamps to `OLD_TS` so a following `write` can
+ * prove it moved `updated_at` forward (and left `created_at` frozen). */
+function backdate(path: string): void {
+  const patched = readFileSync(path, "utf8")
+    .replace(/updated_at:.*/g, "updated_at: " + OLD_TS)
+    .replace(/created_at:.*/g, "created_at: " + OLD_TS);
+  writeFileSync(path, patched, { mode: 0o600 });
 }
 
 const USER_SPEC = "# The person\n- Ships to Berlin.\n- HARD-NO: leather.";
@@ -271,220 +285,233 @@ describe("sil_learn create — mints method + PRD into the frontmatter-as-truth 
     expect(existsSync(join(shopperDir(), "domains"))).toBe(false);
   });
 
-  it("a method change bumps the file's own frontmatter (no manifest) — updated_at present, frontmatter intact after append", async () => {
+  it("create REFUSES to clobber an existing method (create only mints) → invalid_request (field kind), on-disk body unchanged", async () => {
     const methodPath = await seedSkiMethod();
     const before = readFileSync(methodPath, "utf8");
-    expect(before).toMatch(/updated_at:/);
-    await getTool(api, LEARN).execute("b1", {
+    const payload = payloadOf(
+      await getTool(api, LEARN).execute("ce1", {
+        target: "method",
+        domain: "ski",
+        kind: "create",
+        name: "Ski",
+        body: "# a WHOLLY different guide that must NOT land\n",
+      }),
+    );
+    expect(payload["status"]).toBe("invalid_request");
+    // The error points the model at kind:write (the only path that overwrites).
+    expect(payload["field"]).toBe("kind");
+    // Nothing was clobbered — the seeded method is byte-for-byte intact.
+    expect(readFileSync(methodPath, "utf8")).toBe(before);
+  });
+
+  it("create REFUSES to clobber an existing PRD → invalid_request (field kind), on-disk body unchanged", async () => {
+    await getTool(api, MATERIALIZE).execute("cp0", { name: "sil shopper", userSpec: USER_SPEC });
+    await getTool(api, LEARN).execute("cp1", {
       target: "method",
       domain: "ski",
-      kind: "append",
-      section: "Taste & stance",
-      text: "Budget under 200.",
+      kind: "create",
+      name: "Ski",
+      body: "#g",
     });
-    const after = readFileSync(methodPath, "utf8");
-    expect(after.startsWith("---")).toBe(true);
-    expect(after).toMatch(/updated_at:/);
-    expect(after).toContain("Budget under 200.");
+    const prdCoords = {
+      target: "prd" as const,
+      domain: "ski",
+      prd: "gloves-slope",
+      product: "gloves",
+      intent: "slope",
+      title: "G",
+      kind: "create" as const,
+    };
+    const first = payloadOf(
+      await getTool(api, LEARN).execute("cp2", { ...prdCoords, body: "## Requirements\n- original\n" }),
+    );
+    expect(first["status"]).toBe("ok");
+    const prdPath = join(domainDir("ski"), "prds", "gloves-slope.md");
+    const before = readFileSync(prdPath, "utf8");
+    const second = payloadOf(
+      await getTool(api, LEARN).execute("cp3", { ...prdCoords, body: "## Requirements\n- DIFFERENT\n" }),
+    );
+    expect(second["status"]).toBe("invalid_request");
+    expect(second["field"]).toBe("kind");
+    expect(readFileSync(prdPath, "utf8")).toBe(before);
+  });
+
+  it("strips a model-authored leading frontmatter block from a create body — never stacks two blocks", async () => {
+    // A model sometimes prepends its OWN `--- … ---` to the body. The store owns
+    // frontmatter (frontmatter-as-truth), so serialization must strip it and emit
+    // exactly one block (the store's coordinates), never two stacked.
+    await getTool(api, MATERIALIZE).execute("fm0", { name: "sil shopper", userSpec: USER_SPEC });
+    const bodyWithFm =
+      "---\nnote: MODEL-AUTHORED-FRONTMATTER\ntitle: not the real title\n---\n" +
+      "# Buying guide\n\nStability first, then sound.\n";
+    const payload = payloadOf(
+      await getTool(api, LEARN).execute("fm1", {
+        target: "method",
+        domain: "running",
+        name: "running shoes",
+        kind: "create",
+        body: bodyWithFm,
+      }),
+    );
+    expect(payload["status"]).toBe("ok"); // create succeeded
+    const raw = readFileSync(join(domainDir("running"), "method.md"), "utf8");
+    // Exactly one frontmatter block: the file opens with the store's fence, and after its
+    // close fence the body begins with the real content — NOT a second `---` fence.
+    expect(raw.startsWith("---")).toBe(true);
+    const afterOpen = raw.slice(3);
+    const close = afterOpen.match(/\n---[ \t]*\r?\n/)!;
+    const body = afterOpen.slice(close.index! + close[0].length);
+    expect(body.startsWith("# Buying guide")).toBe(true);
+    // The model's stray frontmatter content is gone entirely (stripped, not embedded).
+    expect(raw).not.toContain("MODEL-AUTHORED-FRONTMATTER");
+    // The store's own coordinates ARE present in the single frontmatter block.
+    expect(raw).toContain("domain: running");
+    expect(raw).toContain("name: running shoes");
   });
 });
 
 /* ===========================================================================
- * sil_learn append / amend / retract — section-aware, single-match, fail-closed.
+ * sil_learn write — replace an EXISTING doc's WHOLE body with a reconciled version
+ * (the model reads current, reconciles in context, writes the whole doc back). No
+ * append/amend/retract: a correction can never stack a contradicting line. Coordinates
+ * + created_at are preserved and updated_at bumps (user_spec carries no timestamp).
+ * Fail-closed: not_found on an absent target (write never mints), unreadable on a
+ * present-but-corrupt one (never clobbers a recoverable artefact).
  * ========================================================================= */
-describe("sil_learn append / amend / retract — refine in place, fail-closed", () => {
-  it("append under a NAMED section adds a bullet; a missing section fails closed (invalid_request), never at EOF-by-accident", async () => {
-    await seedSkiMethod();
-    const ok = payloadOf(
-      await getTool(api, LEARN).execute("a1", {
-        target: "method",
-        domain: "ski",
-        kind: "append",
-        section: "Taste & stance",
-        text: "Shimano over SRAM.",
-      }),
-    );
-    expect(ok["status"]).toBe("ok");
-    expect(readFileSync(join(domainDir("ski"), "method.md"), "utf8")).toContain("Shimano over SRAM.");
-
-    const bad = payloadOf(
-      await getTool(api, LEARN).execute("a2", {
-        target: "method",
-        domain: "ski",
-        kind: "append",
-        section: "No Such Heading",
-        text: "orphan",
-      }),
-    );
-    expect(bad["status"]).toBe("invalid_request");
-  });
-
-  it("append/amend/retract require the target to already exist → not_found (never resurrects a seed-less doc)", async () => {
-    await getTool(api, MATERIALIZE).execute("n0", { name: "sil shopper", userSpec: USER_SPEC });
-    for (const kind of ["append", "amend", "retract"] as const) {
-      const payload = payloadOf(
-        await getTool(api, LEARN).execute("n1", {
-          target: "method",
-          domain: "never-minted",
-          kind,
-          text: "x",
-          from: "x",
-          to: "y",
-        }),
-      );
-      expect(payload["status"]).toBe("not_found");
-    }
-  });
-
-  it("amend replaces a single-occurrence match; an ambiguous (2+) match is invalid_request, not a silent multi-write", async () => {
+describe("sil_learn write — reconcile an existing doc's whole body, no stacking", () => {
+  it("write method REPLACES the whole body (old content GONE — reconciled, not stacked); domain/name preserved; updated_at bumped", async () => {
     const methodPath = await seedSkiMethod();
-    // Two identical bullets → an amend `from` that matches both must refuse.
-    await getTool(api, LEARN).execute("am0", {
-      target: "method", domain: "ski", kind: "append", section: "Taste & stance", text: "dup line",
-    });
-    await getTool(api, LEARN).execute("am1", {
-      target: "method", domain: "ski", kind: "append", section: "Taste & stance", text: "dup line",
-    });
-    const ambiguous = payloadOf(
-      await getTool(api, LEARN).execute("am2", {
-        target: "method", domain: "ski", kind: "amend", from: "dup line", to: "changed",
+    // Backdate so the bump is provable against a fixed sentinel (no wall-clock race).
+    backdate(methodPath);
+    const newBody = "# Buying guide — ski (rebuilt)\n\n## Fresh stance\n- Only current-year models.\n";
+    const payload = payloadOf(
+      await getTool(api, LEARN).execute("w1", {
+        target: "method",
+        domain: "ski",
+        kind: "write",
+        body: newBody,
       }),
     );
-    expect(ambiguous["status"]).toBe("invalid_request");
-    // The doc pins the ambiguous-match discriminant.
-    expect(JSON.stringify(ambiguous)).toContain("ambiguous");
-
-    // A unique match amends cleanly.
-    const unique = payloadOf(
-      await getTool(api, LEARN).execute("am3", {
-        target: "method", domain: "ski", kind: "amend", from: "Prefer last-year models.", to: "Prefer current-year models.",
-      }),
-    );
-    expect(unique["status"]).toBe("ok");
+    expect(payload["status"]).toBe("ok");
+    expect(payload["kind"]).toBe("write");
     const raw = readFileSync(methodPath, "utf8");
-    expect(raw).toContain("Prefer current-year models.");
+    // Reconciliation, not accretion: the seeded line is GONE, the new body is in.
     expect(raw).not.toContain("Prefer last-year models.");
+    expect(raw).toContain("Only current-year models.");
+    // Coordinates survive the whole-body rewrite.
+    expect(raw).toMatch(/domain:\s*ski/);
+    expect(raw).toMatch(/name:\s*Ski/);
+    // updated_at moved OFF the backdated sentinel to a real, strictly-newer stamp.
+    expect(raw).not.toContain(OLD_TS);
+    const updatedAt = raw.match(/updated_at:\s*(\S+)/)![1]!;
+    expect(updatedAt > OLD_TS).toBe(true);
   });
 
-  it("`hard` is valid only on append to user_spec / prd — rejected on a method target (category error)", async () => {
-    await seedSkiMethod();
+  it("write prd replaces the body; {key,product,intent,title,domain,created_at} preserved; updated_at bumped", async () => {
+    await getTool(api, MATERIALIZE).execute("wp0", { name: "sil shopper", userSpec: USER_SPEC });
+    await getTool(api, LEARN).execute("wp1", {
+      target: "method", domain: "ski", kind: "create", name: "Ski", body: "#g",
+    });
+    await getTool(api, LEARN).execute("wp2", {
+      target: "prd", domain: "ski", prd: "gloves-slope", product: "gloves", intent: "slope",
+      title: "Ski gloves for the slope", kind: "create", body: "## Requirements\n- original waterproofing\n",
+    });
+    const prdPath = join(domainDir("ski"), "prds", "gloves-slope.md");
+    backdate(prdPath);
     const payload = payloadOf(
-      await getTool(api, LEARN).execute("h1", {
-        target: "method",
-        domain: "ski",
-        kind: "append",
-        section: "Taste & stance",
-        text: "never leather",
-        hard: true,
+      await getTool(api, LEARN).execute("wp3", {
+        target: "prd", domain: "ski", prd: "gloves-slope", kind: "write",
+        body: "## Requirements\n- rebuilt: insulation over waterproofing\n",
       }),
     );
-    expect(payload["status"]).toBe("invalid_request");
+    expect(payload["status"]).toBe("ok");
+    expect(payload["kind"]).toBe("write");
+    const raw = readFileSync(prdPath, "utf8");
+    expect(raw).not.toContain("original waterproofing");
+    expect(raw).toContain("rebuilt: insulation over waterproofing");
+    // Every PRD coordinate survives.
+    expect(raw).toMatch(/key:\s*gloves-slope/);
+    expect(raw).toMatch(/product:\s*gloves/);
+    expect(raw).toMatch(/intent:\s*slope/);
+    expect(raw).toMatch(/title:\s*Ski gloves for the slope/);
+    expect(raw).toMatch(/domain:\s*ski/);
+    // created_at is FROZEN at the seed; only updated_at moves forward.
+    expect(raw).toContain("created_at: " + OLD_TS);
+    const updatedAt = raw.match(/updated_at:\s*(\S+)/)![1]!;
+    expect(updatedAt > OLD_TS).toBe(true);
   });
 
-  it("`hard` append to user_spec writes the [hard] marker the reject-at-pick rule greps", async () => {
-    await getTool(api, MATERIALIZE).execute("h2", { name: "sil shopper", userSpec: USER_SPEC });
+  it("write user_spec replaces the body (old GONE, new in); the shopper `name` frontmatter is preserved; no updated_at is added", async () => {
+    await getTool(api, MATERIALIZE).execute("wu0", { name: "sil shopper", userSpec: USER_SPEC });
+    const userSpecPath = join(shopperDir(), "user_spec.md");
     const payload = payloadOf(
-      await getTool(api, LEARN).execute("h3", {
+      await getTool(api, LEARN).execute("wu1", {
         target: "user_spec",
-        kind: "append",
-        text: "allergic to wool",
-        hard: true,
+        kind: "write",
+        body: "# The person (rebuilt)\n- Ships to Munich now.\n",
       }),
     );
     expect(payload["status"]).toBe("ok");
-    expect(readFileSync(join(shopperDir(), "user_spec.md"), "utf8")).toContain("[hard]");
+    expect(payload["kind"]).toBe("write");
+    const raw = readFileSync(userSpecPath, "utf8");
+    expect(raw).not.toContain("Ships to Berlin");
+    expect(raw).toContain("Ships to Munich now.");
+    // The name in frontmatter is carried across the rewrite.
+    expect(raw).toMatch(/name:\s*sil shopper/);
+    // user_spec carries no timestamp — only method/prd do.
+    expect(raw).not.toContain("updated_at");
   });
-});
 
-/* ===========================================================================
- * GAP 1 — `hard:true` is REJECTED loudly on EVERY non-append kind (create /
- * amend / retract / attach-asset), never silently dropped. One top-level guard
- * in `learnArtefact` (subsuming the deleted method-only `rejectHardMisuse`) fires
- * BEFORE the kind switch, so `hard` wins error-precedence over per-kind field
- * checks and a hard-constraint promotion is never a silent no-op.
- * ========================================================================= */
-describe("sil_learn — hard:true is rejected on EVERY non-append kind (the silent drop is closed)", () => {
-  // A 1x1 transparent PNG (for the attach-asset kind).
-  const PNG_B64 =
-    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
-
-  it("amend + hard:true → invalid_request (field `hard`) and the PRD bullet stays SOFT — not a silent promotion", async () => {
-    await getTool(api, MATERIALIZE).execute("g1m", { name: "sil shopper", userSpec: USER_SPEC });
-    await getTool(api, LEARN).execute("g1a", {
-      target: "method", domain: "ski", kind: "create", name: "Ski", body: "#g",
-    });
-    await getTool(api, LEARN).execute("g1b", {
-      target: "prd", domain: "ski", prd: "gloves-slope", product: "gloves", intent: "slope", title: "G", kind: "create",
-      body: "## Requirements\n- gore-tex preferred\n",
-    });
-    const payload = payloadOf(
-      await getTool(api, LEARN).execute("g1c", {
-        target: "prd", domain: "ski", prd: "gloves-slope", kind: "amend",
-        from: "gore-tex preferred", to: "gore-tex required", hard: true,
+  it("write on an ABSENT method / PRD → not_found (write never mints — that is create); nothing is written as a side effect", async () => {
+    await getTool(api, MATERIALIZE).execute("wn0", { name: "sil shopper", userSpec: USER_SPEC });
+    const method = payloadOf(
+      await getTool(api, LEARN).execute("wn1", {
+        target: "method", domain: "never-minted", kind: "write", body: "# nope\n",
       }),
     );
-    expect(payload["status"]).toBe("invalid_request");
-    expect(payload["field"]).toBe("hard");
-    // Nothing written: the amend did NOT land and the soft pref was NOT promoted to hard.
-    const raw = readFileSync(join(domainDir("ski"), "prds", "gloves-slope.md"), "utf8");
-    expect(raw).toContain("gore-tex preferred");
-    expect(raw).not.toContain("gore-tex required");
-    expect(raw).not.toContain("[hard]");
-  });
+    expect(method["status"]).toBe("not_found");
+    expect(existsSync(join(domainDir("never-minted"), "method.md"))).toBe(false);
 
-  it("create + hard:true → invalid_request (field `hard`) and NOTHING is minted", async () => {
-    await getTool(api, MATERIALIZE).execute("g1d", { name: "sil shopper", userSpec: USER_SPEC });
-    const payload = payloadOf(
-      await getTool(api, LEARN).execute("g1e", {
-        target: "method", domain: "ski", kind: "create", name: "Ski", body: "# guide", hard: true,
+    await getTool(api, LEARN).execute("wn2", { target: "method", domain: "ski", kind: "create", name: "Ski", body: "#g" });
+    const prd = payloadOf(
+      await getTool(api, LEARN).execute("wn3", {
+        target: "prd", domain: "ski", prd: "no-such-prd", kind: "write", body: "## nope\n",
       }),
     );
-    expect(payload["status"]).toBe("invalid_request");
-    expect(payload["field"]).toBe("hard");
-    expect(existsSync(join(domainDir("ski"), "method.md"))).toBe(false);
+    expect(prd["status"]).toBe("not_found");
+    expect(existsSync(join(domainDir("ski"), "prds", "no-such-prd.md"))).toBe(false);
   });
 
-  it("retract + hard:true → invalid_request (field `hard`) and the bullet is NOT removed", async () => {
+  it("write on a PRESENT-but-corrupt method → unreadable (never clobbers a recoverable artefact); the original bytes are untouched", async () => {
+    await getTool(api, MATERIALIZE).execute("wc0", { name: "sil shopper", userSpec: USER_SPEC });
+    // A hand-corrupted domain: method.md present but with NO valid frontmatter fence.
+    const brokenDir = domainDir("broken");
+    mkdirSync(brokenDir, { recursive: true, mode: 0o700 });
+    const garbage = "no frontmatter here at all\njust prose\n";
+    const methodPath = join(brokenDir, "method.md");
+    writeFileSync(methodPath, garbage, { mode: 0o600 });
+
+    const payload = payloadOf(
+      await getTool(api, LEARN).execute("wc1", {
+        target: "method", domain: "broken", kind: "write", body: "# a replacement that must NOT land\n",
+      }),
+    );
+    expect(payload["status"]).toBe("unreadable");
+    // Fail-closed: the corrupt-but-recoverable bytes are exactly as they were.
+    expect(readFileSync(methodPath, "utf8")).toBe(garbage);
+  });
+
+  it("write with NO body → invalid_request (field body) — write requires the reconciled whole body, and writes nothing", async () => {
     const methodPath = await seedSkiMethod();
+    const before = readFileSync(methodPath, "utf8");
     const payload = payloadOf(
-      await getTool(api, LEARN).execute("g1f", {
-        target: "method", domain: "ski", kind: "retract", from: "Prefer last-year models.", hard: true,
+      await getTool(api, LEARN).execute("wb1", {
+        target: "method", domain: "ski", kind: "write",
       }),
     );
     expect(payload["status"]).toBe("invalid_request");
-    expect(payload["field"]).toBe("hard");
-    expect(readFileSync(methodPath, "utf8")).toContain("Prefer last-year models.");
-  });
-
-  it("attach-asset + hard:true → invalid_request (field `hard`) BEFORE any bytes/link write (hard wins error-precedence)", async () => {
-    await seedSkiMethod();
-    const payload = payloadOf(
-      await getTool(api, LEARN).execute("g1g", {
-        target: "method", domain: "ski", kind: "attach-asset", bytes: PNG_B64, mime: "image/png", hard: true,
-      }),
-    );
-    expect(payload["status"]).toBe("invalid_request");
-    expect(payload["field"]).toBe("hard");
-    expect(existsSync(join(domainDir("ski"), "assets"))).toBe(false);
-    expect(readFileSync(join(domainDir("ski"), "method.md"), "utf8")).not.toContain("assets/");
-  });
-
-  it("append + hard:true is STILL honored on prd (the guard keys on kind+target, never over-narrow to user_spec only)", async () => {
-    await getTool(api, MATERIALIZE).execute("g1h", { name: "sil shopper", userSpec: USER_SPEC });
-    await getTool(api, LEARN).execute("g1i", {
-      target: "method", domain: "ski", kind: "create", name: "Ski", body: "#g",
-    });
-    await getTool(api, LEARN).execute("g1j", {
-      target: "prd", domain: "ski", prd: "gloves-slope", product: "gloves", intent: "slope", title: "G", kind: "create",
-      body: "## Requirements\n- baseline\n",
-    });
-    const payload = payloadOf(
-      await getTool(api, LEARN).execute("g1k", {
-        target: "prd", domain: "ski", prd: "gloves-slope", kind: "append", text: "waterproof to IPX7", hard: true,
-      }),
-    );
-    expect(payload["status"]).toBe("ok");
-    expect(readFileSync(join(domainDir("ski"), "prds", "gloves-slope.md"), "utf8")).toContain("[hard]");
+    expect(payload["field"]).toBe("body");
+    expect(readFileSync(methodPath, "utf8")).toBe(before);
   });
 });
 
@@ -851,13 +878,14 @@ describe("sil_profile_remove — removes a whole domain, or just one PRD", () =>
  * FRONTMATTER-AS-TRUTH — the whole flow leaves NO profile.json anywhere.
  * ========================================================================= */
 describe("frontmatter-as-truth — no manifest ever appears across the whole lifecycle", () => {
-  it("after create → learn → attach-asset → remove, not one profile.json exists under the shopper root", async () => {
+  it("after create → write → remove, not one profile.json exists under the shopper root", async () => {
     await seedSkiMethod();
     await getTool(api, LEARN).execute("z1", {
       target: "prd", domain: "ski", prd: "gloves-slope", product: "gloves", intent: "slope", title: "G", kind: "create", body: "#r",
     });
     await getTool(api, LEARN).execute("z2", {
-      target: "method", domain: "ski", kind: "append", section: "Taste & stance", text: "note",
+      target: "method", domain: "ski", kind: "write",
+      body: "# Buying guide — ski\n\n## Taste & stance\n- Prefer last-year models.\n- note\n",
     });
     await getTool(api, REMOVE).execute("z3", { domainSlug: "ski", prd: "gloves-slope" });
     expect(walkShopper().some((p) => p.endsWith("profile.json"))).toBe(false);

--- a/src/lib/profile-store.ts
+++ b/src/lib/profile-store.ts
@@ -61,10 +61,6 @@ const METHOD_FILE = "method.md";
  * are joined as filesystem path segments, so they carry this guard before any join. */
 const SEGMENT_RE = /^[a-z0-9][a-z0-9-]*$/;
 
-/** The stable marker the shop loop's reject-at-pick rule greps for an inviolable
- * constraint (e.g. `- [hard] never leather`). */
-const HARD_MARKER = "[hard]";
-
 /** attach-asset limits: ~8 MB decoded, image MIME allowlist → file extension. */
 const MAX_ASSET_BYTES = 8 * 1024 * 1024;
 const MIME_EXT: Readonly<Record<string, string>> = {
@@ -209,7 +205,10 @@ function serializeArtefact(fields: Record<string, string>, body: string): string
   const fm = Object.entries(fields)
     .map(([k, v]) => k + ": " + scalar(v))
     .join("\n");
-  const b = body.endsWith("\n") ? body : body + "\n";
+  // The store owns frontmatter — strip any block a model prepended to the body so the
+  // artefact never stacks two (self-heals a previously double-wrapped file on re-write).
+  const clean = stripLeadingFrontmatter(body);
+  const b = clean.endsWith("\n") ? clean : clean + "\n";
   return "---\n" + fm + "\n---\n" + b;
 }
 
@@ -229,6 +228,16 @@ function parseArtefact(raw: string): Artefact | null {
   }
   if (Object.keys(fields).length === 0) return null;
   return { fields, body };
+}
+
+/** Strip a leading `--- … ---` frontmatter block a model may have prepended to a body,
+ * reusing `parseArtefact` so ONLY a fence whose content is real frontmatter (≥1
+ * `key: value`) is removed — a body opening with a bare `---` thematic break parses to
+ * null and is returned untouched. The store owns frontmatter (frontmatter-as-truth), so a
+ * model-authored block must never survive into the serialized body and stack a second. */
+function stripLeadingFrontmatter(body: string): string {
+  const parsed = parseArtefact(body);
+  return parsed === null ? body : parsed.body;
 }
 
 /** Read + parse one artefact file, or null if absent/unreadable/malformed. */
@@ -336,11 +345,14 @@ export function readShopperIdentity(): ShopperIdentity {
 }
 
 // ===========================================================================
-// sil_learn — the single target+change verb. `create` mints a whole method/PRD;
-// `append`/`amend`/`retract` refine in place; `attach-asset` persists image bytes.
+// sil_learn — the single target+change verb. `create` mints a NEW method/PRD;
+// `write` replaces an existing doc's whole body (reconciled); `attach-asset`
+// persists image bytes. The model reads current (sil_profile_get), reconciles in
+// context, and writes the whole doc back — no surgical bullet ops, so a correction
+// can never stack a contradicting line.
 // ===========================================================================
 
-export type LearnKind = "create" | "append" | "amend" | "retract" | "attach-asset";
+export type LearnKind = "create" | "write" | "attach-asset";
 export type LearnTarget = "user_spec" | "method" | "prd";
 
 export interface LearnSpec {
@@ -348,18 +360,13 @@ export interface LearnSpec {
   kind: LearnKind;
   domain?: string;
   prd?: string;
-  /** create: whole-body mint (+ coordinates for a new prd). */
+  /** create: mint a new doc (+ coordinates for a new prd). write: the reconciled
+   * whole body that replaces an existing doc. */
   name?: string;
   body?: string;
   product?: string;
   intent?: string;
   title?: string;
-  /** append/amend/retract change fields. */
-  text?: string;
-  from?: string;
-  to?: string;
-  section?: string;
-  hard?: boolean;
   /** attach-asset. */
   bytes?: string;
   mime?: string;
@@ -379,6 +386,7 @@ export type LearnResult =
     }
   | InvalidRequest
   | NotFound
+  | Unreadable
   | PersistenceFailed;
 
 /** A resolved target artefact + its human label. */
@@ -414,42 +422,28 @@ function resolveTarget(spec: LearnSpec): ResolvedTarget | InvalidRequest {
 }
 
 export function learnArtefact(spec: LearnSpec): LearnResult {
-  // `hard` is valid ONLY on append to user_spec / prd. Every other combination —
-  // all four non-append kinds on any target, and append to method — is rejected
-  // LOUDLY, never silently dropped: a buyer who passes `hard:true` expecting to
-  // promote a constraint must learn at once when the promotion does not land.
-  // Hoisted ABOVE the kind switch so a hard misuse wins error-precedence over the
-  // per-kind field checks (this subsumes the old method-only append guard).
-  if (spec.hard === true && !(spec.kind === "append" && spec.target !== "method")) {
-    return invalid(
-      "hard",
-      "hard is valid only on append to user_spec or prd — a method carries no hard"
-        + " constraints, and create/amend/retract/attach-asset take no hard flag.",
-    );
-  }
   switch (spec.kind) {
     case "create":
       return learnCreate(spec);
-    case "append":
-      return learnAppend(spec);
-    case "amend":
-    case "retract":
-      return learnAmendRetract(spec);
+    case "write":
+      return learnWrite(spec);
     case "attach-asset":
       return learnAttachAsset(spec);
     default:
-      return invalid("kind", "kind must be one of create|append|amend|retract|attach-asset.");
+      return invalid("kind", "kind must be one of create|write|attach-asset.");
   }
 }
 
-/** `create` mints a whole method or PRD body atomically — the file IS the
- * registration (no manifest). NOT valid for user_spec (that is materialize). */
+/** `create` mints a NEW method or PRD body atomically — the file IS the registration
+ * (no manifest). Refuses if one already exists at these coordinates (→ use `write` to
+ * replace it), so a mint never silently clobbers. NOT valid for user_spec (that is
+ * materialize; refine it with `write`). */
 function learnCreate(spec: LearnSpec): LearnResult {
   if (spec.target === "user_spec") {
     return invalid(
       "target",
       "create is not valid for user_spec — the shopper's shared spec is written by"
-        + " sil_profile_materialize (setup), then refined with append/amend/retract.",
+        + " sil_profile_materialize (setup), then refined with kind:write.",
     );
   }
   if (!nonBlank(spec.body)) return invalid("body", "body is required and must be non-empty.");
@@ -462,6 +456,13 @@ function learnCreate(spec: LearnSpec): LearnResult {
   if (spec.target === "method") {
     if (!nonBlank(spec.name)) return invalid("name", "name is required for a method.");
     const path = join(getDomainArtefactDir(slug), METHOD_FILE);
+    if (existsSync(path)) {
+      return invalid(
+        "kind",
+        'a method already exists for domain "' + slug + '" — use kind:write to replace its'
+          + " body (create only mints a new one, it never overwrites).",
+      );
+    }
     const fields = { domain: slug, name: spec.name as string, updated_at: now };
     try {
       atomicWrite(path, serializeArtefact(fields, spec.body as string));
@@ -479,16 +480,20 @@ function learnCreate(spec: LearnSpec): LearnResult {
     if (!nonBlank(spec[f])) return invalid(f, f + " is required for a prd.");
   }
   const path = join(getDomainArtefactDir(slug), PRDS_SUBDIR, prd + ".md");
-  // Preserve created_at on a re-mint; advance updated_at.
-  const prior = readArtefactFile(path);
-  const createdAt = prior?.fields["created_at"] ?? now;
+  if (existsSync(path)) {
+    return invalid(
+      "kind",
+      'a PRD "' + prd + '" already exists in domain "' + slug + '" — use kind:write to'
+        + " replace its body (create only mints a new one, it never overwrites).",
+    );
+  }
   const fields = {
     key: prd,
     product: spec.product as string,
     intent: spec.intent as string,
     title: spec.title as string,
     domain: slug,
-    created_at: createdAt,
+    created_at: now,
     updated_at: now,
   };
   try {
@@ -499,90 +504,25 @@ function learnCreate(spec: LearnSpec): LearnResult {
   return { ok: true, kind: "create", target: "prd", domain: slug, prd, path };
 }
 
-/** append — add `- <text>` (or `- [hard] <text>`) under `## <section>` when given
- * (fail-closed if that heading is absent), else at EOF. The target must already
- * exist → not_found (never resurrects a seed-less doc). `hard` is guarded up-front
- * in `learnArtefact` (append to method / any non-append kind is rejected there). */
-function learnAppend(spec: LearnSpec): LearnResult {
-  if (!nonBlank(spec.text)) return invalid("text", "text is required and must be non-empty.");
-
+/** `write` replaces the WHOLE body of an EXISTING method / PRD / user_spec with a
+ * reconciled version — the model reads current (`sil_profile_get`), reconciles in
+ * context, and writes the whole doc back. Frontmatter coordinates + `created_at` are
+ * preserved and `updated_at` bumps (user_spec carries no timestamp). Fail-closed on a
+ * missing doc (`not_found` — write never mints, that is create) and on a present-but-
+ * corrupt one (`unreadable` — inspect / repair, never clobber a recoverable artefact). */
+function learnWrite(spec: LearnSpec): LearnResult {
+  if (!nonBlank(spec.body)) return invalid("body", "body is required and must be non-empty.");
   const target = resolveTarget(spec);
   if ("ok" in target) return target;
   const existing = readArtefactFile(target.path);
   if (existing === null) {
+    if (existsSync(target.path)) return unreadable(target.path);
     return notFound(
-      "The target " + target.label + " does not exist — create it first (append never"
-        + " resurrects a seed-less doc).",
+      "The target " + target.label + " does not exist — mint it with kind:create first"
+        + " (write replaces an existing doc, it never mints).",
     );
   }
-
-  const mark = spec.hard === true ? HARD_MARKER + " " : "";
-  const bullet = "- " + mark + (spec.text as string).trim();
-
-  let body: string;
-  if (nonBlank(spec.section)) {
-    const inserted = insertUnderSection(existing.body, spec.section as string, bullet);
-    if (inserted === null) {
-      const sections = listSections(existing.body);
-      return invalid(
-        "section",
-        'no "## ' + spec.section + '" heading in the ' + target.label + "; existing sections: "
-          + (sections.length > 0 ? sections.join(", ") : "(none)"),
-      );
-    }
-    body = inserted;
-  } else {
-    body = existing.body.replace(/\n*$/, "\n") + bullet + "\n";
-  }
-
-  return writeArtefactBody(target, existing.fields, body, "append");
-}
-
-/** amend/retract — exact single-occurrence bullet match on `from`; 0 → not_found,
- * 2+ → invalid_request(ambiguous_match). A `[hard]` marker is preserved on amend. */
-function learnAmendRetract(spec: LearnSpec): LearnResult {
-  if (!nonBlank(spec.from)) return invalid("from", "from is required and must be non-empty.");
-  if (spec.kind === "amend" && !nonBlank(spec.to)) {
-    return invalid("to", "to is required for amend.");
-  }
-
-  const target = resolveTarget(spec);
-  if ("ok" in target) return target;
-  const existing = readArtefactFile(target.path);
-  if (existing === null) {
-    return notFound("The target " + target.label + " does not exist — nothing to change.");
-  }
-
-  const from = (spec.from as string).trim();
-  const lines = existing.body.split("\n");
-  const matches: number[] = [];
-  const scoped = nonBlank(spec.section)
-    ? sectionLineRange(lines, spec.section as string)
-    : { start: 0, end: lines.length };
-  for (let i = scoped.start; i < scoped.end; i++) {
-    const parsed = parseBullet(lines[i] as string);
-    if (parsed && parsed.text.trim() === from) matches.push(i);
-  }
-  if (matches.length === 0) {
-    return notFound('No bullet matching "' + from + '" in the ' + target.label + ".");
-  }
-  if (matches.length > 1) {
-    return invalid(
-      "ambiguous_match",
-      "the text matches " + matches.length + " bullets — refine `from` (or scope with"
-        + " `section`) so it matches exactly one; refusing an ambiguous multi-write.",
-    );
-  }
-
-  const idx = matches[0] as number;
-  if (spec.kind === "retract") {
-    lines.splice(idx, 1);
-  } else {
-    const parsed = parseBullet(lines[idx] as string)!;
-    const mark = parsed.hard ? HARD_MARKER + " " : "";
-    lines[idx] = parsed.indent + "- " + mark + (spec.to as string).trim();
-  }
-  return writeArtefactBody(target, existing.fields, lines.join("\n"), spec.kind);
+  return writeArtefactBody(target, existing.fields, spec.body as string, "write");
 }
 
 /** attach-asset — persist image bytes into `domains/<slug>/assets/<hash>.<ext>`
@@ -680,65 +620,6 @@ function writeArtefactBody(
     ...(target.prd !== undefined ? { prd: target.prd } : {}),
     path: target.path,
   };
-}
-
-// --- section/bullet helpers -------------------------------------------------
-
-interface Bullet {
-  indent: string;
-  hard: boolean;
-  text: string;
-}
-
-/** Parse a markdown bullet line (`- text` / `- [hard] text`), or null. */
-function parseBullet(line: string): Bullet | null {
-  const m = /^(\s*)-\s+(\[hard\]\s+)?(.*)$/.exec(line);
-  if (!m) return null;
-  return { indent: m[1] as string, hard: m[2] !== undefined, text: m[3] as string };
-}
-
-/** All `## <section>` heading texts present in a body (for a fail-closed message). */
-function listSections(body: string): string[] {
-  return body
-    .split("\n")
-    .map((l) => /^##\s+(.*)$/.exec(l))
-    .filter((m): m is RegExpExecArray => m !== null)
-    .map((m) => (m[1] as string).trim());
-}
-
-/** The [start,end) line range of a `## <section>` body (heading exclusive, up to the
- * next `## ` heading or EOF). `start === -1` when the heading is absent. */
-function sectionLineRange(lines: string[], section: string): { start: number; end: number } {
-  const target = section.trim();
-  let start = -1;
-  for (let i = 0; i < lines.length; i++) {
-    const m = /^##\s+(.*)$/.exec(lines[i] as string);
-    if (m && (m[1] as string).trim() === target) {
-      start = i + 1;
-      break;
-    }
-  }
-  if (start === -1) return { start: 0, end: 0 };
-  let end = lines.length;
-  for (let i = start; i < lines.length; i++) {
-    if (/^##\s+/.test(lines[i] as string)) {
-      end = i;
-      break;
-    }
-  }
-  return { start, end };
-}
-
-/** Insert `bullet` at the end of `## <section>` (before the next heading, after the
- * section's last non-blank line), or null when the heading is absent. */
-function insertUnderSection(body: string, section: string, bullet: string): string | null {
-  if (!listSections(body).includes(section.trim())) return null;
-  const lines = body.split("\n");
-  const range = sectionLineRange(lines, section);
-  let at = range.end;
-  while (at > range.start && (lines[at - 1] as string).trim() === "") at--;
-  lines.splice(at, 0, bullet);
-  return lines.join("\n");
 }
 
 // ===========================================================================

--- a/src/tools/profile.ts
+++ b/src/tools/profile.ts
@@ -7,8 +7,8 @@
  *   - `sil_profile_materialize { name, userSpec }` — SETUP-ONLY: write user_spec.md
  *     (its frontmatter carries the shopper name). Does NOT mint methods/PRDs.
  *   - `sil_learn { target, domain?, prd?, kind, … }` — the single target+change verb
- *     for the whole method/PRD lifecycle: create mints a whole doc; append/amend/
- *     retract refine in place; attach-asset persists image bytes by path.
+ *     for the whole method/PRD lifecycle: create mints a NEW doc; write replaces an
+ *     existing doc's whole body (reconciled); attach-asset persists image bytes by path.
  *   - `sil_profile_search { domain?, product?, intent?, query? }` — query artefact
  *     FRONTMATTER (coordinates only, no bodies); the discovery / reuse-before-mint
  *     primitive. Malformed frontmatter surfaces in `unreadable`, never dropped.
@@ -100,12 +100,14 @@ function registerLearn(api: PluginAPI): void {
     description:
       "The single target+change verb owning the sil shopper's method/PRD lifecycle."
       + " `target` (user_spec | method | prd) picks WHERE the change lands; `kind`"
-      + " (create | append | amend | retract | attach-asset) picks the change — the"
-      + " per-field schema names which fields each needs. `create` mints a whole method/"
-      + "PRD (not valid for user_spec); append/amend/retract/attach-asset need the target"
-      + " to exist (else not_found). `hard` (append to user_spec/prd only) marks an"
-      + " inviolable constraint. Local-only, atomic, owner-only, no network; a bad field"
-      + " → invalid_request and writes nothing.",
+      + " (create | write | attach-asset) picks the change. `create` mints a NEW method/"
+      + "PRD (not valid for user_spec; errors if one already exists — use write). `write`"
+      + " replaces an EXISTING doc's whole body with a reconciled version you author (read"
+      + " it first with sil_profile_get and carry every buyer line forward; else not_found)."
+      + " `attach-asset` links image bytes. To change anything, WRITE the whole reconciled"
+      + " doc — there is no append/amend, so a correction never stacks a contradicting"
+      + " line. Local-only, atomic, owner-only, no network; a bad field → invalid_request"
+      + " and writes nothing.",
     parameters: Type.Object({
       target: Type.Union(
         [Type.Literal("user_spec"), Type.Literal("method"), Type.Literal("prd")],
@@ -114,12 +116,10 @@ function registerLearn(api: PluginAPI): void {
       kind: Type.Union(
         [
           Type.Literal("create"),
-          Type.Literal("append"),
-          Type.Literal("amend"),
-          Type.Literal("retract"),
+          Type.Literal("write"),
           Type.Literal("attach-asset"),
         ],
-        { description: "The change: create | append | amend | retract | attach-asset." },
+        { description: "The change: create (mint new) | write (replace whole body) | attach-asset." },
       ),
       domain: Type.Optional(
         Type.String({ description: "The domain slug (lower-kebab, not \"main\") — required for method/prd." }),
@@ -128,17 +128,10 @@ function registerLearn(api: PluginAPI): void {
         Type.String({ description: "The PRD key <product>-<intent> (lower-kebab) — required for a prd target." }),
       ),
       name: Type.Optional(Type.String({ description: "create method: the human-readable domain name." })),
-      body: Type.Optional(Type.String({ description: "create: the whole markdown body to mint." })),
+      body: Type.Optional(Type.String({ description: "create / write: the whole markdown body (mint, or the reconciled replacement)." })),
       product: Type.Optional(Type.String({ description: "create prd: the product type." })),
       intent: Type.Optional(Type.String({ description: "create prd: the use-context (general when context-free)." })),
       title: Type.Optional(Type.String({ description: "create prd: the human-readable job title." })),
-      text: Type.Optional(Type.String({ description: "append: the one bullet to add." })),
-      from: Type.Optional(Type.String({ description: "amend/retract: the exact bullet text to match (single occurrence)." })),
-      to: Type.Optional(Type.String({ description: "amend: the replacement bullet text." })),
-      section: Type.Optional(Type.String({ description: "append/amend/retract: the `## section` to scope to." })),
-      hard: Type.Optional(
-        Type.Boolean({ description: "append to user_spec/prd only: mark an inviolable constraint the shop loop rejects against." }),
-      ),
       bytes: Type.Optional(Type.String({ description: "attach-asset: the image bytes, base64-encoded." })),
       mime: Type.Optional(Type.String({ description: "attach-asset: image/jpeg | image/png | image/webp | image/gif." })),
       caption: Type.Optional(Type.String({ description: "attach-asset: an optional caption for the markdown link." })),
@@ -146,7 +139,7 @@ function registerLearn(api: PluginAPI): void {
     async execute(_callId, params) {
       const spec: LearnSpec = {
         target: (params["target"] as LearnTarget) ?? "method",
-        kind: (params["kind"] as LearnKind) ?? "append",
+        kind: (params["kind"] as LearnKind) ?? "write",
         domain: optString(params["domain"]),
         prd: optString(params["prd"]),
         name: optString(params["name"]),
@@ -154,11 +147,6 @@ function registerLearn(api: PluginAPI): void {
         product: optString(params["product"]),
         intent: optString(params["intent"]),
         title: optString(params["title"]),
-        text: optString(params["text"]),
-        from: optString(params["from"]),
-        to: optString(params["to"]),
-        section: optString(params["section"]),
-        hard: params["hard"] === true ? true : undefined,
         bytes: optString(params["bytes"]),
         mime: optString(params["mime"]),
         caption: optString(params["caption"]),


### PR DESCRIPTION
## Why

A real earbuds-shop on the live 0.4.1 gateway surfaced two structural weaknesses in the shopper's artefact + tool-policy layer. This PR fixes both.

## Tool policy — stop pretending to sandbox the shell

`create-shopper.mjs` used to set `tools.deny = ["exec","write","edit","apply_patch"]`. On the codex runtime that's inert: codex brings its **own** shell (surfaced as `bash`), a tool the name-matching deny can't name and which the model uses to read its own Tier-3 skill files — and per OpenClaw's docs, denying the fs-mutators while any shell is open never makes it read-only. So the deny is **removed entirely**. The shopper inherits the host default toolset; the shell stays open by design (trusted single-operator posture) and persistence is steered to the sil tools by the skill.

## Artefact model — `sil_learn` is now document-first

The surgical bullet ops were the root cause of a self-contradicting PRD (a "prefer transparency" requirement sitting beside a later "transparency not valued" correction). Reworked:

- **Verbs: `create` / `write` / `attach-asset`** (`append` / `amend` / `retract` and the `text`/`from`/`to`/`section`/`hard` params deleted, along with the bullet-manipulation helpers). `create` mints a NEW doc (errors if it exists); `write` replaces an existing doc's **whole reconciled body** — read-first, carry every buyer line forward. A correction rewrites the line it changes; stacking a contradicting bullet is structurally impossible.
- **Method = general**: `## How it's bought` + a coined `## Search vocabulary` (dimensions, never this-buyer values), reusable across every intent.
- **PRD = specific**: carries a **`## Search specs`** block — the resolved `{ns,key,op,value,hard?}` predicate set projected **verbatim** into `sil_search.filters.specs`, so structured filters no longer decay to keyword-only mid-session.
- **Beat 1** pins the domain to the broad reusable category (`earbuds`, never `wireless-gym-earbuds` — never fold the use-context into the slug, which kills method reuse).
- **`prefer X, Y/Z acceptable`** → one `op:in` set + a Beat-5 ranking, not an over-hard `eq` (which wrongly empties the result set).

## Also in this change

- **Double-frontmatter fix**: `serializeArtefact` strips a model-authored leading frontmatter block at the store boundary, so artefacts never stack two blocks (existing files self-heal on their next `write`).
- **Always-on SKILL.md steers**: the `≤ 4 spec-filtered searches` cap and "your memory is the sil store, never `MEMORY.md`" now live in the Tier-2 contract so they stay salient every turn.

## Testing

`pnpm build` + `pnpm typecheck` + `pnpm test` → **930 passed**. The only failures are the 10 `repo-scaffold` checks, a known worktree-only artifact (gitignored `CLAUDE.md` / `docs/` aren't checked out in a worktree). Net **−41 lines** despite the added capability — the delete-first payoff from dropping the surgical ops.

## Out of scope (noted, not fixed here)

- The `.trajectory.jsonl` redaction of spec **keys** to `<redacted>` is written by the OpenClaw **gateway**, not this plugin — it can't be fixed in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
