### PR TITLE
refactor: derive shopper agentId from display name

### DIFF
--- a/scripts/create-shopper.mjs
+++ b/scripts/create-shopper.mjs
@@ -13,14 +13,18 @@
  * consent gate; this bin executes an already-assembled, already-endorsed spec
  * non-interactively. It never prompts, never re-runs the interview.
  *
- * Input — ONE JSON object `{ agentId, name, workspace, persona, userSpec, channel? }`,
+ * Input — ONE JSON object `{ name, workspace, persona, userSpec, channel? }`,
  * read from stdin (primary) or `--spec <path>` (fallback). Passing multiline
  * persona/userSpec as JSON dodges shell-arg escaping. Unparseable/blank input →
- * `invalid_request`, nothing attempted. `channel` is OPTIONAL — the current-channel
- * override for the step-10 bind; absent/blank is fail-open, never invalid_request.
+ * `invalid_request`, nothing attempted. There is NO `agentId` input — it is derived
+ * from `name` (`deriveAgentId`), so the user never invents an id; a stray `agentId`
+ * key is ignored. `channel` is OPTIONAL — the current-channel override for the
+ * step-10 bind; absent/blank is fail-open, never invalid_request.
  *
  * Choreography (validate-first, then atomic, fail-closed):
- *   1. validate the spec           — bad/blank field ⇒ invalid_request, nothing attempted
+ *   1. validate the spec + derive the id — bad/blank field ⇒ invalid_request, nothing
+ *      attempted; then agentId = deriveAgentId(name) (lower-kebab; empty/`main` slug ⇒
+ *      the silent `sil-shopper` fallback — the postcondition guarantees a conforming id)
  *   2. resolve the host config     — none ⇒ persistence_failed (precondition), nothing written
  *   3. singleton + agentId pre-flight — a shopper OR the agentId already exists ⇒ collision;
  *      an INCONCLUSIVE read (degraded store / CLI error) fails closed — never fabricates
@@ -86,6 +90,7 @@ import {
   getShopperArtefactDir,
 } from "../dist/lib/profile-store.js";
 import { resolveBindChannel } from "../dist/lib/bind-channel.js";
+import { deriveAgentId } from "../dist/lib/derive-agent-id.js";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 /** The sibling operator bin that performs the additive, self-validating trust merge. */
@@ -93,9 +98,6 @@ const ALLOWLIST_BIN = resolve(ROOT, "scripts", "allowlist-openclaw.mjs");
 /** The shipped plugin manifest — the single source of truth for sil's facts (id,
  * skill name), read the same way `scripts/allowlist-openclaw.mjs` reads it. */
 const MANIFEST_PATH = resolve(ROOT, "openclaw.plugin.json");
-
-/** A shopper id path-segment shape — lower-kebab, never `main` (host-reserved). */
-const AGENT_ID_RE = /^[a-z0-9][a-z0-9-]*$/;
 
 /** The sil creed appended to every shopper's SOUL.md after its persona — a soul, not a
  * rulebook. It carries the mantra (explore first), the loop in three lines, and the one
@@ -196,29 +198,18 @@ function readSpecRaw() {
   }
 }
 
-/** Validate the endorsed spec — deterministic field order (agentId → name →
- * workspace → persona → userSpec). Returns `{ field, message }` on the FIRST bad
- * field, or null when the whole spec is good. Writes/attempts nothing. `channel`
- * is deliberately NOT validated: it is an optional fail-open convenience, so an
- * absent/blank/malformed channel is never invalid_request — it folds to `null` in
- * `resolveBindChannel` and degrades to a manual-bind hint at step 10. */
+/** Validate the endorsed spec — deterministic field order (name → workspace →
+ * persona → userSpec). Returns `{ field, message }` on the FIRST bad field, or null
+ * when the whole spec is good. Writes/attempts nothing. `agentId` is NOT a spec field
+ * — it is derived from `name` (`deriveAgentId`) after validate; a stray `agentId` key
+ * is ignored. `channel` is deliberately NOT validated: it is an optional fail-open
+ * convenience, so an absent/blank/malformed channel is never invalid_request — it
+ * folds to `null` in `resolveBindChannel` and degrades to a manual-bind hint at step 10. */
 function validateSpec(spec) {
   if (typeof spec !== "object" || spec === null || Array.isArray(spec)) {
     return {
       field: "spec",
-      message: "spec must be a JSON object with { agentId, name, workspace, persona, userSpec, channel? }.",
-    };
-  }
-  if (!nonBlank(spec.agentId)) {
-    return { field: "agentId", message: "agentId is required and must be non-empty." };
-  }
-  if (spec.agentId === "main") {
-    return { field: "agentId", message: '"main" is host-reserved and cannot be an agentId.' };
-  }
-  if (!AGENT_ID_RE.test(spec.agentId)) {
-    return {
-      field: "agentId",
-      message: "agentId must be lower-kebab (a-z, 0-9, hyphen) — got: " + JSON.stringify(spec.agentId),
+      message: "spec must be a JSON object with { name, workspace, persona, userSpec, channel? }.",
     };
   }
   if (!nonBlank(spec.name)) {
@@ -438,7 +429,11 @@ function main() {
   if (bad) {
     emitFailure("invalid_request", { field: bad.field, cause: bad.message });
   }
-  const { agentId, name, workspace, persona, userSpec, channel } = spec;
+  const { name, workspace, persona, userSpec, channel } = spec;
+  // Derive the host id from the ONE friendly name — the user never invents an id.
+  // The lib's postcondition guarantees a conforming lower-kebab id, never `main`
+  // (empty/`main` slug ⇒ silent `sil-shopper`), so no runtime re-validation here.
+  const agentId = deriveAgentId(name);
 
   // --- 2. Resolve the host config (precondition — nothing written yet) ---
   const configPath = resolveConfigPath();

--- a/sil-shopping/references/agent_creation_engine.md
+++ b/sil-shopping/references/agent_creation_engine.md
@@ -57,11 +57,12 @@ authored here**; they mint **lazily on first shop** ([`shop_loop.md`](shop_loop.
 
 ### Assemble + endorse — the gate
 
-- **Identity** — propose an `agentId` (lower-kebab, ≠ `main`) and a `name`; confirm both.
-- **Assemble** — compose **`{ agentId, name, persona, userSpec }`**, present a readable
-  summary, self-check the shape (`agentId` lower-kebab & ≠ `main`; non-blank
-  `name`/`persona`/`userSpec`). Writes nothing — the engine's validate-first step is the
-  authoritative gate.
+- **Identity** — confirm ONE friendly display `name`. There is **no `agentId` to invent**:
+  the engine derives it from `name` (lower-kebab; a `main`/empty slug silently falls back
+  to `sil-shopper`), so identity is just the name.
+- **Assemble** — compose **`{ name, persona, userSpec }`**, present a readable summary,
+  self-check the shape (non-blank `name`/`persona`/`userSpec`). Writes nothing — the
+  engine's validate-first step is the authoritative gate.
 - **Endorse** — ask for an explicit go-ahead. Endorsement is an affirmative act
   ("yes, create it") — **not** inferred from the last answer or from silence. **Only on
   that explicit yes** do you run Part 2.
@@ -101,7 +102,7 @@ holds. Feed the endorsed spec as one JSON object on **`stdin`** (or `--spec <pat
 
 ```
 sil-openclaw-create-shopper <<'JSON'
-{ "agentId": "my-shopper", "name": "My Shopper",
+{ "name": "My Shopper",
   "workspace": "~/.openclaw/workspace-my-shopper",
   "persona": "…endorsed persona…", "userSpec": "…seeded shared user spec…",
   "channel": "telegram" }
@@ -112,12 +113,14 @@ JSON
 
 | Field | Meaning | Goes to | Required? |
 |---|---|---|---|
-| **agentId** | Lower-kebab (`^[a-z0-9][a-z0-9-]*$`), never `main`. | host | yes |
-| **name** | Human-readable name. | sil store | yes |
+| **name** | Human-readable display name; the `agentId` is **derived** from it. | sil store | yes |
 | **persona** | Who the shopper is — a generalist, its voice, standing rules. | host **`SOUL.md`** | yes |
 | **workspace** | The shopper's workspace directory. | host | yes |
 | **userSpec** | Shared **cross-niche** facts + hard constraints (seeded partial). | sil `user_spec.md` | yes |
 | **channel** | Setup conversation's channel, bound to the shopper. | host bindings | optional (fail-open) |
+
+The `agentId` is **not an input** — the bin derives it as `deriveAgentId(name)`
+(lower-kebab `^[a-z0-9][a-z0-9-]*$`; a `main`/empty slug silently folds to `sil-shopper`).
 
 **No per-niche input at create** — no method, no PRD; those mint lazily on first shop
 via `sil_learn create`. The shopper needs web tools (inherited from `agents.defaults`)
@@ -126,9 +129,10 @@ to mint/refresh domains; if defaults grant none, the bin reports `created` with 
 
 ### What the bin does, in order (atomic, fail-closed)
 
-1. **Validate first** — bad/blank `agentId` (lower-kebab, ≠ `main`), `name`, `persona`,
-   `workspace`, or `userSpec` → **`invalid_request`** naming the field; **nothing
-   written**.
+1. **Validate first, then derive the id** — bad/blank `name`, `persona`, `workspace`, or
+   `userSpec` → **`invalid_request`** naming the field; **nothing written**. Then
+   `agentId = deriveAgentId(name)` — the derivation always yields a conforming id (empty
+   or `main` slug → the silent `sil-shopper` fallback), so the id is never a failure mode.
 2. **Config + singleton pre-flight** — no host config → `persistence_failed`. An
    existing shopper `user_spec.md`, or an `agentId` clash → **`collision`** ("a shopper
    already exists"); steer to shop-a-new-niche or refine, **never a second shopper**. An

--- a/src/__tests__/create-shopper.integration.test.ts
+++ b/src/__tests__/create-shopper.integration.test.ts
@@ -20,7 +20,9 @@
  *                        carries the name — frontmatter-as-truth, no manifest, no
  *                        domain minted at create), the sil skill attached,
  *                        `sil` admitted at ALL THREE allow surfaces, exit 0, the
- *                        result carries name + agentId.
+ *                        result carries the friendly `name` + the DERIVED `agentId`
+ *                        (`agentId = deriveAgentId(name)` — no longer a spec input;
+ *                        an empty/`main` slug folds SILENTLY to `sil-shopper`).
  *   invalid_request    — a bad/blank/malformed spec ⇒ NOTHING attempted (validate-
  *                        first runs ahead of every host command); names the field.
  *   collision          — a singleton violation OR an agentId clash ⇒ NOTHING
@@ -76,6 +78,8 @@ import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { deriveAgentId } from "../lib/derive-agent-id.js";
+
 const HERE = dirname(fileURLToPath(import.meta.url));
 /** Repo root of the checkout under test (…/src/__tests__ → root). */
 const REPO_ROOT = join(HERE, "..", "..");
@@ -112,8 +116,9 @@ interface RunResult {
   stderr: string;
 }
 
+/** The endorsed create-shopper spec. `agentId` is NOT a field — the bin derives it
+ * from `name` (`deriveAgentId`), so the user authors ONE friendly display name. */
 interface Spec {
-  agentId: string;
   name: string;
   workspace: string;
   persona: string;
@@ -394,11 +399,10 @@ function readConfig(): Record<string, any> {
  * default — the fail-open "undetermined channel" baseline; pass `channel` to drive
  * the step-10 bind. */
 function validSpec(overrides: Partial<Spec> = {}): Spec {
-  const agentId = overrides.agentId ?? "my-shopper";
+  const name = overrides.name ?? "My Shopper";
   const spec: Spec = {
-    agentId,
-    name: overrides.name ?? "My Shopper",
-    workspace: overrides.workspace ?? join(workdir, `workspace-${agentId}`),
+    name,
+    workspace: overrides.workspace ?? join(workdir, `workspace-${deriveAgentId(name)}`),
     persona: overrides.persona ?? `A careful generalist buyer. ${PERSONA_SECRET}`,
     userSpec: overrides.userSpec ?? `Ships to Athens; UK size 10; ${USERSPEC_SECRET}`,
   };
@@ -491,17 +495,20 @@ function seedExistingShopper(): void {
 // created — the happy path: every surface wired, exit 0, identity returned.
 // ===========================================================================
 describe("created — one valid run wires every surface and returns the identity", () => {
-  it("exits 0 with status:created and the result carries name + agentId (so the agent can open it)", () => {
+  it("exits 0 with status:created; the result carries the friendly name + the DERIVED agentId", () => {
     writeConfig(freshConfig());
-    const spec = validSpec();
+    const spec = validSpec(); // name "My Shopper" ⇒ derived agentId "my-shopper"
     const r = runBin({ spec });
 
     expect(r.status).toBe(0);
     const m = parseMarker(r.stdout);
     expect(m["event"]).toBe("sil_shopper_created");
     expect(m["status"]).toBe("created");
-    expect(m["name"]).toBe(spec.name);
-    expect(m["agentId"]).toBe(spec.agentId);
+    // The friendly display name rides back verbatim …
+    expect(m["name"]).toBe("My Shopper");
+    // … and the agentId is the lower-kebab id DERIVED from it — a concrete literal,
+    // never echoed from an input (agentId is no longer a spec field).
+    expect(m["agentId"]).toBe("my-shopper");
     // No failure marker on stderr for a clean create.
     expect(r.stderr.includes("sil_shopper_create_failed")).toBe(false);
   });
@@ -566,7 +573,7 @@ describe("created — one valid run wires every surface and returns the identity
     // NAME (`sil-shopping` = manifest skills basename), the key the host resolves a
     // skill by — NEVER the plugin id `sil` (attaching the plugin id is the bug this
     // card kills: the host finds no skill named `sil` and `sil-shopping` never loads).
-    const agent = c.agents.list.find((a: any) => a.id === spec.agentId);
+    const agent = c.agents.list.find((a: any) => a.id === deriveAgentId(spec.name));
     expect(agent).toBeTruthy();
     expect(agent.skills).toEqual([SIL_SKILL]);
   });
@@ -582,7 +589,7 @@ describe("created — one valid run wires every surface and returns the identity
     // tools.deny (an fs-mutator deny is inert while codex's own shell stays open, by
     // design — it reads the shopper's skill files and writes regardless) and NO
     // tools.profile override — only the sil skill is attached to the agent entry.
-    const idx = c.agents.list.findIndex((a: any) => a.id === spec.agentId);
+    const idx = c.agents.list.findIndex((a: any) => a.id === deriveAgentId(spec.name));
     expect(idx).toBeGreaterThanOrEqual(0);
     expect(c.agents.list[idx].tools?.deny).toBeUndefined();
     expect(c.agents.list[idx].tools?.profile).toBeUndefined();
@@ -629,7 +636,6 @@ describe("created — additive: a co-installed peer (klodi) keeps its trust", ()
 // ===========================================================================
 describe("invalid_request — validate-first refuses a bad/blank spec, attempting NOTHING", () => {
   const REQUIRED: ReadonlyArray<keyof Spec> = [
-    "agentId",
     "name",
     "workspace",
     "persona",
@@ -674,21 +680,123 @@ describe("invalid_request — validate-first refuses a bad/blank spec, attemptin
     });
   }
 
-  it("rejects a host-reserved agentId `main` (never a shopper named main)", () => {
+  // NOTE: there is NO invalid_request for a bad/reserved/non-kebab agentId anymore —
+  // agentId is no longer a spec input. Slugify + the sil-shopper fallback GUARANTEE a
+  // conforming id, so that entire user-facing failure mode is gone (BR5). The former
+  // `main` and non-kebab agentId-INPUT rejections are REPLACED by the derive-side
+  // fallbacks below (a name slugging to `main`/empty folds to sil-shopper, still created).
+});
+
+// ===========================================================================
+// derive — agentId is DERIVED from the friendly display name (no agentId input).
+// The single friendly `name` is the ONLY identity the user supplies; the bin
+// derives `agentId = deriveAgentId(name)` and the id never surfaces as a second
+// thing they had to author. Empty/`main` slugs fold to `sil-shopper`, SILENTLY.
+// ===========================================================================
+describe("derive — the agentId is slugified from the display name (no agentId input)", () => {
+  it("name → derived lower-kebab id round-trips into the result, agents.list, AND the skill attach", () => {
     writeConfig(freshConfig());
-    const r = runBin({ spec: validSpec({ agentId: "main" }) });
-    expect(r.status).not.toBe(0);
-    const m = parseMarker(r.stderr);
-    expect(m["status"]).toBe("invalid_request");
-    expect(shimLog()).toBe("");
+    const spec = validSpec({ name: "My Shopper" });
+    const r = runBin({ spec });
+
+    expect(r.status).toBe(0);
+    const m = parseMarker(r.stdout);
+    expect(m["status"]).toBe("created");
+    // Result carries the DERIVED id as a concrete literal (proves the derivation).
+    expect(m["agentId"]).toBe("my-shopper");
+    // The SAME id keys the new agents.list entry, and the sil skill is attached to it.
+    const c = readConfig();
+    const agent = c.agents.list.find((a: any) => a.id === "my-shopper");
+    expect(agent, "expected an agents.list entry keyed by the derived id").toBeTruthy();
+    expect(agent.skills).toEqual([SIL_SKILL]);
   });
 
-  it("rejects a non-lower-kebab agentId (path-segment shape guard)", () => {
+  it('an emoji-only name (empty slug) folds to the sil-shopper fallback — created, never ""', () => {
     writeConfig(freshConfig());
-    const r = runBin({ spec: validSpec({ agentId: "My_Shopper!" }) });
-    expect(r.status).not.toBe(0);
-    expect(parseMarker(r.stderr)["status"]).toBe("invalid_request");
-    expect(shimLog()).toBe("");
+    const spec = validSpec({ name: "🛍️" });
+    const r = runBin({ spec });
+
+    expect(r.status).toBe(0);
+    const m = parseMarker(r.stdout);
+    expect(m["status"]).toBe("created");
+    expect(m["agentId"]).toBe("sil-shopper");
+    // The host never sees an empty id — the fallback lands in agents.list, not "".
+    const c = readConfig();
+    expect(c.agents.list.some((a: any) => a.id === "sil-shopper")).toBe(true);
+    expect(c.agents.list.some((a: any) => a.id === "")).toBe(false);
+  });
+
+  it("a punctuation-only name (empty slug) folds to the sil-shopper fallback — created", () => {
+    writeConfig(freshConfig());
+    const r = runBin({ spec: validSpec({ name: "!!!" }) });
+    expect(r.status).toBe(0);
+    const m = parseMarker(r.stdout);
+    expect(m["status"]).toBe("created");
+    expect(m["agentId"]).toBe("sil-shopper");
+  });
+
+  it("a name whose slug is the reserved `main` folds to sil-shopper — created, never `main`", () => {
+    writeConfig(freshConfig());
+    const r = runBin({ spec: validSpec({ name: "Main" }) });
+    expect(r.status).toBe(0);
+    const m = parseMarker(r.stdout);
+    expect(m["status"]).toBe("created");
+    expect(m["agentId"]).toBe("sil-shopper");
+    expect(m["agentId"]).not.toBe("main");
+    // The host-reserved id is never added as an agent.
+    const c = readConfig();
+    expect(c.agents.list.some((a: any) => a.id === "main")).toBe(false);
+  });
+
+  it("the friendly name is stored verbatim AND returned DISTINCT from the derived id", () => {
+    writeConfig(freshConfig());
+    const spec = validSpec({ name: "My Shopper" });
+    const r = runBin({ spec });
+    expect(r.status).toBe(0);
+    const m = parseMarker(r.stdout);
+    // The one friendly display name is preserved — verbatim in the result …
+    expect(m["name"]).toBe("My Shopper");
+    // … and verbatim in user_spec.md frontmatter (frontmatter-as-truth) …
+    const userSpec = readFileSync(userSpecPath(), "utf8");
+    expect(userSpec).toMatch(/name:\s*My Shopper/);
+    // … while the derived id is a DISTINCT value (the user authored one name, not two).
+    expect(m["agentId"]).toBe("my-shopper");
+    expect(m["name"]).not.toBe(m["agentId"]);
+  });
+
+  it("the empty/main fallback is SILENT — status is exactly created with NO warnings entry for it (BR4)", () => {
+    // A resolvable channel binds + verifies, so the ONLY thing that could add a warning
+    // is the id fallback. BR4: the fallback adds NONE — a deterministic derivation is
+    // not a convenience that failed to fire. warnings must be exactly [].
+    writeConfig(freshConfig());
+    const r = runBin({ spec: validSpec({ name: "Main", channel: "telegram" }) });
+    expect(r.status).toBe(0);
+    const m = parseMarker(r.stdout);
+    expect(m["status"]).toBe("created");
+    expect(m["agentId"]).toBe("sil-shopper");
+    // Silent fallback: the bind was clean, so warnings is empty — no id-fallback notice.
+    expect(Array.isArray(m["warnings"])).toBe(true);
+    expect(m["warnings"]).toEqual([]);
+    // The bind still worked with the fallback id (nothing about the id blocks it).
+    expect(m["boundChannel"]).toBe("telegram");
+    // The fallback minted no new status — the taxonomy is unchanged.
+    expect(m["status"]).not.toBe("invalid_request");
+  });
+
+  it("a STRAY `agentId` key in a hand-fed spec is IGNORED (not read, not rejected) — Q2", () => {
+    // The user-facing contract is "agentId is not an input." A stray key must neither be
+    // honored (the derived id from `name` wins) NOR rejected (no back-compat reject path).
+    writeConfig(freshConfig());
+    const strayed = { ...validSpec({ name: "My Shopper" }), agentId: "totally-different" };
+    const r = runBin({ stdin: JSON.stringify(strayed) });
+    expect(r.status).toBe(0);
+    const m = parseMarker(r.stdout);
+    expect(m["status"]).toBe("created");
+    // Derived from `name`, NOT taken from the stray key.
+    expect(m["agentId"]).toBe("my-shopper");
+    expect(m["agentId"]).not.toBe("totally-different");
+    const c = readConfig();
+    expect(c.agents.list.some((a: any) => a.id === "totally-different")).toBe(false);
   });
 });
 
@@ -788,23 +896,27 @@ describe("collision — a shopper already exists (singleton): refuse, write noth
     expect(first.status).toBe(0);
     expect(parseMarker(first.stdout)["status"]).toBe("created");
 
-    // Second run — same singleton, now populated by the first create.
+    // Second run — a DIFFERENT name (⇒ a different derived id), yet the singleton gate
+    // (keyed on the shopper store, not the id) still catches it before any add.
     rmSync(logPath, { force: true });
-    const second = runBin({ spec: validSpec({ agentId: "my-shopper-2", name: "Second" }) });
+    const second = runBin({ spec: validSpec({ name: "Second" }) });
     expect(second.status).not.toBe(0);
     expect(parseMarker(second.stderr)["status"]).toBe("collision");
     expect(shimLog()).not.toContain("agents add");
   });
 });
 
-describe("collision — an agentId clash refuses without overwriting the existing agent", () => {
-  it("the proposed agentId already in agents.list ⇒ collision, existing agent untouched, no shopper dir", () => {
+describe("collision — an agentId clash on the DERIVED id refuses without overwriting the existing agent", () => {
+  it("the id the name DERIVES to already sits in agents.list (no shopper yet) ⇒ collision, existing agent untouched, no shopper dir", () => {
+    // Seed the clash on `deriveAgentId("My Shopper")` = "my-shopper" — the DERIVED id,
+    // not an input id (agentId is no longer fed in). A pre-existing non-shopper agent on
+    // that id must block the create fail-closed (BR7).
     const cfg = freshConfig() as any;
-    cfg.agents = { list: [{ id: "my-shopper", skills: ["other"], workspace: "/pre/existing" }] };
+    cfg.agents = { list: [{ id: deriveAgentId("My Shopper"), skills: ["other"], workspace: "/pre/existing" }] };
     writeConfig(cfg);
     const preConfig = readFileSync(configPath, "utf8");
 
-    const r = runBin({ spec: validSpec({ agentId: "my-shopper" }) });
+    const r = runBin({ spec: validSpec({ name: "My Shopper" }) });
 
     expect(r.status).not.toBe(0);
     expect(parseMarker(r.stderr)["status"]).toBe("collision");
@@ -1089,7 +1201,7 @@ describe("no PII/secret leakage — the markers never echo the persona or userSp
     expect(ok.stdout).not.toContain(USERSPEC_SECRET);
 
     // A forced failure carries a path + cause — still never the persona/userSpec.
-    const fail = runBin({ spec: validSpec({ agentId: "leak-check" }), fail: ["config-validate"] });
+    const fail = runBin({ spec: validSpec({ name: "Leak Check" }), fail: ["config-validate"] });
     expect(fail.status).not.toBe(0);
     expect(fail.stderr).not.toContain(PERSONA_SECRET);
     expect(fail.stderr).not.toContain(USERSPEC_SECRET);
@@ -1102,11 +1214,12 @@ describe("no PII/secret leakage — the markers never echo the persona or userSp
 describe("input channels — the spec arrives via stdin (primary) OR a --spec file (fallback)", () => {
   it("a --spec <path> file drives an identical created outcome (no stdin needed)", () => {
     writeConfig(freshConfig());
-    const spec = validSpec({ agentId: "spec-file-shopper", name: "Spec File Shopper" });
+    const spec = validSpec({ name: "Spec File Shopper" });
     const r = runBin({ spec, viaSpecFile: true });
     expect(r.status).toBe(0);
     const m = parseMarker(r.stdout);
     expect(m["status"]).toBe("created");
+    // agentId is DERIVED from the name even on the --spec-file path.
     expect(m["agentId"]).toBe("spec-file-shopper");
     expect(existsSync(userSpecPath())).toBe(true);
   });
@@ -1184,10 +1297,10 @@ describe("bind-the-channel — a resolvable channel binds the new shopper by def
     const m = parseMarker(r.stdout);
     expect(m["status"]).toBe("created");
     // The route was actually written into openclaw.json bindings[] …
-    const route = routeFor(readConfig().bindings, spec.agentId, "telegram");
+    const route = routeFor(readConfig().bindings, deriveAgentId(spec.name), "telegram");
     expect(route, "expected a bindings[] route <shopper> → telegram").toBeTruthy();
     expect(route.match.channel).toBe("telegram");
-    expect(route.agentId).toBe(spec.agentId);
+    expect(route.agentId).toBe(deriveAgentId(spec.name));
     // … the bind WRITE was actually issued against the host …
     expect(shimLog()).toContain("agents bind --agent");
     // … the created result NAMES the bound channel (honesty rail: reported ⇒ verified) …
@@ -1205,7 +1318,7 @@ describe("bind-the-channel — a resolvable channel binds the new shopper by def
     expect(r.status).toBe(0);
     const m = parseMarker(r.stdout);
     expect(m["status"]).toBe("created");
-    expect(routeFor(readConfig().bindings, spec.agentId, "telegram")).toBeTruthy();
+    expect(routeFor(readConfig().bindings, deriveAgentId(spec.name), "telegram")).toBeTruthy();
     expect(m["boundChannel"]).toBe("telegram");
     expect(m["warnings"]).toEqual([]);
   });
@@ -1219,9 +1332,9 @@ describe("bind-the-channel — a resolvable channel binds the new shopper by def
     expect(r.status).toBe(0);
     const m = parseMarker(r.stdout);
     expect(m["boundChannel"]).toBe("telegram");
-    expect(routeFor(readConfig().bindings, spec.agentId, "telegram")).toBeTruthy();
+    expect(routeFor(readConfig().bindings, deriveAgentId(spec.name), "telegram")).toBeTruthy();
     // The env channel was NOT bound — spec took precedence, and there is no second route.
-    expect(routeFor(readConfig().bindings, spec.agentId, "whatsapp")).toBeFalsy();
+    expect(routeFor(readConfig().bindings, deriveAgentId(spec.name), "whatsapp")).toBeFalsy();
   });
 });
 
@@ -1240,7 +1353,7 @@ describe("bind-the-channel — fail-open: an undetermined channel still creates 
     // The hint must (a) name the shopper and (b) name a concrete one-command manual
     // step — never imply a broken create (product business rules).
     const hint = (m["warnings"] as string[]).find((w) => /\bbind\b/i.test(w)) ?? "";
-    expect(hint).toContain(spec.agentId);
+    expect(hint).toContain(deriveAgentId(spec.name));
     expect(hint).toMatch(/agents bind|\/agent/i);
     // No routing written, and the bind was never even attempted (no channel to bind).
     expect(readConfig().bindings ?? []).toEqual([]);
@@ -1322,7 +1435,7 @@ describe("bind-the-channel — a conflicting channel is NOT stolen (no --force; 
     // The prior owner's route survives EXACTLY; the shopper got NO route.
     const bindings = readConfig().bindings;
     expect(routeFor(bindings, "other-agent", "telegram")).toBeTruthy();
-    expect(routeFor(bindings, spec.agentId, "telegram")).toBeFalsy();
+    expect(routeFor(bindings, deriveAgentId(spec.name), "telegram")).toBeFalsy();
     expect(bindings).toEqual([
       { type: "route", agentId: "other-agent", match: { channel: "telegram" } },
     ]);

--- a/src/__tests__/lib/derive-agent-id.test.ts
+++ b/src/__tests__/lib/derive-agent-id.test.ts
@@ -1,0 +1,136 @@
+/**
+ * UNIT — deriveAgentId() display-name → shopper-id derivation (tier: unit, pure,
+ * in-memory, no I/O, no host).
+ *
+ * Card: derive-shopper-agentid-from-display-name. Onboarding used to make the user
+ * invent TWO names for ONE shopper — a lower-kebab `agentId` AND a friendly display
+ * `name`. This card deletes the id-authoring step: the user supplies ONE friendly
+ * `name` and the bin derives `agentId = deriveAgentId(name)` invisibly. This is the
+ * pure, total resolver the bin imports (like `resolveBindChannel` /
+ * `src/lib/bind-channel.ts`), unit-tested here so its edge-dense derivation (empty /
+ * `main` / unicode / hyphen-collapse) is pinned cheaply rather than only through the
+ * slow spawn-the-bin integration tier.
+ *
+ * Contract this file pins for the implementation (expert-developer),
+ * `src/lib/derive-agent-id.ts` → `dist/lib/derive-agent-id.js`:
+ *   deriveAgentId(name: string): string
+ *     · lowercase → NFKD-normalize + strip combining marks (so `Café` keeps `cafe`,
+ *       not `caf`) → replace each run of non-`[a-z0-9]` with a single `-` → trim
+ *       edge hyphens;
+ *     · a slug that comes out EMPTY (emoji/punctuation/hyphens/whitespace only) folds
+ *       to the fallback constant `sil-shopper` — NEVER `""`;
+ *     · a slug equal to the host-reserved `main` folds to `sil-shopper` — a shopper
+ *       must never land on `main` (the host `/agent main` handle);
+ *     · POSTCONDITION (total): the result ALWAYS matches `^[a-z0-9][a-z0-9-]*$`,
+ *       never starts/ends with a hyphen, and is never `main`. No throw, ever.
+ *     · DETERMINISTIC: the same `name` always derives the same id.
+ *
+ * THESE ASSERTIONS ARE THE SPEC. Do NOT weaken them to match the implementation.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { deriveAgentId } from "../../lib/derive-agent-id.js";
+
+/** The path-segment shape a shopper id must satisfy — the lib's postcondition. */
+const AGENT_ID_RE = /^[a-z0-9][a-z0-9-]*$/;
+/** The empty/`main`-slug fallback constant. */
+const FALLBACK = "sil-shopper";
+
+describe("deriveAgentId — a friendly name derives a deterministic lower-kebab id", () => {
+  it('a multi-word name lowercases and hyphenates each whitespace run ("My Shopper" → "my-shopper")', () => {
+    expect(deriveAgentId("My Shopper")).toBe("my-shopper");
+  });
+
+  it("is deterministic — the same name always derives the same id", () => {
+    expect(deriveAgentId("My Shopper")).toBe(deriveAgentId("My Shopper"));
+    expect(deriveAgentId("Café Buyer")).toBe(deriveAgentId("Café Buyer"));
+  });
+
+  it("keeps digits and single-word names intact", () => {
+    expect(deriveAgentId("shopper")).toBe("shopper");
+    expect(deriveAgentId("Buyer 2000")).toBe("buyer-2000");
+    expect(deriveAgentId("A")).toBe("a");
+    expect(deriveAgentId("123")).toBe("123");
+  });
+});
+
+describe("deriveAgentId — non-[a-z0-9] runs collapse to ONE hyphen; edge hyphens are trimmed", () => {
+  it('interspersed punctuation/emoji collapse to a single hyphen ("My   Shopper!! 🛍️" → "my-shopper")', () => {
+    expect(deriveAgentId("My   Shopper!! 🛍️")).toBe("my-shopper");
+  });
+
+  it("never emits a double hyphen or a leading/trailing hyphen", () => {
+    expect(deriveAgentId("My  Shopper!")).toBe("my-shopper");
+    expect(deriveAgentId("  --My Shopper--  ")).toBe("my-shopper");
+    expect(deriveAgentId("!Shopper!")).toBe("shopper");
+  });
+});
+
+describe("deriveAgentId — a slug equal to the reserved `main` folds to the fallback", () => {
+  for (const name of ["main", "Main", "MAIN", "MAIN!", "  main  "]) {
+    it(`"${name}" (slug === "main") → ${FALLBACK}, never "main"`, () => {
+      const id = deriveAgentId(name);
+      expect(id).toBe(FALLBACK);
+      expect(id).not.toBe("main");
+    });
+  }
+});
+
+describe("deriveAgentId — an EMPTY slug folds to the fallback (never `\"\"`)", () => {
+  for (const name of ["🛍️", "!!!", "---", "   ", "@#$%", "‑‑‑"]) {
+    it(`"${name}" (slug empty) → ${FALLBACK}, never ""`, () => {
+      const id = deriveAgentId(name);
+      expect(id).toBe(FALLBACK);
+      expect(id).not.toBe("");
+    });
+  }
+});
+
+describe("deriveAgentId — diacritics NFKD-normalize (combining marks stripped, letters kept)", () => {
+  it('"Café Buyer" → "cafe-buyer" (the é keeps its base `e`, not dropped mid-word)', () => {
+    // The architecture DECIDED NFKD + strip-combining-marks (Approach section) — a
+    // plain ascii-strip that dropped the é to yield "caf-buyer" is data loss and is
+    // NOT the production-grade bar this pins.
+    expect(deriveAgentId("Café Buyer")).toBe("cafe-buyer");
+  });
+
+  it('"Zoë Picks" → "zoe-picks" (diaeresis stripped, base letter kept)', () => {
+    expect(deriveAgentId("Zoë Picks")).toBe("zoe-picks");
+  });
+});
+
+describe("deriveAgentId — POSTCONDITION: total, always AGENT_ID_RE, never `main`, never edge-hyphen", () => {
+  const NAMES = [
+    "My Shopper",
+    "My   Shopper!! 🛍️",
+    "🛍️",
+    "!!!",
+    "---",
+    "   ",
+    "main",
+    "Main",
+    "MAIN!",
+    "Café Buyer",
+    "  --x--  ",
+    "A",
+    "123",
+    "Buyer 2000",
+    "a".repeat(500),
+    "日本語ショッパー",
+    "shop💥💥keeper",
+  ];
+
+  for (const name of NAMES) {
+    it(`"${name.length > 24 ? name.slice(0, 24) + "…" : name}" → a valid, non-empty, non-\`main\` id`, () => {
+      const id = deriveAgentId(name);
+      expect(typeof id).toBe("string");
+      expect(id.length).toBeGreaterThan(0);
+      expect(id).toMatch(AGENT_ID_RE);
+      expect(id.startsWith("-")).toBe(false);
+      expect(id.endsWith("-")).toBe(false);
+      expect(id.includes("--")).toBe(false);
+      expect(id).not.toBe("main");
+    });
+  }
+});

--- a/src/lib/derive-agent-id.ts
+++ b/src/lib/derive-agent-id.ts
@@ -1,0 +1,40 @@
+/**
+ * Derive a shopper's host `agentId` from its ONE friendly display `name`.
+ *
+ * Onboarding used to make the user invent TWO names for one shopper — a lower-kebab
+ * `agentId` AND a friendly display `name`. The id is pure host plumbing (a workspace
+ * path segment, the `/agent <id>` switch handle, the channel-bind target) the user
+ * should never author. `create-shopper` now takes only the `name`; the bin derives the
+ * id here, so the id never surfaces as a second thing the user has to get right.
+ *
+ * The slug: NFKD-normalize + strip combining marks (so `Café`/`Málaga` keep their base
+ * letters — `cafe`, `malaga` — instead of splitting mid-word on the accent) → lowercase
+ * → collapse each run of non-`[a-z0-9]` to a single hyphen → trim edge hyphens. An empty
+ * slug (emoji-only / punctuation-only name) OR the host-reserved `main` both fold to the
+ * `sil-shopper` fallback — the display `name` the user chose stays intact; only the
+ * plumbing id falls back, silently.
+ *
+ * Pure and total: no I/O, no host, no throw. For ANY string the result satisfies the
+ * postcondition `AGENT_ID_RE` (`^[a-z0-9][a-z0-9-]*$`) and is never `main` — so the bin
+ * needs no runtime re-validation of the derived id.
+ */
+
+/** The lower-kebab shopper-id shape — never `main` (host-reserved). The postcondition
+ * every `deriveAgentId` result satisfies; also the bin's documented DERIVED shape. */
+export const AGENT_ID_RE = /^[a-z0-9][a-z0-9-]*$/;
+
+/** Fallback id when the slug is empty or lands on the host-reserved `main`. */
+const FALLBACK_AGENT_ID = "sil-shopper";
+
+/** The one host-reserved id a derived slug must never become. */
+const RESERVED_AGENT_ID = "main";
+
+export function deriveAgentId(name: string): string {
+  const slug = name
+    .normalize("NFKD")
+    .replace(/\p{M}/gu, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug === "" || slug === RESERVED_AGENT_ID ? FALLBACK_AGENT_ID : slug;
+}


### PR DESCRIPTION
## Card
`cards/derive-shopper-agentid-from-display-name.md` (lives in the `card/derive-shopper-agentid-from-display-name` branch — gitignored, local-only; see the card body for full intent + handoffs). Epic `cut-onboarding-naming-2026-07`.

## Summary
Onboarding used to make the user invent TWO names for ONE shopper — a lower-kebab `agentId` AND a friendly display `name`. This deletes the id-authoring step: the user supplies ONE friendly `name`, and the bin derives `agentId = deriveAgentId(name)` invisibly.

- **NEW `src/lib/derive-agent-id.ts`** — pure/total `deriveAgentId(name): string` (mirrors `bind-channel.ts`): NFKD → strip combining marks → lowercase → collapse non-`[a-z0-9]` runs to one `-` → trim edges; empty-or-`main` slug folds to the `sil-shopper` constant. Postcondition: always `^[a-z0-9][a-z0-9-]*$`, never `main`. Exports `AGENT_ID_RE`.
- **`scripts/create-shopper.mjs`** — `agentId` removed from the input contract entirely (no back-compat optional path); `validateSpec` drops the three agentId guards; `main()` derives the id right after validate; all downstream consumes it unchanged. The bin's now-dead `AGENT_ID_RE` const removed (lib owns it; no runtime re-validation).
- **`sil-shopping/references/agent_creation_engine.md`** — identity beat rewritten name-only; example JSON, spec table, and step-1 clause de-agentId'd.

Behavior preserved (hard): endorsement gate, singleton re-run guarantee, fail-open channel bind, whole-file snapshot-restore teardown, and the five-status taxonomy — all unchanged. The empty/`main` fallback is SILENT (`created`, no `warnings`, no new status). A stray `agentId` key is ignored, not rejected.

## Test plan
- [x] `pnpm typecheck` — clean (src + `src/__tests__`)
- [x] Unit `src/__tests__/lib/derive-agent-id.test.ts` — edge table (collapse, `main`/empty fallback, diacritics NFKD, 16-name postcondition sweep)
- [x] Integration `src/__tests__/create-shopper.integration.test.ts` — `Spec`/`REQUIRED` drop `agentId`; derive block (name→id, emoji/punct/`main`→`sil-shopper`, name-distinct-from-id, silent-fallback `warnings===[]`, stray-`agentId`-ignored); taxonomy/teardown/singleton untouched
- [x] `pnpm build` + full `vitest run` — 968 pass; the only 10 failures are `repo-scaffold.integration.test.ts`, the known worktree-only false-red (gitignored CLAUDE.md/docs not checked out), unrelated to this diff
- [x] Real-bin boundary smoke — no-`agentId` spec validates-then-derives

No `openclaw.plugin.json#contracts.tools` change (no `sil_*` tool added).

## Distillation target
Knowledge capture happens **after Review PASS** in the `distilling` stage — `solutions-architect` runs in this same worktree, commits to this same branch, and pushes here. Target: EDIT `docs/decisions/create-shopper-bin.md` (input contract now `{ name, workspace, persona, userSpec, channel? }`, `agentId` derived from `name`).