### PR TITLE
feat: host-wiring drift + gateway-compat advisories (detect-only)

### DIFF
--- a/src/__tests__/advisory.integration.test.ts
+++ b/src/__tests__/advisory.integration.test.ts
@@ -1,0 +1,1065 @@
+/**
+ * INTEGRATION — the host-wiring + gateway-compat advisories on all three real
+ * surfaces (tier: integration; the real `register()`, the real tool `execute()`s,
+ * the real `sil_doctor`, a real temp `$SIL_DATA_DIR`).
+ *
+ * Card: self-upgrade-detect-host-wiring-advisory — **AC2, AC3, AC6, AC7, AC11–AC14**.
+ *
+ * **Drift is driven by handing the mock api a crafted `config` tree** — that IS the
+ * production seam. `api.config` is the FULL OpenClawConfig the host hands the plugin
+ * at load (`src/types/openclaw.d.ts:26-35`), so a config literal here is the same
+ * datum production reads. Nothing about the wiring path is stubbed: the detector,
+ * the fold, the doctor rows, and the register warn are all real.
+ *
+ * **The only thing mocked is `fetch`** — and only because `sil_doctor`'s OWN
+ * ClawHub probe (sil-doctor's `version.plugin_behind`) would otherwise hit the live
+ * network. This card issues **zero** outbound requests of its own; several tests
+ * below assert exactly that.
+ *
+ * **Why three surfaces, and why they are not interchangeable** (the reachability
+ * matrix — this is load-bearing spec, not trivia):
+ *
+ *   | drift state                        | loads? | sil_* callable? | only live surface |
+ *   |------------------------------------|--------|-----------------|-------------------|
+ *   | skill attached by id `sil`         | yes    | YES             | tool fold + doctor|
+ *   | `tools.alsoAllow` omits `sil`      | yes    | no              | register-time log |
+ *   | non-empty `plugins.allow` omits it | NO     | no              | none — unreportable|
+ *
+ * A mis-wired skill is not running its own flow, so it cannot carry its own warning
+ * — the tools are the only surviving messenger. And `sil_doctor` is itself a sil
+ * tool, so the drift that filters sil's tools filters the doctor too: that state's
+ * ONLY carrier is the register-time `logger.warn` (AC13).
+ *
+ * **The four catches an end-to-end assertion misses**, each pinned explicitly below:
+ *   - **AC12** — `api.config` is the host's LIVE tree. Every surface is asserted
+ *     deep-equal before/after AND driven once against a DEEPLY FROZEN config, and
+ *     `mergeSilAllowlist` is spied to prove it is never reached for (it mutates its
+ *     argument in place by design — `openclaw-allowlist.ts:100-104, :174, :193, :202`).
+ *   - **AC6** — the happy path has NO `advisories` key at all; the drifted payload
+ *     MINUS `advisories` is deep-equal to the healthy payload. Present-only-on-drift
+ *     is what keeps today's payloads byte-identical.
+ *   - **AC14** — `api.config` can hold OTHER plugins' credentials. The secret-bearing
+ *     fixture plants three, in three different blocks, and every finding + every log
+ *     line is scanned for all three.
+ *   - **rule 10** — the HOME decoy: a HEALTHY `~/.openclaw/openclaw.json` on disk
+ *     next to a DRIFTED `api.config` must still advise. We report the EFFECTIVE
+ *     (running) wiring, never the INTENDED (on-disk) wiring — a file read would
+ *     green-wash a fix that has not been reloaded yet.
+ *
+ * Contract pinned for the implementation (expert-developer):
+ *   - Every `sil_*` SUCCESS payload gains `advisories: Finding[]` **iff** wiring
+ *     drift exists; on a healthy host the key is ABSENT (never `[]`, never `null`).
+ *     Error envelopes are NOT folded (MVP).
+ *   - `sil_doctor` contributes the same `wiring.*` findings to its `findings[]`
+ *     (NOT an `advisories` key) plus `version.gateway_compat`; report shape unchanged.
+ *   - Compat surfaces on `sil_doctor` ONLY — never on a tool fold.
+ *   - `register()` logs exactly one `sil_plugin_wiring_drift` warn on drift, and
+ *     nothing on a clean config. It stays synchronous and opens nothing.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, readdirSync, lstatSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { tmpdir } from "node:os";
+import { basename, dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type { PluginAPI } from "openclaw/plugin-sdk";
+
+import { registerCatalogTools } from "../tools/catalog.js";
+import { registerDoctorTools } from "../tools/doctor.js";
+import { registerIdentityTools } from "../tools/identity.js";
+import { registerProfileTools } from "../tools/profile.js";
+import { sortFindings, type Finding } from "../lib/findings.js";
+import * as allowlist from "../lib/openclaw-allowlist.js";
+import { setApiUrl, setWebUrl } from "../lib/config.js";
+import { getTokensPath } from "../lib/credentials.js";
+import {
+  createMockPluginApi,
+  getTool,
+  type MockPluginAPI,
+} from "./helpers/mock-plugin-api.js";
+
+// The real entry, captured the way index.test.ts captures it — AC13 drives the
+// FULL real register(), not a hand-rolled stand-in.
+let capturedRegisterFn: ((api: PluginAPI) => void) | null = null;
+vi.mock("openclaw/plugin-sdk/plugin-entry", () => ({
+  definePluginEntry: vi.fn((entry: { register: (api: PluginAPI) => void }) => {
+    capturedRegisterFn = entry.register;
+    return entry;
+  }),
+}));
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+// ---------------------------------------------------------------------------
+// Facts + fixtures, DERIVED from the shipped manifest / package.json. A literal
+// here would let the test agree with a detector that hardcodes the same literal,
+// and would rot silently the day the skill dir is renamed (incident #1's root).
+// ---------------------------------------------------------------------------
+
+const manifest = (): { id: string; skills: string[] } =>
+  JSON.parse(readFileSync(join(REPO_ROOT, "openclaw.plugin.json"), "utf8"));
+
+const packageJson = (): {
+  openclaw: { compat: { minGatewayVersion: string } };
+} => JSON.parse(readFileSync(join(REPO_ROOT, "package.json"), "utf8"));
+
+const PLUGIN_ID = manifest().id;
+/** The PUBLISHED skill name = the skill-dir basename, NOT the ref, NOT the id. */
+const SKILL_NAME = basename(manifest().skills[0]!);
+/** Our declared gateway floor, e.g. ">=2026.4.15" → "2026.4.15". */
+const REQUIRED_HOST = packageJson().openclaw.compat.minGatewayVersion.replace(/^>=\s*/, "");
+
+/** Below/above any plausible calendar floor, so neither tracks the shipped value. */
+const HOST_TOO_OLD = "0.0.1";
+const HOST_FINE = "9999.0.0";
+
+const SKILL_MISATTACHED = "wiring.skill_misattached";
+const TOOLS_NOT_ADMITTED = "wiring.tools_not_admitted";
+const GATEWAY_COMPAT = "version.gateway_compat";
+/** The structured marker AC13's register-time warn rides on. */
+const WIRING_WARN_MARKER = "sil_plugin_wiring_drift";
+
+type Config = Record<string, unknown>;
+
+/**
+ * The host version rides `api.runtime.version` — NOT the config tree. Probed
+ * against a live `alpine/openclaw:2026.6.9` and re-verified independently by qa:
+ * `config.gateway` does not exist, and `config.meta.lastTouchedVersion` is the
+ * version that last WROTE the config file, not the one now running. So the wiring
+ * config and the host version are two separate api surfaces here, exactly as they
+ * are in production.
+ */
+const hostRuntime = (version?: string): Record<string, unknown> | undefined =>
+  version === undefined ? undefined : { version };
+
+/** Fully healthy: skill by published name, plugin enabled, tools admitted, and a
+ * PERMISSIVE (empty) `plugins.allow` — the auto-load-everything default, which is
+ * NOT drift (AC9's trap, re-pinned end-to-end here). */
+const healthyConfig = (): Config => ({
+  agents: { list: [{ id: "shopper", skills: [SKILL_NAME] }] },
+  tools: { alsoAllow: [PLUGIN_ID] },
+  plugins: { allow: [], entries: { [PLUGIN_ID]: { enabled: true, config: {} } } },
+});
+
+/** Incident #1: `skills: ["sil"]` where `["sil-shopping"]` was meant. */
+const misattachedConfig = (): Config => ({
+  ...healthyConfig(),
+  agents: { list: [{ id: "shopper", skills: [PLUGIN_ID] }] },
+});
+
+/** Half-trust: enabled, but a non-empty `tools.alsoAllow` omits us. */
+const unadmittedConfig = (): Config => ({
+  ...healthyConfig(),
+  tools: { alsoAllow: ["klodi"] },
+});
+
+/** Every WIRING drift at once — the AC7 fixture. Compat drift is driven
+ * separately, via the runtime host version. */
+const allDriftConfig = (): Config => ({
+  agents: { list: [{ id: "shopper", skills: [PLUGIN_ID] }] },
+  tools: { alsoAllow: ["klodi"] },
+  plugins: { allow: [], entries: { [PLUGIN_ID]: { enabled: true, config: {} } } },
+});
+
+// The three planted secrets, in the three places `api.config` really carries them.
+const PLUGIN_SECRET = "sk-live-klodi-PLUGIN-SECRET-NEVER-SURFACE";
+const GATEWAY_SECRET = "gateway-bearer-SECRET-NEVER-SURFACE";
+const AGENT_SECRET = "agent-env-OPENAI-SECRET-NEVER-SURFACE";
+const ALL_SECRETS = [PLUGIN_SECRET, GATEWAY_SECRET, AGENT_SECRET];
+
+/** Maximum drift AND maximum adjacent secrecy. Every drift fires, so every code
+ * path that builds a string runs — while three other tenants' credentials sit one
+ * key away from the facts we DO emit. */
+const secretBearingConfig = (): Config => ({
+  agents: {
+    list: [
+      { id: "shopper", skills: [PLUGIN_ID], env: { OPENAI_API_KEY: AGENT_SECRET } },
+    ],
+  },
+  tools: { alsoAllow: ["klodi"] },
+  plugins: {
+    allow: [],
+    entries: {
+      [PLUGIN_ID]: { enabled: true, config: {} },
+      klodi: { enabled: true, config: { apiKey: PLUGIN_SECRET } },
+    },
+  },
+  gateway: { auth: { token: GATEWAY_SECRET } },
+  meta: { lastTouchedVersion: "9999.0.0" },
+});
+
+// ---------------------------------------------------------------------------
+// The fetch double. `sil_doctor`'s ClawHub probe is the ONLY thing that would go
+// out; this card adds nothing. Every test stubs it — a live call in CI is a hard
+// failure, not a flake.
+// ---------------------------------------------------------------------------
+
+let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+const jsonResponse = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+
+/** The probe answers, and reports us current (so sil-doctor's own version finding
+ * stays silent and cannot be confused with THIS card's compat finding). */
+function probeUpToDate(): void {
+  const installed = JSON.parse(readFileSync(join(REPO_ROOT, "package.json"), "utf8")).version;
+  fetchSpy.mockImplementation(async () =>
+    jsonResponse({ package: { name: "@4gpts/sil", latestVersion: installed, tags: { latest: installed } } }),
+  );
+}
+
+/** The network is DOWN. AC2: the local checks are the floor and always run. */
+function probeUnreachable(): void {
+  fetchSpy.mockRejectedValue(new Error("ENETDOWN — the network is down"));
+}
+
+/** sil-api answers a real, EMPTY catalog search — a success, not an error. */
+function catalogEmptyOk(): void {
+  fetchSpy.mockImplementation(async (input: unknown) => {
+    const url = typeof input === "string" ? input : String(input);
+    if (url.includes("/catalog/search")) return jsonResponse({ products: [] });
+    return jsonResponse({ package: { name: "@4gpts/sil", latestVersion: null, tags: {} } });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Data dir + HOME. HOME is redirected so the rule-10 decoy below is hermetic and
+// so nothing can touch the developer's real ~/.openclaw.
+// ---------------------------------------------------------------------------
+
+let parentDir: string;
+let dataDir: string;
+let homeDir: string;
+let priorEnv: Record<string, string | undefined> = {};
+
+function writeTokensFile(): void {
+  const path = getTokensPath();
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  writeFileSync(path, JSON.stringify({ access_token: "at", refresh_token: "rt" }), { mode: 0o600 });
+}
+
+/** relpath → mode + content hash. Proves an absence of writes (bytes AND modes). */
+function snapshot(root: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      const st = lstatSync(full);
+      if (entry.isDirectory()) {
+        out[relative(root, full)] = `dir:${st.mode & 0o777}`;
+        walk(full);
+      } else {
+        out[relative(root, full)] =
+          `file:${st.mode & 0o777}:${createHash("sha256").update(readFileSync(full)).digest("hex")}`;
+      }
+    }
+  };
+  walk(root);
+  return out;
+}
+
+beforeAll(async () => {
+  await import("../index.js");
+});
+
+beforeEach(() => {
+  parentDir = mkdtempSync(join(tmpdir(), "sil-advisory-test-"));
+  dataDir = join(parentDir, "data");
+  homeDir = join(parentDir, "home");
+  mkdirSync(dataDir, { recursive: true, mode: 0o700 });
+  mkdirSync(homeDir, { recursive: true, mode: 0o700 });
+  for (const key of ["SIL_DATA_DIR", "XDG_DATA_HOME", "HOME", "SIL_WEB_URL", "SIL_API_URL"]) {
+    priorEnv[key] = process.env[key];
+  }
+  process.env["SIL_DATA_DIR"] = dataDir;
+  process.env["HOME"] = homeDir;
+  delete process.env["XDG_DATA_HOME"];
+  setWebUrl("https://sil-web.test.example.com");
+  setApiUrl("https://sil-api.test.example.com");
+  fetchSpy = vi.spyOn(globalThis, "fetch");
+  probeUpToDate();
+});
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(priorEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  priorEnv = {};
+  setWebUrl("");
+  setApiUrl("");
+  vi.restoreAllMocks();
+  rmSync(parentDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Running the real surfaces.
+// ---------------------------------------------------------------------------
+
+interface DoctorReport {
+  status: string;
+  healthy: boolean;
+  dataDir: string;
+  installedVersion: string;
+  counts: { info: number; warn: number; critical: number };
+  findings: Finding[];
+}
+
+type Payload = Record<string, unknown> & { advisories?: Finding[] };
+
+/** Every registered group, on ONE api — the way `register()` wires them, so a fold
+ * that only reaches one group is caught. */
+function registerAll(api: PluginAPI): void {
+  registerIdentityTools(api);
+  registerCatalogTools(api);
+  registerProfileTools(api);
+  registerDoctorTools(api);
+}
+
+let lastApi: MockPluginAPI;
+
+/** `hostVersion` omitted ⇒ the api carries NO runtime, which is the honest
+ * default: the compat check is inconclusive and emits nothing. */
+async function runTool(
+  name: string,
+  params: Record<string, unknown>,
+  config: Config,
+  hostVersion?: string,
+): Promise<Payload> {
+  const api = createMockPluginApi({ config, runtime: hostRuntime(hostVersion) });
+  lastApi = api;
+  registerAll(api);
+  const result = await getTool(api, name).execute("call-1", params);
+  expect(result.content).toHaveLength(1);
+  return JSON.parse(result.content[0]?.text as string) as Payload;
+}
+
+async function runDoctor(config: Config, hostVersion?: string): Promise<DoctorReport> {
+  return (await runTool("sil_doctor", {}, config, hostVersion)) as unknown as DoctorReport;
+}
+
+/**
+ * The four real `sil_*` success paths this file drives — one per tool group, so
+ * "EVERY `sil_*` result" (AC3) is proven across the whole surface rather than on
+ * one convenient tool. Each is a genuine success against real state: no stub
+ * asserts a stubbed response here.
+ */
+const SUCCESS_PATHS: Array<{
+  tool: string;
+  params: Record<string, unknown>;
+  /** Real state the success needs, beyond a temp data dir. */
+  setup?: () => void;
+}> = [
+  // profile — an empty store is `status: ok`, zero network.
+  { tool: "sil_profile_search", params: {} },
+  // identity — `already_registered` short-circuits on stored tokens, zero network.
+  { tool: "sil_register", params: {}, setup: writeTokensFile },
+  // catalog — an empty match IS a success (`status: ok, products: []`).
+  { tool: "sil_search", params: { query: "chair" }, setup: () => { writeTokensFile(); catalogEmptyOk(); } },
+];
+
+const advisoryIds = (payload: Payload): string[] => (payload.advisories ?? []).map((a) => a.id).sort();
+const findingIds = (report: DoctorReport): string[] => report.findings.map((f) => f.id);
+const wiringFindings = (report: DoctorReport): Finding[] =>
+  report.findings.filter((f) => f.id.startsWith("wiring."));
+
+/** Every string a run emitted: the payload AND every logger call. A leak hides in
+ * a log line just as easily as in a field. */
+function emittedStrings(payload: unknown): string {
+  const logs = (["info", "warn", "error", "debug"] as const)
+    .flatMap((level) => vi.mocked(lastApi.logger[level]).mock.calls)
+    .map((call) => JSON.stringify(call))
+    .join("\n");
+  return JSON.stringify(payload) + "\n" + logs;
+}
+
+const deepFreeze = <T>(value: T): T => {
+  if (value !== null && typeof value === "object") {
+    Object.values(value as Record<string, unknown>).forEach(deepFreeze);
+    Object.freeze(value);
+  }
+  return value;
+};
+
+// ===========================================================================
+// AC3 — skill wired by id → advisory on EVERY sil_* result AND on sil_doctor
+// ===========================================================================
+
+describe("AC3 — skill attached by id: the tools are the only surviving messenger", () => {
+  for (const { tool, params, setup } of SUCCESS_PATHS) {
+    it(`${tool} folds the wiring advisory into its SUCCESS result`, async () => {
+      setup?.();
+      const payload = await runTool(tool, params, misattachedConfig());
+
+      expect(payload["status"]).toBe(tool === "sil_register" ? "already_registered" : "ok");
+      expect(advisoryIds(payload)).toEqual([SKILL_MISATTACHED]);
+    });
+
+    it(`${tool}'s advisory is warn + advisory + appliedAction null, with the exact fix`, async () => {
+      setup?.();
+      const payload = await runTool(tool, params, misattachedConfig());
+      const advisory = payload.advisories![0]!;
+
+      expect(advisory.severity).toBe("warn");
+      expect(advisory.status).toBe("advisory");
+      expect(advisory.appliedAction).toBeNull();
+      // The exact one-line fix: replace the id with the published name, in THAT
+      // agent's skills — plus how it takes effect (rule 3 + rule 10).
+      expect(advisory.suggestedAction).toContain(SKILL_NAME);
+      expect(advisory.suggestedAction).toContain(PLUGIN_ID);
+      expect(advisory.suggestedAction).toContain("shopper");
+      expect(advisory.suggestedAction!.toLowerCase()).toContain("reload");
+    });
+
+    it(`${tool}'s OWN payload is unchanged and complete — the advisory is additive only`, async () => {
+      // Rule 7: a result carrying an advisory is still, byte-for-byte, the same
+      // result. The advisory is a sibling block — never a wrapper, never a re-rank,
+      // never a substitute for data the caller asked for.
+      setup?.();
+      const healthy = await runTool(tool, params, healthyConfig());
+      setup?.();
+      const drifted = await runTool(tool, params, misattachedConfig());
+
+      const { advisories, ...rest } = drifted;
+      expect(advisories).toBeDefined();
+      expect(rest).toEqual(healthy);
+    });
+  }
+
+  it("sil_doctor reports the SAME finding, with the same id — byte-identical across surfaces", async () => {
+    // AC3: "the finding is byte-identical whichever surface carries it". Both read
+    // the EFFECTIVE wiring from the same `api.config`, so anything else would mean
+    // two detectors — i.e. two things to drift apart.
+    const payload = await runTool("sil_profile_search", {}, misattachedConfig());
+    const report = await runDoctor(misattachedConfig());
+
+    const fromTool = payload.advisories!.find((a) => a.id === SKILL_MISATTACHED);
+    const fromDoctor = report.findings.find((f) => f.id === SKILL_MISATTACHED);
+    expect(fromDoctor).toBeDefined();
+    expect(fromDoctor).toEqual(fromTool);
+  });
+
+  it("the doctor carries wiring findings in `findings[]` — NOT in an `advisories` key", async () => {
+    // The doctor's product IS the findings array; a second parallel channel on the
+    // same report would be two places to look and two places to drift.
+    const report = await runDoctor(misattachedConfig());
+    expect(findingIds(report)).toContain(SKILL_MISATTACHED);
+    expect(report).not.toHaveProperty("advisories");
+  });
+
+  it("the advisory RECURS on every call while the drift persists — recurrence is the feature", async () => {
+    // OQ3: no fire-once, no cooldown, no "acknowledged" state. A persistent silent
+    // misconfiguration is exactly what a fire-once advisory lets rot — and this one
+    // was silent enough to cause incident #1. A cooldown here is a documented
+    // regression, not a cleanup.
+    const first = await runTool("sil_profile_search", {}, misattachedConfig());
+    const second = await runTool("sil_profile_search", {}, misattachedConfig());
+    const third = await runTool("sil_profile_search", {}, misattachedConfig());
+    expect(advisoryIds(first)).toEqual([SKILL_MISATTACHED]);
+    expect(advisoryIds(second)).toEqual([SKILL_MISATTACHED]);
+    expect(advisoryIds(third)).toEqual([SKILL_MISATTACHED]);
+  });
+
+  it("compat NEVER rides a tool result — it is a doctor-only question (the catalogue)", async () => {
+    // A gateway-compat gap answers a question nobody asked mid-`sil_search`. The
+    // fold is earned by the self-carry paradox, which applies ONLY to wiring.
+    const payload = await runTool("sil_profile_search", {}, allDriftConfig());
+    expect(advisoryIds(payload)).not.toContain(GATEWAY_COMPAT);
+    for (const advisory of payload.advisories ?? []) {
+      expect(advisory.id.startsWith("wiring.")).toBe(true);
+    }
+  });
+});
+
+// ===========================================================================
+// AC2 — gateway compat, with no network needed
+// ===========================================================================
+
+describe("AC2 — gateway compat gap → advisory, purely local", () => {
+  it("a host BELOW our declared floor → a warn advisory naming required vs running", async () => {
+    const report = await runDoctor(healthyConfig(), HOST_TOO_OLD);
+    const compat = report.findings.find((f) => f.id === GATEWAY_COMPAT);
+
+    expect(compat).toBeDefined();
+    expect(compat!.severity).toBe("warn");
+    expect(compat!.status).toBe("advisory");
+    expect(compat!.appliedAction).toBeNull();
+    expect(compat!.detected).toContain(REQUIRED_HOST);
+    expect(compat!.detected).toContain(HOST_TOO_OLD);
+    expect(compat!.suggestedAction!.toLowerCase()).toContain("openclaw");
+  });
+
+  it("STILL fires with the network DOWN — compat is not coupled to the remote channel", async () => {
+    // The card's sharpest degradation rule: the local checks are the floor and
+    // ALWAYS run. sil-doctor's ClawHub probe failing must not take compat (or the
+    // wiring advisory) down with it — a diagnosis that fails when the network does
+    // is worthless precisely when it is needed.
+    probeUnreachable();
+    const report = await runDoctor(allDriftConfig(), HOST_TOO_OLD);
+
+    expect(findingIds(report)).toContain(GATEWAY_COMPAT);
+    expect(findingIds(report)).toContain(SKILL_MISATTACHED);
+    // ...and the remote-only finding is omitted, never fabricated (sil-doctor's AC6c).
+    expect(findingIds(report)).not.toContain("version.plugin_behind");
+    expect(report.status).toBe("ok");
+  });
+
+  it("a host AT or ABOVE the floor → NO compat finding", async () => {
+    for (const version of [REQUIRED_HOST, HOST_FINE]) {
+      const report = await runDoctor(healthyConfig(), version);
+      expect(findingIds(report), version).not.toContain(GATEWAY_COMPAT);
+    }
+  });
+
+  it("an UNREADABLE host version → NO compat finding (inconclusive, never fabricated)", async () => {
+    // `readHostVersion` → null: the host supplied no runtime version. Not
+    // hypothetical — one real load path registers plugins with `runtime: {}`.
+    // Never "your host is too old" from a failed read, never a silent green dressed
+    // up as a real check.
+    const report = await runDoctor(healthyConfig());
+
+    expect(findingIds(report)).not.toContain(GATEWAY_COMPAT);
+    expect(report.status).toBe("ok");
+  });
+
+  it("NEVER fabricates a verdict from `meta.lastTouchedVersion` (config provenance, not the host)", async () => {
+    // The trap sitting one key from the wiring we DO read: `meta.lastTouchedVersion`
+    // is semver-shaped, lives on every real config, and means "which version last
+    // WROTE this file". A doctor reading it would tell a user who ran a newer
+    // OpenClaw once and downgraded that their host is fine.
+    const report = await runDoctor({
+      ...healthyConfig(),
+      meta: { lastTouchedVersion: HOST_FINE, lastTouchedAt: "2026-07-17T09:59:47.329Z" },
+    });
+    expect(findingIds(report)).not.toContain(GATEWAY_COMPAT);
+  });
+
+  it("is NOT VACUOUS — the doctor's compat row does fire on the same code path", async () => {
+    // Guards the whole describe block: a compat row wired to nothing would satisfy
+    // every silence assertion above.
+    const report = await runDoctor(healthyConfig(), HOST_TOO_OLD);
+    expect(findingIds(report)).toContain(GATEWAY_COMPAT);
+  });
+});
+
+// ===========================================================================
+// AC6 — healthy → silence, on every surface
+// ===========================================================================
+
+describe("AC6 — a healthy host is SILENT everywhere (absence of a problem is not a finding)", () => {
+  for (const { tool, params, setup } of SUCCESS_PATHS) {
+    it(`${tool} carries NO advisories key at all — the payload is byte-identical to today's`, async () => {
+      // Not `advisories: []`, not `advisories: null` — ABSENT. Present-only-on-drift
+      // is what makes "the happy-path payload is unchanged" literally true.
+      setup?.();
+      const payload = await runTool(tool, params, healthyConfig());
+      expect(payload).not.toHaveProperty("advisories");
+      expect(Object.keys(payload)).not.toContain("advisories");
+    });
+  }
+
+  it("sil_doctor reports no wiring and no compat finding on a healthy host", async () => {
+    const report = await runDoctor(healthyConfig());
+    expect(wiringFindings(report)).toEqual([]);
+    expect(findingIds(report)).not.toContain(GATEWAY_COMPAT);
+  });
+
+  it("nothing this card contributes is above `info` on a healthy host", async () => {
+    const report = await runDoctor(healthyConfig());
+    const ours = report.findings.filter(
+      (f) => f.id.startsWith("wiring.") || f.id === GATEWAY_COMPAT,
+    );
+    expect(ours).toEqual([]);
+  });
+
+  it("register() logs NO warning on a clean config", async () => {
+    const api = createMockPluginApi({ config: healthyConfig() });
+    lastApi = api;
+    capturedRegisterFn!(api);
+    expect(api.logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("AC9 end-to-end — an EMPTY `plugins.allow` is permissive, and stays silent", async () => {
+    // The auto-load-everything default: sil IS allowed. Flagging it would fire a
+    // false advisory on a correctly-working default install — on every sil_* result,
+    // forever. This is the easiest false positive in the card to ship.
+    const payload = await runTool("sil_profile_search", {}, healthyConfig());
+    const report = await runDoctor(healthyConfig());
+    expect(payload).not.toHaveProperty("advisories");
+    expect(wiringFindings(report)).toEqual([]);
+  });
+
+  it("AC9 end-to-end — an ABSENT `plugins` block is likewise permissive, and stays silent", async () => {
+    const config: Config = {
+      agents: { list: [{ id: "shopper", skills: [SKILL_NAME] }] },
+      tools: { alsoAllow: [PLUGIN_ID] },
+      gateway: { version: HOST_FINE },
+    };
+    const payload = await runTool("sil_profile_search", {}, config);
+    expect(payload).not.toHaveProperty("advisories");
+    expect(wiringFindings(await runDoctor(config))).toEqual([]);
+  });
+
+  it("the silence holds REGARDLESS of plugin-version drift (that family is sil-doctor's)", async () => {
+    // Architect 2026-07-17: this card's silence must not depend on the version datum
+    // that moved to sil-doctor. A `version.plugin_behind` info riding alongside is
+    // NOT a violation of this AC.
+    fetchSpy.mockImplementation(async () =>
+      jsonResponse({ package: { name: "@4gpts/sil", latestVersion: "9999.0.0", tags: { latest: "9999.0.0" } } }),
+    );
+    const report = await runDoctor(healthyConfig());
+
+    expect(findingIds(report)).toContain("version.plugin_behind");
+    expect(wiringFindings(report)).toEqual([]);
+    expect(findingIds(report)).not.toContain(GATEWAY_COMPAT);
+  });
+
+  it("is NOT VACUOUS — the same surfaces DO speak when the host is drifted", async () => {
+    // Without this, an implementation that folds nothing anywhere passes every
+    // silence assertion in this block.
+    const payload = await runTool("sil_profile_search", {}, allDriftConfig());
+    const report = await runDoctor(allDriftConfig());
+    expect(payload.advisories!.length).toBeGreaterThan(0);
+    expect(wiringFindings(report).length).toBeGreaterThan(0);
+  });
+});
+
+// ===========================================================================
+// AC13 — the register-time warn: the tools-filtered state's ONLY carrier
+// ===========================================================================
+
+describe("AC13 — register() is the only live surface when sil's tools are filtered", () => {
+  it("logs EXACTLY ONE structured wiring warning on a drifted config", async () => {
+    const api = createMockPluginApi({ config: unadmittedConfig() });
+    lastApi = api;
+    capturedRegisterFn!(api);
+
+    const warns = vi.mocked(api.logger.warn).mock.calls;
+    expect(warns).toHaveLength(1);
+    expect(warns[0]![0]).toBe(WIRING_WARN_MARKER);
+  });
+
+  it("the warn carries the SAME wiring finding — id, fix, and the bin (AC4's audience)", async () => {
+    // In this state NO agent-facing surface exists — `sil_doctor` is a sil tool, so
+    // the drift that filters sil's tools filters the doctor too. The operator
+    // reading gateway logs (because their sil tools do nothing) is the only reader
+    // left, and they must get the same six fields and the same exact one-line fix.
+    const api = createMockPluginApi({ config: unadmittedConfig() });
+    lastApi = api;
+    capturedRegisterFn!(api);
+
+    const emitted = JSON.stringify(vi.mocked(api.logger.warn).mock.calls[0]);
+    expect(emitted).toContain(TOOLS_NOT_ADMITTED);
+    expect(emitted).toContain("sil-openclaw-allowlist");
+    expect(emitted.toLowerCase()).not.toContain("config set");
+  });
+
+  it("still logs exactly ONE warning when SEVERAL drifts are present", async () => {
+    const api = createMockPluginApi({ config: allDriftConfig() });
+    lastApi = api;
+    capturedRegisterFn!(api);
+
+    const warns = vi.mocked(api.logger.warn).mock.calls;
+    expect(warns).toHaveLength(1);
+    expect(warns[0]![0]).toBe(WIRING_WARN_MARKER);
+    const emitted = JSON.stringify(warns[0]);
+    expect(emitted).toContain(TOOLS_NOT_ADMITTED);
+    expect(emitted).toContain(SKILL_MISATTACHED);
+  });
+
+  it("completes SYNCHRONOUSLY and opens NOTHING — no timer, no socket (the install-hang guard)", () => {
+    // The register() invariant: an open handle holds the host's install subprocess
+    // event loop open and blocks `&& exec openclaw gateway`. A config read + a
+    // logger.warn opens neither — but only if it stays that way.
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const intervalSpy = vi.spyOn(globalThis, "setInterval");
+    const immediateSpy = vi.spyOn(
+      globalThis as unknown as { setImmediate: (...a: unknown[]) => unknown },
+      "setImmediate",
+    );
+    try {
+      const api = createMockPluginApi({ config: allDriftConfig() });
+      lastApi = api;
+      const returned = capturedRegisterFn!(api);
+
+      expect(returned).toBeUndefined();
+      expect(timeoutSpy).not.toHaveBeenCalled();
+      expect(intervalSpy).not.toHaveBeenCalled();
+      expect(immediateSpy).not.toHaveBeenCalled();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      timeoutSpy.mockRestore();
+      intervalSpy.mockRestore();
+      immediateSpy.mockRestore();
+    }
+  });
+
+  it("still registers the full tool set and still logs `sil_plugin_loaded` on a drifted config", async () => {
+    // The advisory is additive at register time too: a drifted host is a WARNING,
+    // never a refusal to load. Breaking load here would turn a fixable wiring typo
+    // into a dead plugin.
+    const api = createMockPluginApi({ config: allDriftConfig() });
+    lastApi = api;
+    capturedRegisterFn!(api);
+
+    const declared: string[] = JSON.parse(
+      readFileSync(join(REPO_ROOT, "openclaw.plugin.json"), "utf8"),
+    ).contracts.tools;
+    expect([...api._tools.keys()].sort()).toEqual([...declared].sort());
+    expect(api.logger.info).toHaveBeenCalledWith("sil_plugin_loaded", expect.anything());
+  });
+
+  it("never throws on a corrupt host config — a bad config must not wedge gateway startup", () => {
+    // register() throwing is fail-closed for an unusable DATA DIR (that is correct).
+    // An operator typo in an unrelated config block is NOT that: the host rejects a
+    // plugin whose register() throws, so a throw here turns a wiring advisory into
+    // an outage — the exact inversion of a detect-and-surface card.
+    for (const config of [
+      {},
+      { agents: "nope" },
+      { agents: { list: "nope" } },
+      { agents: { list: [null] } },
+      { plugins: { entries: "nope" } },
+      { tools: { alsoAllow: "sil" } },
+    ] as Config[]) {
+      const api = createMockPluginApi({ config });
+      expect(() => capturedRegisterFn!(api), JSON.stringify(config)).not.toThrow();
+    }
+  });
+});
+
+// ===========================================================================
+// AC12 — the host's LIVE config object is never mutated in memory
+// ===========================================================================
+
+describe("AC12 — `api.config` is the host's live tree, and we never write to it", () => {
+  it("is deep-equal before and after EVERY surface (doctor, tool fold, register)", async () => {
+    const config = allDriftConfig();
+    const before = structuredClone(config);
+
+    const api = createMockPluginApi({ config });
+    lastApi = api;
+    capturedRegisterFn!(api);
+    expect(config).toEqual(before);
+
+    registerAll(api);
+    await getTool(api, "sil_profile_search").execute("call-1", {});
+    expect(config).toEqual(before);
+
+    await getTool(api, "sil_doctor").execute("call-2", {});
+    expect(config).toEqual(before);
+  });
+
+  it("survives a DEEPLY FROZEN config on every surface — an in-place edit would throw", async () => {
+    // The structural counterpart to deep-equal: ESM is strict, so a write to a frozen
+    // object throws rather than silently no-op'ing. This is what would catch
+    // `mergeSilAllowlist` being reached for — its very first act on a config missing
+    // `plugins`/`tools` is to CREATE them (`openclaw-allowlist.ts:127`, `:136`).
+    const config = deepFreeze(allDriftConfig());
+    const api = createMockPluginApi({ config });
+    lastApi = api;
+
+    expect(() => capturedRegisterFn!(api)).not.toThrow();
+    registerAll(api);
+    await expect(getTool(api, "sil_profile_search").execute("call-1", {})).resolves.toBeDefined();
+    await expect(getTool(api, "sil_doctor").execute("call-2", {})).resolves.toBeDefined();
+  });
+
+  it("`mergeSilAllowlist` is NEVER invoked from any detection path", async () => {
+    // The card's sharpest trap. The merge core shares SURFACE KNOWLEDGE with the
+    // detector, not an operation: it is a mutation planner that edits its argument
+    // in place by design. Reusing it for a read would silently corrupt the host's
+    // live state from a detect-only path — and would look like a tidy DRY win in
+    // review. A read-only sibling inspector is the correct shape.
+    const spy = vi.spyOn(allowlist, "mergeSilAllowlist");
+    const config = allDriftConfig();
+
+    const api = createMockPluginApi({ config });
+    lastApi = api;
+    capturedRegisterFn!(api);
+    registerAll(api);
+    await getTool(api, "sil_profile_search").execute("call-1", {});
+    await getTool(api, "sil_doctor").execute("call-2", {});
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("repeated detection is idempotent — the config never drifts across runs", async () => {
+    const config = allDriftConfig();
+    const before = structuredClone(config);
+    for (let i = 0; i < 3; i += 1) {
+      await runTool("sil_profile_search", {}, config);
+      await runDoctor(config);
+    }
+    expect(config).toEqual(before);
+  });
+});
+
+// ===========================================================================
+// AC7 — the detect-only posture + the audit scope
+// ===========================================================================
+
+describe("AC7 — detect and surface only: nothing is applied, nothing outside the scope is touched", () => {
+  it("EVERY finding this card emits carries `appliedAction: null` (nothing is ever fixed)", async () => {
+    // There is no safe-auto-fix posture available to this card by construction: we
+    // cannot write host config, so `fixed` / `fix_failed` / `needs_confirmation` are
+    // unreachable. An advisory that says "fixed" is a lie about a mutation that
+    // never happened — the honesty rail.
+    const report = await runDoctor(allDriftConfig(), HOST_TOO_OLD);
+    const ours = report.findings.filter(
+      (f) => f.id.startsWith("wiring.") || f.id === GATEWAY_COMPAT,
+    );
+    // Both families present: wiring AND compat.
+    expect(ours.map((f) => f.id)).toContain(GATEWAY_COMPAT);
+    expect(ours.length).toBeGreaterThan(1);
+    for (const finding of ours) {
+      expect(finding.appliedAction).toBeNull();
+      expect(finding.status).toBe("advisory");
+    }
+
+    const payload = await runTool("sil_profile_search", {}, allDriftConfig());
+    for (const advisory of payload.advisories!) {
+      expect(advisory.appliedAction).toBeNull();
+      expect(advisory.status).toBe("advisory");
+    }
+  });
+
+  it("rule 10 — reports the EFFECTIVE (running) wiring, NOT a healthy file on disk", async () => {
+    // The decoy: `~/.openclaw/openclaw.json` says the wiring is perfect; `api.config`
+    // — the tree in force in the RUNNING process — says it is mis-wired. A file read
+    // would green-wash a fix that has not been reloaded yet, which is the exact
+    // false-green this repo bans. The advisory MUST still fire.
+    const openclawDir = join(homeDir, ".openclaw");
+    mkdirSync(openclawDir, { recursive: true, mode: 0o700 });
+    writeFileSync(join(openclawDir, "openclaw.json"), JSON.stringify(healthyConfig()), { mode: 0o600 });
+
+    const payload = await runTool("sil_profile_search", {}, misattachedConfig());
+    expect(advisoryIds(payload)).toEqual([SKILL_MISATTACHED]);
+  });
+
+  it("rule 10 — a DRIFTED file on disk does NOT manufacture an advisory either", async () => {
+    // The mirror image, and the half that catches a file read the test above cannot:
+    // an implementation reading `~/.openclaw` would fire here, on a running process
+    // whose EFFECTIVE wiring is healthy. The product question is "is my skill
+    // actually running?", and it is.
+    const openclawDir = join(homeDir, ".openclaw");
+    mkdirSync(openclawDir, { recursive: true, mode: 0o700 });
+    writeFileSync(join(openclawDir, "openclaw.json"), JSON.stringify(allDriftConfig()), { mode: 0o600 });
+
+    const payload = await runTool("sil_profile_search", {}, healthyConfig());
+    const report = await runDoctor(healthyConfig());
+    expect(payload).not.toHaveProperty("advisories");
+    expect(wiringFindings(report)).toEqual([]);
+  });
+
+  it("the host config file is BYTE-IDENTICAL after every surface runs", async () => {
+    const openclawDir = join(homeDir, ".openclaw");
+    mkdirSync(openclawDir, { recursive: true, mode: 0o700 });
+    writeFileSync(join(openclawDir, "openclaw.json"), JSON.stringify(allDriftConfig()), { mode: 0o600 });
+    const before = snapshot(homeDir);
+
+    const config = allDriftConfig();
+    const api = createMockPluginApi({ config });
+    lastApi = api;
+    capturedRegisterFn!(api);
+    registerAll(api);
+    await getTool(api, "sil_profile_search").execute("call-1", {});
+    await getTool(api, "sil_doctor").execute("call-2", {});
+
+    // No write, no chmod, no new file, and nothing under $HOME touched at all —
+    // so `security.filesystemScope` needs no widening (OQ1).
+    expect(snapshot(homeDir)).toEqual(before);
+  });
+
+  it("the wiring modules reach for no installer, no child process, and no host config file", async () => {
+    // The audit-scope half a behavioural assertion cannot reach: the manifest
+    // declares `noChildProcess` + `noInstallScripts`, and this card's whole premise
+    // is that the plugin can't be its own installer and doesn't try. A source scan
+    // is the honest guard for "this code CANNOT do X", rather than "it happened not
+    // to today".
+    for (const file of ["src/lib/host-wiring.ts", "src/lib/version-advisory.ts"]) {
+      const source = readFileSync(join(REPO_ROOT, file), "utf8");
+      for (const forbidden of [
+        "child_process",
+        "execSync",
+        "spawnSync",
+        ".openclaw/",
+        "homedir",
+        "npm install",
+      ]) {
+        expect(source, `${file} must not reference ${forbidden}`).not.toContain(forbidden);
+      }
+    }
+  });
+});
+
+// ===========================================================================
+// AC11 — the finding shape, and the doctor's existing sort
+// ===========================================================================
+
+describe("AC11 — six flat fields, folded into the doctor's existing deterministic order", () => {
+  it("every finding this card contributes is EXACTLY the six fields — no extras, no sub-object", async () => {
+    // Zero schema change (PO invariant 8 + sil-doctor's domain-agnostic invariant #4).
+    // Version numbers and the fix ride `detected` / `suggestedAction` as STRINGS —
+    // no structured `advisory: { required, running }` sub-object.
+    const report = await runDoctor(allDriftConfig(), HOST_TOO_OLD);
+    const ours = report.findings.filter(
+      (f) => f.id.startsWith("wiring.") || f.id === GATEWAY_COMPAT,
+    );
+    expect(ours.map((f) => f.id)).toContain(GATEWAY_COMPAT);
+    for (const finding of ours) {
+      expect(Object.keys(finding).sort(), finding.id).toEqual([
+        "appliedAction",
+        "detected",
+        "id",
+        "severity",
+        "status",
+        "suggestedAction",
+      ]);
+    }
+  });
+
+  it("the folded advisories on a tool result carry the same six fields", async () => {
+    const payload = await runTool("sil_profile_search", {}, allDriftConfig());
+    for (const advisory of payload.advisories!) {
+      expect(Object.keys(advisory).sort(), advisory.id).toEqual([
+        "appliedAction",
+        "detected",
+        "id",
+        "severity",
+        "status",
+        "suggestedAction",
+      ]);
+    }
+  });
+
+  it("the report stays sorted (severity desc, id asc) with our findings folded in", async () => {
+    const report = await runDoctor(allDriftConfig(), HOST_TOO_OLD);
+    expect(report.findings).toEqual(sortFindings(report.findings));
+  });
+
+  it("our warns sort ABOVE the store/identity `info` findings, alongside them in ONE array", async () => {
+    const report = await runDoctor(allDriftConfig(), HOST_TOO_OLD);
+    const firstInfo = report.findings.findIndex((f) => f.severity === "info");
+    const ourIndices = report.findings
+      .map((f, i) => (f.id.startsWith("wiring.") || f.id === GATEWAY_COMPAT ? i : -1))
+      .filter((i) => i >= 0);
+
+    expect(ourIndices.length).toBeGreaterThan(0);
+    for (const i of ourIndices) expect(i).toBeLessThan(firstInfo);
+  });
+
+  it("sil_doctor's report SHAPE is unchanged — this card adds no report key", async () => {
+    const report = await runDoctor(allDriftConfig(), HOST_TOO_OLD);
+    expect(Object.keys(report).sort()).toEqual([
+      "counts",
+      "dataDir",
+      "findings",
+      "healthy",
+      "installedVersion",
+      "status",
+    ]);
+  });
+
+  it("the roll-ups count our findings — `healthy: false` is the truth on a drifted host", async () => {
+    // The severity call has teeth here: `warn` means `healthy` flips. A mis-wired
+    // skill genuinely IS a degradation, and a `healthy: true` beside a dead skill is
+    // exactly what trains consumers to ignore the roll-up.
+    const drifted = await runDoctor(allDriftConfig(), HOST_TOO_OLD);
+    expect(drifted.counts.warn).toBeGreaterThanOrEqual(wiringFindings(drifted).length);
+    expect(drifted.healthy).toBe(false);
+
+    const healthy = await runDoctor(healthyConfig());
+    expect(healthy.healthy).toBe(true);
+  });
+});
+
+// ===========================================================================
+// AC14 — no host-config value leaks, and the local path makes no network call
+// ===========================================================================
+
+describe("AC14 — `api.config` is the WHOLE config tree, and none of it may escape", () => {
+  it("no finding field and no log line carries another plugin's credential", async () => {
+    // The second-highest, least obvious risk in the card: `api.config` is not a
+    // sil-scoped slice, it is the whole OpenClawConfig — it can hold other tenants'
+    // credentials one key away from the facts we DO emit. Findings carry only
+    // DERIVED facts (agent id, membership booleans, the fix string), never a config
+    // fragment. Scanned across the doctor report, the tool payload, and every log.
+    const config = secretBearingConfig();
+
+    const report = await runDoctor(config, HOST_TOO_OLD);
+    for (const secret of ALL_SECRETS) {
+      expect(emittedStrings(report), secret).not.toContain(secret);
+    }
+
+    const payload = await runTool("sil_profile_search", {}, config);
+    for (const secret of ALL_SECRETS) {
+      expect(emittedStrings(payload), secret).not.toContain(secret);
+    }
+  });
+
+  it("the register-time warn carries no config value either", async () => {
+    const api = createMockPluginApi({ config: secretBearingConfig() });
+    lastApi = api;
+    capturedRegisterFn!(api);
+
+    const emitted = emittedStrings(null);
+    for (const secret of ALL_SECRETS) expect(emitted, secret).not.toContain(secret);
+    // Non-vacuity: the warn DID fire on this config — the scan above is scanning
+    // something real, not an empty string.
+    expect(vi.mocked(api.logger.warn)).toHaveBeenCalledWith(
+      WIRING_WARN_MARKER,
+      expect.anything(),
+    );
+  });
+
+  it("does not dump adjacent keys even while naming the agent it must name (rule 9)", async () => {
+    // The agent id IS a wiring fact and is required by the fix string. The agent's
+    // `env` block sitting beside it is NOT — a naive implementation that serializes
+    // the whole agent entry to name it leaks in the same breath as it helps.
+    const payload = await runTool("sil_profile_search", {}, secretBearingConfig());
+    const advisory = payload.advisories!.find((a) => a.id === SKILL_MISATTACHED)!;
+
+    expect(advisory.detected).toContain("shopper");
+    expect(JSON.stringify(advisory)).not.toContain(AGENT_SECRET);
+    expect(JSON.stringify(advisory)).not.toContain("OPENAI_API_KEY");
+  });
+
+  it("the wiring + compat path issues ZERO network calls", async () => {
+    // This card is 100% local — a stronger property than "no network on the hot
+    // path", and one that falls out of the design rather than being engineered. Two
+    // surfaces that make no request of their own prove it: register(), and a profile
+    // read (local-only by contract).
+    const api = createMockPluginApi({ config: allDriftConfig() });
+    lastApi = api;
+    capturedRegisterFn!(api);
+    registerAll(api);
+    await getTool(api, "sil_profile_search").execute("call-1", {});
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("`networkEndpoints` is untouched by this card — it adds no outbound surface", () => {
+    // The ClawHub entry is sil-doctor's (founder ruling, §8.3 CLOSED). This card
+    // adds none: if a detection ever needed a host, THIS assertion is the one that
+    // must be argued with first, in a security declaration a reviewer audits.
+    const endpoints: string[] = JSON.parse(
+      readFileSync(join(REPO_ROOT, "openclaw.plugin.json"), "utf8"),
+    ).security.networkEndpoints;
+    expect([...endpoints].sort()).toEqual([
+      "https://clawhub.ai",
+      "https://sil-api.4gpts.com",
+      "https://sil.4gpts.com",
+    ]);
+  });
+});

--- a/src/__tests__/helpers/mock-plugin-api.ts
+++ b/src/__tests__/helpers/mock-plugin-api.ts
@@ -33,6 +33,20 @@ export interface MockPluginAPI extends PluginAPI {
 export interface CreateMockPluginApiOptions {
   pluginConfig?: Record<string, unknown>;
   config?: Record<string, unknown>;
+  /**
+   * The host runtime facade. Only `version` is consumed today (the RUNNING
+   * OpenClaw's own version — `readHostVersion`'s single source). Probed against
+   * a live `alpine/openclaw:2026.6.9`: the host passes this straight through at
+   * `api-builder:122`, and it is the ONLY source for the host version —
+   * `config.gateway` does not exist, and `config.meta.lastTouchedVersion` is the
+   * version that last WROTE the config file, not the one now running.
+   *
+   * OMITTED BY DEFAULT, on purpose: a host that supplies no runtime version must
+   * degrade to an INCONCLUSIVE compat check (no finding), never a fabricated
+   * verdict — and one real load path (`registrationMode: "cli-metadata"`) passes
+   * `runtime: {}`, so absent is a state production genuinely reaches.
+   */
+  runtime?: Record<string, unknown>;
 }
 
 export function createMockPluginApi(
@@ -56,6 +70,9 @@ export function createMockPluginApi(
 
     config: options.config ?? {},
     pluginConfig: options.pluginConfig ?? {},
+    // Absent unless a test asks for it — the double must not hand every caller a
+    // host version production would not have.
+    ...(options.runtime !== undefined ? { runtime: options.runtime } : {}),
   } as unknown as MockPluginAPI;
 }
 

--- a/src/__tests__/lib/host-wiring.test.ts
+++ b/src/__tests__/lib/host-wiring.test.ts
@@ -1,0 +1,668 @@
+/**
+ * UNIT — `detectWiringDrift()` + `readSilWiringFacts()` + `readHostVersion()`
+ * (tier: unit; pure config literals, zero I/O, zero network, no host present).
+ *
+ * Card: self-upgrade-detect-host-wiring-advisory — **AC4, AC8, AC9** (+ the
+ * `readHostVersion` seam AC2/AC10 depend on).
+ *
+ * This is the incident-#1 detector. A skill attaches per-agent at
+ * `agents.list[i].skills` by its **published name** (`sil-shopping` = the skill-dir
+ * basename); tools admit by **plugin id** (`sil` in `tools.alsoAllow`). They are two
+ * different host keys, and conflating them is what seeded incident #1 — silently,
+ * because the host fails a bad skill ref with a warning, not an error.
+ *
+ * The four things this file exists to catch:
+ *
+ * 1. **The empty-allow FALSE POSITIVE (AC9).** An empty/absent `plugins.allow` is
+ *    the permissive default that auto-loads every discovered plugin
+ *    (`openclaw-allowlist.ts:4-7`, `:36-40`, `:164-175`) — sil **is** allowed, so it
+ *    is **not** drift. Flagging it fires a false advisory on a correctly-working
+ *    default install. This is the easiest false positive in the card to ship.
+ * 2. **The enable≠admit FALSE NEGATIVE.** `plugins.entries.sil.enabled === true`
+ *    does NOT mean sil's tools are admitted — that is the half-trust state (the
+ *    agent-creation-engine bug: plugin loads, tools stay filtered). A detector that
+ *    treats "enabled" as evidence of admission goes silent in exactly the state
+ *    `wiring.tools_not_admitted` exists for.
+ * 3. **A HARDCODED id/skill name.** Every `detectWiringDrift` test below drives
+ *    SYNTHETIC facts (`ALIEN`) alongside the real ones, and asserts the findings
+ *    name the synthetic values. A detector with `"sil"` / `"sil-shopping"` baked in
+ *    passes the real-facts tests and fails the alien ones — which is the point: the
+ *    published name must come from the shipped manifest, never a literal that drifts
+ *    the day the skill dir is renamed (the rename card is incident #1's root).
+ * 4. **A fix string that BREAKS the host.** `tools.alsoAllow` is overwrite-only on
+ *    2026.6.9, so an inline `openclaw config set tools.alsoAllow …` clobbers every
+ *    other admitted plugin. A "fix" that breaks klodi to fix sil is not a fix (AC4).
+ *
+ * Contract pinned for the implementation (expert-developer) — src/lib/host-wiring.ts:
+ *
+ *   export interface SilWiringFacts { readonly id: string; readonly skill: string }
+ *     — `id`    = the plugin id (`openclaw.plugin.json#id` → "sil").
+ *     — `skill` = the PUBLISHED skill name = `basename(manifest.skills[0])` →
+ *       "sil-shopping". NOT the ref "./sil-shopping", NOT the plugin id.
+ *
+ *   export function readSilWiringFacts(): SilWiringFacts;
+ *     — reads the SHIPPED `openclaw.plugin.json` (module-cached), never hardcodes.
+ *       The one I/O in this module; `detectWiringDrift` itself stays pure. Mirrors
+ *       `version-advisory.ts`'s pure-core + `readInstalledVersion()` split.
+ *
+ *   export function detectWiringDrift(config: unknown, facts: SilWiringFacts): Finding[];
+ *     — PURE: no fs, no network, no mutation of `config` (it is the host's LIVE
+ *       in-memory tree). `config` is `unknown` because it is operator-editable —
+ *       narrow with `typeof` / `Array.isArray` at every step, and NEVER throw.
+ *       Returns 0..2 findings, each `severity: "warn"`, `status: "advisory"`,
+ *       `appliedAction: null`.
+ *
+ *   export function readHostVersion(api: PluginAPI): string | null;
+ *     — the running host's version, or `null` when nothing readable is present.
+ *       `null` ⇒ the compat check is INCONCLUSIVE and emits NO finding. Never
+ *       throws, never fabricates.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  detectWiringDrift,
+  readSilWiringFacts,
+  readHostVersion,
+  type SilWiringFacts,
+} from "../../lib/host-wiring.js";
+import { createMockPluginApi } from "../helpers/mock-plugin-api.js";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+
+const manifest = (): { id: string; skills: string[] } =>
+  JSON.parse(readFileSync(join(REPO_ROOT, "openclaw.plugin.json"), "utf8"));
+
+// ---------------------------------------------------------------------------
+// Facts. `REAL` mirrors the shipped manifest; `ALIEN` shares NO substring with
+// it, so any hardcoded "sil" / "sil-shopping" in the detector fails loudly.
+// ---------------------------------------------------------------------------
+
+const REAL: SilWiringFacts = { id: "sil", skill: "sil-shopping" };
+const ALIEN: SilWiringFacts = { id: "zeta", skill: "zeta-buying" };
+
+const SKILL_MISATTACHED = "wiring.skill_misattached";
+const TOOLS_NOT_ADMITTED = "wiring.tools_not_admitted";
+
+const ids = (config: unknown, facts: SilWiringFacts = REAL): string[] =>
+  detectWiringDrift(config, facts).map((f) => f.id).sort();
+
+const only = (config: unknown, id: string, facts: SilWiringFacts = REAL) => {
+  const found = detectWiringDrift(config, facts).filter((f) => f.id === id);
+  expect(found).toHaveLength(1);
+  return found[0]!;
+};
+
+/** An agent entry as the host writes it (`openclaw agents add` → `{id, skills}`;
+ * `create-shopper.mjs` then sets `agents.list[i].skills`). */
+const agent = (id: string, skills: unknown): Record<string, unknown> => ({ id, skills });
+
+/** A fully HEALTHY config for the given facts: skill attached by published name,
+ * plugin enabled, tools admitted, permissive (empty) `plugins.allow`. */
+const healthy = (facts: SilWiringFacts = REAL): Record<string, unknown> => ({
+  agents: { list: [agent("shopper", [facts.skill])] },
+  tools: { alsoAllow: [facts.id] },
+  plugins: { allow: [], entries: { [facts.id]: { enabled: true, config: {} } } },
+});
+
+// ===========================================================================
+// AC8 — the drift set, exactly
+// ===========================================================================
+
+describe("detectWiringDrift — skill attached by ID instead of PUBLISHED NAME (AC8/AC3)", () => {
+  it("flags an agent whose `skills` carries the plugin id and lacks the published name", () => {
+    // Incident #1, verbatim: `skills: ["sil"]` where `["sil-shopping"]` was meant.
+    const config = {
+      ...healthy(),
+      agents: { list: [agent("shopper", [REAL.id])] },
+    };
+    expect(ids(config)).toEqual([SKILL_MISATTACHED]);
+  });
+
+  it("is `warn` + `advisory` + `appliedAction: null` — it names a fix, it never applies one", () => {
+    const finding = only(
+      { ...healthy(), agents: { list: [agent("shopper", [REAL.id])] } },
+      SKILL_MISATTACHED,
+    );
+    expect(finding.severity).toBe("warn");
+    expect(finding.status).toBe("advisory");
+    expect(finding.appliedAction).toBeNull();
+  });
+
+  it("carries exactly the six flat fields — no extra keys, no `advisory` sub-object", () => {
+    const finding = only(
+      { ...healthy(), agents: { list: [agent("shopper", [REAL.id])] } },
+      SKILL_MISATTACHED,
+    );
+    expect(Object.keys(finding).sort()).toEqual([
+      "appliedAction",
+      "detected",
+      "id",
+      "severity",
+      "status",
+      "suggestedAction",
+    ]);
+  });
+
+  it("`suggestedAction` names the EXACT edit — both tokens, and the agent it lands on (AC3)", () => {
+    // "your wiring is wrong" without the exact edit is noise that costs a support
+    // round-trip. The fix string is the only thing standing in for the mutation we
+    // refuse to make (invariant 3).
+    const finding = only(
+      { ...healthy(), agents: { list: [agent("beta-shopper", [REAL.id])] } },
+      SKILL_MISATTACHED,
+    );
+    expect(finding.suggestedAction).not.toBeNull();
+    const fix = finding.suggestedAction!;
+    expect(fix).toContain(REAL.skill);
+    expect(fix).toContain(REAL.id);
+    expect(fix).toContain("beta-shopper");
+  });
+
+  it("`suggestedAction` names that the edit takes effect on the next OpenClaw RELOAD (AC8, rule 3/10)", () => {
+    // `api.config` is the wiring in force in the RUNNING process. An operator who
+    // edits the file, sees the advisory persist, and distrusts it is worse off than
+    // with no advisory: the fix is only complete if it says how it takes effect.
+    const finding = only(
+      { ...healthy(), agents: { list: [agent("shopper", [REAL.id])] } },
+      SKILL_MISATTACHED,
+    );
+    expect(finding.suggestedAction!.toLowerCase()).toContain("reload");
+  });
+
+  it("`detected` names the mis-wired agent, so the operator knows WHICH one", () => {
+    const finding = only(
+      { ...healthy(), agents: { list: [agent("beta-shopper", [REAL.id])] } },
+      SKILL_MISATTACHED,
+    );
+    expect(finding.detected).toContain("beta-shopper");
+  });
+
+  it("emits exactly ONE finding when SEVERAL agents are mis-wired, naming each", () => {
+    // The id is bare (`wiring.skill_misattached`), not per-agent-suffixed — AC8/AC11
+    // pin the exact id, and AC3 requires the doctor and the tool fold to carry the
+    // SAME id. So multiple drifted agents fold into one finding that names them all;
+    // dropping one silently would leave a mis-wired agent un-diagnosed forever.
+    const config = {
+      ...healthy(),
+      agents: {
+        list: [
+          agent("shopper-a", [REAL.id]),
+          agent("shopper-b", [REAL.skill]),
+          agent("shopper-c", [REAL.id, "other-skill"]),
+        ],
+      },
+    };
+    const drift = detectWiringDrift(config, REAL).filter((f) => f.id === SKILL_MISATTACHED);
+    expect(drift).toHaveLength(1);
+    expect(drift[0]!.detected).toContain("shopper-a");
+    expect(drift[0]!.detected).toContain("shopper-c");
+  });
+
+  it("NAMES NOTHING FROM THE MANIFEST ITSELF — the detector is fact-driven, never hardcoded", () => {
+    // The anti-hardcode proof. Same drift, ALIEN facts: a detector with "sil" /
+    // "sil-shopping" baked in reports nothing here (or reports the wrong tokens),
+    // and the published name silently rots the day the skill dir is renamed — which
+    // is exactly incident #1's root.
+    const config = {
+      ...healthy(ALIEN),
+      agents: { list: [agent("zeta-agent", [ALIEN.id])] },
+    };
+    const finding = only(config, SKILL_MISATTACHED, ALIEN);
+    expect(finding.suggestedAction).toContain(ALIEN.skill);
+    expect(finding.suggestedAction).toContain(ALIEN.id);
+    expect(finding.detected).toContain("zeta-agent");
+    // And it must not smuggle sil's own names into an alien-facts run.
+    expect(finding.detected + finding.suggestedAction).not.toContain("sil-shopping");
+  });
+});
+
+describe("detectWiringDrift — tools not admitted: the half-trust state (AC8/AC4)", () => {
+  it("flags a NON-EMPTY `tools.alsoAllow` that omits the plugin id", () => {
+    const config = {
+      ...healthy(),
+      tools: { alsoAllow: ["klodi", "other-plugin"] },
+    };
+    expect(ids(config)).toEqual([TOOLS_NOT_ADMITTED]);
+  });
+
+  it("STILL flags it when the plugin is ENABLED — enable ≠ admit (the false-negative trap)", () => {
+    // The exact agent-creation-engine bug: `plugins.entries.sil.enabled === true`
+    // (the plugin loads) while a non-empty `tools.alsoAllow` omits it (every sil
+    // tool stays filtered). An implementation that reads `enabled` as evidence of
+    // admission goes silent in precisely the state this finding exists for — and
+    // the register-time log is the ONLY surface alive there.
+    const config = {
+      agents: { list: [agent("shopper", [REAL.skill])] },
+      tools: { alsoAllow: ["klodi"] },
+      plugins: { allow: [], entries: { [REAL.id]: { enabled: true, config: {} } } },
+    };
+    expect(ids(config)).toEqual([TOOLS_NOT_ADMITTED]);
+  });
+
+  it("flags `plugins.entries.<id>.enabled === false` — a disabled entry admits nothing (AC8)", () => {
+    const config = {
+      ...healthy(),
+      plugins: { allow: [], entries: { [REAL.id]: { enabled: false, config: {} } } },
+    };
+    expect(ids(config)).toContain(TOOLS_NOT_ADMITTED);
+  });
+
+  it("is `warn` + `advisory` + `appliedAction: null`, with exactly the six flat fields", () => {
+    const finding = only({ ...healthy(), tools: { alsoAllow: ["klodi"] } }, TOOLS_NOT_ADMITTED);
+    expect(finding.severity).toBe("warn");
+    expect(finding.status).toBe("advisory");
+    expect(finding.appliedAction).toBeNull();
+    expect(Object.keys(finding).sort()).toEqual([
+      "appliedAction",
+      "detected",
+      "id",
+      "severity",
+      "status",
+      "suggestedAction",
+    ]);
+  });
+
+  it("AC4 — `suggestedAction` names the shipped `sil-openclaw-allowlist` bin", () => {
+    // The bin is additive + idempotent across all three trust surfaces. It is the
+    // ONLY fix we may name.
+    const finding = only({ ...healthy(), tools: { alsoAllow: ["klodi"] } }, TOOLS_NOT_ADMITTED);
+    expect(finding.suggestedAction).not.toBeNull();
+    expect(finding.suggestedAction!).toContain("sil-openclaw-allowlist");
+  });
+
+  it("AC4 — `suggestedAction` NEVER names an inline `openclaw config set` (it would clobber klodi)", () => {
+    // `config set tools.alsoAllow` is OVERWRITE-ONLY on 2026.6.9: following that
+    // "fix" silently un-admits every other plugin already in the array. A fix that
+    // breaks klodi to fix sil is not a fix — and a user only discovers it later,
+    // in a different plugin, with no trail back to us.
+    const finding = only({ ...healthy(), tools: { alsoAllow: ["klodi"] } }, TOOLS_NOT_ADMITTED);
+    const fix = finding.suggestedAction!.toLowerCase();
+    expect(fix).not.toContain("config set");
+    expect(fix).not.toContain("alsoallow");
+  });
+
+  it("AC4 — the fix names the RELOAD too (edit + reload, or the advisory is incomplete)", () => {
+    const finding = only({ ...healthy(), tools: { alsoAllow: ["klodi"] } }, TOOLS_NOT_ADMITTED);
+    expect(finding.suggestedAction!.toLowerCase()).toContain("reload");
+  });
+
+  it("names NO config VALUE from the surrounding tree — only derived wiring facts (rule 9)", () => {
+    // `api.config` is the WHOLE OpenClawConfig; the admitted list can name another
+    // operator's plugins, and adjacent blocks can hold their secrets. The finding
+    // reports THAT sil is unadmitted, never a dump of what else is.
+    const finding = only(
+      {
+        ...healthy(),
+        tools: { alsoAllow: ["klodi-internal-plugin-name"] },
+        plugins: {
+          allow: [],
+          entries: {
+            [REAL.id]: { enabled: true, config: {} },
+            klodi: { enabled: true, config: { apiKey: "SECRET-VALUE-NEVER-EMIT" } },
+          },
+        },
+      },
+      TOOLS_NOT_ADMITTED,
+    );
+    const emitted = JSON.stringify(finding);
+    expect(emitted).not.toContain("SECRET-VALUE-NEVER-EMIT");
+    expect(emitted).not.toContain("klodi-internal-plugin-name");
+  });
+
+  it("is fact-driven — an ALIEN id drives the same detection", () => {
+    const config = { ...healthy(ALIEN), tools: { alsoAllow: ["klodi"] } };
+    expect(ids(config, ALIEN)).toEqual([TOOLS_NOT_ADMITTED]);
+  });
+});
+
+// ===========================================================================
+// AC9 — no false positive on a permissive or correct config
+// ===========================================================================
+
+describe("detectWiringDrift — silence on a healthy config (AC9/AC6, rule 6)", () => {
+  it("returns NO finding for a fully healthy config", () => {
+    expect(detectWiringDrift(healthy(), REAL)).toEqual([]);
+  });
+
+  it("AC9 — an EMPTY `plugins.allow` is PERMISSIVE, not drift (the false-positive trap)", () => {
+    // An empty/absent `plugins.allow` is the auto-load-everything default under
+    // which sil IS allowed (`openclaw-allowlist.ts:4-7`, `:36-40`, `:164-175`).
+    // Flagging it fires a false advisory on a correctly-working default install —
+    // on EVERY sil_* result, forever, since recurrence is the feature. This is the
+    // easiest false positive in the card to ship.
+    expect(detectWiringDrift({ ...healthy(), plugins: { allow: [] } }, REAL)).toEqual([]);
+  });
+
+  it("AC9 — an ABSENT `plugins.allow` is likewise permissive, not drift", () => {
+    expect(
+      detectWiringDrift(
+        {
+          agents: { list: [agent("shopper", [REAL.skill])] },
+          tools: { alsoAllow: [REAL.id] },
+          plugins: { entries: { [REAL.id]: { enabled: true, config: {} } } },
+        },
+        REAL,
+      ),
+    ).toEqual([]);
+  });
+
+  it("AC9 — an entirely ABSENT `plugins` block is permissive, not drift", () => {
+    expect(
+      detectWiringDrift(
+        {
+          agents: { list: [agent("shopper", [REAL.skill])] },
+          tools: { alsoAllow: [REAL.id] },
+        },
+        REAL,
+      ),
+    ).toEqual([]);
+  });
+
+  it("a NON-EMPTY `plugins.allow` that omits the id is NOT reported — it is unreportable by construction", () => {
+    // The plugin never loads in that state, so nothing it ships can speak (the
+    // reachability matrix). Emitting a finding here would be theatre: the code path
+    // cannot run. Do not write code chasing it — it is the parked §6b core track.
+    expect(
+      detectWiringDrift({ ...healthy(), plugins: { allow: ["klodi"], entries: {} } }, REAL),
+    ).toEqual([]);
+  });
+
+  it("a NON-EMPTY `plugins.allow` that INCLUDES the id is healthy — still no finding", () => {
+    expect(
+      detectWiringDrift(
+        {
+          ...healthy(),
+          plugins: {
+            allow: ["klodi", REAL.id],
+            entries: { [REAL.id]: { enabled: true, config: {} } },
+          },
+        },
+        REAL,
+      ),
+    ).toEqual([]);
+  });
+
+  it("an agent with NO sil skill at all is NOT drift (the fan-out false positive)", () => {
+    // The killer FP: a host runs many agents and only one is the shopper. "Lacks
+    // the published name" cannot itself be drift, or every unrelated agent fires an
+    // advisory. Drift is the agent that reached for sil and used the WRONG token.
+    const config = {
+      ...healthy(),
+      agents: {
+        list: [
+          agent("shopper", [REAL.skill]),
+          agent("coder", ["some-other-skill"]),
+          agent("writer", []),
+        ],
+      },
+    };
+    expect(detectWiringDrift(config, REAL)).toEqual([]);
+  });
+
+  it("an agent carrying BOTH the id and the published name is NOT drift — the skill runs", () => {
+    // `["sil", "sil-shopping"]`: the published name attaches, the skill is alive,
+    // nothing is degraded. Absence of a problem is not a finding (rule 6).
+    const config = {
+      ...healthy(),
+      agents: { list: [agent("shopper", [REAL.skill, REAL.id])] },
+    };
+    expect(detectWiringDrift(config, REAL)).toEqual([]);
+  });
+
+  it("an EMPTY/ABSENT `tools.alsoAllow` is not flagged — only a NON-EMPTY one that omits the id (AC4/AC8)", () => {
+    // QA NOTE — the one arm the card pins by wording rather than by evidence.
+    // AC4 and AC8 both qualify this drift as "absent from a **NON-EMPTY**
+    // `tools.alsoAllow`", so that is the spec encoded here. It is the conservative
+    // direction (a false advisory on a default install is the named risk class).
+    // Counter-evidence worth the dev's Step-0 probe: `mergeSilAllowlist` seeds an
+    // empty `plugins.allow` with every known plugin id before appending sil (the
+    // OQ3 guard against un-trusting others), but does NOT do the same for an empty
+    // `tools.alsoAllow` — it just appends sil. That asymmetry reads as "empty
+    // alsoAllow admits nothing", which would make this state real drift. If the
+    // probe confirms that, the card moves first and this test moves with it.
+    // Do NOT flip it silently in either direction.
+    expect(detectWiringDrift({ ...healthy(), tools: { alsoAllow: [] } }, REAL)).toEqual([]);
+    expect(
+      detectWiringDrift(
+        {
+          agents: { list: [agent("shopper", [REAL.skill])] },
+          plugins: { allow: [], entries: { [REAL.id]: { enabled: true, config: {} } } },
+        },
+        REAL,
+      ),
+    ).toEqual([]);
+  });
+});
+
+// ===========================================================================
+// AC8 — purity, non-mutation, and hostile input
+// ===========================================================================
+
+describe("detectWiringDrift — pure, non-mutating, and unthrowable (AC8/AC12)", () => {
+  it("leaves the config DEEP-EQUAL to its pre-call value", () => {
+    // `api.config` is the host's LIVE in-memory tree, not a copy. The sharpest trap
+    // in the card is reaching for `mergeSilAllowlist` to do this read: it is a
+    // mutation planner that edits its argument in place (`openclaw-allowlist.ts`
+    // :100-104, :174, :193, :202) — calling it here would silently corrupt host
+    // state from a detect-only path, the precise inversion of this card's invariant.
+    const config = { ...healthy(), tools: { alsoAllow: ["klodi"] } };
+    const before = structuredClone(config);
+    detectWiringDrift(config, REAL);
+    expect(config).toEqual(before);
+  });
+
+  it("does not mutate even a DEEPLY FROZEN config — an in-place edit would throw", () => {
+    // The structural counterpart to deep-equal: ESM runs strict, so any write to a
+    // frozen object throws a TypeError instead of silently no-op'ing. This catches
+    // a mutation that deep-equal could miss (e.g. one that writes then restores).
+    const deepFreeze = <T>(value: T): T => {
+      if (value !== null && typeof value === "object") {
+        Object.values(value as Record<string, unknown>).forEach(deepFreeze);
+        Object.freeze(value);
+      }
+      return value;
+    };
+    const config = deepFreeze({
+      agents: { list: [agent("shopper", [REAL.id])] },
+      tools: { alsoAllow: ["klodi"] },
+      plugins: { allow: [], entries: {} },
+    });
+    expect(() => detectWiringDrift(config, REAL)).not.toThrow();
+    expect(ids(config)).toEqual([SKILL_MISATTACHED, TOOLS_NOT_ADMITTED].sort());
+  });
+
+  it("issues NO network call (the card is 100% local — AC2/AC14)", () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    try {
+      detectWiringDrift({ ...healthy(), tools: { alsoAllow: ["klodi"] } }, REAL);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("is deterministic — repeated calls yield an equal result and accumulate no state", () => {
+    const config = { ...healthy(), tools: { alsoAllow: ["klodi"] } };
+    expect(detectWiringDrift(config, REAL)).toEqual(detectWiringDrift(config, REAL));
+  });
+
+  it("never throws on an operator-corrupted config, whatever the shape", () => {
+    // The config is operator-editable and arrives as `unknown` — every read must
+    // narrow with typeof/Array.isArray. A detector that throws here takes down the
+    // tool result it was folded into, turning an advisory into an outage.
+    const hostile: unknown[] = [
+      null,
+      undefined,
+      42,
+      "a string config",
+      [],
+      {},
+      { agents: null },
+      { agents: "nope" },
+      { agents: { list: "not-an-array" } },
+      { agents: { list: [null, 7, "x"] } },
+      { agents: { list: [{ id: "a", skills: "sil" }] } },
+      { agents: { list: [{ id: "a", skills: [null, 3, {}] }] } },
+      { agents: { list: [{ skills: [REAL.id] }] } },
+      { tools: "nope" },
+      { tools: { alsoAllow: "sil" } },
+      { tools: { alsoAllow: [null, 3] } },
+      { plugins: "nope" },
+      { plugins: { allow: "sil" } },
+      { plugins: { entries: "nope" } },
+      { plugins: { entries: { sil: null } } },
+      { plugins: { entries: { sil: "enabled" } } },
+      { plugins: { entries: { sil: { enabled: "yes" } } } },
+    ];
+    for (const config of hostile) {
+      expect(() => detectWiringDrift(config, REAL), JSON.stringify(config)).not.toThrow();
+      for (const finding of detectWiringDrift(config, REAL)) {
+        expect(finding.severity).toBe("warn");
+        expect(finding.status).toBe("advisory");
+        expect(finding.appliedAction).toBeNull();
+      }
+    }
+  });
+
+  it("an agent entry with a mis-attached skill but NO usable id still reports legibly", () => {
+    // `agents.list[i].id` is what the fix string points at. An entry without one is
+    // operator corruption — the finding must still fire (the drift is real) and
+    // must not print `undefined` at the operator.
+    const config = { agents: { list: [{ skills: [REAL.id] }] }, tools: { alsoAllow: [REAL.id] } };
+    const drift = detectWiringDrift(config, REAL).filter((f) => f.id === SKILL_MISATTACHED);
+    expect(drift).toHaveLength(1);
+    expect(drift[0]!.detected).not.toContain("undefined");
+    expect(drift[0]!.suggestedAction).not.toContain("undefined");
+  });
+});
+
+// ===========================================================================
+// readSilWiringFacts — the published name comes from the manifest, not a literal
+// ===========================================================================
+
+describe("readSilWiringFacts — the shipped manifest is the single source (incident #1's root)", () => {
+  it("reports the manifest's plugin id", () => {
+    expect(readSilWiringFacts().id).toBe(manifest().id);
+  });
+
+  it("reports the PUBLISHED skill name = basename(manifest.skills[0]) — not the ref, not the id", () => {
+    // A skill attaches by its published name, which IS the skill-dir basename. The
+    // two adjacent wrong answers are exactly incident #1's shape: attaching the ref
+    // ("./sil-shopping") or the plugin id ("sil"). Derived from the manifest here,
+    // never asserted against a literal, so a skill-dir rename can't rot this test
+    // into agreeing with a stale detector.
+    const facts = readSilWiringFacts();
+    expect(facts.skill).toBe(basename(manifest().skills[0]!));
+    expect(facts.skill).not.toBe(manifest().skills[0]);
+    expect(facts.skill).not.toContain("/");
+    expect(facts.skill).not.toBe(facts.id);
+  });
+
+  it("is usable as-is: the facts it returns detect real drift against a real-shaped config", () => {
+    // Non-vacuity: facts that parse but are wrong (id and skill swapped, say) would
+    // pass the field assertions above and detect nothing in production.
+    const facts = readSilWiringFacts();
+    const config = {
+      agents: { list: [agent("shopper", [facts.id])] },
+      tools: { alsoAllow: [facts.id] },
+      plugins: { allow: [], entries: { [facts.id]: { enabled: true, config: {} } } },
+    };
+    expect(ids(config, facts)).toEqual([SKILL_MISATTACHED]);
+  });
+});
+
+// ===========================================================================
+// readHostVersion — the compat check's seam (AC2/AC10's `null` arm)
+// ===========================================================================
+
+describe("readHostVersion — the running host's version, or an honest null", () => {
+  // SOURCE = `api.runtime.version`, and nothing else. This block originally pinned
+  // `config.gateway.version` / `config.meta.version` — the card's NAMED CANDIDATES,
+  // flagged here as an empirical question the Step-0 probe owed an answer to. The
+  // probe ran against a live `alpine/openclaw:2026.6.9` and DISPROVED both; these
+  // expectations moved with the evidence, exactly as this block's own caveat
+  // pre-authorized. Re-verified independently by qa against the same image:
+  //
+  //   - `config.gateway` DOES NOT EXIST. A default host writes exactly
+  //     `{"tools":…,"meta":{"lastTouchedVersion","lastTouchedAt"}}`.
+  //   - `config.meta.version` DOES NOT EXIST. The real key is
+  //     `meta.lastTouchedVersion` — and it is CONFIG-FILE PROVENANCE ("which
+  //     version last wrote this file"), NOT the running host. Reading it would
+  //     fabricate a compat verdict for anyone who ran a newer OpenClaw once and
+  //     downgraded. AC10 forbids exactly that, so it is pinned shut below.
+  //   - `api.runtime` is a real pass-through member the host builds
+  //     (`api-builder-CX43eAAh.js:122` → `runtime: params.runtime`), which is what
+  //     licenses re-adding it to the shim — evidence, never speculation.
+  //
+  // What did NOT move, and must not: the seam. `null` ⇒ no compat finding, ever.
+  const withHost = (version: unknown) =>
+    createMockPluginApi({ runtime: { version } as Record<string, unknown> });
+
+  it("reads the running host's version from `api.runtime.version`", () => {
+    expect(readHostVersion(withHost("2026.6.9"))).toBe("2026.6.9");
+  });
+
+  it("returns null when the host supplies no runtime at all (INCONCLUSIVE, never a guess)", () => {
+    // Not hypothetical: one real load path (`registrationMode: "cli-metadata"`,
+    // `loader-CUGwG1IR.js:2630`) passes `runtime: {}`, so a plugin genuinely does
+    // get registered with no host version available.
+    expect(readHostVersion(createMockPluginApi({}))).toBeNull();
+    expect(readHostVersion(createMockPluginApi({ runtime: {} }))).toBeNull();
+  });
+
+  it("NEVER reads `config.meta.lastTouchedVersion` — that is the config's provenance, not the host", () => {
+    // The fabrication trap, pinned shut. `lastTouchedVersion` is one rename away
+    // from the `meta.version` this test originally guessed at, it is semver-shaped,
+    // and on a real host it is RIGHT THERE next to the wiring we do read — so an
+    // implementation reaching one key further looks correct and is not. Its value is
+    // "which version last WROTE this file": a user who ran a newer OpenClaw once and
+    // downgraded would be told their host is fine when it is not.
+    const api = createMockPluginApi({
+      config: { meta: { lastTouchedVersion: "9999.0.0", lastTouchedAt: "2026-07-17T09:59:47.329Z" } },
+    });
+    expect(readHostVersion(api)).toBeNull();
+  });
+
+  it("does not fall back to `config.gateway.version` — a dead key on the pinned host", () => {
+    // Coding a fallback to a key that does not exist is speculation the card bars
+    // ("re-add … ONLY if the probe proves it exists"). If a future host grows one,
+    // the probe re-runs and this moves — deliberately, not by accident.
+    expect(readHostVersion(createMockPluginApi({ config: { gateway: { version: "9999.0.0" } } }))).toBeNull();
+  });
+
+  it("returns null for a non-string version rather than coercing one", () => {
+    // A coerced `String(2026)` would fabricate a host version and, through
+    // `compareSemver`, a compat verdict — the exact fabrication AC10 forbids.
+    for (const version of [2026, null, "", "   ", {}, [], true]) {
+      expect(readHostVersion(withHost(version)), JSON.stringify(version)).toBeNull();
+    }
+  });
+
+  it("never throws on a hostile api surface", () => {
+    for (const runtime of [undefined, {}, { version: 7 }, { version: {} }] as (
+      | Record<string, unknown>
+      | undefined
+    )[]) {
+      expect(() =>
+        readHostVersion(createMockPluginApi(runtime === undefined ? {} : { runtime })),
+      ).not.toThrow();
+    }
+    expect(() =>
+      readHostVersion(createMockPluginApi({ config: { meta: 7 } as Record<string, unknown> })),
+    ).not.toThrow();
+  });
+
+  it("reads only in memory — no network call", () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    try {
+      readHostVersion(withHost("2026.6.9"));
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+});

--- a/src/__tests__/lib/version-advisory.test.ts
+++ b/src/__tests__/lib/version-advisory.test.ts
@@ -65,14 +65,19 @@ import {
   compareSemver,
   readInstalledVersion,
   buildVersionBehindFinding,
+  buildGatewayCompatFinding,
   probeLatestVersion,
   type FetchLike,
 } from "../../lib/version-advisory.js";
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
 
-const packageVersion = (): string =>
-  JSON.parse(readFileSync(join(REPO_ROOT, "package.json"), "utf8")).version;
+const packageJson = (): {
+  version: string;
+  openclaw: { compat: { pluginApi: string; minGatewayVersion: string } };
+} => JSON.parse(readFileSync(join(REPO_ROOT, "package.json"), "utf8"));
+
+const packageVersion = (): string => packageJson().version;
 
 /** Sign of a comparator result — the contract is the SIGN, not the magnitude, so
  * an implementation returning -1/0/1 and one returning a numeric difference both
@@ -371,5 +376,235 @@ describe("probeLatestVersion — bounded by a DEADLINE, not merely by an abort",
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+// ===========================================================================
+// Card: self-upgrade-detect-host-wiring-advisory — **AC10** (+ AC2's local half).
+//
+// `buildGatewayCompatFinding()` is the ONE function that card adds to this file.
+// It answers a genuinely different question from `buildVersionBehindFinding` — not
+// "am I current?" (installed vs published, a ClawHub probe) but "is my HOST new
+// enough for me?" (the running gateway vs our own declared `package.json#openclaw.
+// compat`). It is **100% local**: no probe, no network, no `networkEndpoints` entry.
+// That is why the two share a file and share `compareSemver` — and why nothing here
+// re-derives the comparator, the installed read, or the probe (sil-doctor's AC9
+// owns all three; re-testing them here would fork the contract).
+//
+// The two things this block exists to catch:
+//
+// 1. **A FABRICATED verdict.** An unreadable host version (`readHostVersion` → null)
+//    or a range shape the parser does not fully understand must yield NO finding —
+//    never a guess in either direction. A partial semver-range parser that guesses is
+//    strictly worse than no check: it tells a working install to "update OpenClaw",
+//    which the user cannot un-learn. Fail CLOSED to inconclusive.
+// 2. **A STRING-COMPARE compat check.** The same fail-quiet trap the block above
+//    pins, one datum over: lexicographically "2026.4.9" > "2026.4.15", so a string
+//    compare silently passes a host that is genuinely too old. Calendar versions hit
+//    this every single month, not eventually.
+//
+// Contract pinned for the implementation (expert-developer):
+//
+//   export function buildGatewayCompatFinding(
+//     hostVersion: string | null,
+//     requiredRange?: string,   // defaults to the shipped
+//                               // package.json#openclaw.compat.minGatewayVersion
+//   ): Finding | null;
+//     — EXACTLY ONE `version.gateway_compat` Finding (`warn` + `advisory`,
+//       `appliedAction: null`) iff the host is BELOW the required range; otherwise
+//       `null`. Reuses `compareSemver`. No network, no host, no fabrication.
+// ===========================================================================
+
+/** The plugin's OWN declared floor, read from the shipped manifest — never a
+ * literal. `pnpm version` and a compat bump must not be able to rot this file into
+ * agreeing with a stale check. */
+const requiredRange = (): string => packageJson().openclaw.compat.minGatewayVersion;
+
+/** The bare version inside a `>=X.Y.Z` range. */
+const requiredVersion = (): string => requiredRange().replace(/^>=\s*/, "");
+
+/** Below/above ANY plausible calendar-versioned floor, so neither depends on the
+ * shipped range's actual value. */
+const ANCIENT_HOST = "0.0.1";
+const FUTURE_HOST = "9999.0.0";
+
+describe("buildGatewayCompatFinding — host below our floor → advise, else silence (AC10)", () => {
+  it("host BELOW the required range → exactly one version.gateway_compat finding", () => {
+    const finding = buildGatewayCompatFinding("2026.4.14", ">=2026.4.15");
+    expect(finding).not.toBeNull();
+    expect(finding!.id).toBe("version.gateway_compat");
+  });
+
+  it("is `warn` + `advisory` + `appliedAction: null` (degraded, but we never act)", () => {
+    // `warn`, not `info`: unlike a version-behind, this install may genuinely not
+    // run — that IS a degradation and `healthy: false` is the truth. And not
+    // `critical`: by sil-doctor's ladder that means the core path is broken, and a
+    // plugin broken enough to qualify could not run a tool to say so.
+    const finding = buildGatewayCompatFinding("2026.4.14", ">=2026.4.15")!;
+    expect(finding.severity).toBe("warn");
+    expect(finding.status).toBe("advisory");
+    expect(finding.appliedAction).toBeNull();
+  });
+
+  it("`detected` names BOTH the required and the running version (AC2)", () => {
+    const finding = buildGatewayCompatFinding("2026.4.14", ">=2026.4.15")!;
+    expect(finding.detected).toContain("2026.4.15");
+    expect(finding.detected).toContain("2026.4.14");
+  });
+
+  it("`suggestedAction` directs the user to update OpenClaw — the plugin ships no installer", () => {
+    // The plugin cannot be its own installer (noChildProcess + noInstallScripts +
+    // read-only api.config + it cannot hot-swap its own running code). It points at
+    // OpenClaw's own trusted update path and stops.
+    const finding = buildGatewayCompatFinding("2026.4.14", ">=2026.4.15")!;
+    expect(finding.suggestedAction).not.toBeNull();
+    expect(finding.suggestedAction!.toLowerCase()).toContain("openclaw");
+    expect(finding.suggestedAction!.toLowerCase()).not.toContain("npm install");
+    expect(finding.suggestedAction!.toLowerCase()).not.toContain("curl");
+  });
+
+  it("carries exactly the six flat fields — no extra keys, no `advisory` sub-object", () => {
+    const finding = buildGatewayCompatFinding("2026.4.14", ">=2026.4.15")!;
+    expect(Object.keys(finding).sort()).toEqual([
+      "appliedAction",
+      "detected",
+      "id",
+      "severity",
+      "status",
+      "suggestedAction",
+    ]);
+  });
+
+  it("host EXACTLY AT the required version → NO finding (`>=` includes the floor)", () => {
+    // The off-by-one that would fire a permanent false advisory on the single most
+    // common supported host: the one that is exactly at our declared floor.
+    expect(buildGatewayCompatFinding("2026.4.15", ">=2026.4.15")).toBeNull();
+  });
+
+  it("host ABOVE the required version → NO finding", () => {
+    expect(buildGatewayCompatFinding("2026.6.9", ">=2026.4.15")).toBeNull();
+    expect(buildGatewayCompatFinding("2027.1.0", ">=2026.4.15")).toBeNull();
+  });
+
+  it("uses semver PRECEDENCE, not string compare (2026.4.9 IS below 2026.4.15)", () => {
+    // Lexicographically "2026.4.9" > "2026.4.15", so a string compare decides this
+    // too-old host is fine and stays SILENT — fail-quiet, on a host that may not run
+    // us at all. Calendar versions cross this boundary every month.
+    const finding = buildGatewayCompatFinding("2026.4.9", ">=2026.4.15");
+    expect(finding).not.toBeNull();
+    expect(finding!.detected).toContain("2026.4.9");
+  });
+
+  it("ranks the major component first (2025.x is below 2026.4.15)", () => {
+    expect(buildGatewayCompatFinding("2025.12.31", ">=2026.4.15")).not.toBeNull();
+  });
+});
+
+describe("buildGatewayCompatFinding — fails CLOSED to inconclusive, never a verdict (AC10)", () => {
+  it("an UNREADABLE host version (null) → NO finding", () => {
+    // `readHostVersion(api)` returns null when the running host's version is not
+    // reachable in `api.config` / the SDK shim. Unknown is not a state we invent a
+    // value for: no "your host is too old" (a false alarm), no silent "you're fine"
+    // dressed up as a real check.
+    expect(buildGatewayCompatFinding(null, ">=2026.4.15")).toBeNull();
+    expect(buildGatewayCompatFinding(null)).toBeNull();
+  });
+
+  it("an UNPARSEABLE host version → NO finding", () => {
+    for (const host of ["", "unknown", "2026.4", "v2026.4.15", "latest", "2026.04.15-nightly+x y"]) {
+      expect(buildGatewayCompatFinding(host, ">=2026.4.15"), host).toBeNull();
+    }
+  });
+
+  it("ANY range shape other than a single `>=X.Y.Z` → NO finding (the parser refuses to guess)", () => {
+    // We ship a ~20-line tuple compare rather than a `semver` dependency, because
+    // every range we declare is a single `>=X.Y.Z`. The whole licence for that is
+    // that it fails closed on everything else: a caret/tilde/OR/range-pair parsed
+    // "approximately" is how a working host gets told to update. If we ever declare
+    // one of these for real, the parser grows to meet it FIRST — this test going red
+    // is the signal, and loosening it to `toContain` would hide exactly that.
+    const ancient = "0.0.1";
+    for (const range of [
+      "^2026.4.15",
+      "~2026.4.15",
+      ">2026.4.15",
+      "<=2026.4.15",
+      "=2026.4.15",
+      "2026.4.15",
+      ">=2026.4.15 <2027.0.0",
+      ">=2026.4.15 || >=2025.1.0",
+      ">=2026.x",
+      ">=2026.4",
+      ">=",
+      "",
+      "*",
+      "latest",
+    ]) {
+      expect(buildGatewayCompatFinding(ancient, range), range).toBeNull();
+    }
+  });
+
+  it("a PRERELEASE or non-numeric floor → NO finding (unparsed ⇒ inconclusive)", () => {
+    expect(buildGatewayCompatFinding("0.0.1", ">=2026.4.15-rc.1")).toBeNull();
+    expect(buildGatewayCompatFinding("0.0.1", ">=abc.def.ghi")).toBeNull();
+  });
+
+  it("is NOT VACUOUS — the same call path DOES fire for a real `>=` floor", () => {
+    // Without this, a `buildGatewayCompatFinding` that simply `return null`ed would
+    // pass every assertion in this describe block, and the compat check would be
+    // dead code that never speaks in production while the suite stays green.
+    expect(buildGatewayCompatFinding("0.0.1", ">=2026.4.15")).not.toBeNull();
+  });
+});
+
+describe("buildGatewayCompatFinding — the floor comes from the SHIPPED manifest (AC10)", () => {
+  it("defaults to package.json#openclaw.compat.minGatewayVersion", () => {
+    // Derived, never hardcoded: `pnpm version` / a compat bump must move the check,
+    // not silently drift from it. `package.json` is the source of truth that
+    // `sync-version.mjs` mirrors OUTWARD, and it always ships in an npm tarball.
+    const finding = buildGatewayCompatFinding(ANCIENT_HOST);
+    expect(finding).not.toBeNull();
+    expect(finding!.id).toBe("version.gateway_compat");
+    expect(finding!.detected).toContain(requiredVersion());
+    expect(finding!.detected).toContain(ANCIENT_HOST);
+  });
+
+  it("the shipped floor is a single `>=X.Y.Z` — the exact shape the parser supports", () => {
+    // The gate on the no-`semver`-dependency call: the moment a declared range stops
+    // being a bare `>=`, the parser fails closed and the compat check goes SILENT.
+    // This asserts the premise still holds, so that silence can never be a surprise.
+    expect(requiredRange()).toMatch(/^>=\d+\.\d+\.\d+$/);
+  });
+
+  it("a host at the shipped floor is silent; a far-future host is silent", () => {
+    expect(buildGatewayCompatFinding(requiredVersion())).toBeNull();
+    expect(buildGatewayCompatFinding(FUTURE_HOST)).toBeNull();
+  });
+});
+
+describe("buildGatewayCompatFinding — local, pure, and never a network call (AC2/AC14)", () => {
+  it("issues NO network request — it must still fire with the network down", () => {
+    // AC2's teeth: the compat check must not be coupled to any remote channel. This
+    // card has none at all — its two detections are 100% local, so the plugin-behind
+    // probe going dark must not take compat down with it.
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    try {
+      buildGatewayCompatFinding("2026.4.14", ">=2026.4.15");
+      buildGatewayCompatFinding(null);
+      buildGatewayCompatFinding(ANCIENT_HOST);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("is synchronous — a compat verdict needs no await", () => {
+    expect(buildGatewayCompatFinding("2026.4.14", ">=2026.4.15")).not.toBeInstanceOf(Promise);
+  });
+
+  it("is deterministic — repeated calls yield an equal finding and no accumulated state", () => {
+    expect(buildGatewayCompatFinding("2026.4.14", ">=2026.4.15")).toEqual(
+      buildGatewayCompatFinding("2026.4.14", ">=2026.4.15"),
+    );
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ import {
   type SilPluginConfig,
 } from "./lib/config.js";
 import { ensureDataDir, getDataDir } from "./lib/credentials.js";
+import { detectWiringDrift, readSilWiringFacts } from "./lib/host-wiring.js";
 import { registerCatalogTools } from "./tools/catalog.js";
 import { registerDoctorTools } from "./tools/doctor.js";
 import { registerIdentityTools } from "./tools/identity.js";
@@ -82,6 +83,31 @@ export default definePluginEntry({
     registerCatalogTools(api);
     registerProfileTools(api);
     registerDoctorTools(api);
+
+    // Host-wiring drift, at the ONE surface that survives it.
+    //
+    // `tools.alsoAllow` is GLOBAL, so the state where sil's tools are filtered
+    // filters `sil_doctor` too — it is a sil tool. A detector living inside the
+    // plugin can only speak where its own surface is callable, and here the
+    // gateway log is all that is left; its audience (an operator wondering why
+    // their sil tools do nothing) is exactly the right one.
+    //
+    // Invariant-safe: a config read already in memory plus a synchronous log.
+    // The rule is "opens nothing" — no timer, no socket, no unawaited promise —
+    // and this opens nothing. `readSilWiringFacts()` also warms its cache here,
+    // so a broken build fails loud at load (as `ensureDataDir` does) instead of
+    // throwing inside a tool result later.
+    const drift = detectWiringDrift(api.config, readSilWiringFacts());
+    if (drift.length > 0) {
+      api.logger.warn("sil_plugin_wiring_drift", {
+        message:
+          "sil is installed but MIS-WIRED in this OpenClaw host, so part of it is"
+          + " not doing anything. Each finding names the exact one-line fix. sil"
+          + " only reports this — it never edits host config or reloads the"
+          + " gateway.",
+        findings: drift,
+      });
+    }
 
     api.logger.info("sil_plugin_loaded", {
       message: "sil plugin registered.",

--- a/src/lib/host-wiring.ts
+++ b/src/lib/host-wiring.ts
@@ -1,0 +1,293 @@
+/**
+ * Host-wiring drift — is sil wired the way it thinks it is?
+ *
+ * A skill attaches per-agent at `agents.list[i].skills` by its PUBLISHED NAME
+ * (`sil-shopping` = the skill-dir basename); tools admit by PLUGIN ID (`sil`).
+ * Two different host keys, and conflating them seeded incident #1 — silently,
+ * because the host fails a bad skill ref with a warning, not an error.
+ *
+ * That silence is why this detector exists, and why the wiring advisory rides
+ * every `sil_*` result: a mis-wired skill isn't running its own flow, so it
+ * cannot carry its own warning. The tools are the only surviving messenger.
+ *
+ * DETECT ONLY. Everything here reads; nothing writes. In particular this module
+ * does NOT import `openclaw-allowlist.ts`: that is a mutation planner which
+ * edits its argument IN PLACE (`:100-104`, `:174`, `:193`, `:202`), and the
+ * config we are handed is the host's LIVE in-memory tree. Sharing it for a read
+ * would silently corrupt host state from a detect-only path. The two share
+ * surface knowledge, not an operation.
+ *
+ * Wiring is read from `api.config` — the tree in force in the RUNNING process —
+ * never from `~/.openclaw` on disk. That keeps `filesystemScope` unchanged and,
+ * more importantly, reports what is actually running: a fixed-on-disk config
+ * that has not been reloaded is STILL mis-wired, so the advisory persisting is
+ * truthful, not stale. Hence every fix string names edit + RELOAD.
+ */
+
+import { readFileSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type { PluginAPI } from "openclaw/plugin-sdk";
+
+import type { Finding } from "./findings.js";
+
+/** The shipped manifest, resolved relative to this module — two levels up from
+ * both `src/lib/` and `dist/lib/`. It ships via `package.json#files`. */
+const MANIFEST_PATH = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "openclaw.plugin.json",
+);
+
+/**
+ * sil's own wiring identity, read from the shipped manifest — never hardcoded.
+ *
+ * The published name rotting into a stale literal is incident #1's exact root
+ * (the skill dir was renamed), so both values are derived, and every finding
+ * below names these rather than a constant.
+ */
+export interface SilWiringFacts {
+  /** The plugin id — `openclaw.plugin.json#id`. Admits TOOLS. */
+  readonly id: string;
+  /** The PUBLISHED skill name = `basename(manifest.skills[0])`. Attaches the
+   * SKILL. Not the ref (`./sil-shopping`), not the plugin id. */
+  readonly skill: string;
+}
+
+let cachedFacts: SilWiringFacts | undefined;
+
+/**
+ * Read sil's wiring facts from the shipped manifest (module-cached).
+ *
+ * The one I/O in this module; `detectWiringDrift` itself stays pure. Throws when
+ * the manifest is missing or shapeless: that is a broken build, not a runtime
+ * state to model — the same call `readInstalledVersion()` makes.
+ */
+export function readSilWiringFacts(): SilWiringFacts {
+  if (cachedFacts !== undefined) return cachedFacts;
+
+  const parsed: unknown = JSON.parse(readFileSync(MANIFEST_PATH, "utf8"));
+  const id = (parsed as { id?: unknown }).id;
+  if (typeof id !== "string" || id.length === 0) {
+    throw new Error(`${MANIFEST_PATH}: manifest carries no plugin id`);
+  }
+
+  const skills = (parsed as { skills?: unknown }).skills;
+  const ref = Array.isArray(skills) ? skills[0] : undefined;
+  if (typeof ref !== "string" || ref.length === 0) {
+    throw new Error(`${MANIFEST_PATH}: manifest declares no skill to attach`);
+  }
+
+  cachedFacts = { id, skill: basename(ref) };
+  return cachedFacts;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** The string members of `value`, or null when it isn't an array at all. A
+ * mixed array yields only its strings — the config is operator-editable, and a
+ * detector that throws on junk turns an advisory into an outage. */
+function stringsOf(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null;
+  return value.filter((x): x is string => typeof x === "string");
+}
+
+/**
+ * The running host's version, or `null` when nothing readable is present.
+ *
+ * `api.runtime.version` is the ONLY source, proven by probe against a live
+ * `alpine/openclaw:2026.6.9`. There is deliberately no fallback:
+ * `config.gateway` does not exist, and `config.meta.lastTouchedVersion` is the
+ * version that last WROTE the config file — reading that as the running host
+ * would fabricate a compat verdict for anyone who ran a newer OpenClaw once and
+ * downgraded. `null` ⇒ INCONCLUSIVE ⇒ no compat finding, ever.
+ */
+export function readHostVersion(api: PluginAPI): string | null {
+  const version = api.runtime?.version;
+  if (typeof version !== "string") return null;
+  const trimmed = version.trim();
+  return trimmed.length === 0 ? null : trimmed;
+}
+
+/**
+ * Detect host-wiring drift. Pure: no I/O, no network, no mutation.
+ *
+ * `config` is `unknown` because it is the operator-editable OpenClawConfig tree;
+ * every read narrows, and nothing here throws. Returns 0..2 findings, each
+ * `warn` / `advisory` / `appliedAction: null` — we name a fix, we never apply
+ * one.
+ *
+ * `plugins.allow` is deliberately NOT read. Empty/absent is the permissive
+ * default that auto-loads everything (so sil IS allowed — flagging it would fire
+ * a false advisory on a correctly-working default install), and a NON-EMPTY
+ * allow that omits sil is unreportable by construction: the plugin never loads,
+ * so this code never runs. Reporting neither state means reading neither key.
+ */
+export function detectWiringDrift(config: unknown, facts: SilWiringFacts): Finding[] {
+  if (!isRecord(config)) return [];
+
+  const findings: Finding[] = [];
+  const misattached = findMisattachedAgents(config, facts);
+  if (misattached.length > 0) {
+    findings.push(buildSkillMisattachedFinding(misattached, facts));
+  }
+
+  const reasons = findUnadmittedReasons(config, facts);
+  if (reasons.length > 0) {
+    findings.push(buildToolsNotAdmittedFinding(reasons, facts));
+  }
+
+  return findings;
+}
+
+/**
+ * Agents that reached for sil and used the WRONG token: `skills` carries the
+ * plugin id but NOT the published name.
+ *
+ * Both halves are load-bearing. "Lacks the published name" alone is not drift —
+ * a host runs many agents and only one is the shopper, so that would fire on
+ * every unrelated agent. And an agent carrying BOTH tokens is not drift either:
+ * the published name attaches, the skill runs, nothing is degraded.
+ */
+function findMisattachedAgents(
+  config: Record<string, unknown>,
+  facts: SilWiringFacts,
+): string[] {
+  const agents = isRecord(config["agents"]) ? config["agents"] : undefined;
+  const list = Array.isArray(agents?.["list"]) ? agents["list"] : [];
+
+  const labels: string[] = [];
+  for (let i = 0; i < list.length; i += 1) {
+    const entry: unknown = list[i];
+    if (!isRecord(entry)) continue;
+
+    const skills = stringsOf(entry["skills"]);
+    if (skills === null) continue;
+    if (!skills.includes(facts.id) || skills.includes(facts.skill)) continue;
+
+    // The fix string points at this agent, so it must be legible. An entry with
+    // no usable id is operator corruption — the drift is still real, so report
+    // it positionally rather than printing `undefined` at the operator.
+    const id = entry["id"];
+    labels.push(
+      typeof id === "string" && id.length > 0 ? id : `agents.list[${i}]`,
+    );
+  }
+  return labels;
+}
+
+/**
+ * Why sil's tools are filtered, if they are. Two independent causes, folded into
+ * ONE finding — AC3/AC11 pin a bare `wiring.tools_not_admitted` id that the
+ * doctor and the tool fold must both carry, so it cannot be per-cause suffixed.
+ *
+ * ENABLE ≠ ADMIT is the false negative this exists for: `enabled: true` means
+ * the plugin LOADS, not that its tools are admitted. That is the half-trust
+ * state (the agent-creation-engine bug) where the register-time log is the only
+ * surface still alive.
+ */
+function findUnadmittedReasons(
+  config: Record<string, unknown>,
+  facts: SilWiringFacts,
+): string[] {
+  const reasons: string[] = [];
+
+  // Only a NON-EMPTY allowlist that omits the id counts: an empty/absent one
+  // admits by default, and flagging it would fire on a default install.
+  const tools = isRecord(config["tools"]) ? config["tools"] : undefined;
+  const alsoAllow = stringsOf(tools?.["alsoAllow"]);
+  if (alsoAllow !== null && alsoAllow.length > 0 && !alsoAllow.includes(facts.id)) {
+    reasons.push(
+      `the plugin id "${facts.id}" is absent from a non-empty \`tools.alsoAllow\``,
+    );
+  }
+
+  const plugins = isRecord(config["plugins"]) ? config["plugins"] : undefined;
+  const entries = isRecord(plugins?.["entries"]) ? plugins["entries"] : undefined;
+  const entry = entries?.[facts.id];
+  // An ABSENT entry is not drift (the host loads discovered plugins by default);
+  // only an explicit `false` is.
+  if (isRecord(entry) && entry["enabled"] === false) {
+    reasons.push(`\`plugins.entries.${facts.id}.enabled\` is false`);
+  }
+
+  return reasons;
+}
+
+/**
+ * The advisory block to spread onto a `sil_*` SUCCESS payload.
+ *
+ * PRESENT-ONLY-ON-DRIFT: healthy wiring yields `{}`, so the happy-path payload
+ * stays byte-identical to today. Absence of a problem is not a finding, and an
+ * always-present key is one consumers start depending on.
+ *
+ * Additive, never a wrapper: a `sil_search` result carrying an advisory is still
+ * the same search result, with the same products in the same order.
+ *
+ * It recurs on every result while the drift persists — that is the feature, not
+ * noise: the misconfiguration it reports is silent by construction, which is
+ * exactly how it rotted into incident #1. It self-clears when the fix is IN
+ * EFFECT (after the reload), not when the file is merely edited.
+ *
+ * No I/O on this hot path: `readSilWiringFacts()` is module-cached and warmed at
+ * register(), where a broken build correctly fails loud instead of taking down
+ * the tool result it was folded into.
+ */
+export function wiringAdvisories(api: PluginAPI): { advisories?: Finding[] } {
+  const drift = detectWiringDrift(api.config, readSilWiringFacts());
+  return drift.length === 0 ? {} : { advisories: drift };
+}
+
+function buildSkillMisattachedFinding(
+  agentLabels: string[],
+  facts: SilWiringFacts,
+): Finding {
+  const agents = agentLabels.join(", ");
+  const plural = agentLabels.length > 1;
+  return {
+    id: "wiring.skill_misattached",
+    severity: "warn",
+    status: "advisory",
+    detected:
+      `${plural ? "Agents" : "Agent"} ${agents} attach${plural ? "" : "es"} sil by`
+      + ` plugin id "${facts.id}" instead of its published skill name`
+      + ` "${facts.skill}". A skill attaches by published name, so the sil skill`
+      + ` is NOT running for ${plural ? "these agents" : "that agent"} — its`
+      + ` tools still work, which is why this rides the tool result.`,
+    suggestedAction:
+      `In each listed agent's \`skills\` (${agents}), replace "${facts.id}" with`
+      + ` "${facts.skill}", then reload OpenClaw — the edit takes effect on the`
+      + ` next reload, and sil never reloads the gateway itself.`,
+    appliedAction: null,
+  };
+}
+
+function buildToolsNotAdmittedFinding(
+  reasons: string[],
+  facts: SilWiringFacts,
+): Finding {
+  return {
+    id: "wiring.tools_not_admitted",
+    severity: "warn",
+    status: "advisory",
+    detected:
+      `sil's tools are not admitted by the running OpenClaw: ${reasons.join("; ")}.`
+      + ` The plugin loads, but every sil_* tool stays filtered.`,
+    // NEVER an inline `openclaw config set tools.alsoAllow …`: that key is
+    // overwrite-only on 2026.6.9, so following such a "fix" would silently
+    // un-admit every other plugin already in the array. A fix that breaks klodi
+    // to fix sil is not a fix — and the user would discover it later, in a
+    // different plugin, with no trail back to us. The shipped bin is additive
+    // and idempotent across all three trust surfaces.
+    suggestedAction:
+      `Run the shipped \`sil-openclaw-allowlist\` bin — it admits "${facts.id}"`
+      + ` additively, preserving every other trusted plugin — then reload`
+      + ` OpenClaw. The edit takes effect on the next reload, and sil never`
+      + ` writes host config or reloads the gateway itself.`,
+    appliedAction: null,
+  };
+}

--- a/src/lib/version-advisory.ts
+++ b/src/lib/version-advisory.ts
@@ -217,6 +217,89 @@ export async function probeLatestVersion(
  * minute before. Anything higher turns every install permanently yellow the
  * moment we publish, and the `healthy` roll-up stops meaning anything.
  */
+/**
+ * A single `>=X.Y.Z` floor — the ONLY range shape we parse.
+ *
+ * Every range we declare is exactly this (`package.json#openclaw.compat`), which
+ * is the whole licence for a ~20-line tuple compare instead of a `semver`
+ * dependency. The licence holds only because anything else FAILS CLOSED: a
+ * caret/tilde/OR/range-pair parsed "approximately" is how a working host gets
+ * told to update. No prerelease floor, no wildcards, no compound ranges — if we
+ * ever declare one for real, this parser grows to meet it FIRST.
+ */
+const GATEWAY_RANGE_RE = /^>=(\d+\.\d+\.\d+)$/;
+
+/**
+ * Our declared minimum gateway version, or `null` when it is absent or not a
+ * bare `>=X.Y.Z`.
+ *
+ * Read from `package.json#openclaw.compat` (not the manifest): compat lives ONLY
+ * there, and `package.json` is the source of truth `sync-version.mjs` mirrors
+ * outward. Unlike `readInstalledVersion()` this never throws — an unreadable
+ * floor is inconclusive, and a compat check that threw would be a worse failure
+ * than the one it diagnoses.
+ */
+function readDeclaredGatewayRange(): string | null {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(PACKAGE_JSON_PATH, "utf8"));
+    const range = (parsed as {
+      openclaw?: { compat?: { minGatewayVersion?: unknown } };
+    }).openclaw?.compat?.minGatewayVersion;
+    return typeof range === "string" ? range : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The host-compat advisory: a finding IFF the RUNNING gateway is below our
+ * declared floor. Local, synchronous, no probe — the question is "is my host new
+ * enough for me?", not "am I current?", so nothing here touches the network and
+ * it still fires with the network down.
+ *
+ * FAILS CLOSED TO INCONCLUSIVE — `null` (no finding) whenever we cannot be sure:
+ * an unreadable host version (`readHostVersion` → null), a host that is not
+ * semver, or a range we do not fully understand. Never a fabricated verdict in
+ * either direction: "your host is too old" is not something a user can un-learn,
+ * and a silent "you're fine" dressed up as a real check is worse.
+ *
+ * `warn`, not `info`: unlike a version-behind, this install may genuinely not
+ * run — that IS a degradation. Not `critical`: by the doctor's ladder that means
+ * the core path is broken, and a plugin that broken could not run a tool to say
+ * so.
+ */
+export function buildGatewayCompatFinding(
+  hostVersion: string | null,
+  requiredRange: string | null = readDeclaredGatewayRange(),
+): Finding | null {
+  if (hostVersion === null || requiredRange === null) return null;
+
+  const required = GATEWAY_RANGE_RE.exec(requiredRange.trim())?.[1];
+  if (required === undefined) return null;
+
+  // Parse-check the host explicitly rather than leaning on compareSemver's
+  // unparseable-sorts-equal rule: silence must be a decision here, not a
+  // by-product of a comparator contract that exists for a different caller.
+  if (!SEMVER_RE.test(hostVersion.trim())) return null;
+
+  if (compareSemver(hostVersion.trim(), required) >= 0) return null;
+
+  return {
+    id: "version.gateway_compat",
+    severity: "warn",
+    status: "advisory",
+    detected:
+      `This OpenClaw host is older than sil requires: sil needs ${required} or`
+      + ` newer, and the running host is ${hostVersion.trim()}. Some sil tools`
+      + " may not work correctly on this host.",
+    suggestedAction:
+      `Update OpenClaw itself to ${required} or newer using OpenClaw's own`
+      + " update path, then reload. sil never updates the host and ships no"
+      + " installer.",
+    appliedAction: null,
+  };
+}
+
 export function buildVersionBehindFinding(
   installed: string,
   latest: string | null,

--- a/src/tools/catalog.ts
+++ b/src/tools/catalog.ts
@@ -62,6 +62,7 @@ import { Type } from "typebox";
 
 import { getApiUrl } from "../lib/config.js";
 import { clearTokens, readTokens } from "../lib/credentials.js";
+import { wiringAdvisories } from "../lib/host-wiring.js";
 import {
   lookupCatalog,
   refreshAndRetryOnce,
@@ -483,7 +484,7 @@ function registerSearch(api: PluginAPI): void {
 function mapSearchOutcome(api: PluginAPI, outcome: SearchOutcome) {
   switch (outcome.kind) {
     case "ok":
-      return searchResult(outcome);
+      return searchResult(api, outcome);
     case "forbidden":
       // A 403 surfaces the SAME forbidden envelope `sil_whoami` emits — never the
       // false-transient `retryable`. On `user_not_provisioned` (and ONLY that exact
@@ -646,7 +647,7 @@ function registerProductGet(api: PluginAPI): void {
 function mapLookupOutcome(api: PluginAPI, outcome: LookupOutcome) {
   switch (outcome.kind) {
     case "ok":
-      return lookupResult(outcome);
+      return lookupResult(api, outcome);
     case "forbidden":
       // Symmetric with sil_search (one vocabulary, AC2/AC7/AC10): a 403 is the shared
       // forbidden envelope, and `user_not_provisioned` — and ONLY that exact reason —
@@ -800,7 +801,7 @@ function registerSpecs(api: PluginAPI): void {
 function mapSpecsOutcome(api: PluginAPI, outcome: SpecsOutcome) {
   switch (outcome.kind) {
     case "ok":
-      return specsResult(outcome);
+      return specsResult(api, outcome);
     case "forbidden":
       // Symmetric with sil_search/sil_product_get (one vocabulary): a 403 is the
       // shared forbidden envelope, and `user_not_provisioned` — and ONLY that exact
@@ -837,9 +838,9 @@ function readIds(params: Record<string, unknown>): string[] {
  * optional `not_found`); spread its payload (minus the `kind` discriminant) onto
  * the agent-facing `{ status: "ok", ... }` envelope. A `not_found` list is
  * partial-success DATA, NOT an error and NOT a recovery hint. */
-function lookupResult(outcome: Extract<LookupOutcome, { kind: "ok" }>) {
+function lookupResult(api: PluginAPI, outcome: Extract<LookupOutcome, { kind: "ok" }>) {
   const { kind: _kind, ...payload } = outcome;
-  return jsonResult({ status: "ok", ...payload });
+  return jsonResult({ status: "ok", ...payload, ...wiringAdvisories(api) });
 }
 
 /** Client-side validation: the request named no usable id. Distinct from a sil-api
@@ -1212,9 +1213,9 @@ function hasUsableInput(params: SearchParams): boolean {
  * An empty `products` list is a valid, successful empty match. The `ok` outcome
  * already carries `products` (+ optional `cursor`); spread its payload (minus the
  * `kind` discriminant) onto the agent-facing `{ status: "ok", ... }` envelope. */
-function searchResult(outcome: Extract<SearchOutcome, { kind: "ok" }>) {
+function searchResult(api: PluginAPI, outcome: Extract<SearchOutcome, { kind: "ok" }>) {
   const { kind: _kind, ...payload } = outcome;
-  return jsonResult({ status: "ok", ...payload });
+  return jsonResult({ status: "ok", ...payload, ...wiringAdvisories(api) });
 }
 
 /** Not registered: a distinct, actionable outcome naming the recovery tool. No
@@ -1281,9 +1282,9 @@ function invalidSpec(field: string) {
 /** Success: the resolved canonicalizations — no token, no Bearer header. The `ok`
  * outcome carries `resolved` directly; spread its payload (minus the `kind`
  * discriminant) onto the agent-facing `{ status: "ok", resolved }` envelope. */
-function specsResult(outcome: Extract<SpecsOutcome, { kind: "ok" }>) {
+function specsResult(api: PluginAPI, outcome: Extract<SpecsOutcome, { kind: "ok" }>) {
   const { kind: _kind, ...payload } = outcome;
-  return jsonResult({ status: "ok", ...payload });
+  return jsonResult({ status: "ok", ...payload, ...wiringAdvisories(api) });
 }
 
 /** Client-side validation: no usable canonicalization input (a blank `query` or an

--- a/src/tools/doctor.ts
+++ b/src/tools/doctor.ts
@@ -51,11 +51,17 @@ import {
 } from "../lib/credentials.js";
 import { sortFindings, type Finding, type Severity } from "../lib/findings.js";
 import {
+  detectWiringDrift,
+  readHostVersion,
+  readSilWiringFacts,
+} from "../lib/host-wiring.js";
+import {
   readShopperIdentity,
   searchProfileFrontmatter,
 } from "../lib/profile-store.js";
 import { jsonResult } from "../lib/tool-result.js";
 import {
+  buildGatewayCompatFinding,
   buildVersionBehindFinding,
   probeLatestVersion,
   readInstalledVersion,
@@ -123,6 +129,15 @@ export function registerDoctorTools(
         findings.push(...checkStore());
       }
       findings.push(...checkIdentity());
+
+      // Host wiring + host compat: both read the tree already in memory, so they
+      // are local and unconditional — they still report with the network down.
+      // `sil_doctor` is the SECOND surface for the wiring advisory (it also rides
+      // every sil_* result); it is the ONLY one for compat, which answers a
+      // question nobody asked mid-search.
+      findings.push(...detectWiringDrift(api.config, readSilWiringFacts()));
+      const compat = buildGatewayCompatFinding(readHostVersion(api));
+      if (compat !== null) findings.push(compat);
 
       const installedVersion = readInstalledVersion();
       const behind = buildVersionBehindFinding(

--- a/src/tools/identity.ts
+++ b/src/tools/identity.ts
@@ -43,6 +43,7 @@ import {
   writeConfig,
   writeTokens,
 } from "../lib/credentials.js";
+import { wiringAdvisories } from "../lib/host-wiring.js";
 import { deriveChallenge, newSessionId, newVerifier } from "../lib/pkce.js";
 import {
   POLL_DEADLINE_MS,
@@ -92,6 +93,10 @@ function registerRegister(api: PluginAPI): void {
           status: "already_registered",
           user: config?.user ?? null,
           next_step: "offer_shopper",
+          // Folded here but NOT onto `awaiting_browser`: this is a terminal
+          // result, whereas that one is a mid-flow auth handoff whose whole job
+          // is to get one link in front of the user.
+          ...wiringAdvisories(api),
         });
       }
 
@@ -292,7 +297,7 @@ function identityOutcomeToResult(
 ) {
   switch (outcome.kind) {
     case "ok":
-      return identityResult(outcome.identity, originBlock);
+      return identityResult(api, outcome.identity, originBlock);
     case "forbidden":
       // Decision B — the dead-token clear is UNIFORM across all three sil-api tools.
       // `sil_whoami` is the tool that is legible TODAY; an agent that diagnoses the
@@ -319,8 +324,17 @@ function identityOutcomeToResult(
 /** Success: the identity payload + the web-origin visibility block (FIX B) —
  * no token, no Bearer header. The origin block (strings only) lets the agent
  * relay the resolved origin + its source so a wrong origin is diagnosable. */
-function identityResult(identity: Identity, originBlock: OriginBlock) {
-  return jsonResult({ status: "ok", identity, ...originBlock });
+function identityResult(
+  api: PluginAPI,
+  identity: Identity,
+  originBlock: OriginBlock,
+) {
+  return jsonResult({
+    status: "ok",
+    identity,
+    ...originBlock,
+    ...wiringAdvisories(api),
+  });
 }
 
 /** Not registered: a distinct, actionable outcome naming the recovery tool. No

--- a/src/tools/profile.ts
+++ b/src/tools/profile.ts
@@ -24,6 +24,7 @@
 import type { PluginAPI } from "openclaw/plugin-sdk";
 import { Type } from "typebox";
 
+import { wiringAdvisories } from "../lib/host-wiring.js";
 import {
   learnArtefact,
   materializeProfile,
@@ -86,7 +87,12 @@ function registerMaterialize(api: PluginAPI): void {
       });
       if (result.ok) {
         api.logger.info("sil_profile_materialized", {});
-        return jsonResult({ status: "ok", dir: result.dir, userSpecPath: result.userSpecPath });
+        return jsonResult({
+          status: "ok",
+          dir: result.dir,
+          userSpecPath: result.userSpecPath,
+          ...wiringAdvisories(api),
+        });
       }
       return mapFailure(api, "sil_profile_materialize", result);
     },
@@ -168,6 +174,7 @@ function registerLearn(api: PluginAPI): void {
           ...(result.prd !== undefined ? { prd: result.prd } : {}),
           path: result.path,
           ...(result.assetPath !== undefined ? { assetPath: result.assetPath } : {}),
+          ...wiringAdvisories(api),
         });
       }
       return mapFailure(api, "sil_learn", result);
@@ -228,6 +235,7 @@ function registerSearch(api: PluginAPI): void {
                 + " answered from the sil catalog, never from the open web.",
             }
           : {}),
+        ...wiringAdvisories(api),
       });
     },
   });
@@ -265,6 +273,7 @@ function registerGet(api: PluginAPI): void {
           fields: result.fields,
           body: result.body,
           path: result.path,
+          ...wiringAdvisories(api),
         });
       }
       return mapFailure(api, "sil_profile_get", result);
@@ -299,6 +308,7 @@ function registerRemove(api: PluginAPI): void {
           status: "removed",
           domainSlug: result.domainSlug,
           ...(result.prd !== undefined ? { prd: result.prd } : {}),
+          ...wiringAdvisories(api),
         });
       }
       return mapFailure(api, "sil_profile_remove", result);

--- a/src/types/openclaw.d.ts
+++ b/src/types/openclaw.d.ts
@@ -41,6 +41,27 @@ declare module "openclaw/plugin-sdk" {
      * plugin-specific overrides.
      */
     pluginConfig?: Record<string, unknown>;
+    /**
+     * The host runtime facade. Only `version` is declared — the running
+     * OpenClaw's own version (e.g. `"2026.6.9"`), which is the ONLY
+     * source for it: `config.gateway` does not exist, and
+     * `config.meta.lastTouchedVersion` is the version that last WROTE the
+     * config file, not the one now running. Probed empirically against
+     * `alpine/openclaw:2026.6.9` — the host builds this member at
+     * `api-builder:122`.
+     *
+     * Optional because a host that does not supply it must degrade to an
+     * INCONCLUSIVE compat check (no finding), never a fabricated verdict.
+     *
+     * The rest of the facade (`agent`, `llm`, `system`, `state`,
+     * `subagent`, `config.mutateConfigFile`, …) is deliberately NOT
+     * declared: this plugin detects and surfaces, it never mutates host
+     * state. Add back the exact member a tool needs when it needs it.
+     *
+     * NOTE: `api.version` (not declared) is the PLUGIN's own version, not
+     * the host's — an easy and silent mis-read.
+     */
+    runtime?: { version?: string };
   }
 
   export interface ToolDefinition {


### PR DESCRIPTION
## Card
`cards/self-upgrade-detect-host-wiring-advisory.md` (local-only — `cards/` is gitignored in this repo, so the card body rides the worktree, not the PR).

## Summary

Two **detect-and-surface** advisory families, on sil-doctor's existing six-field finding schema (**zero schema change**), both **100% local — no network call of any kind**:

- **`wiring.skill_misattached`** — an agent attaches sil by the plugin id `sil` instead of the published skill name `sil-shopping`. This is incident #1, and the reason the advisory rides tool results: a mis-wired skill isn't running its own flow, so it cannot carry its own warning. The tools are the only surviving messenger.
- **`wiring.tools_not_admitted`** — the half-trust state (plugin loads, tools filtered).
- **`version.gateway_compat`** — the running host is below our declared `package.json#openclaw.compat.minGatewayVersion`.

Nothing here writes host config, spawns a process, reloads the gateway, or ships an installer. Every finding is `status: advisory` / `appliedAction: null`. No new tool (`contracts.tools` unchanged), no new dependency, `networkEndpoints` untouched.

### What's in it
- **`src/lib/host-wiring.ts`** (new) — pure `detectWiringDrift`, `readSilWiringFacts` (facts from the shipped manifest, never hardcoded — a stale literal is incident #1's root), the `readHostVersion` seam, and the `wiringAdvisories` fold.
- **`src/lib/version-advisory.ts`** — adds `buildGatewayCompatFinding()` **only**, reusing the existing `compareSemver`.
- **Three carriers** — the `register()` warn, the per-tool success fold, the doctor's wiring + compat rows.

### Design notes worth a reviewer's eye
- **The allowlist merge core is deliberately NOT reused for this read.** `mergeSilAllowlist` mutates its argument in place, and `api.config` is the host's **live** tree. The two share surface knowledge, not an operation.
- **Effective, not intended, wiring.** Read from `api.config` only — never `~/.openclaw` — so `filesystemScope` is unchanged and a fixed-but-unreloaded config still reports truthfully. Hence every fix string names **edit + reload**.
- **Present-only-on-drift.** No drift ⇒ no `advisories` key ⇒ the happy-path payload is byte-identical to today.
- **Fail closed.** The compat parser accepts a single `>=X.Y.Z` and yields **no finding** on anything else — that fail-closed is the whole licence for not taking a `semver` dep. An unreadable host version is inconclusive, never a fabricated verdict.
- **The admit advisory names the shipped `sil-openclaw-allowlist` bin**, never an inline `openclaw config set tools.alsoAllow` — that key is overwrite-only on 2026.6.9 and would clobber every other admitted plugin.

## Step 0 — the host-version probe (closed Discovery's one open unknown)

Empirical, against a live `alpine/openclaw:2026.6.9` (a throwaway probe plugin dumping the real `api` object from inside `register()`):

| Question | Answer |
|---|---|
| Does the SDK expose the host version? | **Yes — `api.runtime.version`** (`"2026.6.9"`). The shim gets back that **one** member. |
| Does `api.config` carry it under `gateway`/`meta`? | **No.** `config.gateway` doesn't exist; `config.meta.lastTouchedVersion` is config-file **provenance**, not the running host — so there is **no fallback** (reading it would fabricate a verdict on a downgraded host). |
| Is `api.config.agents` populated? | **Yes** — and `api.config` is the **sparse config-file tree**, so absent keys mean silence, never drift. |

## Reviewer note — one flagged spec conflict (implemented as spec'd, ruling requested)

AC8/AC4 define `wiring.tools_not_admitted` as "absent from a **non-empty** `tools.alsoAllow`". The probe found the host **does not work that way**: `alsoAllow` is additive on top of a restrictive policy and a **no-op without one** (`mergeAlsoAllowPolicy` returns early unless `policy.allow` exists). Live A/B on the real host: `alsoAllow: ["klodi"]` omitting sil → **`Blocked by allowlist: 0`**, identical to the pure default.

**AC8-literal is shipped as written** — it is founder/PO-authored spec, and qa's RED pins it; diverging would have meant failing a binding test on my own reading. The evidence, the narrowing alternative, and the residual risk (recurring advisory noise for a user with an `alsoAllow` entry and no profile) are recorded on the card for a founder/review ruling.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] Full suite — **1270 passing**; the only failures are `repo-scaffold.integration.test.ts` (10), the known worktree artifact (gitignored `docs/` + `CLAUDE.md` not checked out), not a regression
- [x] Unit — `lib/host-wiring.test.ts` (41), additions to `lib/version-advisory.test.ts` (48)
- [x] Integration — `advisory.integration.test.ts` (54)
- [x] **Live-verified** against `alpine/openclaw:2026.6.9` with the real plugin installed: drifted config → exactly one `sil_plugin_wiring_drift`; healthy config → **zero**; an adjacent plugin's planted secret never surfaces

## Review round 1 — code-quality-guardian: **PASS**, with one merge gate

Re-verified independently, not taken on trust: typecheck clean, **1270 passing** (the 10 `repo-scaffold` reds are the known worktree artifact, excluded from the verdict).

**Every binding constraint holds**, checked against the diff: no host write / reload / spawn / installer; `mergeSilAllowlist` never imported (only its own definition); `api.config` never mutated; zero network and `networkEndpoints` untouched; no config fragment emitted; compat fails closed to inconclusive with the `meta.lastTouchedVersion` fallback pinned *shut* as a negative; exact-six-fields; `Finding` / `compareSemver` imported, not re-derived; `register()` synchronous and opens nothing (spied on `setTimeout` / `setInterval` / `setImmediate` / `fetch`); no new dependency; no speculative abstraction.

**The tests genuinely pin behaviour** — the ALIEN-facts technique (a detector with `"sil"` baked in passes the real cases and fails the alien ones, aimed straight at incident #1's root), an `is NOT VACUOUS` companion on every silence block (they otherwise pass vacuously against an unimplemented card), and exact-set assertions kept exact (`toEqual`, never loosened to `toContain`).

### ⚠️ MERGE GATE — founder ruling needed on AC8 before this lands

The guardian's position: **deferring to spec was the right call** (a dev must not narrow a PO criterion on its own reading of a minified bundle, and qa forbade a silent flip) — **but do not merge on it.** The residual risk is worse than "advisory noise":

- On the **tool-fold and doctor surfaces, `wiring.tools_not_admitted` can only ever be false** — the true state filters those very surfaces, so the advisory cannot reach you from the one place it would matter.
- Its `detected` string asserts *"every `sil_*` tool stays filtered"* on a `sil_search` payload **full of products**.

**Root cause — the false premise isn't this card's.** [`docs/decisions/openclaw-allowlist-surface.md`](docs/decisions/openclaw-allowlist-surface.md) stated it as settled fact, and AC8/AC4 inherited it faithfully. It will keep generating specs with the same premise until corrected — that correction landed in the `distilling` stage.

> **Correction to this PR's earlier review note (it was wrong, and the error is instructive).** The review first recorded the agent-creation-engine incident's cause as "a `tools.profile` override". **That was itself an unverified claim** — the creation engine sets **no** `tools.profile` at all (zero grep hits); it writes `plugins.entries.sil.enabled` + the per-agent skill attach. The **verified** account: *every* sil host config carries `tools: {"profile": "coding", ...}` — so the restrictive policy is the **global host config**, not anything the engine wrote, and that is why the `alsoAllow` fix genuinely worked there. The real error was **recording a fix that worked in one configuration as a universal host semantic**, with the precondition (`profile: "coding"`) holding on every config anyone looked at — so nothing contradicted it for months. Writing an unverified cause into the very doc being corrected for an unverified cause would have reproduced the failure one level up.

**This sharpens the ruling rather than settling it.** On the verified evidence, **AC8-literal is *correct* on every sil-owned host config** (a restrictive `profile: "coding"` is always in force); it false-positives only where **no** restrictive policy runs. Which configurations users actually run is **explicitly not established** — asserting it would repeat the very overgeneralization the correction exists to kill.

**The ruling:** should `wiring.tools_not_admitted` fire on

1. the **AC8-literal** `alsoAllow` proxy (as shipped), or
2. the **evidence-based** condition — a restrictive allow policy in force **AND** id ∉ `tools.allow` ∪ `tools.alsoAllow`?

Option 2 is strictly fewer findings and detects AC4's own state description. The guardian's findings B (`detected` overclaims), C (the likely-unreachable `enabled: false` arm) and D (correct the decision doc) all fold into this one decision.

*Related, already settled:* the `empty/absent alsoAllow` = **not drift** pin is **correct** and stays — absent a restrictive policy an empty `alsoAllow` admits everything. (qa's seed-asymmetry counter-evidence reads a *write*-path convenience as host semantics: the merge seeds `plugins.allow` because emptiness *there* fires the host's auto-load warning — a fact about `plugins.allow`, not `alsoAllow`.) If AC8 is narrowed, the question dissolves.

## Distillation

`docs/` and `CLAUDE.md` are **gitignored in this repo**, so distillation does **not** ride this PR — it lands in the local knowledge store on the founder's checkout. This PR is implementation + tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

