### PR TITLE
feat: versioned store migrations + on-load self-migrate (Migration #1: 0.3.x → 0.4.0)

### DIFF
--- a/src/__tests__/lib/store-migrations-runner.test.ts
+++ b/src/__tests__/lib/store-migrations-runner.test.ts
@@ -1,0 +1,431 @@
+/**
+ * UNIT — the versioned store-migration runner + registry (tier: unit, real temp
+ * $SIL_DATA_DIR, no fs mocking, no network, no host).
+ *
+ * Card: versioned-store-migrations-on-load-self-migrate. THESE ASSERTIONS ARE THE
+ * SPEC (RED-first). The runner is sil-agnostic: `detect → backup → apply → verify →
+ * record`, fail-closed, driven by a registry of ascending `Migration` hops keyed by
+ * an INTEGER store-format version (decoupled from package.json semver).
+ *
+ * This file pins the GENERIC runner over a SYNTHETIC ordered registry of fake
+ * migrations — the only way to exercise multi-hop ordering (AC3), verify-before-
+ * record (AC5), and the generic revert (AC4 companion) when just ONE real migration
+ * exists today. Migration #1's real transform + the on-load trigger are the
+ * integration file's job (store-migrations.integration.test.ts).
+ *
+ * Contract this file pins for the implementation (expert-developer):
+ *
+ *   src/lib/migrations/types.ts
+ *     interface Migration {
+ *       readonly version: number;                 // ascending, contiguous from 1
+ *       readonly description: string;
+ *       detectApplicable(dataDir: string): boolean;   // content-probe of the PRE-state
+ *       apply(dataDir: string): void;                  // atomic writes; throw on hard failure
+ *       verify(dataDir: string): string | null;        // reason string, or null when the floor holds
+ *     }
+ *     type MigrationRunResult =
+ *       | { ok: true; from: number; to: number; applied: number[] }
+ *       | MigrationFailed;
+ *     interface MigrationFailed {
+ *       ok: false; kind: "migration_failed"; version: number;
+ *       reason: string; reverted: boolean; recovery: "inspect_store";
+ *     }
+ *
+ *   src/lib/migrations/registry.ts
+ *     export const MIGRATIONS: readonly Migration[];              // ascending, from 1
+ *     export const CURRENT_STORE_VERSION: number;                // MIGRATIONS.at(-1)?.version ?? 0
+ *
+ *   src/lib/migrations/runner.ts
+ *     export function readStoreVersion(dataDir: string): number;  // marker, or 0 (absent/unparseable)
+ *     export function writeStoreVersion(dataDir: string, version: number): void;  // atomic 0600, data-dir ROOT
+ *     export function runStoreMigrations(
+ *       dataDir: string,
+ *       migrations?: readonly Migration[],   // defaults to MIGRATIONS; INJECTABLE so this
+ *     ): MigrationRunResult;                 //   file can drive a synthetic ordered registry.
+ *     export function ensureStoreMigrated(): MigrationRunResult;  // memoized on-load gate (integration file)
+ *
+ * The store-format marker is `$SIL_DATA_DIR/store-format.json` = `{ "version": <int> }`
+ * at the DATA-DIR ROOT (sibling to tokens.json — NOT under shopper/, so a shopper-
+ * subtree backup/revert never touches it). The per-hop backup is
+ * `$SIL_DATA_DIR/.sil-migration-backup/` (also at root, outside the reverted subtree).
+ *
+ * Hermetic via a fresh mkdtemp $SIL_DATA_DIR per test.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+  existsSync,
+  statSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  readStoreVersion,
+  writeStoreVersion,
+  runStoreMigrations,
+} from "../../lib/migrations/runner.js";
+import { MIGRATIONS, CURRENT_STORE_VERSION } from "../../lib/migrations/registry.js";
+import type { Migration } from "../../lib/migrations/types.js";
+
+let dataDir: string;
+let priorSilDataDir: string | undefined;
+
+const MARKER = "store-format.json";
+const BACKUP_DIR = ".sil-migration-backup";
+const SHOPPER = "shopper";
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), "sil-store-mig-runner-"));
+  priorSilDataDir = process.env["SIL_DATA_DIR"];
+  process.env["SIL_DATA_DIR"] = dataDir;
+});
+
+afterEach(() => {
+  if (priorSilDataDir === undefined) delete process.env["SIL_DATA_DIR"];
+  else process.env["SIL_DATA_DIR"] = priorSilDataDir;
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Fixtures: a shopper subtree with a known sentinel + a fake-migration builder.
+// ---------------------------------------------------------------------------
+
+/** Seed `$SIL_DATA_DIR/shopper/sentinel.txt` with known bytes — the subtree the
+ * runner backs up + reverts. Returns the sentinel path. */
+function seedShopper(contents = "ORIGINAL-BYTES\n"): string {
+  const dir = join(dataDir, SHOPPER);
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  const p = join(dir, "sentinel.txt");
+  writeFileSync(p, contents, { mode: 0o600 });
+  return p;
+}
+
+interface FakeSpec {
+  detect?: (dataDir: string) => boolean;
+  apply?: (dataDir: string) => void;
+  verify?: (dataDir: string) => string | null;
+}
+
+/** A fake Migration with call-count spies on every hook. */
+function fakeMigration(version: number, spec: FakeSpec = {}) {
+  const calls = { detect: 0, apply: 0, verify: 0 };
+  const migration: Migration = {
+    version,
+    description: `fake migration v${version}`,
+    detectApplicable(dir: string) {
+      calls.detect++;
+      return spec.detect ? spec.detect(dir) : true;
+    },
+    apply(dir: string) {
+      calls.apply++;
+      if (spec.apply) spec.apply(dir);
+    },
+    verify(dir: string) {
+      calls.verify++;
+      return spec.verify ? spec.verify(dir) : null;
+    },
+  };
+  return { migration, calls };
+}
+
+/** Recursively list every relative path under the shopper subtree (sorted). */
+function walkShopper(): string[] {
+  const dir = join(dataDir, SHOPPER);
+  if (!existsSync(dir)) return [];
+  return (readdirSync(dir, { recursive: true }) as string[]).sort();
+}
+
+// ===========================================================================
+// registry.ts — the ascending, contiguous-from-1 registry + CURRENT constant.
+// ===========================================================================
+describe("registry — ascending contiguous versions from 1; CURRENT is the last hop", () => {
+  it("MIGRATIONS is non-empty and each hop has the Migration shape", () => {
+    expect(Array.isArray(MIGRATIONS)).toBe(true);
+    expect(MIGRATIONS.length).toBeGreaterThanOrEqual(1);
+    for (const m of MIGRATIONS) {
+      expect(typeof m.version).toBe("number");
+      expect(typeof m.description).toBe("string");
+      expect(m.description.length).toBeGreaterThan(0);
+      expect(typeof m.detectApplicable).toBe("function");
+      expect(typeof m.apply).toBe("function");
+      expect(typeof m.verify).toBe("function");
+    }
+  });
+
+  it("versions are ascending and contiguous starting at 1 (no gaps, no dupes)", () => {
+    const versions = MIGRATIONS.map((m) => m.version);
+    expect(versions).toEqual(versions.map((_, i) => i + 1));
+  });
+
+  it("CURRENT_STORE_VERSION equals the last hop's version (= MIGRATIONS.length)", () => {
+    expect(CURRENT_STORE_VERSION).toBe(MIGRATIONS[MIGRATIONS.length - 1]!.version);
+    expect(CURRENT_STORE_VERSION).toBe(MIGRATIONS.length);
+  });
+
+  it("Migration #1 (the 0.3.x → 0.4.0 frontmatter-store move) is version 1", () => {
+    expect(MIGRATIONS[0]!.version).toBe(1);
+  });
+});
+
+// ===========================================================================
+// readStoreVersion / writeStoreVersion — the integer marker at the data-dir root.
+// ===========================================================================
+describe("store-format marker — integer version at the data-dir root, absent/corrupt ⇒ 0", () => {
+  it("an ABSENT marker reads as version 0 (safe default, not a throw)", () => {
+    expect(existsSync(join(dataDir, MARKER))).toBe(false);
+    expect(readStoreVersion(dataDir)).toBe(0);
+  });
+
+  it("writeStoreVersion round-trips through readStoreVersion", () => {
+    writeStoreVersion(dataDir, 3);
+    expect(readStoreVersion(dataDir)).toBe(3);
+  });
+
+  it("the marker is store-format.json at the DATA-DIR ROOT (sibling of tokens.json, NOT under shopper/)", () => {
+    writeStoreVersion(dataDir, 2);
+    // At the root — so a shopper-subtree backup/revert can never touch it.
+    expect(existsSync(join(dataDir, MARKER))).toBe(true);
+    expect(existsSync(join(dataDir, SHOPPER, MARKER))).toBe(false);
+    const parsed = JSON.parse(readFileSync(join(dataDir, MARKER), "utf8")) as { version: number };
+    expect(parsed.version).toBe(2);
+  });
+
+  it("the marker is written owner-only (0600)", () => {
+    writeStoreVersion(dataDir, 1);
+    // eslint-disable-next-line no-bitwise
+    expect(statSync(join(dataDir, MARKER)).mode & 0o777).toBe(0o600);
+  });
+
+  it("an UNPARSEABLE marker reads as version 0 (content-probe self-heal, never a brick)", () => {
+    writeFileSync(join(dataDir, MARKER), "not json { at all", { mode: 0o600 });
+    expect(readStoreVersion(dataDir)).toBe(0);
+  });
+
+  it("a marker that parses but carries no integer `version` reads as 0", () => {
+    writeFileSync(join(dataDir, MARKER), JSON.stringify({ version: "seven" }), { mode: 0o600 });
+    expect(readStoreVersion(dataDir)).toBe(0);
+    writeFileSync(join(dataDir, MARKER), JSON.stringify({ nope: 1 }), { mode: 0o600 });
+    expect(readStoreVersion(dataDir)).toBe(0);
+  });
+});
+
+// ===========================================================================
+// AC3 — multi-hop skipped-release: every applicable hop applies in ASCENDING
+// order in ONE pass; the recorded version advances to the registry's last.
+// ===========================================================================
+describe("runStoreMigrations — AC3 multi-hop ordered application over a synthetic registry", () => {
+  it("a store at 0 with a 3-hop registry applies 1 → 2 → 3 IN ORDER, records 3, applied=[1,2,3]", () => {
+    seedShopper();
+    const orderLog = join(dataDir, SHOPPER, "order.log");
+    const appendVersion = (v: number) => (dir: string) => {
+      const prev = existsSync(join(dir, SHOPPER, "order.log"))
+        ? readFileSync(join(dir, SHOPPER, "order.log"), "utf8")
+        : "";
+      writeFileSync(join(dir, SHOPPER, "order.log"), prev + v + "\n", { mode: 0o600 });
+    };
+    const m1 = fakeMigration(1, { apply: appendVersion(1) });
+    const m2 = fakeMigration(2, { apply: appendVersion(2) });
+    const m3 = fakeMigration(3, { apply: appendVersion(3) });
+
+    const result = runStoreMigrations(dataDir, [m1.migration, m2.migration, m3.migration]);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.from).toBe(0);
+    // `to` is the version the store actually advanced to — NOT the global
+    // CURRENT_STORE_VERSION (that is the REAL registry's max, wrong here).
+    expect(result.to).toBe(3);
+    expect(result.to).toBe(readStoreVersion(dataDir));
+    expect(result.applied).toEqual([1, 2, 3]);
+    // Every hop's transform ran exactly once, in ascending order.
+    expect(readFileSync(orderLog, "utf8")).toBe("1\n2\n3\n");
+    for (const m of [m1, m2, m3]) expect(m.calls.apply).toBe(1);
+  });
+
+  it("a store already at version 1 applies ONLY the later hops (2, 3) — version-1's transform never re-runs", () => {
+    seedShopper();
+    writeStoreVersion(dataDir, 1);
+    const m1 = fakeMigration(1);
+    const m2 = fakeMigration(2);
+    const m3 = fakeMigration(3);
+
+    const result = runStoreMigrations(dataDir, [m1.migration, m2.migration, m3.migration]);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.from).toBe(1);
+    expect(result.to).toBe(3);
+    expect(result.applied).toEqual([2, 3]);
+    // Hop 1 is below `from` → not even probed.
+    expect(m1.calls.detect).toBe(0);
+    expect(m1.calls.apply).toBe(0);
+    expect(m2.calls.apply).toBe(1);
+    expect(m3.calls.apply).toBe(1);
+  });
+});
+
+// ===========================================================================
+// AC7 (unit) — idempotent no-op: an already-current store rewrites NOTHING.
+// ===========================================================================
+describe("runStoreMigrations — AC7 idempotent no-op on an already-current store", () => {
+  it("a store at the registry's top version does nothing — no probe, no apply, no marker rewrite, no backup", () => {
+    const sentinel = seedShopper();
+    writeStoreVersion(dataDir, 3);
+    const markerMtime = statSync(join(dataDir, MARKER)).mtimeMs;
+    const sentinelMtime = statSync(sentinel).mtimeMs;
+    const m1 = fakeMigration(1);
+    const m2 = fakeMigration(2);
+    const m3 = fakeMigration(3);
+
+    const result = runStoreMigrations(dataDir, [m1.migration, m2.migration, m3.migration]);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.from).toBe(3);
+    expect(result.to).toBe(3);
+    expect(result.applied).toEqual([]);
+    // No hook ran at all — nothing is above `from`.
+    for (const m of [m1, m2, m3]) {
+      expect(m.calls.detect).toBe(0);
+      expect(m.calls.apply).toBe(0);
+      expect(m.calls.verify).toBe(0);
+    }
+    // Zero churn: neither the marker nor the shopper subtree was rewritten.
+    expect(statSync(join(dataDir, MARKER)).mtimeMs).toBe(markerMtime);
+    expect(statSync(sentinel).mtimeMs).toBe(sentinelMtime);
+    expect(existsSync(join(dataDir, BACKUP_DIR))).toBe(false);
+  });
+
+  it("a hop whose detectApplicable is FALSE records the version but runs NO transform + creates NO backup", () => {
+    seedShopper();
+    const m1 = fakeMigration(1, { detect: () => false });
+
+    const result = runStoreMigrations(dataDir, [m1.migration]);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected ok");
+    // The version is recorded (so it is never re-probed) but the transform is a no-op.
+    expect(readStoreVersion(dataDir)).toBe(1);
+    expect(m1.calls.detect).toBe(1);
+    expect(m1.calls.apply).toBe(0);
+    // A no-op hop is not "applied" and takes no backup.
+    expect(result.applied).toEqual([]);
+    expect(existsSync(join(dataDir, BACKUP_DIR))).toBe(false);
+  });
+});
+
+// ===========================================================================
+// AC5 — verify-before-record: apply COMPLETING is not success; the floor being
+// met is. A failed verify is treated as FAILURE — reverted, NOT recorded.
+// ===========================================================================
+describe("runStoreMigrations — AC5 verify-before-record (anti false-healthy)", () => {
+  it("apply returns cleanly but verify returns a reason ⇒ FAILED: reverted, marker NOT advanced, migration_failed surfaced", () => {
+    const sentinel = seedShopper("ORIGINAL\n");
+    // apply mutates the subtree (looks migrated) but verify rejects it.
+    const m1 = fakeMigration(1, {
+      apply: (dir) => writeFileSync(join(dir, SHOPPER, "sentinel.txt"), "MUTATED\n", { mode: 0o600 }),
+      verify: () => "preservation floor unmet: user_spec name is blank",
+    });
+
+    const result = runStoreMigrations(dataDir, [m1.migration]);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected failure");
+    expect(result.kind).toBe("migration_failed");
+    expect(result.version).toBe(1);
+    expect(result.reverted).toBe(true);
+    expect(result.recovery).toBe("inspect_store");
+    // verify DID run (apply completed first) — that is the whole point of the gate.
+    expect(m1.calls.apply).toBe(1);
+    expect(m1.calls.verify).toBe(1);
+    // "looks migrated but lost the floor" is NEVER recorded as success.
+    expect(readStoreVersion(dataDir)).toBe(0);
+    // Byte-exact revert: the mutation is gone.
+    expect(readFileSync(sentinel, "utf8")).toBe("ORIGINAL\n");
+    // The failure reason is carried (non-empty, names the floor miss).
+    expect(result.reason.length).toBeGreaterThan(0);
+  });
+});
+
+// ===========================================================================
+// AC4 (generic companion) — fail-closed revert: a hop that throws mid-apply is
+// reverted to the BYTE-EXACT pre-migration subtree; the version is NOT advanced;
+// the backup is RETAINED for inspection.
+// ===========================================================================
+describe("runStoreMigrations — AC4 generic revert to byte-exact prior state", () => {
+  it("a hop that THROWS mid-apply reverts the whole subtree byte-exactly + retains the backup + does not advance the marker", () => {
+    const sentinel = seedShopper("PRISTINE\n");
+    const before = walkShopper();
+    const m1 = fakeMigration(1, {
+      apply: (dir) => {
+        // Partial mutation, THEN a hard failure — the classic half-applied hazard.
+        writeFileSync(join(dir, SHOPPER, "half-written.txt"), "garbage\n", { mode: 0o600 });
+        throw new Error("disk exploded mid-apply");
+      },
+    });
+
+    const result = runStoreMigrations(dataDir, [m1.migration]);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected failure");
+    expect(result.kind).toBe("migration_failed");
+    expect(result.version).toBe(1);
+    expect(result.reverted).toBe(true);
+    expect(result.reason).toMatch(/disk exploded/);
+    // Byte-exact restore: the original file is intact and the half-written file is GONE.
+    expect(readFileSync(sentinel, "utf8")).toBe("PRISTINE\n");
+    expect(walkShopper()).toEqual(before);
+    expect(existsSync(join(dataDir, SHOPPER, "half-written.txt"))).toBe(false);
+    // The version is NOT advanced — a reverted hop leaves the marker at its prior value.
+    expect(readStoreVersion(dataDir)).toBe(0);
+    // The backup is RETAINED on failure so sil_doctor / a human can recover.
+    expect(existsSync(join(dataDir, BACKUP_DIR))).toBe(true);
+  });
+
+  it("an early hop that SUCCEEDS stays applied when a LATER hop fails (per-hop transactional, not per-chain rollback)", () => {
+    seedShopper();
+    const m1 = fakeMigration(1, {
+      apply: (dir) => writeFileSync(join(dir, SHOPPER, "hop1.txt"), "kept\n", { mode: 0o600 }),
+    });
+    const m2 = fakeMigration(2, {
+      apply: () => {
+        throw new Error("hop 2 blew up");
+      },
+    });
+
+    const result = runStoreMigrations(dataDir, [m1.migration, m2.migration]);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected failure");
+    expect(result.version).toBe(2);
+    // Hop 1 committed: its file survives and the marker sits at 1 (not rolled back to 0).
+    expect(existsSync(join(dataDir, SHOPPER, "hop1.txt"))).toBe(true);
+    expect(readStoreVersion(dataDir)).toBe(1);
+  });
+});
+
+// ===========================================================================
+// Success cleans up its backup — a green hop leaves no retained backup behind.
+// ===========================================================================
+describe("runStoreMigrations — a successful hop removes its own backup", () => {
+  it("after a clean apply+verify, no .sil-migration-backup remains", () => {
+    seedShopper();
+    const m1 = fakeMigration(1, {
+      apply: (dir) => writeFileSync(join(dir, SHOPPER, "done.txt"), "ok\n", { mode: 0o600 }),
+    });
+
+    const result = runStoreMigrations(dataDir, [m1.migration]);
+
+    expect(result.ok).toBe(true);
+    expect(readStoreVersion(dataDir)).toBe(1);
+    // The transient backup is gone on success (retained ONLY on failure).
+    expect(existsSync(join(dataDir, BACKUP_DIR))).toBe(false);
+  });
+});

--- a/src/__tests__/lib/store-migrations-runner.test.ts
+++ b/src/__tests__/lib/store-migrations-runner.test.ts
@@ -61,6 +61,7 @@ import {
   writeFileSync,
   existsSync,
   statSync,
+  chmodSync,
   rmSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -72,7 +73,7 @@ import {
   runStoreMigrations,
 } from "../../lib/migrations/runner.js";
 import { MIGRATIONS, CURRENT_STORE_VERSION } from "../../lib/migrations/registry.js";
-import type { Migration } from "../../lib/migrations/types.js";
+import type { Migration, MigrationRunResult } from "../../lib/migrations/types.js";
 
 let dataDir: string;
 let priorSilDataDir: string | undefined;
@@ -81,6 +82,10 @@ const MARKER = "store-format.json";
 const BACKUP_DIR = ".sil-migration-backup";
 const SHOPPER = "shopper";
 
+// Root bypasses the permission bits the fault-injection levers below rely on, so those
+// cases skip under root (idiom per create-shopper.integration.test.ts).
+const AS_ROOT = typeof process.getuid === "function" && process.getuid() === 0;
+
 beforeEach(() => {
   dataDir = mkdtempSync(join(tmpdir(), "sil-store-mig-runner-"));
   priorSilDataDir = process.env["SIL_DATA_DIR"];
@@ -88,6 +93,15 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  // Defensive: restore any perms a fault-injection lever dropped on the data-dir root or the
+  // backup subtree, so the temp-dir teardown never EACCESes if a test threw before its finally.
+  for (const p of [dataDir, join(dataDir, BACKUP_DIR)]) {
+    try {
+      chmodSync(p, 0o700);
+    } catch {
+      /* may not exist */
+    }
+  }
   if (priorSilDataDir === undefined) delete process.env["SIL_DATA_DIR"];
   else process.env["SIL_DATA_DIR"] = priorSilDataDir;
   rmSync(dataDir, { recursive: true, force: true });
@@ -428,4 +442,162 @@ describe("runStoreMigrations — a successful hop removes its own backup", () =>
     // The transient backup is gone on success (retained ONLY on failure).
     expect(existsSync(join(dataDir, BACKUP_DIR))).toBe(false);
   });
+});
+
+// ===========================================================================
+// Fail-closed I/O gap (review round 1, P2). The runner's contract is that NO path
+// escapes as a raw throw — EVERY failure surfaces as a structured migration_failed
+// (business rule 3). The apply/verify seam is already guarded; these pin the
+// previously-unguarded sites: createBackup, BOTH writeStoreVersion calls (the no-op
+// record and the post-verify record), and removeBackup. Real-fs fault injection
+// (chmod / marker-as-directory), no synthetic hook, mirroring the AC6 lever.
+//
+// The `reverted` discriminator is load-bearing here and differs BY SITE, keyed on
+// whether a transform was already COMMITTED when the I/O failed:
+//   - before any transform (createBackup, the no-op-branch record) ⇒ store is provably
+//     untouched ⇒ reverted:true (honest "prior state intact"), never a false-alarm dirty.
+//   - after a verified transform (the post-verify record) ⇒ the migration is CORRECT,
+//     only the marker could not be written ⇒ reverted:false, and the good transform is
+//     KEPT (never thrown away — reverting would re-expose the legacy store to a
+//     destructive re-migrate loop next boot).
+//   - a POST-SUCCESS cleanup failure (removeBackup, after apply+verify+record all passed)
+//     is NOT a data-integrity failure ⇒ the run still SUCCEEDS (a leftover backup is
+//     harmless; reporting failure would falsely tell the agent the shopper is broken).
+// ===========================================================================
+describe("runStoreMigrations — fail-closed: every guarded I/O site maps to migration_failed, never a raw throw", () => {
+  it.skipIf(AS_ROOT)(
+    "createBackup cannot snapshot (read-only data-dir root) ⇒ migration_failed, store untouched (reverted:true), version NOT advanced",
+    () => {
+      const sentinel = seedShopper("UNTOUCHED\n");
+      const before = walkShopper();
+      // A hop that WOULD transform — but the backup snapshot can't be created because the
+      // data-dir root is read-only, so createBackup (mkdir .sil-migration-backup) EACCESes
+      // BEFORE apply ever runs. Unguarded, createBackup raw-throws out of the runner (RED);
+      // the fail-closed contract requires a structured migration_failed instead.
+      const m1 = fakeMigration(1, {
+        apply: (dir) => writeFileSync(join(dir, SHOPPER, "should-never-exist.txt"), "x\n", { mode: 0o600 }),
+      });
+      chmodSync(dataDir, 0o500);
+
+      let result: MigrationRunResult;
+      try {
+        result = runStoreMigrations(dataDir, [m1.migration]);
+      } finally {
+        chmodSync(dataDir, 0o700);
+      }
+
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error("expected failure");
+      expect(result.kind).toBe("migration_failed");
+      expect(result.version).toBe(1);
+      // createBackup failed BEFORE apply — the store was never mutated ⇒ reverted:true.
+      expect(result.reverted).toBe(true);
+      expect(result.recovery).toBe("inspect_store");
+      expect(result.reason.length).toBeGreaterThan(0);
+      // apply never ran (createBackup gates it) and the version was not advanced.
+      expect(m1.calls.apply).toBe(0);
+      expect(readStoreVersion(dataDir)).toBe(0);
+      // Byte-exact: the subtree is identical, no half-written file leaked in.
+      expect(readFileSync(sentinel, "utf8")).toBe("UNTOUCHED\n");
+      expect(walkShopper()).toEqual(before);
+    },
+  );
+
+  it.skipIf(AS_ROOT)(
+    "the no-op-branch writeStoreVersion fails (read-only root, detectApplicable false) ⇒ migration_failed, store untouched (reverted:true)",
+    () => {
+      seedShopper("PRISTINE\n");
+      // detectApplicable:false ⇒ the runner records the version WITHOUT a transform. On a
+      // read-only root that marker write EACCESes — unguarded it raw-throws (RED). Mapped:
+      // migration_failed with the store untouched.
+      const m1 = fakeMigration(1, { detect: () => false });
+      chmodSync(dataDir, 0o500);
+
+      let result: MigrationRunResult;
+      try {
+        result = runStoreMigrations(dataDir, [m1.migration]);
+      } finally {
+        chmodSync(dataDir, 0o700);
+      }
+
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error("expected failure");
+      expect(result.kind).toBe("migration_failed");
+      expect(result.version).toBe(1);
+      // No transform of any kind ran (detect was false) — the store is untouched ⇒ reverted:true.
+      expect(result.reverted).toBe(true);
+      expect(m1.calls.apply).toBe(0);
+      expect(readStoreVersion(dataDir)).toBe(0);
+    },
+  );
+
+  it("the post-verify writeStoreVersion fails (marker path unwritable) ⇒ migration_failed, reverted:false, and the verified transform is KEPT", () => {
+    const sentinel = seedShopper("ORIGINAL\n");
+    // Make ONLY the record write fail while backup + apply + verify all succeed: pre-create
+    // the marker PATH as a NON-EMPTY directory, so writeStoreVersion's rename-onto-path
+    // EISDIRs. (This fault reproduces regardless of privilege — no skipIf needed.)
+    const markerAsDir = join(dataDir, MARKER);
+    mkdirSync(markerAsDir, { recursive: true });
+    writeFileSync(join(markerAsDir, "occupied"), "x\n", { mode: 0o600 });
+    const m1 = fakeMigration(1, {
+      apply: (dir) => writeFileSync(join(dir, SHOPPER, "sentinel.txt"), "MIGRATED\n", { mode: 0o600 }),
+      verify: () => null, // the transform met the floor; only recording it fails
+    });
+
+    const result = runStoreMigrations(dataDir, [m1.migration]);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected failure");
+    expect(result.kind).toBe("migration_failed");
+    expect(result.version).toBe(1);
+    // A verified transform was already committed — the migration is CORRECT, only the marker
+    // could not be recorded ⇒ reverted:false (NOT reverted:true, which would claim a
+    // revert-to-prior that did not, and must not, happen).
+    expect(result.reverted).toBe(false);
+    // The verified transform SURVIVES — the runner did not throw away good, floor-meeting work.
+    expect(readFileSync(sentinel, "utf8")).toBe("MIGRATED\n");
+    expect(m1.calls.apply).toBe(1);
+    expect(m1.calls.verify).toBe(1);
+    // The marker never recorded (the unwritable dir parses as absent ⇒ still 0).
+    expect(readStoreVersion(dataDir)).toBe(0);
+  });
+
+  it.skipIf(AS_ROOT)(
+    "removeBackup fails AFTER a successful apply+verify+record ⇒ the run still SUCCEEDS (a post-success cleanup failure is not a data-integrity failure)",
+    () => {
+      seedShopper("PRISTINE\n");
+      // apply mutates the subtree AND drops write on the backup dir the runner created, so the
+      // post-success removeBackup (rmSync of .sil-migration-backup) EACCESes. The migration
+      // ITSELF fully succeeded — apply ran, verify passed, the marker recorded — only the
+      // transient-backup cleanup failed. Contract (pinned with the dev): a cleanup failure
+      // NEVER turns a succeeded migration into migration_failed; the shopper IS migrated and
+      // intact, so reporting failure here would falsely tell the agent the shopper is broken.
+      const m1 = fakeMigration(1, {
+        apply: (dir) => {
+          writeFileSync(join(dir, SHOPPER, "migrated.txt"), "done\n", { mode: 0o600 });
+          chmodSync(join(dir, BACKUP_DIR), 0o500); // block removeBackup's rmSync of the backup children
+        },
+        verify: () => null,
+      });
+
+      let result: MigrationRunResult;
+      try {
+        result = runStoreMigrations(dataDir, [m1.migration]);
+      } finally {
+        chmodSync(join(dataDir, BACKUP_DIR), 0o700); // restore so afterEach teardown succeeds
+      }
+
+      // The migration SUCCEEDED despite the cleanup failure.
+      expect(result.ok).toBe(true);
+      if (!result.ok) throw new Error("expected success");
+      expect(result.from).toBe(0);
+      expect(result.to).toBe(1);
+      expect(result.applied).toEqual([1]);
+      // The version WAS recorded and the transform is present — the shopper is intact.
+      expect(readStoreVersion(dataDir)).toBe(1);
+      expect(existsSync(join(dataDir, SHOPPER, "migrated.txt"))).toBe(true);
+      // The backup could not be cleaned up — a harmless leftover, tolerated (not fatal).
+      expect(existsSync(join(dataDir, BACKUP_DIR))).toBe(true);
+    },
+  );
 });

--- a/src/__tests__/store-migrations.integration.test.ts
+++ b/src/__tests__/store-migrations.integration.test.ts
@@ -35,9 +35,12 @@
  *
  * Contract this file pins for the implementation (expert-developer):
  *   - src/lib/migrations/runner.ts exports `ensureStoreMigrated(): MigrationRunResult`,
- *     the memoized on-load gate wired as the FIRST line of the five store primitives in
- *     profile-store.ts (searchProfileFrontmatter / readArtefactBody / learnArtefact /
- *     materializeProfile / removeArtefact). The memo MUST key on the resolved data dir
+ *     the memoized on-load gate wired as the FIRST line of the FOUR serve-path store
+ *     primitives in profile-store.ts (searchProfileFrontmatter / readArtefactBody /
+ *     learnArtefact / removeArtefact). materializeProfile is deliberately NOT gated — it
+ *     is SETUP (writes a NEW shopper, never serves stale legacy data); gating it would
+ *     stamp the marker at plain setup, which AC8 below (materialize leaves NO marker)
+ *     forbids. The memo MUST key on the resolved data dir
  *     (NOT a single global slot) so that (a) AC2 holds within a process and (b) each
  *     hermetic test with a fresh $SIL_DATA_DIR re-arms the gate — the whole suite below
  *     depends on this, since with pool:'forks' + isolate all tests in this file share the
@@ -208,16 +211,28 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  // Defensive: restore perms an AC6-style test may have dropped, so teardown succeeds.
-  try {
-    chmodSync(shopperDir(), 0o700);
-  } catch {
-    /* dir may not exist */
+  // Defensive: restore perms an AC6-style or I/O-gap test may have dropped on the shopper
+  // subtree OR the data-dir root, so the temp-dir teardown never EACCESes.
+  for (const p of [dataDir, shopperDir()]) {
+    try {
+      chmodSync(p, 0o700);
+    } catch {
+      /* dir may not exist */
+    }
   }
   if (priorSilDataDir === undefined) delete process.env["SIL_DATA_DIR"];
   else process.env["SIL_DATA_DIR"] = priorSilDataDir;
   rmSync(dataDir, { recursive: true, force: true });
 });
+
+/** The args of every `api.logger.info(event, payload)` call recorded by the mock logger. */
+function infoCalls(): unknown[][] {
+  return (api.logger.info as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+}
+/** Just the structured success-observability breadcrumbs. */
+function migratedLogs(): unknown[][] {
+  return infoCalls().filter((c) => c[0] === "sil_store_migrated");
+}
 
 // ===========================================================================
 // Heal-before-serve / on-load gate — the migration runs on the first store-path
@@ -516,4 +531,107 @@ describe("AC8 — a fresh/empty store is never conjured into a shopper", () => {
     expect(readFileSync(join(shopperDir(), "user_spec.md"), "utf8")).toBe(userSpecBefore);
     expect(existsSync(join(dataDir, BACKUP_DIR))).toBe(false);
   });
+});
+
+// ===========================================================================
+// P2 (review round 1) — success-observability breadcrumb. A SUCCESSFUL on-load
+// migration mutates the shopper's on-disk identity destructively (deletes profile.json,
+// rewrites user_spec.md, folds each domain triple into method.md). "Silent on success"
+// is agent-facing — the operator STILL needs one structured breadcrumb that a
+// destructive migration ran (the exact datum incident-#2 debugging lacked). The tool
+// boundary emits `sil_store_migrated { from, to, applied_count, domain_count }` ONCE when
+// a transform actually ran (applied.length > 0) — the runner stays logger-free.
+// ===========================================================================
+describe("P2 — success-observability: a destructive heal emits ONE sil_store_migrated breadcrumb", () => {
+  it("logs sil_store_migrated { from, to, applied_count, domain_count } once on the heal, and NEVER again on a memoized touch", async () => {
+    seedLegacyStore({ domains: [SKI, ESPRESSO] });
+
+    await getTool(api, SEARCH).execute("obs1", {});
+
+    const logs = migratedLogs();
+    expect(logs).toHaveLength(1);
+    // applied_count (1 real migration ran) and domain_count (2 domains folded) are DISTINCT —
+    // the breadcrumb must not conflate them. from=0 (legacy) → to=CURRENT.
+    expect(logs[0]![1]).toMatchObject({
+      from: 0,
+      to: CURRENT_STORE_VERSION,
+      applied_count: 1,
+      domain_count: 2,
+    });
+
+    // Silent for every SUBSEQUENT touch: the memoized gate never re-logs the (already-run)
+    // destructive migration — a second touch adds no breadcrumb.
+    await getTool(api, SEARCH).execute("obs2", {});
+    expect(migratedLogs()).toHaveLength(1);
+  });
+
+  it("emits the breadcrumb regardless of WHICH gated tool triggers the heal (sil_profile_get as first touch)", async () => {
+    seedLegacyStore({ domains: [SKI, ESPRESSO] });
+
+    // A non-search first touch must ALSO record that a destructive migration ran — the
+    // incident-#2 observability gap exists for every store-path entry point, not just search.
+    await getTool(api, GET).execute("obs3", { domainSlug: "ski" });
+
+    const logs = migratedLogs();
+    expect(logs).toHaveLength(1);
+    expect(logs[0]![1]).toMatchObject({ from: 0, to: CURRENT_STORE_VERSION, applied_count: 1, domain_count: 2 });
+  });
+
+  it("an already-current store emits NO breadcrumb (nothing destructive ran)", async () => {
+    await getTool(api, MATERIALIZE).execute("obs4", { name: "sil shopper", userSpec: "# person\n- x\n" });
+    writeFileSync(join(dataDir, MARKER), JSON.stringify({ version: CURRENT_STORE_VERSION }), { mode: 0o600 });
+
+    await getTool(api, SEARCH).execute("obs5", {});
+
+    expect(migratedLogs()).toHaveLength(0);
+  });
+
+  it("a store only STAMPED (already-new-format, no transform applied) emits NO breadcrumb — the log keys on applied>0, not on a marker change", async () => {
+    // A 0.4.x store created before the framework: new-format, no marker, no profile.json. The
+    // gate STAMPS the version (0 → current) but applies NO migration ⇒ no destructive change
+    // ⇒ no breadcrumb, even though the recorded version advanced.
+    await getTool(api, MATERIALIZE).execute("obs6", { name: "sil shopper", userSpec: "# person\n- NEW-FORMAT\n" });
+    expect(existsSync(join(dataDir, MARKER))).toBe(false);
+
+    await getTool(api, SEARCH).execute("obs7", {});
+
+    expect(readStoreVersion(dataDir)).toBe(CURRENT_STORE_VERSION); // stamped
+    expect(migratedLogs()).toHaveLength(0); // but NOT "migrated"
+  });
+});
+
+// ===========================================================================
+// P2 (review round 1) — the on-load gate must never let a runner I/O failure escape as
+// an UNHANDLED throw out of a gated tool. Business rule 3: EVERY failure surfaces a
+// structured status + recovery hint. Real-fs fault injection: a read-only data-dir root
+// makes the runner's createBackup (mkdir .sil-migration-backup at root) EACCES before
+// apply — an unguarded runner raw-throws through execute(); the fix maps it to the
+// migration_failed envelope. Skipped as root (root bypasses the permission bits).
+// ===========================================================================
+describe("P2 — the on-load gate surfaces migration_failed (never a raw crash) on a runner I/O failure", () => {
+  it.skipIf(AS_ROOT)(
+    "createBackup cannot snapshot (read-only data-dir root) ⇒ the tool returns a structured migration_failed, not an unhandled throw",
+    async () => {
+      seedLegacyStore();
+      // Read-only data-dir ROOT: Migration #1 detects the legacy store, but createBackup
+      // EACCESes before apply. The gated primitive must surface the structured envelope.
+      chmodSync(dataDir, 0o500);
+
+      let payload: Record<string, unknown>;
+      try {
+        payload = payloadOf(await getTool(api, SEARCH).execute("iogap", {}));
+      } finally {
+        chmodSync(dataDir, 0o700);
+      }
+
+      expect(payload["status"]).toBe("migration_failed");
+      // createBackup fails before apply ⇒ the store was never mutated ⇒ safely at prior state.
+      expect(payload["reverted"]).toBe(true);
+      expect(typeof payload["recovery"]).toBe("string");
+      expect((payload["recovery"] as string).length).toBeGreaterThan(0);
+      // The version was not advanced and the legacy signature is untouched (honest prior state).
+      expect(readStoreVersion(dataDir)).toBe(0);
+      expect(existsSync(join(shopperDir(), "profile.json"))).toBe(true);
+    },
+  );
 });

--- a/src/__tests__/store-migrations.integration.test.ts
+++ b/src/__tests__/store-migrations.integration.test.ts
@@ -1,0 +1,519 @@
+/**
+ * INTEGRATION — Migration #1 (0.3.x legacy → 0.4.x frontmatter-as-truth) + the
+ * on-load self-migrate gate, driven through a REAL registered tool `execute()`
+ * against a real temp $SIL_DATA_DIR seeded with a v0.3.9 legacy tree (tier:
+ * integration, real fs, no network, no host).
+ *
+ * Card: versioned-store-migrations-on-load-self-migrate. THESE ASSERTIONS ARE THE
+ * SPEC (RED-first). Incident #2: `0.3.7 → 0.4.0` dropped `profile.json` for
+ * frontmatter-as-truth with no back-compat, so every pre-existing store went
+ * `unreadable` and the shopper vanished. This file pins the resurrection:
+ *
+ *   - AC1 resurrection / preservation floor — the legacy `profile.json` name + the
+ *     frontmatter-LESS legacy `user_spec.md` body fold into ONE frontmatter-as-truth
+ *     `user_spec.md` (non-blank frontmatter `name` == the legacy name, body preserved
+ *     byte-for-byte); the shopper reads as existing again.
+ *   - AC2 silent success + per-process memo — the triggering tool returns its NORMAL
+ *     result (no prompt / confirmation / re-onboarding); a second touch never re-migrates.
+ *   - AC4 fail-closed revert — a forced Migration #1 failure reverts to the BYTE-EXACT
+ *     pre-migration store, does NOT advance the version, fails the tool closed with a
+ *     structured status + recovery hint, and the store still reads its honest prior state.
+ *   - AC6 un-revertable revert — a failure whose revert ALSO fails surfaces the DISTINCT,
+ *     louder `reverted:false` (store-left-dirty), never green-washed as a clean revert.
+ *   - AC7 idempotent no-op — an already-current store rewrites nothing.
+ *   - AC8 never fabricate — a fresh/empty store creates no shopper + invents no user_spec/
+ *     name; it just stamps the current version.
+ *   - Heal-before-serve / on-load gate — the migration runs on the first store-path tool
+ *     `execute()`, NOT in register(); a behind-version store does not serve until healed.
+ *
+ * The legacy fixture is built from the REAL v0.3.9 store shape (`git show
+ * v0.3.9:src/lib/profile-store.ts`): `shopper/{user_spec.md (frontmatter-LESS body),
+ * profile.json (the { name, userSpecPath, createdAt, domains } manifest)}` and
+ * `shopper/domains/<slug>/{domain_spec.md, intent_spec.md, playbook.md}` (all
+ * frontmatter-less bodies). No stubbed store — the migration's whole point is real
+ * prior data.
+ *
+ * Contract this file pins for the implementation (expert-developer):
+ *   - src/lib/migrations/runner.ts exports `ensureStoreMigrated(): MigrationRunResult`,
+ *     the memoized on-load gate wired as the FIRST line of the five store primitives in
+ *     profile-store.ts (searchProfileFrontmatter / readArtefactBody / learnArtefact /
+ *     materializeProfile / removeArtefact). The memo MUST key on the resolved data dir
+ *     (NOT a single global slot) so that (a) AC2 holds within a process and (b) each
+ *     hermetic test with a fresh $SIL_DATA_DIR re-arms the gate — the whole suite below
+ *     depends on this, since with pool:'forks' + isolate all tests in this file share the
+ *     module-level memo.
+ *   - src/tools/profile.ts `mapFailure` gains a `status:"migration_failed"` arm that
+ *     surfaces `reverted` (+ version, reason, recovery) so the agent distinguishes
+ *     "safely reverted, prior state intact" from "store left dirty".
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+  existsSync,
+  statSync,
+  chmodSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { registerProfileTools } from "../tools/profile.js";
+import { readShopperIdentity } from "../lib/profile-store.js";
+import { readStoreVersion } from "../lib/migrations/runner.js";
+import { CURRENT_STORE_VERSION } from "../lib/migrations/registry.js";
+import {
+  createMockPluginApi,
+  getTool,
+  type MockPluginAPI,
+} from "./helpers/mock-plugin-api.js";
+
+const SEARCH = "sil_profile_search";
+const GET = "sil_profile_get";
+const MATERIALIZE = "sil_profile_materialize";
+const MARKER = "store-format.json";
+const BACKUP_DIR = ".sil-migration-backup";
+
+const AS_ROOT = typeof process.getuid === "function" && process.getuid() === 0;
+
+let dataDir: string;
+let priorSilDataDir: string | undefined;
+let api: MockPluginAPI;
+
+function payloadOf(result: { content: { text?: string }[] }): Record<string, unknown> {
+  const text = result.content[0]?.text;
+  if (typeof text !== "string") throw new Error(`tool result has no text payload: ${String(text)}`);
+  return JSON.parse(text) as Record<string, unknown>;
+}
+
+function shopperDir(): string {
+  return join(dataDir, "shopper");
+}
+function domainDir(slug: string): string {
+  return join(shopperDir(), "domains", slug);
+}
+
+// ---------------------------------------------------------------------------
+// The REAL v0.3.9 legacy tree (git show v0.3.9:src/lib/profile-store.ts):
+//   shopper/user_spec.md   — a FRONTMATTER-LESS plain body (name lived in profile.json).
+//   shopper/profile.json   — { name, userSpecPath, createdAt, domains: {<slug>: {...}} }.
+//   shopper/domains/<slug>/{domain_spec.md, intent_spec.md, playbook.md} — plain bodies.
+// Distinctive tokens per body so preservation (or its loss) is unambiguous.
+// ---------------------------------------------------------------------------
+
+const LEGACY_NAME = "Ada Lovelace";
+const LEGACY_USER_SPEC =
+  "# The person\n- Ships to Berlin.\n- HARD-NO: leather.\n- USERSPEC-TOKEN-Δ (must survive)\n";
+
+interface LegacyDomain {
+  slug: string;
+  name: string;
+  domainSpec: string;
+  intentSpec: string;
+  playbook: string;
+}
+
+const SKI: LegacyDomain = {
+  slug: "ski",
+  name: "Ski",
+  domainSpec: "# Ski domain guide\nDOMAINSPEC-TOKEN-α\n",
+  intentSpec: "# Ski intent dimensions\nINTENTSPEC-TOKEN-β\n",
+  playbook: "# Ski taste\nPLAYBOOK-TOKEN-γ\n",
+};
+const ESPRESSO: LegacyDomain = {
+  slug: "espresso",
+  name: "Espresso",
+  domainSpec: "# Espresso domain guide\nDOMAINSPEC-TOKEN-ε\n",
+  intentSpec: "# Espresso intent dimensions\nINTENTSPEC-TOKEN-ζ\n",
+  playbook: "# Espresso taste\nPLAYBOOK-TOKEN-η\n",
+};
+
+interface SeedOptions {
+  name?: string;
+  userSpec?: string;
+  domains?: LegacyDomain[];
+}
+
+/** Write a faithful v0.3.9 legacy store under `$SIL_DATA_DIR/shopper`. */
+function seedLegacyStore(opts: SeedOptions = {}): void {
+  const name = opts.name ?? LEGACY_NAME;
+  const userSpec = opts.userSpec ?? LEGACY_USER_SPEC;
+  const domains = opts.domains ?? [SKI];
+  const dir = shopperDir();
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+
+  const userSpecPath = join(dir, "user_spec.md");
+  // FRONTMATTER-LESS body — exactly how v0.3.9 atomicWrite(userSpecPath, spec.userSpec) wrote it.
+  writeFileSync(userSpecPath, userSpec, { mode: 0o600 });
+
+  const now = "2025-01-01T00:00:00.000Z";
+  const manifestDomains: Record<string, unknown> = {};
+  for (const d of domains) {
+    const leaf = domainDir(d.slug);
+    mkdirSync(leaf, { recursive: true, mode: 0o700 });
+    writeFileSync(join(leaf, "domain_spec.md"), d.domainSpec, { mode: 0o600 });
+    writeFileSync(join(leaf, "intent_spec.md"), d.intentSpec, { mode: 0o600 });
+    writeFileSync(join(leaf, "playbook.md"), d.playbook, { mode: 0o600 });
+    manifestDomains[d.slug] = {
+      slug: d.slug,
+      name: d.name,
+      domainSpecPath: join(leaf, "domain_spec.md"),
+      intentSpecPath: join(leaf, "intent_spec.md"),
+      playbookPath: join(leaf, "playbook.md"),
+      createdAt: now,
+      updatedAt: now,
+    };
+  }
+  const manifest = { name, userSpecPath, createdAt: now, domains: manifestDomains };
+  writeFileSync(join(dir, "profile.json"), JSON.stringify(manifest, null, 2) + "\n", { mode: 0o600 });
+}
+
+/** Snapshot every file under the shopper subtree as relPath → bytes (for byte-exact
+ * revert assertions). */
+function snapshotShopper(): Map<string, string> {
+  const out = new Map<string, string>();
+  const root = shopperDir();
+  if (!existsSync(root)) return out;
+  for (const rel of readdirSync(root, { recursive: true }) as string[]) {
+    const abs = join(root, rel);
+    if (statSync(abs).isFile()) out.set(rel, readFileSync(abs, "utf8"));
+  }
+  return out;
+}
+
+/** Parse the `--- k: v --- body` of a written artefact. */
+function parseArtefact(raw: string): { fields: Record<string, string>; body: string } {
+  expect(raw.startsWith("---")).toBe(true);
+  const close = raw.slice(3).match(/\n---[ \t]*\r?\n/)!;
+  const fmRaw = raw.slice(3, 3 + close.index!);
+  const body = raw.slice(3 + close.index! + close[0].length);
+  const fields: Record<string, string> = {};
+  for (const line of fmRaw.split(/\r?\n/)) {
+    const m = /^([A-Za-z0-9_]+):\s*(.*)$/.exec(line);
+    if (m && m[2] !== "") fields[m[1] as string] = (m[2] as string).trim();
+  }
+  return { fields, body };
+}
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), "sil-store-mig-integ-"));
+  priorSilDataDir = process.env["SIL_DATA_DIR"];
+  process.env["SIL_DATA_DIR"] = dataDir;
+  api = createMockPluginApi();
+  registerProfileTools(api);
+});
+
+afterEach(() => {
+  // Defensive: restore perms an AC6-style test may have dropped, so teardown succeeds.
+  try {
+    chmodSync(shopperDir(), 0o700);
+  } catch {
+    /* dir may not exist */
+  }
+  if (priorSilDataDir === undefined) delete process.env["SIL_DATA_DIR"];
+  else process.env["SIL_DATA_DIR"] = priorSilDataDir;
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+// ===========================================================================
+// Heal-before-serve / on-load gate — the migration runs on the first store-path
+// tool execute(), NOT at register(); a behind-version store does not serve until
+// healed. This is the exact step missing when incident #2 happened.
+// ===========================================================================
+describe("on-load gate — heal on first tool execute(), NEVER at register()", () => {
+  it("registerProfileTools() does NOT migrate — the legacy store is untouched after register (register opens nothing)", () => {
+    seedLegacyStore();
+    // register() already ran in beforeEach. The sync/opens-nothing invariant forbids
+    // migrating here — so the legacy signature must still be fully present.
+    expect(existsSync(join(shopperDir(), "profile.json"))).toBe(true);
+    expect(existsSync(join(dataDir, MARKER))).toBe(false);
+    expect(existsSync(join(domainDir("ski"), "domain_spec.md"))).toBe(true);
+  });
+
+  it("the FIRST store-path tool execute() heals the store before it serves (profile.json consumed, marker stamped)", async () => {
+    seedLegacyStore();
+    // A behind-version store must not serve stale — the gate heals first.
+    await getTool(api, SEARCH).execute("g1", {});
+    expect(existsSync(join(shopperDir(), "profile.json"))).toBe(false);
+    expect(readStoreVersion(dataDir)).toBe(CURRENT_STORE_VERSION);
+  });
+
+  it("the gate is on MULTIPLE store primitives, not one tool — sil_profile_get also triggers the heal", async () => {
+    seedLegacyStore();
+    // Drive a DIFFERENT gated primitive (readArtefactBody) as the first touch.
+    await getTool(api, GET).execute("g2", { domainSlug: "ski" });
+    expect(existsSync(join(shopperDir(), "profile.json"))).toBe(false);
+    expect(readStoreVersion(dataDir)).toBe(CURRENT_STORE_VERSION);
+  });
+});
+
+// ===========================================================================
+// AC1 — resurrection / preservation floor. The shopper survives ⇔ user_spec.md
+// exists with a non-blank frontmatter name AND the legacy user_spec body is preserved.
+// ===========================================================================
+describe("AC1 — resurrection: the preservation floor holds after Migration #1", () => {
+  it("folds the legacy name + frontmatter-less user_spec body into ONE frontmatter-as-truth user_spec.md (name preserved, body preserved byte-for-byte)", async () => {
+    seedLegacyStore();
+    await getTool(api, SEARCH).execute("a1", {});
+
+    const userSpecPath = join(shopperDir(), "user_spec.md");
+    expect(existsSync(userSpecPath)).toBe(true);
+    const raw = readFileSync(userSpecPath, "utf8");
+    const { fields, body } = parseArtefact(raw);
+    // Floor part 1: a NON-BLANK frontmatter name == the legacy profile.json name.
+    expect(fields["name"]).toBe(LEGACY_NAME);
+    expect(fields["name"]!.trim().length).toBeGreaterThan(0);
+    // Floor part 2: the legacy body is preserved byte-for-byte (the store only appends a
+    // trailing newline, never rewrites content — so the raw legacy body is a substring).
+    expect(raw).toContain(LEGACY_USER_SPEC.trimEnd());
+    expect(body).toContain("USERSPEC-TOKEN-Δ (must survive)");
+    expect(body).toContain("HARD-NO: leather.");
+  });
+
+  it("readShopperIdentity returns the resurrected name — the shopper reads as existing again (no re-onboarding)", async () => {
+    seedLegacyStore();
+    // Pre-flight before the heal: the legacy frontmatter-less user_spec reads unreadable.
+    expect(readShopperIdentity().name).toBeUndefined();
+
+    await getTool(api, SEARCH).execute("a2", {});
+
+    const identity = readShopperIdentity();
+    expect(identity.name).toBe(LEGACY_NAME);
+    expect(identity.unreadable).toEqual([]);
+  });
+
+  it("records the store-format version as current after a successful heal", async () => {
+    seedLegacyStore();
+    await getTool(api, SEARCH).execute("a3", {});
+    expect(readStoreVersion(dataDir)).toBe(CURRENT_STORE_VERSION);
+  });
+
+  it("preserves the per-domain legacy triple LOSSLESSLY into method.md and deletes the legacy files — across ALL domains", async () => {
+    seedLegacyStore({ domains: [SKI, ESPRESSO] });
+    await getTool(api, SEARCH).execute("a4", {});
+
+    for (const d of [SKI, ESPRESSO]) {
+      const methodPath = join(domainDir(d.slug), "method.md");
+      expect(existsSync(methodPath)).toBe(true);
+      const raw = readFileSync(methodPath, "utf8");
+      const { fields } = parseArtefact(raw);
+      // Method frontmatter carries a non-blank name + the domain coordinate.
+      expect(fields["name"]!.trim().length).toBeGreaterThan(0);
+      expect(fields["domain"]).toBe(d.slug);
+      // LOSSLESS: all three legacy bodies survive verbatim (headings are the dev's call —
+      // the invariant is that not one body is dropped).
+      for (const token of [d.domainSpec, d.intentSpec, d.playbook]) {
+        expect(raw).toContain(token.split("\n")[1]!); // the distinctive token line
+      }
+      // The three deleted legacy files are GONE (converted, not left as dead bytes).
+      expect(existsSync(join(domainDir(d.slug), "domain_spec.md"))).toBe(false);
+      expect(existsSync(join(domainDir(d.slug), "intent_spec.md"))).toBe(false);
+      expect(existsSync(join(domainDir(d.slug), "playbook.md"))).toBe(false);
+    }
+    // No manifest survives the frontmatter-as-truth conversion.
+    expect(existsSync(join(shopperDir(), "profile.json"))).toBe(false);
+  });
+
+  it("does NOT fabricate methods/PRDs from the deleted triple — no prds/ dir is invented", async () => {
+    seedLegacyStore();
+    await getTool(api, SEARCH).execute("a5", {});
+    // The triple folds into method.md ONLY — a PRD is buyer requirements, never in the
+    // legacy per-domain data, so no PRD may be conjured.
+    expect(existsSync(join(domainDir("ski"), "prds"))).toBe(false);
+  });
+});
+
+// ===========================================================================
+// AC2 — silent success + per-process memo.
+// ===========================================================================
+describe("AC2 — silent success on heal; the migration never re-runs in-process", () => {
+  it("the triggering tool returns its NORMAL result — no prompt / confirmation / re-onboarding / migration noise", async () => {
+    seedLegacyStore();
+    const payload = payloadOf(await getTool(api, SEARCH).execute("s1", {}));
+    // The search just returns its normal ok result over the healed store.
+    expect(payload["status"]).toBe("ok");
+    const domains = payload["domains"] as Array<Record<string, unknown>>;
+    expect(domains.map((d) => d["slug"])).toContain("ski");
+    // Silent = no migration/onboarding signal is added to the success envelope.
+    for (const key of ["migration", "migrated", "prompt", "confirm", "reonboard", "onboarding"]) {
+      expect(payload).not.toHaveProperty(key);
+    }
+    // A healed identity-carrying store with a domain is a MATCH → no mint trigger either.
+    expect(payload).not.toHaveProperty("next_step");
+  });
+
+  it("a second store-path touch never re-migrates — the gate is memoized per process/data-dir", async () => {
+    seedLegacyStore();
+    // First touch heals (marker → current, profile.json consumed).
+    await getTool(api, SEARCH).execute("m1", {});
+    expect(readStoreVersion(dataDir)).toBe(CURRENT_STORE_VERSION);
+
+    // Adversarial memo probe: DELETE the marker AND re-drop a fresh legacy profile.json.
+    // If the gate re-ran, it would read the (now-absent) marker as 0, detect the legacy
+    // signature, and RE-MIGRATE (consuming profile.json + re-stamping). If it is memoized,
+    // it returns the cached result and touches nothing.
+    rmSync(join(dataDir, MARKER), { force: true });
+    writeFileSync(join(shopperDir(), "profile.json"), '{"name":"x","userSpecPath":"","createdAt":"","domains":{}}', {
+      mode: 0o600,
+    });
+
+    await getTool(api, SEARCH).execute("m2", {});
+
+    // Memoized: the re-dropped profile.json is untouched and no new marker was written.
+    expect(existsSync(join(shopperDir(), "profile.json"))).toBe(true);
+    expect(existsSync(join(dataDir, MARKER))).toBe(false);
+  });
+});
+
+// ===========================================================================
+// AC4 — fail-closed revert to the BYTE-EXACT prior state (Migration #1 forced to
+// fail). A legacy profile.json whose `name` is blank is genuine corruption:
+// Migration #1 throws rather than fabricate a name → the runner reverts.
+// ===========================================================================
+describe("AC4 — a failed Migration #1 reverts to the byte-exact prior store + fails the tool closed", () => {
+  it("reverts every byte, does NOT advance the version, and the store still reads its honest prior (unreadable) state", async () => {
+    // A blank name in profile.json = corruption Migration #1 must refuse (never fabricate).
+    seedLegacyStore({ name: "   " });
+    const before = snapshotShopper();
+
+    const payload = payloadOf(await getTool(api, SEARCH).execute("f1", {}));
+
+    // The tool fails closed with a structured migration failure + recovery hint.
+    expect(payload["status"]).toBe("migration_failed");
+    expect(payload["reverted"]).toBe(true);
+    expect(typeof payload["recovery"]).toBe("string");
+    expect((payload["recovery"] as string).length).toBeGreaterThan(0);
+    expect(String(payload["message"] ?? payload["reason"]).length).toBeGreaterThan(0);
+
+    // Byte-exact restore: every file identical to the pre-migration snapshot, nothing added.
+    const after = snapshotShopper();
+    expect([...after.keys()].sort()).toEqual([...before.keys()].sort());
+    for (const [rel, bytes] of before) expect(after.get(rel)).toBe(bytes);
+
+    // The version is NOT advanced — a still-legacy store is not falsely "current".
+    expect(readStoreVersion(dataDir)).toBe(0);
+    // Honest prior state: the frontmatter-less user_spec still reads unreadable (no name),
+    // never a false-healthy shopper.
+    expect(readShopperIdentity().name).toBeUndefined();
+    expect(readShopperIdentity().unreadable.length).toBeGreaterThan(0);
+  });
+});
+
+// ===========================================================================
+// AC6 — un-revertable revert (the louder honesty rail). A failure whose revert-
+// from-backup ALSO fails surfaces reverted:false (store-left-dirty), never a clean
+// revert. Real-fs fault injection: shopper/ is chmod 0500, so apply's first write
+// EACCESes (failure) AND the revert's rmSync of shopper's children EACCESes (revert
+// fails) — while the data-dir root stays writable so the backup snapshot still succeeds.
+// Skipped as root (root bypasses the permission bits).
+// ===========================================================================
+describe("AC6 — an un-revertable revert is a DISTINCT louder outcome (never green-washed)", () => {
+  it.skipIf(AS_ROOT)(
+    "a failed heal whose backup-restore also fails surfaces reverted:false + names the store as left-dirty",
+    async () => {
+      seedLegacyStore();
+      // Drop write on the shopper subtree AFTER seeding: apply can't write (→ failure) and
+      // the revert's rmSync can't remove shopper's children (→ revert fails). The data-dir
+      // root stays 0700 so the backup snapshot under .sil-migration-backup still succeeds.
+      chmodSync(shopperDir(), 0o500);
+
+      let payload: Record<string, unknown>;
+      try {
+        payload = payloadOf(await getTool(api, SEARCH).execute("d1", {}));
+      } finally {
+        chmodSync(shopperDir(), 0o700);
+      }
+
+      expect(payload["status"]).toBe("migration_failed");
+      // The louder rail: revert could NOT be guaranteed → reverted:false, NOT true.
+      expect(payload["reverted"]).toBe(false);
+      // The message tells the agent the store is left dirty / to inspect it — never a
+      // green-washed clean revert.
+      expect(typeof payload["recovery"]).toBe("string");
+      expect((payload["recovery"] as string).length).toBeGreaterThan(0);
+      expect(String(payload["message"] ?? payload["reason"])).toMatch(
+        /dirt|inspect|manual|revert|left|restore|recover|inconsist|backup/i,
+      );
+      // The version is NOT advanced (a failed heal never records success).
+      expect(readStoreVersion(dataDir)).toBe(0);
+      // The backup is retained for recovery.
+      expect(existsSync(join(dataDir, BACKUP_DIR))).toBe(true);
+    },
+  );
+});
+
+// ===========================================================================
+// AC7 — idempotent no-op on an already-current REAL store: rewrites nothing.
+// ===========================================================================
+describe("AC7 — an already-current store is a no-op (no file / marker / version churn)", () => {
+  it("no shopper file mtimes change, the marker is untouched, and no backup is created", async () => {
+    // Build a real CURRENT-format store, then stamp the marker to current.
+    await getTool(api, MATERIALIZE).execute("i0", {
+      name: "sil shopper",
+      userSpec: "# person\n- ships to Berlin\n",
+    });
+    writeFileSync(join(dataDir, MARKER), JSON.stringify({ version: CURRENT_STORE_VERSION }), { mode: 0o600 });
+
+    // Snapshot mtimes of everything under shopper/ + the marker.
+    const mtimes = new Map<string, number>();
+    for (const rel of readdirSync(shopperDir(), { recursive: true }) as string[]) {
+      const abs = join(shopperDir(), rel);
+      if (statSync(abs).isFile()) mtimes.set(rel, statSync(abs).mtimeMs);
+    }
+    const markerMtime = statSync(join(dataDir, MARKER)).mtimeMs;
+
+    const payload = payloadOf(await getTool(api, SEARCH).execute("i1", {}));
+    expect(payload["status"]).toBe("ok");
+
+    // Zero churn: every mtime identical, marker untouched, no backup dir.
+    for (const [rel, was] of mtimes) {
+      expect(statSync(join(shopperDir(), rel)).mtimeMs).toBe(was);
+    }
+    expect(statSync(join(dataDir, MARKER)).mtimeMs).toBe(markerMtime);
+    expect(readStoreVersion(dataDir)).toBe(CURRENT_STORE_VERSION);
+    expect(existsSync(join(dataDir, BACKUP_DIR))).toBe(false);
+  });
+});
+
+// ===========================================================================
+// AC8 — never fabricate identity: a fresh/empty store creates no shopper + invents
+// no user_spec/name; it stamps the current version (or no-ops).
+// ===========================================================================
+describe("AC8 — a fresh/empty store is never conjured into a shopper", () => {
+  it("no shopper/user_spec.md is created, no name is fabricated, and the marker is stamped to current", async () => {
+    // A totally empty data dir — no shopper subtree at all (a clean install).
+    expect(existsSync(shopperDir())).toBe(false);
+
+    const payload = payloadOf(await getTool(api, SEARCH).execute("e1", {}));
+    expect(payload["status"]).toBe("ok");
+
+    // Migration heals; it never conjures — no shopper artefact was fabricated.
+    expect(existsSync(join(shopperDir(), "user_spec.md"))).toBe(false);
+    expect(readShopperIdentity().name).toBeUndefined();
+    // But the version IS stamped so a fresh install is not re-probed every touch.
+    expect(readStoreVersion(dataDir)).toBe(CURRENT_STORE_VERSION);
+    // Nothing was migrated → no backup dir.
+    expect(existsSync(join(dataDir, BACKUP_DIR))).toBe(false);
+  });
+
+  it("a store already in the new format (user_spec present, no profile.json) is NOT re-transformed — only stamped", async () => {
+    // A 0.4.x store created before this framework: new-format, no marker, no profile.json.
+    await getTool(api, MATERIALIZE).execute("e2", {
+      name: "sil shopper",
+      userSpec: "# person\n- NEW-FORMAT-TOKEN\n",
+    });
+    const userSpecBefore = readFileSync(join(shopperDir(), "user_spec.md"), "utf8");
+    expect(existsSync(join(dataDir, MARKER))).toBe(false); // pre-framework: no marker yet
+
+    await getTool(api, SEARCH).execute("e3", {});
+
+    // detectApplicable is false (no profile.json) → record the version, touch nothing.
+    expect(readStoreVersion(dataDir)).toBe(CURRENT_STORE_VERSION);
+    expect(readFileSync(join(shopperDir(), "user_spec.md"), "utf8")).toBe(userSpecBefore);
+    expect(existsSync(join(dataDir, BACKUP_DIR))).toBe(false);
+  });
+});

--- a/src/lib/artefact-io.ts
+++ b/src/lib/artefact-io.ts
@@ -1,0 +1,108 @@
+/**
+ * Low-level artefact IO + frontmatter format for the sil shopper store.
+ *
+ * Extracted so BOTH the live store (`profile-store.ts`) and the store-format
+ * migrations (`lib/migrations/*`) produce and parse BYTE-IDENTICAL frontmatter
+ * without a circular import: the store gates on the migration runner (on-load
+ * heal-before-serve), and Migration #1 must serialize into the exact
+ * frontmatter-as-truth shape the store reads. Both depend DOWN on this leaf, so
+ * the dependency graph stays a DAG (store → runner → registry → migration →
+ * artefact-io; store → artefact-io).
+ *
+ * Atomic single-file writes: tmp sibling → write → rename over target → chmod. A
+ * reader sees the old file or the new one, never a half-written one (mirrors
+ * `credentials.ts`). Frontmatter is `--- key: value … ---` + an opaque body; a
+ * file with malformed/absent frontmatter parses to null (fail-closed read).
+ */
+
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { randomBytes } from "node:crypto";
+
+import { DIR_MODE } from "./credentials.js";
+
+/** Owner-only file mode — artefacts are user-scoped, like tokens. The dir mode
+ * (`DIR_MODE`, `0o700`) is owned by `credentials.ts` and imported, so the data-home
+ * permission lives in exactly one place. */
+export const FILE_MODE = 0o600;
+
+export interface Artefact {
+  fields: Record<string, string>;
+  body: string;
+}
+
+/** One-line scalar for a coordinate value: newlines folded to spaces, trimmed. */
+function scalar(value: string): string {
+  return String(value).replace(/\r?\n/g, " ").trim();
+}
+
+export function serializeArtefact(fields: Record<string, string>, body: string): string {
+  const fm = Object.entries(fields)
+    .map(([k, v]) => k + ": " + scalar(v))
+    .join("\n");
+  // The store owns frontmatter — strip any block a model prepended to the body so the
+  // artefact never stacks two (self-heals a previously double-wrapped file on re-write).
+  const clean = stripLeadingFrontmatter(body);
+  const b = clean.endsWith("\n") ? clean : clean + "\n";
+  return "---\n" + fm + "\n---\n" + b;
+}
+
+/** Parse `--- key: value … ---` frontmatter + body. Returns null (⇒ `unreadable`) on
+ * a missing open fence, a missing close fence, or an empty frontmatter block — a
+ * fail-closed read, never a silent coercion. */
+export function parseArtefact(raw: string): Artefact | null {
+  if (!raw.startsWith("---")) return null;
+  const close = raw.slice(3).match(/\n---[ \t]*\r?\n/);
+  if (!close || close.index === undefined) return null;
+  const fmRaw = raw.slice(3, 3 + close.index);
+  const body = raw.slice(3 + close.index + close[0].length);
+  const fields: Record<string, string> = {};
+  for (const line of fmRaw.split(/\r?\n/)) {
+    const m = /^([A-Za-z0-9_]+):\s*(.*)$/.exec(line);
+    if (m && m[2] !== "") fields[m[1] as string] = (m[2] as string).trim();
+  }
+  if (Object.keys(fields).length === 0) return null;
+  return { fields, body };
+}
+
+/** Strip a leading `--- … ---` frontmatter block a model may have prepended to a body,
+ * reusing `parseArtefact` so ONLY a fence whose content is real frontmatter (≥1
+ * `key: value`) is removed — a body opening with a bare `---` thematic break parses to
+ * null and is returned untouched. The store owns frontmatter (frontmatter-as-truth), so a
+ * model-authored block must never survive into the serialized body and stack a second. */
+function stripLeadingFrontmatter(body: string): string {
+  const parsed = parseArtefact(body);
+  return parsed === null ? body : parsed.body;
+}
+
+/** Read + parse one artefact file, or null if absent/unreadable/malformed. */
+export function readArtefactFile(path: string): Artefact | null {
+  if (!existsSync(path)) return null;
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch {
+    return null;
+  }
+  return parseArtefact(raw);
+}
+
+/** Atomic single-file write: tmp sibling → write → rename over target → chmod. A
+ * reader sees the old file or the new one, never a half-written one. Ensures the
+ * containing dir (0700) first. */
+export function atomicWrite(path: string, contents: string): void {
+  mkdirSync(dirname(path), { recursive: true, mode: DIR_MODE });
+  const tmp = path + "." + randomBytes(6).toString("hex") + ".tmp";
+  writeFileSync(tmp, contents, { mode: FILE_MODE });
+  renameSync(tmp, path);
+  chmodSync(path, FILE_MODE);
+}
+
+/** Write binary bytes atomically, owner-only. */
+export function atomicWriteBytes(path: string, bytes: Buffer): void {
+  mkdirSync(dirname(path), { recursive: true, mode: DIR_MODE });
+  const tmp = path + "." + randomBytes(6).toString("hex") + ".tmp";
+  writeFileSync(tmp, bytes, { mode: FILE_MODE });
+  renameSync(tmp, path);
+  chmodSync(path, FILE_MODE);
+}

--- a/src/lib/migrations/001-frontmatter-store.ts
+++ b/src/lib/migrations/001-frontmatter-store.ts
@@ -1,0 +1,157 @@
+/**
+ * Migration #1 — 0.3.x legacy pack → 0.4.x frontmatter-as-truth (store version 1).
+ *
+ * The 0.4.0 redesign ([[spec-driven-shopping-redesign]]) dropped `profile.json` and
+ * the `domain_spec`/`intent_spec`/`playbook` triple for a frontmatter-as-truth store
+ * with NO back-compat, so a pre-existing 0.3.x store read `unreadable` and the shopper
+ * vanished (incident #2). This hop RESURRECTS such a store: it folds the legacy
+ * `profile.json` `name` + the frontmatter-LESS legacy `user_spec.md` body into ONE
+ * frontmatter-as-truth `user_spec.md`, and folds each domain's legacy triple into a
+ * `method.md`, then deletes the legacy bytes.
+ *
+ * Legacy PRE-state (v0.3.9):
+ *   $SIL_DATA_DIR/shopper/
+ *     ├─ user_spec.md            frontmatter-LESS body; the name lived in profile.json
+ *     ├─ profile.json            { name, userSpecPath, createdAt, domains: { <slug>: { name, … } } }
+ *     └─ domains/<slug>/{ domain_spec.md, intent_spec.md, playbook.md }   frontmatter-less
+ *
+ * Preservation floor (the shopper survives ⇔ BOTH): `user_spec.md` present with a
+ * non-blank frontmatter `name` == the legacy name, AND the legacy `user_spec` body
+ * preserved. The redesign-deleted triple has no faithful forward representation, so we
+ * NEVER fabricate methods/PRDs from it — we preserve its three bodies verbatim under
+ * stable headings (the strongest honest option) and invent nothing.
+ *
+ * The constants below are FROZEN to this historical transition on purpose — a migration
+ * is an immutable snapshot of one format move, so it must not track live store constants
+ * (importing them would also cycle: store → runner → registry → this).
+ */
+
+import { existsSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+
+import { readArtefactFile, serializeArtefact, atomicWrite } from "../artefact-io.js";
+import type { Migration } from "./types.js";
+
+const SHOPPER = "shopper";
+const DOMAINS = "domains";
+const USER_SPEC = "user_spec.md";
+const METHOD = "method.md";
+const PROFILE_JSON = "profile.json";
+const LEGACY_TRIPLE = ["domain_spec.md", "intent_spec.md", "playbook.md"] as const;
+
+/** The legacy 0.3.9 manifest — only the fields this migration reads are narrowed. */
+interface LegacyManifest {
+  name?: unknown;
+  domains?: Record<string, { name?: unknown } | undefined>;
+}
+
+function nonBlank(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function readBody(path: string): string {
+  return existsSync(path) ? readFileSync(path, "utf8") : "";
+}
+
+/** Fold the three legacy per-domain bodies losslessly under stable `## ` headings —
+ * each raw body survives VERBATIM as a substring (this is per-domain DATA, preserved,
+ * never re-derived). Absent files contribute an empty section (still lossless). */
+function mergeDomainBodies(guide: string, intent: string, playbook: string): string {
+  return (
+    "## Domain guide\n" + guide +
+    "\n## Intent dimensions\n" + intent +
+    "\n## Playbook\n" + playbook
+  );
+}
+
+export const migration001: Migration = {
+  version: 1,
+  description: "0.3.x legacy pack (profile.json + domain_spec/intent_spec/playbook) → frontmatter-as-truth store",
+
+  detectApplicable(dataDir: string): boolean {
+    // The unambiguous legacy signature. Absent ⇒ already-new-format or fresh/empty —
+    // record the version, transform nothing (never rewrites correct artefacts, never
+    // fabricates for the empty case).
+    return existsSync(join(dataDir, SHOPPER, PROFILE_JSON));
+  },
+
+  apply(dataDir: string): void {
+    const shopper = join(dataDir, SHOPPER);
+    const profilePath = join(shopper, PROFILE_JSON);
+
+    let manifest: LegacyManifest;
+    try {
+      manifest = JSON.parse(readFileSync(profilePath, "utf8")) as LegacyManifest;
+    } catch (err) {
+      throw new Error("legacy profile.json is unparseable — cannot migrate: " + errCause(err));
+    }
+    const name = manifest.name;
+    if (!nonBlank(name)) {
+      // Legacy materialize always wrote a non-blank name, so a blank/missing one is
+      // genuine corruption — surface it, NEVER fabricate a name.
+      throw new Error("legacy profile.json carries no shopper name — refusing to fabricate one");
+    }
+
+    // The preservation floor: legacy name → frontmatter, legacy body preserved.
+    const legacyUserBody = readBody(join(shopper, USER_SPEC));
+    atomicWrite(join(shopper, USER_SPEC), serializeArtefact({ name }, legacyUserBody));
+
+    const now = new Date().toISOString();
+    const domains = manifest.domains ?? {};
+    for (const slug of Object.keys(domains)) {
+      const domainDir = join(shopper, DOMAINS, slug);
+      const entryName = domains[slug]?.name;
+      const domainName = nonBlank(entryName) ? entryName : slug;
+      const merged = mergeDomainBodies(
+        readBody(join(domainDir, LEGACY_TRIPLE[0])),
+        readBody(join(domainDir, LEGACY_TRIPLE[1])),
+        readBody(join(domainDir, LEGACY_TRIPLE[2])),
+      );
+      atomicWrite(
+        join(domainDir, METHOD),
+        serializeArtefact({ domain: slug, name: domainName, updated_at: now }, merged),
+      );
+      for (const legacy of LEGACY_TRIPLE) rmSync(join(domainDir, legacy), { force: true });
+    }
+
+    rmSync(profilePath, { force: true });
+  },
+
+  verify(dataDir: string): string | null {
+    const shopper = join(dataDir, SHOPPER);
+    if (existsSync(join(shopper, PROFILE_JSON))) {
+      return "legacy profile.json still present after migration";
+    }
+    const userSpec = readArtefactFile(join(shopper, USER_SPEC));
+    if (userSpec === null) {
+      return "user_spec.md is missing or has unparseable frontmatter after migration";
+    }
+    if (!nonBlank(userSpec.fields["name"])) {
+      return "user_spec.md frontmatter carries no shopper name after migration";
+    }
+    const domainsRoot = join(shopper, DOMAINS);
+    if (existsSync(domainsRoot)) {
+      for (const entry of readdirSync(domainsRoot, { withFileTypes: true })) {
+        if (!entry.isDirectory()) continue;
+        const domainDir = join(domainsRoot, entry.name);
+        for (const legacy of LEGACY_TRIPLE) {
+          if (existsSync(join(domainDir, legacy))) {
+            return 'legacy ' + legacy + ' still present in domain "' + entry.name + '" after migration';
+          }
+        }
+        const method = readArtefactFile(join(domainDir, METHOD));
+        if (method === null) {
+          return 'method.md for domain "' + entry.name + '" is missing or unparseable after migration';
+        }
+        if (!nonBlank(method.fields["name"])) {
+          return 'method.md for domain "' + entry.name + '" carries no name after migration';
+        }
+      }
+    }
+    return null;
+  },
+};
+
+function errCause(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/src/lib/migrations/registry.ts
+++ b/src/lib/migrations/registry.ts
@@ -1,0 +1,16 @@
+/**
+ * The ordered store-format migration registry.
+ *
+ * `MIGRATIONS` is ascending and CONTIGUOUS from version 1 — the runner advances a
+ * store one hop at a time through it, so a gap or a duplicate would silently skip or
+ * re-run a transform. `CURRENT_STORE_VERSION` is the top of the chain: the version a
+ * fully-migrated store records. Append the next migration as `002-…`, add it here, and
+ * `CURRENT_STORE_VERSION` advances automatically.
+ */
+
+import type { Migration } from "./types.js";
+import { migration001 } from "./001-frontmatter-store.js";
+
+export const MIGRATIONS: readonly Migration[] = [migration001];
+
+export const CURRENT_STORE_VERSION: number = MIGRATIONS.at(-1)?.version ?? 0;

--- a/src/lib/migrations/runner.ts
+++ b/src/lib/migrations/runner.ts
@@ -1,0 +1,223 @@
+/**
+ * The store-format migration runner — sil-agnostic `detect → backup → apply →
+ * verify → record`, fail-closed.
+ *
+ * A store carries an INTEGER store-format version (decoupled from `package.json`
+ * semver) in a marker at the DATA-DIR ROOT. The runner advances it one hop at a time
+ * through the registry; each hop is independently transactional:
+ *
+ *   for m of MIGRATIONS where m.version > recorded (ascending):
+ *     detectApplicable? no  → record the version, transform nothing
+ *                       yes → backup shopper/ → apply → verify → (record + drop backup)
+ *                             on any throw / verify-miss → revert from backup, DO NOT record
+ *
+ * Fail-closed guarantees: verify-BEFORE-record (apply completing is not success — the
+ * preservation floor being met is); a failure reverts to the byte-exact prior subtree
+ * and leaves the marker untouched; a revert that ITSELF fails is the louder
+ * `reverted:false` outcome (store left dirty) and retains the backup for recovery.
+ *
+ * `ensureStoreMigrated()` is the on-load gate: the store primitives call it on their
+ * first line so a behind-version store HEALS BEFORE IT SERVES. It is NEVER wired into
+ * `register()` (the strictly-synchronous / opens-nothing invariant,
+ * [[sil-data-dir-lifecycle]]). Memoized per resolved data-dir, so it runs at most once
+ * per process (production has one data-dir) and is a cheap cached no-op thereafter.
+ *
+ * Only `SHOPPER_SUBDIR`, the marker filename, and the backup dir are sil constants;
+ * everything else is generic, so a future cross-plugin extraction is mechanical.
+ */
+
+import {
+  chmodSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { randomBytes } from "node:crypto";
+
+import { DIR_MODE, getDataDir } from "../credentials.js";
+import { MIGRATIONS } from "./registry.js";
+import type { Migration, MigrationFailed, MigrationRunResult } from "./types.js";
+
+/** The store-format version marker — JSON `{ version: <int> }`, at the data-dir ROOT
+ * (sibling to tokens.json, NOT under shopper/), so a shopper-subtree backup/revert can
+ * never touch it and a future migration may touch tokens/config under the same version. */
+const MARKER_FILE = "store-format.json";
+/** Owner-only, like every credential/artefact in the data home. */
+const MARKER_MODE = 0o600;
+
+/** The subtree a migration transforms + the runner backs up / reverts. */
+const SHOPPER_SUBDIR = "shopper";
+/** Per-hop backups live here (data-dir root, outside the reverted subtree). RETAINED on
+ * failure for sil_doctor / a human to recover; dropped on hop success. */
+const BACKUP_SUBDIR = ".sil-migration-backup";
+
+// ---------------------------------------------------------------------------
+// Store-format version marker.
+// ---------------------------------------------------------------------------
+
+/** Read the recorded store-format version, or 0 when the marker is absent, unparseable,
+ * or carries no integer `version`. Treating a corrupt marker as 0 is SAFE — the runner
+ * disambiguates via each hop's content-probe `detectApplicable`, so a corrupt marker on
+ * an already-migrated store re-stamps rather than re-transforming; fail-closing here
+ * would brick the store instead of self-healing it. */
+export function readStoreVersion(dataDir: string): number {
+  const path = join(dataDir, MARKER_FILE);
+  if (!existsSync(path)) return 0;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return 0;
+  }
+  const version = (parsed as { version?: unknown } | null)?.version;
+  return typeof version === "number" && Number.isInteger(version) && version >= 0 ? version : 0;
+}
+
+/** Record the store-format version atomically (0600) at the data-dir root. */
+export function writeStoreVersion(dataDir: string, version: number): void {
+  const path = join(dataDir, MARKER_FILE);
+  mkdirSync(dirname(path), { recursive: true, mode: DIR_MODE });
+  const tmp = path + "." + randomBytes(6).toString("hex") + ".tmp";
+  writeFileSync(tmp, JSON.stringify({ version }) + "\n", { mode: MARKER_MODE });
+  renameSync(tmp, path);
+  chmodSync(path, MARKER_MODE);
+}
+
+// ---------------------------------------------------------------------------
+// Backup / restore of the shopper subtree.
+// ---------------------------------------------------------------------------
+
+function shopperDir(dataDir: string): string {
+  return join(dataDir, SHOPPER_SUBDIR);
+}
+
+function backupRoot(dataDir: string): string {
+  return join(dataDir, BACKUP_SUBDIR);
+}
+
+function backupPath(dataDir: string, version: number): string {
+  return join(backupRoot(dataDir), "v" + version);
+}
+
+/** Snapshot the whole shopper subtree before a hop's transform. Recursive copy of a
+ * small markdown tree; cheap. Clears any stale backup at this version first. */
+function createBackup(dataDir: string, version: number): void {
+  const dest = backupPath(dataDir, version);
+  rmSync(dest, { recursive: true, force: true });
+  mkdirSync(backupRoot(dataDir), { recursive: true, mode: DIR_MODE });
+  const src = shopperDir(dataDir);
+  if (existsSync(src)) cpSync(src, dest, { recursive: true });
+  else mkdirSync(dest, { recursive: true, mode: DIR_MODE });
+}
+
+/** Revert the whole shopper subtree to the hop's backup. The rm→copy window is the one
+ * non-atomic seam; a throw here surfaces as the louder `reverted:false` outcome. */
+function restore(dataDir: string, version: number): void {
+  const dest = shopperDir(dataDir);
+  rmSync(dest, { recursive: true, force: true });
+  cpSync(backupPath(dataDir, version), dest, { recursive: true });
+}
+
+/** Drop the transient backup on a hop's success (retained ONLY on failure). At most one
+ * backup is live during a chain — a failed hop returns immediately — so wiping the whole
+ * backup dir is safe and leaves the data-dir clean. */
+function removeBackup(dataDir: string): void {
+  rmSync(backupRoot(dataDir), { recursive: true, force: true });
+}
+
+// ---------------------------------------------------------------------------
+// The runner.
+// ---------------------------------------------------------------------------
+
+function failed(version: number, reason: string, reverted: boolean): MigrationFailed {
+  return { ok: false, kind: "migration_failed", version, reason, reverted, recovery: "inspect_store" };
+}
+
+function errCause(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Run every applicable migration above the recorded version, in ascending order, in one
+ * pass. Pure (no memo) — the on-load gate memoizes; the self-upgrade card calls this
+ * directly. `migrations` is injectable so tests can drive a synthetic ordered registry.
+ */
+export function runStoreMigrations(
+  dataDir: string,
+  migrations: readonly Migration[] = MIGRATIONS,
+): MigrationRunResult {
+  const from = readStoreVersion(dataDir);
+  const ordered = [...migrations].sort((a, b) => a.version - b.version);
+  const applied: number[] = [];
+  let to = from;
+
+  for (const m of ordered) {
+    if (m.version <= from) continue; // at/below the recorded version — never probed
+
+    let isApplicable: boolean;
+    try {
+      isApplicable = m.detectApplicable(dataDir);
+    } catch (err) {
+      // A probe throw is before any mutation/backup — the store is untouched.
+      return failed(m.version, errCause(err), true);
+    }
+
+    if (!isApplicable) {
+      // No-op for this store's shape → record the version, transform nothing, no backup.
+      writeStoreVersion(dataDir, m.version);
+      to = m.version;
+      continue;
+    }
+
+    createBackup(dataDir, m.version);
+    try {
+      m.apply(dataDir);
+      const reason = m.verify(dataDir);
+      if (reason !== null) throw new Error(reason); // verify-BEFORE-record gate
+    } catch (err) {
+      const reason = errCause(err);
+      let reverted: boolean;
+      try {
+        restore(dataDir, m.version);
+        reverted = true;
+      } catch {
+        reverted = false; // revert itself failed → store left DIRTY (louder rail)
+      }
+      // Backup RETAINED on either failure outcome; the marker is NOT advanced.
+      return failed(m.version, reason, reverted);
+    }
+
+    writeStoreVersion(dataDir, m.version); // record only after verify passes
+    removeBackup(dataDir);
+    applied.push(m.version);
+    to = m.version;
+  }
+
+  return { ok: true, from, to, applied };
+}
+
+// ---------------------------------------------------------------------------
+// On-load gate — memoized per resolved data-dir.
+// ---------------------------------------------------------------------------
+
+const migrationMemo = new Map<string, MigrationRunResult>();
+
+/**
+ * The on-load gate the store primitives call on their first line (heal-before-serve).
+ * Memoized on the resolved data-dir: runs `runStoreMigrations` at most once per process
+ * (production has a single data-dir), a cached no-op thereafter. NEVER call this from
+ * `register()` — the sync/opens-nothing invariant lives there.
+ */
+export function ensureStoreMigrated(): MigrationRunResult {
+  const dataDir = getDataDir();
+  const cached = migrationMemo.get(dataDir);
+  if (cached !== undefined) return cached;
+  const result = runStoreMigrations(dataDir);
+  migrationMemo.set(dataDir, result);
+  return result;
+}

--- a/src/lib/migrations/runner.ts
+++ b/src/lib/migrations/runner.ts
@@ -36,10 +36,10 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 import { randomBytes } from "node:crypto";
 
-import { DIR_MODE, getDataDir } from "../credentials.js";
+import { DIR_MODE, ensureDataDir, getDataDir } from "../credentials.js";
 import { MIGRATIONS } from "./registry.js";
 import type { Migration, MigrationFailed, MigrationRunResult } from "./types.js";
 
@@ -78,10 +78,15 @@ export function readStoreVersion(dataDir: string): number {
   return typeof version === "number" && Number.isInteger(version) && version >= 0 ? version : 0;
 }
 
-/** Record the store-format version atomically (0600) at the data-dir root. */
+/** Record the store-format version atomically (0600) at the data-dir root. The data-home
+ * ROOT is created through the single-creator invariant `ensureDataDir()` — NOT a second
+ * bare `mkdirSync` — so every data-home is minted by one mode-consistent path. `dataDir`
+ * is `getDataDir()` on every caller (the on-load gate, the self-upgrade card, and the
+ * hermetic tests all point `$SIL_DATA_DIR` at it), so `ensureDataDir()` ensures exactly
+ * this root. */
 export function writeStoreVersion(dataDir: string, version: number): void {
+  ensureDataDir();
   const path = join(dataDir, MARKER_FILE);
-  mkdirSync(dirname(path), { recursive: true, mode: DIR_MODE });
   const tmp = path + "." + randomBytes(6).toString("hex") + ".tmp";
   writeFileSync(tmp, JSON.stringify({ version }) + "\n", { mode: MARKER_MODE });
   renameSync(tmp, path);
@@ -169,12 +174,24 @@ export function runStoreMigrations(
 
     if (!isApplicable) {
       // No-op for this store's shape → record the version, transform nothing, no backup.
-      writeStoreVersion(dataDir, m.version);
+      try {
+        writeStoreVersion(dataDir, m.version);
+      } catch (err) {
+        // The marker write is the ONLY mutation on this branch — an I/O failure (a
+        // read-only data-dir root) leaves the store byte-exact untouched → reverted:true.
+        return failed(m.version, errCause(err), true);
+      }
       to = m.version;
       continue;
     }
 
-    createBackup(dataDir, m.version);
+    try {
+      createBackup(dataDir, m.version);
+    } catch (err) {
+      // Backup failed BEFORE apply — no transform ran, the store is untouched → reverted:true.
+      return failed(m.version, errCause(err), true);
+    }
+
     try {
       m.apply(dataDir);
       const reason = m.verify(dataDir);
@@ -192,8 +209,24 @@ export function runStoreMigrations(
       return failed(m.version, reason, reverted);
     }
 
-    writeStoreVersion(dataDir, m.version); // record only after verify passes
-    removeBackup(dataDir);
+    try {
+      writeStoreVersion(dataDir, m.version); // record only after verify passes
+    } catch (err) {
+      // The transform is committed + verified (the store is in the healthy new format), but
+      // recording the version failed. Do NOT revert a good transform back to the broken
+      // legacy store — a next boot self-heals (detectApplicable is now false → re-records).
+      // This heal did not COMPLETE though, so fail closed: reverted:false is the honest
+      // signal (the store was NOT restored to prior state); the backup stays retained.
+      return failed(m.version, errCause(err), false);
+    }
+
+    try {
+      removeBackup(dataDir);
+    } catch {
+      // Best-effort cleanup — the hop already succeeded and is recorded. A retained backup
+      // is benign (identical to the retained-on-failure state) and recoverable, so a stray
+      // backup NEVER downgrades a recorded success to a failure.
+    }
     applied.push(m.version);
     to = m.version;
   }
@@ -206,6 +239,7 @@ export function runStoreMigrations(
 // ---------------------------------------------------------------------------
 
 const migrationMemo = new Map<string, MigrationRunResult>();
+const migrationLogged = new Set<string>();
 
 /**
  * The on-load gate the store primitives call on their first line (heal-before-serve).
@@ -220,4 +254,19 @@ export function ensureStoreMigrated(): MigrationRunResult {
   const result = runStoreMigrations(dataDir);
   migrationMemo.set(dataDir, result);
   return result;
+}
+
+/** The one-shot success breadcrumb for the active data-dir: the `{ from, to, applied }` of
+ * a heal that applied ≥1 hop, returned the FIRST time it is drained and null forever after
+ * (per data-dir). The tool boundary drains it after a gated store call and logs
+ * `sil_store_migrated` — a successful heal is SILENT to the agent (product §8.2) but a
+ * destructive on-disk identity rewrite MUST leave one operator breadcrumb (the incident-#2
+ * observability gap). The runner itself stays logger-free so it can be lifted cross-plugin. */
+export function takeMigrationLog(): { from: number; to: number; applied: number[] } | null {
+  const dataDir = getDataDir();
+  const result = migrationMemo.get(dataDir);
+  if (result === undefined || !result.ok || result.applied.length === 0) return null;
+  if (migrationLogged.has(dataDir)) return null;
+  migrationLogged.add(dataDir);
+  return { from: result.from, to: result.to, applied: result.applied };
 }

--- a/src/lib/migrations/types.ts
+++ b/src/lib/migrations/types.ts
@@ -1,0 +1,46 @@
+/**
+ * Versioned store-format migration contract — sil-agnostic.
+ *
+ * A `Migration` advances the on-disk store from `version - 1` to `version`. The
+ * runner (`runner.ts`) drives an ascending, contiguous registry of them through
+ * `detect → backup → apply → verify → record`, fail-closed: a hop that throws or
+ * fails verify is reverted from a byte-exact backup and NEVER half-recorded.
+ *
+ * This is a forward DATA migration (convert old on-disk state to the new format,
+ * delete the legacy bytes), NOT code back-compat — no v1/v2 reader kept alive.
+ */
+
+export interface Migration {
+  /** Store-format version this hop ADVANCES TO (version-1 → version). Ascending, from 1. */
+  readonly version: number;
+  /** One-line, for logs + a future sil_doctor readout. */
+  readonly description: string;
+  /**
+   * Content-probe of this store's PRE-state. Consulted only when `version > recorded`.
+   * FALSE ⇒ the transform is a no-op for this store's shape → record the version, touch
+   * nothing (an already-migrated or fresh/empty store). TRUE ⇒ run the transform. This
+   * is what disambiguates the absent-marker cases without re-transforming.
+   */
+  detectApplicable(dataDir: string): boolean;
+  /** Apply the transform with atomic file writes; THROW on any hard failure. */
+  apply(dataDir: string): void;
+  /** Post-condition check: a reason string when the floor is unmet, or null when it holds. */
+  verify(dataDir: string): string | null;
+}
+
+export type MigrationRunResult =
+  | { ok: true; from: number; to: number; applied: number[] }
+  | MigrationFailed;
+
+export interface MigrationFailed {
+  ok: false;
+  kind: "migration_failed";
+  /** The hop that failed. */
+  version: number;
+  /** Non-PII cause (a thrown-error message or the verify reason). */
+  reason: string;
+  /** true = the store was restored byte-exact to its prior state; false = the revert
+   * itself failed and the store is left DIRTY (the louder honesty rail). */
+  reverted: boolean;
+  recovery: "inspect_store";
+}

--- a/src/lib/profile-store.ts
+++ b/src/lib/profile-store.ts
@@ -179,6 +179,14 @@ export function getDomainArtefactDir(slug: string): string {
   return join(getShopperArtefactDir(), DOMAINS_SUBDIR, slug);
 }
 
+/** Count the shopper's learned domains (dir entries under shopper/domains, 0 when absent).
+ * The `sil_store_migrated` breadcrumb reports it on the rare on-load heal — not a hot path. */
+export function countShopperDomains(): number {
+  const domainsRoot = join(getShopperArtefactDir(), DOMAINS_SUBDIR);
+  if (!existsSync(domainsRoot)) return 0;
+  return readdirSync(domainsRoot, { withFileTypes: true }).filter((d) => d.isDirectory()).length;
+}
+
 // ===========================================================================
 // materializeProfile — SETUP-ONLY. Write user_spec.md (frontmatter name); no
 // manifest, no domains. Re-run overwrites the shared user spec atomically.

--- a/src/lib/profile-store.ts
+++ b/src/lib/profile-store.ts
@@ -26,25 +26,19 @@
  * sil artefact — it is the host workspace SOUL.md, written by the host CLI.
  */
 
-import {
-  chmodSync,
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  readdirSync,
-  renameSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { createHash, randomBytes } from "node:crypto";
+import { createHash } from "node:crypto";
 
 import { DIR_MODE, ensureDataDir, getDataDir } from "./credentials.js";
-
-/** Owner-only file mode — artefacts are user-scoped, like tokens. The dir mode
- * (`DIR_MODE`, `0o700`) is owned by `credentials.ts` and imported, so the data-home
- * permission lives in exactly one place. */
-const FILE_MODE = 0o600;
+import {
+  atomicWrite,
+  atomicWriteBytes,
+  readArtefactFile,
+  serializeArtefact,
+} from "./artefact-io.js";
+import { ensureStoreMigrated } from "./migrations/runner.js";
+import type { MigrationFailed } from "./migrations/types.js";
 
 /** Fixed, compile-time-constant sub-tree under `$SIL_DATA_DIR` that holds the ONE
  * shopper's behaviour artefacts. A SINGLETON, so this is a constant — NOT caller
@@ -186,93 +180,6 @@ export function getDomainArtefactDir(slug: string): string {
 }
 
 // ===========================================================================
-// Frontmatter serialize / parse — coordinates are single-line scalars; the body is
-// opaque prose. `parseArtefact` returns null on a malformed/absent-frontmatter file
-// so a corrupt leaf reads `unreadable`, never half-read.
-// ===========================================================================
-
-interface Artefact {
-  fields: Record<string, string>;
-  body: string;
-}
-
-/** One-line scalar for a coordinate value: newlines folded to spaces, trimmed. */
-function scalar(value: string): string {
-  return String(value).replace(/\r?\n/g, " ").trim();
-}
-
-function serializeArtefact(fields: Record<string, string>, body: string): string {
-  const fm = Object.entries(fields)
-    .map(([k, v]) => k + ": " + scalar(v))
-    .join("\n");
-  // The store owns frontmatter — strip any block a model prepended to the body so the
-  // artefact never stacks two (self-heals a previously double-wrapped file on re-write).
-  const clean = stripLeadingFrontmatter(body);
-  const b = clean.endsWith("\n") ? clean : clean + "\n";
-  return "---\n" + fm + "\n---\n" + b;
-}
-
-/** Parse `--- key: value … ---` frontmatter + body. Returns null (⇒ `unreadable`) on
- * a missing open fence, a missing close fence, or an empty frontmatter block — a
- * fail-closed read, never a silent coercion. */
-function parseArtefact(raw: string): Artefact | null {
-  if (!raw.startsWith("---")) return null;
-  const close = raw.slice(3).match(/\n---[ \t]*\r?\n/);
-  if (!close || close.index === undefined) return null;
-  const fmRaw = raw.slice(3, 3 + close.index);
-  const body = raw.slice(3 + close.index + close[0].length);
-  const fields: Record<string, string> = {};
-  for (const line of fmRaw.split(/\r?\n/)) {
-    const m = /^([A-Za-z0-9_]+):\s*(.*)$/.exec(line);
-    if (m && m[2] !== "") fields[m[1] as string] = (m[2] as string).trim();
-  }
-  if (Object.keys(fields).length === 0) return null;
-  return { fields, body };
-}
-
-/** Strip a leading `--- … ---` frontmatter block a model may have prepended to a body,
- * reusing `parseArtefact` so ONLY a fence whose content is real frontmatter (≥1
- * `key: value`) is removed — a body opening with a bare `---` thematic break parses to
- * null and is returned untouched. The store owns frontmatter (frontmatter-as-truth), so a
- * model-authored block must never survive into the serialized body and stack a second. */
-function stripLeadingFrontmatter(body: string): string {
-  const parsed = parseArtefact(body);
-  return parsed === null ? body : parsed.body;
-}
-
-/** Read + parse one artefact file, or null if absent/unreadable/malformed. */
-function readArtefactFile(path: string): Artefact | null {
-  if (!existsSync(path)) return null;
-  let raw: string;
-  try {
-    raw = readFileSync(path, "utf8");
-  } catch {
-    return null;
-  }
-  return parseArtefact(raw);
-}
-
-/** Atomic single-file write: tmp sibling → write → rename over target → chmod. A
- * reader sees the old file or the new one, never a half-written one (mirrors
- * `credentials.ts`). Ensures the containing dir (0700) first. */
-function atomicWrite(path: string, contents: string): void {
-  mkdirSync(dirname(path), { recursive: true, mode: DIR_MODE });
-  const tmp = path + "." + randomBytes(6).toString("hex") + ".tmp";
-  writeFileSync(tmp, contents, { mode: FILE_MODE });
-  renameSync(tmp, path);
-  chmodSync(path, FILE_MODE);
-}
-
-/** Write binary bytes atomically, owner-only. */
-function atomicWriteBytes(path: string, bytes: Buffer): void {
-  mkdirSync(dirname(path), { recursive: true, mode: DIR_MODE });
-  const tmp = path + "." + randomBytes(6).toString("hex") + ".tmp";
-  writeFileSync(tmp, bytes, { mode: FILE_MODE });
-  renameSync(tmp, path);
-  chmodSync(path, FILE_MODE);
-}
-
-// ===========================================================================
 // materializeProfile — SETUP-ONLY. Write user_spec.md (frontmatter name); no
 // manifest, no domains. Re-run overwrites the shared user spec atomically.
 // ===========================================================================
@@ -292,6 +199,14 @@ export type MaterializeResult =
  * shopper `name` and whose body is the shared user spec. SETUP-ONLY: it mints no
  * method/PRD (that is `sil_learn create`) and writes no manifest. Validate-first: a
  * blank `name`/`userSpec` returns `invalid_request` and writes nothing.
+ *
+ * NOT migration-gated. Unlike the four serve-path primitives, materialize is SETUP: it
+ * writes a NEW shopper's user_spec, never serving stale legacy data. Gating it would
+ * (a) stamp the store-format marker at plain setup and (b) hijack the create-shopper
+ * bin's `persistence_failed` taxonomy on an unwritable data dir. The create-shopper bin
+ * can never reach materialize on a LEGACY store anyway — its `readShopperIdentity`
+ * pre-flight reads a frontmatter-less legacy user_spec as `unreadable` and aborts — so a
+ * legacy store heals via the first serve-path tool touch, never through setup.
  */
 export function materializeProfile(spec: ProfileSpec): MaterializeResult {
   if (!nonBlank(spec.name)) return invalid("name", "name is required and must be non-empty.");
@@ -387,7 +302,8 @@ export type LearnResult =
   | InvalidRequest
   | NotFound
   | Unreadable
-  | PersistenceFailed;
+  | PersistenceFailed
+  | MigrationFailed;
 
 /** A resolved target artefact + its human label. */
 interface ResolvedTarget {
@@ -422,6 +338,8 @@ function resolveTarget(spec: LearnSpec): ResolvedTarget | InvalidRequest {
 }
 
 export function learnArtefact(spec: LearnSpec): LearnResult {
+  const migrated = ensureStoreMigrated();
+  if (!migrated.ok) return migrated;
   switch (spec.kind) {
     case "create":
       return learnCreate(spec);
@@ -657,7 +575,9 @@ export interface SearchResult {
   unreadable: Array<{ id: string; error: string }>;
 }
 
-export function searchProfileFrontmatter(query: SearchQuery = {}): SearchResult {
+export function searchProfileFrontmatter(query: SearchQuery = {}): SearchResult | MigrationFailed {
+  const migrated = ensureStoreMigrated();
+  if (!migrated.ok) return migrated;
   const domainsRoot = join(getShopperArtefactDir(), DOMAINS_SUBDIR);
   const domains: DomainCoord[] = [];
   const prds: PrdCoord[] = [];
@@ -740,9 +660,12 @@ export type ReadResult =
     }
   | NotFound
   | Unreadable
-  | InvalidRequest;
+  | InvalidRequest
+  | MigrationFailed;
 
 export function readArtefactBody(domainSlug: string, prd?: string): ReadResult {
+  const migrated = ensureStoreMigrated();
+  if (!migrated.ok) return migrated;
   const badSlug = rejectBadSegment(domainSlug, "domainSlug");
   if (badSlug) return badSlug;
 
@@ -775,9 +698,12 @@ export type RemoveResult =
   | { ok: true; domainSlug: string; prd?: string }
   | NotFound
   | InvalidRequest
-  | PersistenceFailed;
+  | PersistenceFailed
+  | MigrationFailed;
 
 export function removeArtefact(domainSlug: string, prd?: string): RemoveResult {
+  const migrated = ensureStoreMigrated();
+  if (!migrated.ok) return migrated;
   const badSlug = rejectBadSegment(domainSlug, "domainSlug");
   if (badSlug) return badSlug;
 

--- a/src/tools/profile.ts
+++ b/src/tools/profile.ts
@@ -25,6 +25,7 @@ import type { PluginAPI } from "openclaw/plugin-sdk";
 import { Type } from "typebox";
 
 import {
+  countShopperDomains,
   learnArtefact,
   materializeProfile,
   readArtefactBody,
@@ -34,6 +35,7 @@ import {
   type LearnSpec,
   type LearnTarget,
 } from "../lib/profile-store.js";
+import { takeMigrationLog } from "../lib/migrations/runner.js";
 import { jsonResult } from "../lib/tool-result.js";
 
 /** Narrow a host-validated param to a string, defaulting to "" so the store does the
@@ -46,6 +48,24 @@ function asString(value: unknown): string {
  * so a selector is never carried as a spurious empty value. */
 function optString(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+/** Emit the one-shot `sil_store_migrated` breadcrumb when THIS gated tool touch healed a
+ * behind-version store. A successful heal is SILENT to the agent (product §8.2 — no change
+ * to the tool's own result), but it rewrites the shopper's on-disk identity destructively
+ * (drops profile.json, folds each legacy domain triple into method.md) — exactly the state
+ * transition incident-#2 debugging needs a log for. Drained once from the runner (null on
+ * every non-migrating call), so a hot serve path never logs. `domain_count` is the sil-
+ * specific enrichment the logger-free runner can't compute. */
+function logStoreMigration(api: PluginAPI): void {
+  const migrated = takeMigrationLog();
+  if (migrated === null) return;
+  api.logger.info("sil_store_migrated", {
+    from: migrated.from,
+    to: migrated.to,
+    applied_count: migrated.applied.length,
+    domain_count: countShopperDomains(),
+  });
 }
 
 export function registerProfileTools(api: PluginAPI): void {
@@ -152,6 +172,7 @@ function registerLearn(api: PluginAPI): void {
         caption: optString(params["caption"]),
       };
       const result = learnArtefact(spec);
+      logStoreMigration(api);
       if (result.ok) {
         // Non-PII markers only — no artefact body/text is ever logged.
         api.logger.info("sil_learned", {
@@ -201,6 +222,7 @@ function registerSearch(api: PluginAPI): void {
         intent: optString(params["intent"]),
         query: optString(params["query"]),
       });
+      logStoreMigration(api);
       if (!result.ok) return mapFailure(api, "sil_profile_search", result);
       api.logger.info("sil_profile_searched", {
         domain_count: result.domains.length,
@@ -256,6 +278,7 @@ function registerGet(api: PluginAPI): void {
     }),
     async execute(_callId, params) {
       const result = readArtefactBody(asString(params["domainSlug"]), optString(params["prd"]));
+      logStoreMigration(api);
       if (result.ok) {
         api.logger.info("sil_profile_read", { target: result.target, domain_slug: result.domain, prd: result.prd });
         return jsonResult({
@@ -294,6 +317,7 @@ function registerRemove(api: PluginAPI): void {
     }),
     async execute(_callId, params) {
       const result = removeArtefact(asString(params["domainSlug"]), optString(params["prd"]));
+      logStoreMigration(api);
       if (result.ok) {
         api.logger.info("sil_profile_removed", { domain_slug: result.domainSlug, prd: result.prd });
         return jsonResult({

--- a/src/tools/profile.ts
+++ b/src/tools/profile.ts
@@ -201,6 +201,7 @@ function registerSearch(api: PluginAPI): void {
         intent: optString(params["intent"]),
         query: optString(params["query"]),
       });
+      if (!result.ok) return mapFailure(api, "sil_profile_search", result);
       api.logger.info("sil_profile_searched", {
         domain_count: result.domains.length,
         prd_count: result.prds.length,
@@ -314,7 +315,8 @@ function mapFailure(
     | { ok: false; kind: "invalid_request"; field: string; message: string }
     | { ok: false; kind: "not_found"; message: string }
     | { ok: false; kind: "unreadable"; message: string }
-    | { ok: false; kind: "persistence_failed"; error: string; message: string; recovery: "fix_data_dir" },
+    | { ok: false; kind: "persistence_failed"; error: string; message: string; recovery: "fix_data_dir" }
+    | { ok: false; kind: "migration_failed"; version: number; reason: string; reverted: boolean; recovery: "inspect_store" },
 ) {
   if (result.kind === "invalid_request") {
     api.logger.warn(tool + "_invalid_request", { field: result.field });
@@ -329,6 +331,30 @@ function mapFailure(
     // over it (silent data loss on a recoverable artefact). Distinct from not_found.
     api.logger.warn(tool + "_unreadable", {});
     return jsonResult({ status: "unreadable", message: result.message, recovery: "inspect_artefact" });
+  }
+  if (result.kind === "migration_failed") {
+    // A behind-version store failed to self-migrate on this touch (heal-before-serve).
+    // `reverted` is the honesty rail: true = safely reverted to the exact prior state
+    // (nothing half-applied), false = the revert ITSELF failed and the store is LEFT
+    // DIRTY — the agent must NOT proceed as if the shopper is intact.
+    api.logger.error(tool + "_migration_failed", { version: result.version, reverted: result.reverted });
+    return jsonResult({
+      status: "migration_failed",
+      version: result.version,
+      reason: result.reason,
+      reverted: result.reverted,
+      recovery: result.recovery,
+      message: result.reverted
+        ? "The sil store was behind the current format and a self-migration failed at store"
+          + " version " + result.version + ". It was reverted to its exact prior state — nothing"
+          + " was half-applied, and the store still reads its honest prior status. Cause: "
+          + result.reason + ". Inspect the data directory (a backup is retained under"
+          + " .sil-migration-backup), then retry."
+        : "The sil store self-migration failed at store version " + result.version + " AND could"
+          + " NOT be reverted — the store is LEFT DIRTY (possibly half-migrated). Do NOT proceed as"
+          + " if the shopper is intact. Cause: " + result.reason + ". A backup is retained under"
+          + " .sil-migration-backup — inspect / restore it manually.",
+    });
   }
   api.logger.error(tool + "_persistence_failed", { error: result.error });
   return jsonResult({


### PR DESCRIPTION
## Card
`cards/versioned-store-migrations-on-load-self-migrate.md` (gitignored-mode — lives in the `card/…` branch worktree; body carries the full intent + handoffs).

Kills incident #2: `0.3.7 → 0.4.0` dropped `profile.json` for frontmatter-as-truth with no back-compat, so every pre-existing store read `unreadable` and the shopper vanished. This adds a versioned, ordered, idempotent, fail-closed store-migration framework that self-heals on the first tool touch, and encodes Migration #1 to resurrect legacy stores.

## Summary
- **`src/lib/migrations/`** — new sil-agnostic module: `types.ts` (`Migration`/`MigrationRunResult`/`MigrationFailed`), `registry.ts` (ascending `MIGRATIONS` + `CURRENT_STORE_VERSION`), `runner.ts` (`detect→backup→apply→verify→record`, the integer store-format marker at the data-dir root, `runStoreMigrations`, and the memoized `ensureStoreMigrated()` on-load gate), `001-frontmatter-store.ts` (Migration #1).
- **On-load trigger** gates the FOUR serve-path store primitives (`search`/`get`/`learn`/`remove`), never `register()` (the sync/opens-nothing invariant) and never setup-only `materialize`. Memoized per data-dir → heal-before-serve, runs once per process.
- **Migration #1** folds the legacy `profile.json` name + frontmatter-less `user_spec.md` body into one frontmatter-as-truth `user_spec.md`, folds each domain's `domain_spec`/`intent_spec`/`playbook` triple losslessly into `method.md`, deletes the legacy bytes — and never fabricates methods/PRDs. Fail-closed: byte-exact revert on any failure; louder `reverted:false` (store-left-dirty) when the revert itself fails.
- **`src/lib/artefact-io.ts`** — extracted frontmatter serialize/parse + atomic writes so the store and the migrations share one serializer without an import cycle.
- **`src/tools/profile.ts`** — `mapFailure` gains a `migration_failed` arm surfacing `reverted` (the honesty rail); no tool added/removed (`contracts.tools` untouched).

## Test plan
- [x] `pnpm typecheck` clean
- [x] Full suite `963 passed` (only failures: the known worktree `repo-scaffold` gitignore artefact — unrelated)
- [x] Unit: `store-migrations-runner.test.ts` — registry shape, marker read/write, AC3 multi-hop ordering, AC5 verify-before-record, AC4 generic revert + per-hop transactional, AC7 idempotent, success drops its backup
- [x] Integration: `store-migrations.integration.test.ts` — on-load gate (register opens nothing; heal on first `execute()`; multiple primitives), AC1 resurrection/preservation floor, AC2 silent success + memo, AC4 byte-exact revert, AC6 un-revertable revert, AC7 no-op, AC8 never-fabricate
- [x] Live-verified end-to-end through compiled `dist/`: real legacy store → `{ok, from:0, to:1, applied:[1]}`, name resurrected, body preserved, triple folded, legacy deleted, no PRD conjured

## Distillation target
Knowledge capture happens **after Review PASS** in the `distilling` stage — `solutions-architect` runs in this same worktree, commits to this branch, and pushes here so the PR ends up implementation + tests + distillation in one mergeable unit. Candidate targets: the store-migration framework contract (decisions/), the four-not-five gate + `materialize`-excluded rule (knowledge/), verify-is-structural + byte-exactness-via-apply (knowledge/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)