### PR TITLE
fix: creation entrypoint unreachable on ClawHub installs — sil_doctor is the path oracle

### DIFF
--- a/sil-shopping/SKILL.md
+++ b/sil-shopping/SKILL.md
@@ -40,7 +40,7 @@ shipped admission helper repairs it (additively admitting sil at `plugins.allow`
 `wiring.tools_not_admitted` finding names the exact command: a `node "<absolute
 path>"` invocation, never a bare bin name (that name is on PATH only for some
 installs). If no sil tool runs at all, this is an operator fix — run
-`scripts/allowlist-openclaw.mjs` from the sil plugin's install directory. Most flows
+`node scripts/allowlist-openclaw.mjs` from the sil plugin's install directory. Most flows
 need an identity: call a catalog tool first and let an unregistered outcome route
 to `sil_register`, or run `sil_register` up front when intent requires it.
 

--- a/sil-shopping/SKILL.md
+++ b/sil-shopping/SKILL.md
@@ -34,9 +34,13 @@ it knows, view or forget a domain, refine it.
 
 ## Session start
 
-Confirm the `sil_*` tools are exposed. If missing, the host is filtering them —
-run the shipped admission helper `sil-openclaw-allowlist` (it additively admits
-sil at `plugins.allow` + `tools.alsoAllow`), then reopen the session. Most flows
+Confirm the `sil_*` tools are exposed. If missing, the host is filtering them — the
+shipped admission helper repairs it (additively admitting sil at `plugins.allow` +
+`tools.alsoAllow`), then reopen the session. If `sil_doctor` still runs, its
+`wiring.tools_not_admitted` finding names the exact command: a `node "<absolute
+path>"` invocation, never a bare bin name (that name is on PATH only for some
+installs). If no sil tool runs at all, this is an operator fix — run
+`scripts/allowlist-openclaw.mjs` from the sil plugin's install directory. Most flows
 need an identity: call a catalog tool first and let an unregistered outcome route
 to `sil_register`, or run `sil_register` up front when intent requires it.
 

--- a/sil-shopping/references/agent_creation_engine.md
+++ b/sil-shopping/references/agent_creation_engine.md
@@ -95,18 +95,41 @@ first shop.
 
 ### The one command
 
-Run one shipped bin — **`sil-openclaw-create-shopper`** — **non-interactive**,
-**atomic**, **fail-closed**; it emits one JSON result. It is a standalone operator
-script, not the plugin process, so the plugin's "never write host config" guarantee
-holds. Feed the endorsed spec as one JSON object on **`stdin`** (or `--spec <path>`):
+Run one shipped script — **non-interactive**, **atomic**, **fail-closed**; it emits one
+JSON result. It is a standalone operator script, not the plugin process, so the plugin's
+"never write host config" guarantee holds.
+
+**Get its path from `sil_doctor` — never guess it, and never derive it from this file's
+own location.** Call `sil_doctor` and read the report's top-level **`creationEntrypoint`**:
+an absolute path, reported every run. It is the only sound source. This file is published
+to you as a *symlink*, so a `../scripts/…` hop off this directory does not resolve for
+`node` even though `cat` and `ls` say it does; and the bare bin name is on PATH only for
+some installs. Both dead-end at this exact step.
+
+Feed the endorsed spec as a **file**, not a heredoc — shell quoting must never touch
+model-authored prose (apostrophes, quotes, backticks, `$`, newlines are the norm in a
+persona). Write it **0600 under a private dir**, run, then **remove it**: the spec carries
+the user's `userSpec` (address, sizes, allergy/ethics rules), so it must not linger
+world-readable. The script never deletes an input it does not own — that is yours.
 
 ```
-sil-openclaw-create-shopper <<'JSON'
+# 1. sil_doctor → creationEntrypoint (absolute path to the creation script)
+# 2. write the endorsed spec, owner-only, in a private dir:
+umask 077 && mkdir -p ~/.sil-tmp && SPEC=~/.sil-tmp/shopper-spec.json
+#    …write the JSON object below to "$SPEC"…
+# 3. run it by absolute path, via node:
+node "<creationEntrypoint>" --spec "$SPEC"
+# 4. remove it, whatever the result:
+rm -f "$SPEC"
+```
+
+The spec file's contents — one JSON object:
+
+```json
 { "name": "My Shopper",
   "workspace": "~/.openclaw/workspace-my-shopper",
   "persona": "…endorsed persona…", "userSpec": "…seeded shared user spec…",
   "channel": "telegram" }
-JSON
 ```
 
 ### The spec (input)
@@ -153,7 +176,8 @@ to mint/refresh domains; if defaults grant none, the bin reports `created` with 
    design: it reads the shopper's skill files and can write regardless. The shell stays
    open (trusted single-operator posture); persistence is steered through the sil tools by
    the skill, not enforced by tool policy.
-8. **Admit sil (plugin trust)** — the shipped **`sil-openclaw-allowlist`** helper
+8. **Admit sil (plugin trust)** — the shipped **`scripts/allowlist-openclaw.mjs`** helper
+   (which the script runs itself, by absolute path via `node` — never the bare name)
    additively merges the three trust surfaces (`plugins.allow` + `tools.alsoAllow` +
    `plugins.entries.sil`) — the only way to un-filter `sil_*` without clobbering a
    co-installed plugin. A non-zero exit → **`persistence_failed`** (never a green

--- a/src/__tests__/advisory.integration.test.ts
+++ b/src/__tests__/advisory.integration.test.ts
@@ -660,7 +660,14 @@ describe("AC13 — register() is the only live surface when sil's tools are filt
 
     const emitted = JSON.stringify(vi.mocked(api.logger.warn).mock.calls[0]);
     expect(emitted).toContain(TOOLS_NOT_ADMITTED);
-    expect(emitted).toContain("sil-openclaw-allowlist");
+    // DELIBERATELY STRENGTHENED by card `creation-bin-unreachable-on-clawhub-installs`
+    // (founder ruling 2). This read `toContain("sil-openclaw-allowlist")`, which stays
+    // green on BOTH the old bare-bin advice and the new runnable form — so it would
+    // have silently certified advice this very operator cannot run. They are the last
+    // reader left (the drift that filters sil's tools filters sil_doctor too), so the
+    // fix they are handed must be executable as printed.
+    expect(emitted).toMatch(/node\s+.{0,4}\/[^"'`\s\\]*\/scripts\/allowlist-openclaw\.mjs/);
+    expect(emitted).not.toContain("sil-openclaw-allowlist");
     expect(emitted.toLowerCase()).not.toContain("config set");
   });
 
@@ -887,7 +894,19 @@ describe("AC7 — detect and surface only: nothing is applied, nothing outside t
     // is that the plugin can't be its own installer and doesn't try. A source scan
     // is the honest guard for "this code CANNOT do X", rather than "it happened not
     // to today".
-    for (const file of ["src/lib/host-wiring.ts", "src/lib/version-advisory.ts"]) {
+    //
+    // ⚠️ THIS LIST IS A WHITELIST, NOT A SWEEP. A module absent from it is invisible
+    // to this guard — SILENTLY, with a green suite. That is worse than a red: the
+    // module ships unguarded on the posture the manifest declares. ADD EVERY NEW
+    // audit-scope module here (add-only). `creation-entrypoint.ts` was added by card
+    // `creation-bin-unreachable-on-clawhub-installs` (AC D2): it resolves and probes
+    // the creation script's path, and the ONE thing it must never do is RUN it —
+    // naming a path is not spawning it, which is what keeps `noChildProcess` true.
+    for (const file of [
+      "src/lib/host-wiring.ts",
+      "src/lib/version-advisory.ts",
+      "src/lib/creation-entrypoint.ts",
+    ]) {
       const source = readFileSync(join(REPO_ROOT, file), "utf8");
       for (const forbidden of [
         "child_process",
@@ -900,6 +919,50 @@ describe("AC7 — detect and surface only: nothing is applied, nothing outside t
         expect(source, `${file} must not reference ${forbidden}`).not.toContain(forbidden);
       }
     }
+  });
+
+  it("AC D1 — NO plugin source module reaches for a child process (a SWEEP, not a whitelist)", () => {
+    // The manifest declares `security.noChildProcess: true`, and this card's Out of
+    // scope exists to protect it: creation stays a separate operator script, and
+    // `sil_doctor` REPORTS the path rather than spawning it. Naming a path is not
+    // running it.
+    //
+    // Deliberately a SWEEP over every source file tsc compiles into `dist/` — the
+    // whitelist above cannot carry this claim, because a module absent from that list
+    // is invisible to it SILENTLY. This one has no list to forget: a new module is
+    // covered the moment it exists. (It is scoped to `child_process` alone precisely
+    // because the other five literals are NOT plugin-wide invariants — `credentials.ts`
+    // legitimately resolves `homedir` for the data dir, which is why that list is
+    // hand-maintained and this one is not.)
+    //
+    // Source, not `dist/`: `dist/` is derived from exactly these files by `tsc`, which
+    // injects no imports, and a scan of a possibly-stale `dist/` would certify the
+    // wrong bytes. `.mjs` operator scripts under `scripts/` are OUT of scope by design
+    // — they are separate processes, not the plugin, which is the whole architecture
+    // the audit line protects.
+    const sources: string[] = [];
+    const walk = (dir: string): void => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const path = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          if (entry.name !== "__tests__") walk(path);
+        } else if (entry.name.endsWith(".ts")) {
+          sources.push(path);
+        }
+      }
+    };
+    walk(join(REPO_ROOT, "src"));
+
+    // Anti-vacuity: a walk that found nothing would pass this test forever.
+    expect(sources.length).toBeGreaterThan(10);
+    expect(sources.some((p) => p.endsWith("creation-entrypoint.ts"))).toBe(true);
+
+    const offenders = sources.filter((path) =>
+      /child_process|\bexecSync\b|\bspawnSync\b|\bexecFileSync\b|\bspawn\(/.test(
+        readFileSync(path, "utf8"),
+      ),
+    );
+    expect(offenders.map((p) => relative(REPO_ROOT, p))).toEqual([]);
   });
 });
 
@@ -959,10 +1022,22 @@ describe("AC11 — six flat fields, folded into the doctor's existing determinis
     for (const i of ourIndices) expect(i).toBeLessThan(firstInfo);
   });
 
-  it("sil_doctor's report SHAPE is unchanged — this card adds no report key", async () => {
+  it("sil_doctor's report carries EXACTLY the seven top-level keys — no extras", async () => {
+    // A SECOND exact-set mirror of the report shape (the first is
+    // `REPORT_KEYS` in `tools/doctor.test.ts`) — this one over the REAL `execute()`
+    // rather than the pure assembler, so it also proves the tool actually threads
+    // the field through. Both are `toEqual`, never a subset: an exact set is what
+    // catches drift in BOTH directions.
+    //
+    // Bumped ADD-ONLY by card `creation-bin-unreachable-on-clawhub-installs`, which
+    // adds `creationEntrypoint`. This test's previous title claimed "this card adds
+    // no report key" — true of #67, which wrote it, and false now. A key change
+    // bites HERE as well as in `tools/doctor.test.ts` and (silently, since a
+    // structural cast tolerates extras) `doctor.integration.test.ts`'s local mirror.
     const report = await runDoctor(allDriftConfig(), HOST_TOO_OLD);
     expect(Object.keys(report).sort()).toEqual([
       "counts",
+      "creationEntrypoint",
       "dataDir",
       "findings",
       "healthy",

--- a/src/__tests__/create-shopper.integration.test.ts
+++ b/src/__tests__/create-shopper.integration.test.ts
@@ -79,6 +79,7 @@ import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { deriveAgentId } from "../lib/derive-agent-id.js";
+import { resolveCreationEntrypoint } from "../lib/creation-entrypoint.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 /** Repo root of the checkout under test (…/src/__tests__ → root). */
@@ -449,7 +450,11 @@ function runBin(opts: RunOpts = {}): RunResult {
   };
 
   try {
-    const stdout = execFileSync("node", args, {
+    // `process.execPath`, never the bare "node": the ClawHub-channel tests below
+    // hand this an env whose PATH holds ONLY the `openclaw` shim, and a PATH lookup
+    // for the interpreter itself would fail there for a reason that has nothing to
+    // do with what those tests are proving.
+    const stdout = execFileSync(process.execPath, args, {
       input,
       env,
       encoding: "utf8",
@@ -1468,5 +1473,217 @@ describe("bind-the-channel — a VERIFIED route is reversed by whole-create tear
     expect(readConfig().bindings ?? []).toEqual([]);
     expect(existsSync(shopperDir())).toBe(false);
     expect(existsSync(spec.workspace)).toBe(false);
+  });
+});
+
+// ===========================================================================
+// Card: creation-bin-unreachable-on-clawhub-installs — AC A1/A5 and C1.
+//
+// THE CLAWHUB CHANNEL'S TESTABLE ESSENCE IS "the sil bins are not on PATH".
+// `openclaw plugins install` extracts the tarball and links nothing, so the bare
+// `sil-openclaw-create-shopper` the skill used to document simply did not exist and
+// creation died at its last step. We reproduce exactly that property — PATH holds
+// ONLY the `openclaw` shim — and drive the documented form
+// `node <absolute entrypoint> --spec <file>` through it.
+//
+// This is NOT a claim to have tested a real ClawHub install. This repo has no
+// host-load gate; true channel parity and agent path-following are closed by a
+// companion card in the sil-stage sibling, which boots alpine/openclaw and installs
+// the packed tarball via `openclaw plugins install --link`. What IS proved here is
+// the defining property, which is what the bug turned on.
+//
+// `openclaw` itself STAYS on PATH deliberately: create-shopper.mjs shells it
+// (`execFileSync("openclaw", …)`), and `openclaw` is always on PATH on every
+// channel — which is precisely why the pre-0.3.8 design worked everywhere. An
+// EMPTY PATH would fail for that unrelated reason and would prove nothing.
+// ===========================================================================
+
+/**
+ * The ClawHub channel: `openclaw` and `node` reachable, every sil bin absent.
+ *
+ * The interpreter's own directory is on PATH deliberately — the `openclaw` shim's
+ * `#!/usr/bin/env node` shebang needs it, and on a real host node is obviously
+ * present (OpenClaw runs on it). The ONE property being reproduced is that no sil
+ * bin was linked, which is exactly what `openclaw plugins install` does not do.
+ * The `command -v` test below proves that property really holds here rather than
+ * assuming it — if a global `npm i -g sil-openclaw` ever put the bin in node's bin
+ * dir on this machine, that test fails loudly instead of quietly making this whole
+ * block vacuous.
+ */
+const clawhubChannelEnv = (): Record<string, string> => ({
+  PATH: `${binDir}:${dirname(process.execPath)}`,
+});
+
+describe("AC A1/A5 — the documented entrypoint runs with the sil bins OFF PATH", () => {
+  it("the bare bin name really IS unreachable in this env (the channel is reproduced)", () => {
+    // ANTI-VACUITY, and the most important assertion in this block: if the sil bins
+    // were somehow still resolvable here, every test below would pass without ever
+    // reproducing the bug. Proven by asking a shell to resolve the exact command the
+    // skill used to document. 127 is "command not found".
+    let status = 0;
+    let stderr = "";
+    try {
+      execFileSync("/bin/sh", ["-c", "sil-openclaw-create-shopper --help"], {
+        env: clawhubChannelEnv(),
+        encoding: "utf8",
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+    } catch (err: unknown) {
+      const e = err as { status?: number; stderr?: Buffer | string };
+      status = e.status ?? 1;
+      stderr = (e.stderr ?? "").toString();
+    }
+    expect(status).toBe(127);
+    expect(stderr.toLowerCase()).toContain("not found");
+
+    // …while `openclaw` — the thing the bin legitimately shells — still resolves.
+    expect(() =>
+      execFileSync("/bin/sh", ["-c", "command -v openclaw"], {
+        env: clawhubChannelEnv(),
+        stdio: ["pipe", "pipe", "pipe"],
+      }),
+    ).not.toThrow();
+  });
+
+  it("AC A1 — `node <entrypoint> --spec <file>` CREATES the shopper on that channel", () => {
+    // The regression test for the whole card: this is the exact form the skill now
+    // documents, run under the exact channel property that broke it.
+    writeConfig(freshConfig());
+    const spec = validSpec();
+    const r = runBin({ spec, viaSpecFile: true, env: clawhubChannelEnv() });
+
+    expect(parseMarker(r.stdout)["status"]).toBe("created");
+    expect(r.status).toBe(0);
+    // Never a shell failure, and never the MODULE_NOT_FOUND the naive `../scripts/…`
+    // fix would have traded it for — the same silent-late failure at the same step.
+    const emitted = r.stdout + r.stderr;
+    expect(emitted).not.toContain("command not found");
+    expect(emitted).not.toContain("MODULE_NOT_FOUND");
+    expect(emitted).not.toContain("Cannot find module");
+  });
+
+  it("AC A5 — the entrypoint the PLUGIN resolves is the one that runs (loadable by node)", () => {
+    // Closes the loop the card is built on: the path `sil_doctor` reports as
+    // `creationEntrypoint` is spawned here for real. Reachability asserted by an
+    // actual `node` load — never `existsSync`, which is the proven trap: `cat
+    // <skilldir>/../scripts/x` exits 0 while `node` throws MODULE_NOT_FOUND on the
+    // IDENTICAL string, because node's path.resolve normalizes `..` lexically, before
+    // the filesystem. A real run also proves the static `../dist/lib/*.js` imports
+    // resolve — the bin is not standalone and must stay in-tree.
+    writeConfig(freshConfig());
+    const resolved = resolveCreationEntrypoint();
+    expect(resolved).toBe(SCRIPT);
+
+    const specPath = join(workdir, "resolved-spec.json");
+    const spec = validSpec();
+    writeFileSync(specPath, JSON.stringify(spec));
+
+    const stdout = execFileSync(process.execPath, [resolved, "--spec", specPath], {
+      env: {
+        ...clawhubChannelEnv(),
+        HOME: emptyHome,
+        OPENCLAW_CONFIG_PATH: configPath,
+        SIL_DATA_DIR: dataDir,
+        OPENCLAW_SHIM_LOG: logPath,
+      },
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    expect(parseMarker(stdout)["status"]).toBe("created");
+    expect(existsSync(userSpecPath())).toBe(true);
+  });
+
+  it("runs identically from a FOREIGN cwd — no PATH, no cwd, no linking (AC A2)", () => {
+    // Production cwd is the agent's workspace, not the plugin root. Static ESM
+    // specifiers resolve against the MODULE file, so an absolute invocation is sound
+    // from anywhere — the property that lets ONE documented command serve both
+    // channels with no conditional branch.
+    writeConfig(freshConfig());
+    const spec = validSpec();
+    const specPath = join(workdir, "cwd-spec.json");
+    writeFileSync(specPath, JSON.stringify(spec));
+
+    const stdout = execFileSync(process.execPath, [SCRIPT, "--spec", specPath], {
+      cwd: emptyHome,
+      env: {
+        ...clawhubChannelEnv(),
+        HOME: emptyHome,
+        OPENCLAW_CONFIG_PATH: configPath,
+        SIL_DATA_DIR: dataDir,
+        OPENCLAW_SHIM_LOG: logPath,
+      },
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    expect(parseMarker(stdout)["status"]).toBe("created");
+  });
+});
+
+// ===========================================================================
+// AC C1 — the spec travels as a FILE, so shell quoting is never in the path.
+// ===========================================================================
+
+describe("AC C1 — shell metacharacters round-trip verbatim via --spec", () => {
+  // Persona and userSpec are free-form, model-authored prose: apostrophes and quotes
+  // are the NORM, not the edge case. The heredoc form mangled them into unparseable
+  // stdin, which surfaced as `invalid_request` — so the flow did not merely fail, it
+  // failed while BLAMING THE USER for a spec that was fine.
+  const NASTY_PERSONA = [
+    `A buyer who says "it's fine" and won't budge.`,
+    "Runs `rm -rf /` jokes; $HOME is not a place; $(whoami) neither.",
+    "Backticks: `` and 'single' and \"double\" quotes.",
+    "Costs $5.00 — 100% sure. 50%的中文. Emoji 🛍️.",
+    "A trailing backslash \\ and a semicolon; then | a pipe && an and.",
+  ].join("\n");
+  const NASTY_USERSPEC = [
+    "Ships to O'Brien's Café, 12 King's Rd.",
+    'Allergic to "tree nuts"; NEVER buy $(cat /etc/passwd).',
+    "Budget: $200-$400. Size `M`. #hash & ampersand.",
+    "Newline-separated\nrules > with > angles < and back\\slashes.",
+  ].join("\n");
+
+  it("creates the shopper and lands the bytes VERBATIM in SOUL.md and user_spec.md", () => {
+    writeConfig(freshConfig());
+    const spec = validSpec({ persona: NASTY_PERSONA, userSpec: NASTY_USERSPEC });
+    const r = runBin({ spec, viaSpecFile: true, env: clawhubChannelEnv() });
+
+    // It succeeds — `invalid_request` here would be the taxonomy lying about whose
+    // fault it is.
+    expect(parseMarker(r.stdout)["status"]).toBe("created");
+
+    const soul = readFileSync(join(spec.workspace, "SOUL.md"), "utf8");
+    expect(soul).toContain(NASTY_PERSONA);
+
+    const userSpec = readFileSync(userSpecPath(), "utf8");
+    expect(userSpec).toContain(NASTY_USERSPEC);
+  });
+
+  it("NOTHING was shell-expanded or executed — the bytes are data, never code", () => {
+    // The failure this catches is not "it crashed" but "it silently ran": a spec that
+    // travels through a shell can have `$(…)` substituted or `$HOME` expanded, and the
+    // user's persona would be quietly rewritten — or worse.
+    writeConfig(freshConfig());
+    const spec = validSpec({ persona: NASTY_PERSONA, userSpec: NASTY_USERSPEC });
+    runBin({ spec, viaSpecFile: true, env: clawhubChannelEnv() });
+
+    const written =
+      readFileSync(join(spec.workspace, "SOUL.md"), "utf8")
+      + readFileSync(userSpecPath(), "utf8");
+    // The literals survive UNEXPANDED …
+    expect(written).toContain("$(whoami)");
+    expect(written).toContain("$HOME");
+    expect(written).toContain("$(cat /etc/passwd)");
+    // … and their expansions are nowhere to be seen.
+    expect(written).not.toContain("root:x:0:0");
+    expect(written).not.toContain(emptyHome);
+  });
+
+  it("a persona that is ONLY quotes still creates (the pathological case)", () => {
+    writeConfig(freshConfig());
+    const spec = validSpec({ persona: `'"'"'`, userSpec: `"'\`$\\` });
+    const r = runBin({ spec, viaSpecFile: true, env: clawhubChannelEnv() });
+    expect(parseMarker(r.stdout)["status"]).toBe("created");
+    expect(readFileSync(join(spec.workspace, "SOUL.md"), "utf8")).toContain(`'"'"'`);
   });
 });

--- a/src/__tests__/doctor.integration.test.ts
+++ b/src/__tests__/doctor.integration.test.ts
@@ -69,6 +69,7 @@ import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { registerDoctorTools } from "../tools/doctor.js";
+import * as creationEntrypoint from "../lib/creation-entrypoint.js";
 import { getDataDir, getTokensPath } from "../lib/credentials.js";
 import {
   createMockPluginApi,
@@ -289,6 +290,12 @@ interface DoctorReport {
   healthy: boolean;
   dataDir: string;
   installedVersion: string;
+  /** Added by card `creation-bin-unreachable-on-clawhub-installs`. This local
+   * mirror is a SILENT carrier — a structural cast tolerates extra fields, so an
+   * omission here never fails; it is bumped for accuracy, and the exact-set drift
+   * guards live in `tools/doctor.test.ts` (`REPORT_KEYS`, the assembler) and
+   * `advisory.integration.test.ts` (the real `execute()`). */
+  creationEntrypoint: string;
   counts: { info: number; warn: number; critical: number };
   findings: Finding[];
 }
@@ -1603,5 +1610,159 @@ describe("the ClawHub probe — one declared host, no credentials, nothing else"
     await runDoctor();
     const url = decodeURIComponent(requests[0]!.url);
     expect(url).toContain("@4gpts/sil");
+  });
+});
+
+// ===========================================================================
+// Card: creation-bin-unreachable-on-clawhub-installs — AC B1/B2/B3/B5/B6/B8.
+//
+// The creation entrypoint through the REAL execute(): the real resolver, the real
+// filesystem probe, the real finding builder, the real roll-up.
+//
+// THE ONE INJECTED SEAM is `resolveCreationEntrypoint` — and it injects a REAL
+// TEMP PATH, never a fake verdict. Everything downstream stays real: the probe
+// really stats that path, the builder really reads the real verdict, and `healthy`
+// really rolls it up. What is faked is WHERE the plugin looks, which is precisely
+// what an incomplete install changes. The alternative — moving the repo's own
+// scripts/create-shopper.mjs — would vandalise a worktree the pair is live-editing.
+// ===========================================================================
+
+const CREATION_ID = "creation.entrypoint_present";
+const creationFinding = (r: DoctorReport): Finding | undefined =>
+  r.findings.find((f) => f.id === CREATION_ID);
+
+/** Point the doctor at `path` as its creation entrypoint. Redirects the LOCATION;
+ * the verdict is still whatever the filesystem really says about it. */
+const lookForEntrypointAt = (path: string): void => {
+  vi.spyOn(creationEntrypoint, "resolveCreationEntrypoint").mockReturnValue(path);
+};
+
+describe("AC B1/B8 — a reachable entrypoint on a real tree", () => {
+  it("reports the REAL absolute entrypoint as a top-level report field", async () => {
+    // The datum the whole fix hangs on: it replaces the plugin root the agent cannot
+    // derive. Not prose inside a finding — a field it can hand straight to `node`.
+    const report = await runDoctor();
+    expect(report.creationEntrypoint).toBe(creationEntrypoint.resolveCreationEntrypoint());
+    expect(report.creationEntrypoint.startsWith("/")).toBe(true);
+    expect(existsSync(report.creationEntrypoint)).toBe(true);
+  });
+
+  it("emits the finding EVERY run at info / ok, and healthy stays true", async () => {
+    // A singleton subsystem check, not a problem-only one: `fixed → re-run → ok`
+    // needs the id to still be there after the fix.
+    const report = await runDoctor();
+    const finding = creationFinding(report);
+    expect(finding).toBeDefined();
+    expect(finding!.severity).toBe("info");
+    expect(finding!.status).toBe("ok");
+    expect(finding!.suggestedAction).toBeNull();
+    expect(report.healthy).toBe(true);
+  });
+
+  it("the reported field and the probed path are the SAME path (AC B7 by construction)", async () => {
+    // A doctor that certifies a path it never probed is the same class of lie this
+    // card kills. One resolver, called once: the finding's `detected` must name the
+    // very path the report hands the agent.
+    const report = await runDoctor();
+    expect(creationFinding(report)!.detected).toContain(report.creationEntrypoint);
+  });
+});
+
+describe("AC B2/B3 — an unreachable entrypoint (the incomplete tree)", () => {
+  it("reports warn + healthy:false, naming THAT path and the concrete verdict", async () => {
+    const absent = join(parentDir, "incomplete", "scripts", "create-shopper.mjs");
+    lookForEntrypointAt(absent);
+
+    const report = await runDoctor();
+    const finding = creationFinding(report)!;
+    expect(finding.severity).toBe("warn");
+    expect(finding.status).toBe("advisory");
+    expect(finding.detected).toContain(absent);
+    expect(finding.detected.toLowerCase()).toContain("missing");
+    // `healthy` is the load-bearing half — doctor.ts derives it from the warn count.
+    expect(report.healthy).toBe(false);
+    // The datum is reported even when it cannot be reached: a path we cannot reach
+    // is still the path we mean, and hiding it would hide the diagnosis.
+    expect(report.creationEntrypoint).toBe(absent);
+  });
+
+  it("distinguishes `unresolvable` from `missing` — a non-file at the path", async () => {
+    const occupied = join(parentDir, "occupied-entrypoint");
+    mkdirSync(occupied, { recursive: true });
+    lookForEntrypointAt(occupied);
+
+    const report = await runDoctor();
+    const finding = creationFinding(report)!;
+    expect(finding.severity).toBe("warn");
+    expect(finding.detected).toContain(occupied);
+    expect(finding.detected.toLowerCase()).not.toContain("missing");
+  });
+
+  it("the suggested recovery is runnable on the channel being diagnosed (AC B4)", async () => {
+    // The whole point: advice the operator cannot run teaches them the doctor cannot
+    // be trusted. No sil bin is on PATH on a plugin-install channel; `openclaw` is.
+    lookForEntrypointAt(join(parentDir, "incomplete", "scripts", "create-shopper.mjs"));
+    const fix = creationFinding(await runDoctor())!.suggestedAction!;
+    expect(fix).toContain("openclaw plugins install");
+    expect(fix).not.toContain("sil-openclaw-create-shopper");
+    expect(fix).not.toMatch(/\bPATH\b/);
+  });
+
+  it("still returns the standard envelope and never throws", async () => {
+    lookForEntrypointAt(join(parentDir, "incomplete", "scripts", "create-shopper.mjs"));
+    await expect(runDoctor()).resolves.toBeDefined();
+  });
+});
+
+describe("AC B5 — fixed → re-run → ok, on one stable id", () => {
+  it("flips to ok and healthy:true once the operator repairs the tree", async () => {
+    const scripts = join(parentDir, "repairable", "scripts");
+    const entrypoint = join(scripts, "create-shopper.mjs");
+    lookForEntrypointAt(entrypoint);
+
+    const before = await runDoctor();
+    expect(creationFinding(before)!.severity).toBe("warn");
+    expect(before.healthy).toBe(false);
+
+    // The operator reinstalls: the file really appears on the real filesystem.
+    mkdirSync(scripts, { recursive: true });
+    writeFileSync(entrypoint, "export {};\n");
+
+    const after = await runDoctor();
+    // SAME id — a problem-only finding would simply vanish here, and the consumer
+    // could not tell a repaired install from one that was never checked.
+    expect(creationFinding(after)).toBeDefined();
+    expect(creationFinding(after)!.id).toBe(creationFinding(before)!.id);
+    expect(creationFinding(after)!.severity).toBe("info");
+    expect(creationFinding(after)!.status).toBe("ok");
+    expect(creationFinding(after)!.suggestedAction).toBeNull();
+    expect(after.healthy).toBe(true);
+  });
+});
+
+describe("AC B6 — determinate with the network down", () => {
+  it("still reports the entrypoint and a verdict when the probe is unreachable", async () => {
+    // The ClawHub GET is the doctor's ONE outbound call and this is not it: the
+    // entrypoint check is a local stat. A doctor is needed MOST when things are
+    // broken, and "broken" often includes the network.
+    installFetch(async () => {
+      throw new Error("ENETDOWN — the channel is unreachable");
+    });
+
+    const report = await runDoctor();
+    const finding = creationFinding(report);
+    expect(finding).toBeDefined();
+    expect(finding!.status).toBe("ok");
+    expect(report.creationEntrypoint).toBe(creationEntrypoint.resolveCreationEntrypoint());
+
+    // Anti-vacuity: prove the network really WAS down for this run — the version
+    // advisory fails soft to silence, so its absence is the receipt.
+    expect(versionFindings(report)).toEqual([]);
+  });
+
+  it("makes NO extra outbound request for the entrypoint check", async () => {
+    // A reachability check that phoned home would be a second declared endpoint.
+    await runDoctor();
+    expect(requests).toHaveLength(1);
   });
 });

--- a/src/__tests__/lib/creation-entrypoint.test.ts
+++ b/src/__tests__/lib/creation-entrypoint.test.ts
@@ -1,0 +1,420 @@
+/**
+ * UNIT — the creation-entrypoint resolver, probe, and pure finding builder
+ * (tier: unit — one temp-dir probe seam aside, no network, no spawn, <100ms).
+ *
+ * Card: creation-bin-unreachable-on-clawhub-installs — **AC A7, B3, B4**, and the
+ * pure half of B1/B2.
+ *
+ * **The bug this module exists to kill.** `openclaw plugins install` extracts the
+ * tarball and links no bins, so the documented bare `sil-openclaw-create-shopper`
+ * existed only on the npm-global channel and the creation flow died at its last
+ * step. The plugin process is the only party that knows its own root, so it
+ * resolves the path and reports it.
+ *
+ * **The two traps these tests exist to catch, both of which pass a naive suite:**
+ *
+ * 1. **A cwd-derived root.** `process.cwd()` IS the repo root under vitest, so a
+ *    cwd variant is green in CI and broken in production, where cwd is the
+ *    agent's workspace. The A7 test below therefore re-imports the module with
+ *    the process ACTUALLY chdir'd elsewhere and demands the same absolute path.
+ *    That assertion is total: it fails for a cwd root, a PATH lookup, a homedir
+ *    root, and a hardcoded install path alike, because it pins the ONE right
+ *    answer rather than forbidding a list of wrong mechanisms.
+ *      Deliberately NOT a source scan for `process.cwd`: this module's docstring
+ *    correctly DISAVOWS cwd by name, so a substring ban would fail the very prose
+ *    that documents the fix.
+ * 2. **A finding that reports a path it never probed.** The builder is pure — a
+ *    function of (path, verdict) — so the tests below hand it a verdict that
+ *    CONTRADICTS the filesystem and assert the verdict wins. A builder that
+ *    re-probed would "correct" them and the doctor's report could then disagree
+ *    with the doctor's own probe.
+ *
+ * Contract pinned for the implementation (`src/lib/creation-entrypoint.ts`) — as
+ * published by expert-developer on the card:
+ *   export const CREATION_ENTRYPOINT_RELATIVE = "scripts/create-shopper.mjs";
+ *   export const ALLOWLIST_SCRIPT_RELATIVE   = "scripts/allowlist-openclaw.mjs";
+ *   export type CreationEntrypointVerdict = "present" | "missing" | "unresolvable";
+ *   export function resolveCreationEntrypoint(): string;   // absolute
+ *   export function resolveAllowlistScript(): string;      // absolute
+ *   export function probeCreationEntrypoint(entrypoint?: string): CreationEntrypointVerdict;
+ *   export function buildCreationEntrypointFinding(
+ *     entrypoint: string, verdict: CreationEntrypointVerdict,
+ *   ): Finding;  // ALWAYS a Finding, never null — a singleton that reports `ok` too
+ *
+ * THESE ASSERTIONS ARE THE SPEC. Do NOT weaken them to match the module.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, isAbsolute, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  ALLOWLIST_SCRIPT_RELATIVE,
+  CREATION_ENTRYPOINT_RELATIVE,
+  buildCreationEntrypointFinding,
+  probeCreationEntrypoint,
+  resolveAllowlistScript,
+  resolveCreationEntrypoint,
+  type CreationEntrypointVerdict,
+} from "../../lib/creation-entrypoint.js";
+
+/** …/src/__tests__/lib → three levels up is the repo (plugin) root. */
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+
+const FAILING_VERDICTS: CreationEntrypointVerdict[] = ["missing", "unresolvable"];
+
+/** Running as root bypasses permission bits, so an EACCES fault cannot fire. */
+const AS_ROOT = typeof process.getuid === "function" && process.getuid() === 0;
+
+const tempDirs: string[] = [];
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "sil-entrypoint-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const dir of tempDirs.splice(0)) {
+    try {
+      chmodSync(dir, 0o700);
+    } catch {
+      /* best effort — the EACCES test drops perms */
+    }
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ===========================================================================
+// AC A7 — the root comes from import.meta.url, and from nothing else.
+// ===========================================================================
+
+describe("resolveCreationEntrypoint — the plugin root is derived from import.meta.url", () => {
+  it("resolves to the plugin root's scripts/create-shopper.mjs, absolutely", () => {
+    const resolved = resolveCreationEntrypoint();
+    expect(isAbsolute(resolved)).toBe(true);
+    expect(resolved).toBe(join(REPO_ROOT, CREATION_ENTRYPOINT_RELATIVE));
+  });
+
+  it("points at a file that really exists in this tree (the path is not a fiction)", () => {
+    // Anti-vacuity for the whole file: every assertion below is about a path, so
+    // one of them must confirm the path is real. If this fails, the `--spec` form
+    // the skill documents is unrunnable and A1 is a lie.
+    expect(existsSync(resolveCreationEntrypoint())).toBe(true);
+  });
+
+  it("AC A7 — resolves IDENTICALLY from a foreign cwd (never process.cwd())", async () => {
+    // THE production-fidelity test. Under vitest, cwd IS the repo root, so a
+    // `resolve("scripts/create-shopper.mjs")` implementation passes every other
+    // test in this file and then fails in production, where cwd is the agent's
+    // workspace. Here the process is REALLY chdir'd (vitest runs a forks pool, so
+    // chdir is available) and the module is re-imported so a root computed at
+    // module scope is recomputed under the foreign cwd.
+    //
+    // Pinning the exact expected path — rather than forbidding `process.cwd` —
+    // makes this total: a cwd root, a PATH lookup, a homedir root and a hardcoded
+    // /usr/lib path all fail it.
+    const elsewhere = tempDir();
+    const original = process.cwd();
+    try {
+      process.chdir(elsewhere);
+      vi.resetModules();
+      const fresh = await import("../../lib/creation-entrypoint.js");
+      expect(fresh.resolveCreationEntrypoint()).toBe(
+        join(REPO_ROOT, CREATION_ENTRYPOINT_RELATIVE),
+      );
+      expect(fresh.resolveCreationEntrypoint()).not.toContain(elsewhere);
+      // And the sibling resolver rides the same root — founder ruling 2's fix is
+      // only as sound as this.
+      expect(fresh.resolveAllowlistScript()).toBe(
+        join(REPO_ROOT, ALLOWLIST_SCRIPT_RELATIVE),
+      );
+    } finally {
+      process.chdir(original);
+    }
+  });
+
+  it("proves the chdir seam actually bites — a cwd-derived path WOULD differ there", () => {
+    // Guard-of-the-guard: if the foreign cwd happened to be the repo root, the
+    // test above would be vacuous — it would pass against a cwd implementation.
+    const elsewhere = tempDir();
+    const original = process.cwd();
+    try {
+      process.chdir(elsewhere);
+      // What a cwd-derived resolver would have produced there, vs the truth.
+      expect(join(process.cwd(), CREATION_ENTRYPOINT_RELATIVE)).not.toBe(
+        join(REPO_ROOT, CREATION_ENTRYPOINT_RELATIVE),
+      );
+    } finally {
+      process.chdir(original);
+    }
+  });
+
+  it("makes NO network call — naming a local path is a local act", () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    resolveCreationEntrypoint();
+    resolveAllowlistScript();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("the ONE literal — the constant every surface is asserted against (AC B7)", () => {
+  it("CREATION_ENTRYPOINT_RELATIVE is the shipped script's repo-relative path", () => {
+    // This exact string is set-equal against the bundled prose and
+    // package.json#bin in skill-bundle-contract.integration.test.ts. If it drifts,
+    // that guard is what catches it — but only if the literal here is real.
+    expect(CREATION_ENTRYPOINT_RELATIVE).toBe("scripts/create-shopper.mjs");
+    expect(ALLOWLIST_SCRIPT_RELATIVE).toBe("scripts/allowlist-openclaw.mjs");
+  });
+
+  it("the resolvers are that constant joined to the root — not a second literal", () => {
+    // The drift the card exists to make impossible: a doctor that REPORTS one path
+    // and PROBES another. One constant, one root, so they cannot disagree.
+    expect(resolveCreationEntrypoint().endsWith(CREATION_ENTRYPOINT_RELATIVE)).toBe(true);
+    expect(resolveAllowlistScript().endsWith(ALLOWLIST_SCRIPT_RELATIVE)).toBe(true);
+  });
+
+  it("both scripts resolve as siblings under one plugin root", () => {
+    expect(dirname(resolveCreationEntrypoint())).toBe(dirname(resolveAllowlistScript()));
+  });
+});
+
+// ===========================================================================
+// The probe — a real filesystem read, determinate and total.
+// ===========================================================================
+
+describe("probeCreationEntrypoint — a local read, never a spawn or a probe", () => {
+  it("reads `present` for a real file", () => {
+    const path = join(tempDir(), "create-shopper.mjs");
+    writeFileSync(path, "export {};\n");
+    expect(probeCreationEntrypoint(path)).toBe("present");
+  });
+
+  it("reads `missing` for a path that is not there (the incomplete tarball)", () => {
+    expect(probeCreationEntrypoint(join(tempDir(), "nope.mjs"))).toBe("missing");
+  });
+
+  it("reads `unresolvable` — NOT `missing` — for a path that exists but is no file", () => {
+    // The distinction is the operator's next move: an absent file means the tree
+    // shipped incomplete; a directory at that path means something else is wrong.
+    const path = join(tempDir(), "create-shopper.mjs");
+    mkdirSync(path);
+    expect(probeCreationEntrypoint(path)).toBe("unresolvable");
+  });
+
+  it.skipIf(AS_ROOT)(
+    "reads `unresolvable` — NOT `missing` — when the parent cannot be traversed",
+    () => {
+      // EACCES is not ENOENT. Reporting "missing" here would send the operator to
+      // reinstall a tree whose file is present and merely unreadable.
+      const dir = tempDir();
+      const nested = join(dir, "scripts");
+      mkdirSync(nested);
+      const path = join(nested, "create-shopper.mjs");
+      writeFileSync(path, "export {};\n");
+      chmodSync(nested, 0o000);
+      try {
+        expect(probeCreationEntrypoint(path)).toBe("unresolvable");
+      } finally {
+        chmodSync(nested, 0o700);
+      }
+    },
+  );
+
+  it("defaults to the resolved entrypoint, and reads `present` in this real tree", () => {
+    expect(probeCreationEntrypoint()).toBe("present");
+  });
+
+  it("NEVER throws — a probe that throws takes the whole diagnosis down", () => {
+    // The doctor is needed most when the install is broken; an exception out of
+    // execute() would replace the diagnosis with a crash.
+    const dir = tempDir();
+    for (const path of [
+      "",
+      "\0invalid",
+      join(dir, "nope.mjs"),
+      join(dir, "a", "deeply", "absent", "path.mjs"),
+      dir,
+    ]) {
+      expect(() => probeCreationEntrypoint(path)).not.toThrow();
+    }
+  });
+
+  it("makes NO network call — it stays determinate with the network down (AC B6)", () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    probeCreationEntrypoint();
+    probeCreationEntrypoint(join(tempDir(), "nope.mjs"));
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("is synchronous — no promise to await, so no I/O can hide inside it", () => {
+    expect(probeCreationEntrypoint()).not.toBeInstanceOf(Promise);
+  });
+
+  it("the `missing → present` lifecycle is real (AC B5's filesystem half)", () => {
+    // `fixed → re-run → ok` needs the probe to actually change its answer when the
+    // operator repairs the tree — not to cache the first verdict.
+    const path = join(tempDir(), "create-shopper.mjs");
+    expect(probeCreationEntrypoint(path)).toBe("missing");
+    writeFileSync(path, "export {};\n");
+    expect(probeCreationEntrypoint(path)).toBe("present");
+  });
+});
+
+// ===========================================================================
+// AC B1/B2/B3/B4 — the pure finding builder.
+// ===========================================================================
+
+describe("buildCreationEntrypointFinding — a singleton that reports EVERY run", () => {
+  it("AC B1 — `present` is info / ok, with nothing to suggest", () => {
+    const finding = buildCreationEntrypointFinding("/plugin/scripts/create-shopper.mjs", "present");
+    expect(finding.id).toBe("creation.entrypoint_present");
+    expect(finding.severity).toBe("info");
+    expect(finding.status).toBe("ok");
+    expect(finding.suggestedAction).toBeNull();
+    expect(finding.appliedAction).toBeNull();
+  });
+
+  it.each(FAILING_VERDICTS)("AC B2 — `%s` is a warn (which is what makes healthy false)", (verdict) => {
+    const finding = buildCreationEntrypointFinding("/plugin/scripts/create-shopper.mjs", verdict);
+    expect(finding.severity).toBe("warn");
+    expect(finding.status).toBe("advisory");
+    expect(finding.appliedAction).toBeNull();
+  });
+
+  it("carries ONE stable id across every verdict — the lifecycle subject (AC B5)", () => {
+    // A problem-only finding could not report `fixed → re-run → ok`: the id would
+    // simply vanish on the run after the fix, and the consumer could not tell a
+    // repaired install from an unchecked one.
+    const ids = new Set(
+      (["present", ...FAILING_VERDICTS] as CreationEntrypointVerdict[]).map(
+        (v) => buildCreationEntrypointFinding("/plugin/scripts/create-shopper.mjs", v).id,
+      ),
+    );
+    expect([...ids]).toEqual(["creation.entrypoint_present"]);
+  });
+
+  it("names the subject in its id, like fs.data_dir_writable / identity.tokens_present", () => {
+    expect(buildCreationEntrypointFinding("/x/y.mjs", "present").id).toMatch(
+      /^creation\.[a-z_]+$/,
+    );
+  });
+
+  it("is EXACTLY the six flat finding fields — no extras, no undefined", () => {
+    // The finding schema is pinned to six flat fields with no extras
+    // (advisory.integration AC11); a path riding an extra key would break it — and
+    // is exactly why `creationEntrypoint` lives on the REPORT instead.
+    for (const verdict of ["present", ...FAILING_VERDICTS] as CreationEntrypointVerdict[]) {
+      const finding = buildCreationEntrypointFinding("/x/y.mjs", verdict);
+      expect(Object.keys(finding).sort()).toEqual([
+        "appliedAction",
+        "detected",
+        "id",
+        "severity",
+        "status",
+        "suggestedAction",
+      ]);
+      expect(JSON.parse(JSON.stringify(finding))).toEqual(finding);
+    }
+  });
+});
+
+describe("buildCreationEntrypointFinding — `detected` names the path AND the verdict (AC B3)", () => {
+  const ENTRYPOINT = "/opt/plugins/sil/scripts/create-shopper.mjs";
+
+  it.each(["present", ...FAILING_VERDICTS] as CreationEntrypointVerdict[])(
+    "names the absolute path it is reporting on, verbatim (%s)",
+    (verdict) => {
+      // The operator's next move depends entirely on WHICH path is absent.
+      expect(buildCreationEntrypointFinding(ENTRYPOINT, verdict).detected).toContain(ENTRYPOINT);
+    },
+  );
+
+  it("distinguishes missing from unresolvable — never a generic 'creation is broken'", () => {
+    const missing = buildCreationEntrypointFinding(ENTRYPOINT, "missing").detected;
+    const unresolvable = buildCreationEntrypointFinding(ENTRYPOINT, "unresolvable").detected;
+    expect(missing).not.toBe(unresolvable);
+    expect(missing.toLowerCase()).toContain("missing");
+  });
+
+  it("says something CONCRETE — not merely the path echoed back", () => {
+    const detected = buildCreationEntrypointFinding(ENTRYPOINT, "missing").detected;
+    expect(detected.replace(ENTRYPOINT, "").trim().length).toBeGreaterThan(20);
+  });
+});
+
+describe("buildCreationEntrypointFinding — the recovery is runnable on the channel it diagnoses (AC B4)", () => {
+  // THE point of founder ruling 2 and of this whole card: advice an operator
+  // cannot run teaches them the doctor cannot be trusted. On a plugin-install
+  // channel no sil bin is on PATH — but `openclaw` itself always is, which is the
+  // card's whole premise.
+  const ENTRYPOINT = "/opt/plugins/sil/scripts/create-shopper.mjs";
+
+  it.each(FAILING_VERDICTS)("suggests a recovery at all, for `%s`", (verdict) => {
+    const fix = buildCreationEntrypointFinding(ENTRYPOINT, verdict).suggestedAction;
+    expect(fix).not.toBeNull();
+    expect(fix!.length).toBeGreaterThan(0);
+  });
+
+  it.each(FAILING_VERDICTS)("NEVER names a bare sil bin — the very defect this card kills (`%s`)", (verdict) => {
+    const fix = buildCreationEntrypointFinding(ENTRYPOINT, verdict).suggestedAction!;
+    expect(fix).not.toContain("sil-openclaw-create-shopper");
+    expect(fix).not.toContain("sil-openclaw-allowlist");
+  });
+
+  it.each(FAILING_VERDICTS)("NEVER prescribes a PATH edit or a global npm install (`%s`)", (verdict) => {
+    // "Add it to your PATH" / "npm i -g" would make the ClawHub operator's install
+    // work by leaving the supported channel — a workaround dressed as a diagnosis.
+    const fix = buildCreationEntrypointFinding(ENTRYPOINT, verdict).suggestedAction!;
+    expect(fix).not.toMatch(/\bPATH\b/);
+    expect(fix).not.toMatch(/npm\s+(i|install|link)\b/);
+  });
+
+  it.each(FAILING_VERDICTS)("names OpenClaw's own plugin install path — the recovery for an incomplete tree (`%s`)", (verdict) => {
+    const fix = buildCreationEntrypointFinding(ENTRYPOINT, verdict).suggestedAction!;
+    expect(fix).toContain("openclaw plugins install");
+  });
+
+  it("suggests NOTHING when the entrypoint is present (no busywork on a healthy install)", () => {
+    expect(buildCreationEntrypointFinding(ENTRYPOINT, "present").suggestedAction).toBeNull();
+  });
+});
+
+describe("buildCreationEntrypointFinding — PURE: the verdict it is handed is the verdict it reports", () => {
+  // A builder that re-probed could contradict the caller's own probe, which is the
+  // "reports a path it never probed" lie in mirror image: the doctor resolves ONCE
+  // and probes ONCE, then reports both. These two tests fail loudly for any
+  // implementation that reaches for the filesystem behind the caller's back.
+
+  it("reports `warn` for a REAL, present file when handed `missing`", () => {
+    const real = resolveCreationEntrypoint();
+    expect(existsSync(real)).toBe(true);
+    const finding = buildCreationEntrypointFinding(real, "missing");
+    expect(finding.severity).toBe("warn");
+    expect(finding.status).toBe("advisory");
+  });
+
+  it("reports `ok` for an absent path when handed `present`", () => {
+    const absent = join(tempDir(), "definitely-not-here.mjs");
+    expect(existsSync(absent)).toBe(false);
+    const finding = buildCreationEntrypointFinding(absent, "present");
+    expect(finding.severity).toBe("info");
+    expect(finding.status).toBe("ok");
+  });
+
+  it("makes NO network call and returns synchronously", () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const finding = buildCreationEntrypointFinding("/x/y.mjs", "missing");
+    expect(finding).not.toBeInstanceOf(Promise);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/lib/host-wiring.test.ts
+++ b/src/__tests__/lib/host-wiring.test.ts
@@ -69,6 +69,7 @@ import {
   readHostVersion,
   type SilWiringFacts,
 } from "../../lib/host-wiring.js";
+import { resolveAllowlistScript } from "../../lib/creation-entrypoint.js";
 import { createMockPluginApi } from "../helpers/mock-plugin-api.js";
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
@@ -266,12 +267,33 @@ describe("detectWiringDrift — tools not admitted: the half-trust state (AC8/AC
     ]);
   });
 
-  it("AC4 — `suggestedAction` names the shipped `sil-openclaw-allowlist` bin", () => {
-    // The bin is additive + idempotent across all three trust surfaces. It is the
-    // ONLY fix we may name.
+  it("AC4 — `suggestedAction` names the allowlist script by ABSOLUTE PATH, via node", () => {
+    // The additive, idempotent trust merge is still the ONLY fix we may name — but
+    // it must be named in a form the reader can actually RUN.
+    //
+    // DELIBERATELY STRENGTHENED by card `creation-bin-unreachable-on-clawhub-installs`
+    // (founder ruling 2). This assertion previously read
+    // `toContain("sil-openclaw-allowlist")`, which is INSENSITIVE to the very defect
+    // that card fixes: it passes on the old, unrunnable bare-bin advice, so it would
+    // have silently certified stale advice forever. `openclaw plugins install` links
+    // no bins, so that name reaches PATH only through a global npm-style install —
+    // an operator who is already broken, follows doctor's advice, and gets "command
+    // not found" learns that sil_doctor cannot be trusted.
     const finding = only({ ...healthy(), tools: { alsoAllow: ["klodi"] } }, TOOLS_NOT_ADMITTED);
     expect(finding.suggestedAction).not.toBeNull();
-    expect(finding.suggestedAction!).toContain("sil-openclaw-allowlist");
+    const fix = finding.suggestedAction!;
+    // The runnable form: `node "<absolute>/scripts/allowlist-openclaw.mjs"`.
+    expect(fix).toMatch(/node\s+["'`]*\/[^"'`\s]*\/scripts\/allowlist-openclaw\.mjs/);
+    expect(fix).toContain(resolveAllowlistScript());
+  });
+
+  it("AC4 — `suggestedAction` NEVER names the bare `sil-openclaw-allowlist` bin", () => {
+    // The bin entry survives in package.json#bin for npm-global operators, but it is
+    // no longer the advice: on the plugin-install channel it does not exist. Not even
+    // as a parenthetical — a model or a hurried operator lifts the shortest thing
+    // that looks like a command.
+    const finding = only({ ...healthy(), tools: { alsoAllow: ["klodi"] } }, TOOLS_NOT_ADMITTED);
+    expect(finding.suggestedAction!).not.toContain("sil-openclaw-allowlist");
   });
 
   it("AC4 — `suggestedAction` NEVER names an inline `openclaw config set` (it would clobber klodi)", () => {

--- a/src/__tests__/skill-bundle-contract.integration.test.ts
+++ b/src/__tests__/skill-bundle-contract.integration.test.ts
@@ -13,6 +13,8 @@ import { describe, it, expect } from "vitest";
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { CREATION_ENTRYPOINT_RELATIVE } from "../lib/creation-entrypoint.js";
+import { buildDoctorReport } from "../tools/doctor.js";
 import { registerIdentityTools } from "../tools/identity.js";
 import { registerCatalogTools } from "../tools/catalog.js";
 import { registerProfileTools } from "../tools/profile.js";
@@ -157,5 +159,157 @@ describe("sil-shopping skill bundle — load-bearing contract (not prose)", () =
     expect(src).toContain("mint_domain"); // the mint trigger
     expect(src).toContain("checkout_url"); // picks come from the sil catalog
     expect(src).toMatch(/open[ -]web/i); // never sourced from the open web
+  });
+});
+
+// ===========================================================================
+// Card: creation-bin-unreachable-on-clawhub-installs — the prose is the third
+// surface, and the only one that can actually drift.
+//
+// `sil_doctor` REPORTS the entrypoint and PROBES it from ONE constant, so the
+// reported path and the probed path cannot disagree by construction. The prose is
+// what the agent actually obeys, and nothing binds it to that constant but these
+// tests. This bug's entire lifetime was underwritten by a GREEN guard
+// (`package-manifest.integration.test.ts:238` pinned the bin map while the flow
+// using it was dead), which is the failure mode this block exists to foreclose.
+// ===========================================================================
+
+const ENGINE = "references/agent_creation_engine.md";
+const engineSrc = (): string => read(ENGINE);
+
+/** The fenced code blocks — what the agent COPIES, as opposed to prose about it.
+ * Command-shape assertions belong here: the prose legitimately DISCUSSES the traps
+ * (a `../scripts/…` hop, a heredoc) in order to disavow them by name, so scanning
+ * the whole document for those constructs would fail the very words that document
+ * the fix. */
+const engineCodeBlocks = (): string =>
+  [...engineSrc().matchAll(/```[a-z]*\n([\s\S]*?)```/g)].map((m) => m[1]).join("\n");
+
+const pkgBin = (): Record<string, string> =>
+  (JSON.parse(readFileSync(join(REPO_ROOT, "package.json"), "utf8")) as {
+    bin: Record<string, string>;
+  }).bin;
+
+describe("creation entrypoint — the surfaces that can actually drift (AC B7)", () => {
+  it("AC B7 — the doc names the REAL DoctorReport field that carries the path", () => {
+    // THE drift guard, retargeted to the drift this design can actually suffer.
+    //
+    // B7 as written asks the prose to name `scripts/create-shopper.mjs` and pins that
+    // literal equal to the constant + the bin map. The shipped design does not put a
+    // path in the prose at all — it documents `node "<creationEntrypoint>"`, where the
+    // value comes from sil_doctor at runtime. That is STRONGER than B7 hoped for
+    // (E and D are one value, not two strings asserted equal), and pinning the path
+    // into prose would ADD a fourth surface that goes stale on the next rename while
+    // guarding nothing.
+    //
+    // But the binding did not vanish — it MOVED, from the path to the FIELD NAME. If
+    // the report's key is ever renamed, the doc still says `creationEntrypoint`, the
+    // agent reads a field that does not exist, and creation dies at exactly the step
+    // this card is fixing, silently, on both channels. Nothing else guards that.
+    //
+    // Derived by VALUE, never by restating the key: plant a sentinel path in a real
+    // report and ask which top-level key came back carrying it. A rename makes `key`
+    // the NEW name and forces the doc to follow.
+    const SENTINEL = "/sentinel-root/scripts/create-shopper.mjs";
+    const report = buildDoctorReport({
+      dataDir: "/tmp/sil-data",
+      installedVersion: "0.0.0",
+      creationEntrypoint: SENTINEL,
+      findings: [],
+    });
+    const key = Object.entries(report).find(([, v]) => v === SENTINEL)?.[0];
+    expect(key).toBeDefined();
+    expect(engineSrc()).toContain(key!);
+  });
+
+  it("package.json#bin maps the resolver's SAME path (the bin is retained for npm-global users)", () => {
+    // "Out of scope" keeps the bin entry: it costs nothing and still serves the
+    // npm-global channel. It is simply no longer the DOCUMENTED invocation. Asserting
+    // it against the same constant is what stops a future cleanup from "restoring"
+    // the bare bin name in the prose.
+    expect(pkgBin()["sil-openclaw-create-shopper"]?.replace(/^\.\//, "")).toBe(
+      CREATION_ENTRYPOINT_RELATIVE,
+    );
+  });
+
+  it("the constant is a real, non-vacuous scripts/*.mjs path (guard-of-the-guard)", () => {
+    // Three surfaces asserted equal to an empty string would pass forever.
+    expect(CREATION_ENTRYPOINT_RELATIVE).toMatch(/^scripts\/[a-z][a-z0-9-]*\.mjs$/);
+    expect(existsSync(join(REPO_ROOT, CREATION_ENTRYPOINT_RELATIVE))).toBe(true);
+  });
+});
+
+describe("the documented creation command is channel-independent (AC A2/A3/A4)", () => {
+  it("AC A4 — the doc sources the path from sil_doctor's creationEntrypoint", () => {
+    // The POSITIVE pin, and the load-bearing one: the agent has no other sound source.
+    // The host publishes plugin skills as SYMLINKS and hands the agent the symlink
+    // path, so there IS no plugin-root datum in its context.
+    const src = engineSrc();
+    expect(src).toContain("sil_doctor");
+    expect(src).toContain("creationEntrypoint");
+  });
+
+  it("AC A3 — the documented command runs node against that path, by absolute path", () => {
+    expect(engineCodeBlocks()).toMatch(/node\s+"<creationEntrypoint>"/);
+  });
+
+  it("AC A3 — NO bundled prose names a bare sil bin anywhere", () => {
+    // The defect itself. `openclaw plugins install` links no bins, so both names
+    // reach PATH only through a global npm-style install. Bundle-wide, and not even
+    // as a disavowal: a model lifts the shortest thing that looks like a command, and
+    // a name-free disavowal (which the doc now does) carries the warning just as well.
+    const offenders: string[] = [];
+    for (const rel of bundleFiles()) {
+      for (const bin of ["sil-openclaw-create-shopper", "sil-openclaw-allowlist"]) {
+        if (read(rel).includes(bin)) offenders.push(`${rel} → ${bin}`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it("AC A4 — no documented command derives the path from the skill file's own location", () => {
+    // The falsified fix direction. `node <skilldir>/../scripts/x` throws
+    // MODULE_NOT_FOUND on the exact string `cat` reads happily: node's path.resolve
+    // normalizes `..` LEXICALLY, before the filesystem, so the symlink hop is erased.
+    // Scoped to code blocks BY DESIGN — the prose names this trap to warn about it.
+    expect(engineCodeBlocks()).not.toMatch(/\.\.\//);
+    expect(engineCodeBlocks()).not.toMatch(/readlink|dirname|\$\(dirname/);
+  });
+
+  it("AC A2 — ONE invocation serves both channels: no channel-conditional branch", () => {
+    // "If you installed via X do A, else B" is how a fix becomes a fork that only one
+    // channel ever exercises.
+    const src = engineSrc().toLowerCase();
+    expect(src).not.toContain("clawhub");
+    expect(src).not.toContain("npm install");
+    expect(src).not.toContain("npm i -g");
+  });
+});
+
+describe("the spec is fed by file, never by shell quoting (AC C2/C3)", () => {
+  it("AC C2 — the documented input form is --spec <path>", () => {
+    expect(engineCodeBlocks()).toContain("--spec");
+  });
+
+  it("AC C2 — NO heredoc or stdin form survives as an alternative", () => {
+    // Delete-first: the heredoc is REMOVED, not left beside the new form. Two
+    // documented forms means the model picks the quoting-fragile one half the time —
+    // and a mangled heredoc reaches the bin as unparseable stdin, so it fails as
+    // `invalid_request` and the agent BLAMES THE USER for a spec that was fine.
+    //
+    // The heredoc OPERATOR, not the word: the prose says "as a file, not a heredoc",
+    // which is correct and must not be punished. stdin stays in the bin (founder
+    // ruling 3) — the DOC is the single-form contract.
+    expect(engineCodeBlocks()).not.toMatch(/<<-?\s*['"]?\w+/);
+    expect(engineSrc()).not.toContain("stdin");
+  });
+
+  it("AC C3 — the doc instructs an owner-only spec file that is removed after the run", () => {
+    // `--spec <path>` writes the user's home address, sizes, and allergy/ethics rules
+    // to disk where stdin left nothing at rest. The agent owns that file's lifecycle:
+    // the bin never deletes an input it does not own (founder ruling 3).
+    const src = engineSrc();
+    expect(src).toMatch(/0600|umask 077/);
+    expect(engineCodeBlocks()).toMatch(/rm -f|rm "/);
   });
 });

--- a/src/__tests__/tools/doctor.test.ts
+++ b/src/__tests__/tools/doctor.test.ts
@@ -32,11 +32,13 @@
  *       Extracts ONLY `exp`.
  *   export interface DoctorReport {
  *     status: "ok"; healthy: boolean; dataDir: string; installedVersion: string;
+ *     creationEntrypoint: string;
  *     counts: { info: number; warn: number; critical: number };
  *     findings: Finding[];
  *   }
  *   export function buildDoctorReport(input: {
- *     dataDir: string; installedVersion: string; findings: Finding[];
+ *     dataDir: string; installedVersion: string; creationEntrypoint: string;
+ *     findings: Finding[];
  *   }): DoctorReport;
  *     — pure assembler: rolls up `healthy` + `counts` from the findings it is
  *       given. Never invents a finding.
@@ -199,8 +201,15 @@ describe("isAccessTokenExpired — leak-free and offline (the top risk)", () => 
 // AC7 — finding/report shape is exactly the founder's six fields + roll-ups.
 // ===========================================================================
 
+// EXACT SET, asserted with `toEqual` — never loosened to a subset/`toContain`,
+// which would silently stop catching drift in BOTH directions. Bumped ADD-ONLY by
+// card `creation-bin-unreachable-on-clawhub-installs`: `creationEntrypoint` joins
+// `dataDir`/`installedVersion` as report CONTEXT (a datum the agent RUNS), because
+// the finding schema is six flat prose fields and a model would otherwise have to
+// regex a path out of one at the creation payoff moment.
 const REPORT_KEYS = [
   "counts",
+  "creationEntrypoint",
   "dataDir",
   "findings",
   "healthy",
@@ -208,15 +217,18 @@ const REPORT_KEYS = [
   "status",
 ];
 
+const CREATION_ENTRYPOINT = "/plugin/scripts/create-shopper.mjs";
+
 const build = (findings: Finding[]) =>
   buildDoctorReport({
     dataDir: "/tmp/sil-data",
     installedVersion: "0.4.2",
+    creationEntrypoint: CREATION_ENTRYPOINT,
     findings,
   });
 
 describe("buildDoctorReport — the envelope payload shape", () => {
-  it("carries exactly the six DoctorReport keys — no extras", () => {
+  it("carries exactly the seven DoctorReport keys — no extras", () => {
     expect(Object.keys(build([])).sort()).toEqual(REPORT_KEYS);
   });
 
@@ -232,6 +244,24 @@ describe("buildDoctorReport — the envelope payload shape", () => {
     expect(report.dataDir).toBe("/tmp/sil-data");
     expect(report.installedVersion).toBe("0.4.2");
     expect(report.installedVersion.length).toBeGreaterThan(0);
+  });
+
+  it("AC B8 — reports the creationEntrypoint it was given, verbatim and unconditionally", () => {
+    // The field the whole fix hangs on: it replaces the plugin root the agent
+    // CANNOT derive (the host hands it a symlink into plugin-skills/, and node
+    // strips a `..` hop lexically). The assembler must pass it through untouched —
+    // no trimming, no relativising, no "helpful" normalisation.
+    expect(build([]).creationEntrypoint).toBe(CREATION_ENTRYPOINT);
+  });
+
+  it("AC B8 — reports the entrypoint even when the install is UNHEALTHY", () => {
+    // A path we cannot reach is still the path we mean. Suppressing the datum on a
+    // failing check would hide the diagnosis exactly when the operator needs it —
+    // and would make the field's presence conditional, which no consumer could rely
+    // on. It rides the report like `dataDir`, not like a finding.
+    const report = build([finding("creation.entrypoint_present", "warn")]);
+    expect(report.healthy).toBe(false);
+    expect(report.creationEntrypoint).toBe(CREATION_ENTRYPOINT);
   });
 
   it("returns the findings it was given — it never invents one (no fabrication)", () => {

--- a/src/lib/creation-entrypoint.ts
+++ b/src/lib/creation-entrypoint.ts
@@ -1,0 +1,132 @@
+/**
+ * The runnable paths of the plugin's shipped operator scripts — resolved from
+ * this module's own location, because the agent cannot derive them.
+ *
+ * WHY THIS EXISTS: a bare bin name (`sil-openclaw-create-shopper`) is on PATH
+ * only when a global npm-style install links it. `openclaw plugins install` just
+ * extracts the tarball and links nothing, so on that channel the documented
+ * creation command did not exist and the flow died at its last step.
+ *
+ * WHY NOT "resolve it from the skill file's location": the host publishes plugin
+ * skills as SYMLINKS into its config tree and hands the agent the symlink path
+ * deliberately. Node's `path.resolve()` normalizes `..` LEXICALLY, before
+ * touching the filesystem, so a `<skilldir>/../scripts/x` hop is erased and the
+ * loader looks beside the symlink, not beside the real file. `cat` and `ls`
+ * succeed on the exact string `node` rejects with MODULE_NOT_FOUND — a trap that
+ * hand-testing certifies as working. The plugin process's own `import.meta.url`
+ * is the ONLY sound root, so the plugin reports the path and the agent runs it.
+ *
+ * The root derivation mirrors `version-advisory.ts` — two levels up reaches the
+ * plugin root from both `src/lib/` and `dist/lib/`. Never cwd (production cwd is
+ * the agent's workspace, and cwd passes every test run from the repo root), never
+ * PATH, never the user's home, never a hardcoded install path.
+ *
+ * This module spawns nothing: reachability is a filesystem read. Naming a path is
+ * not running it, which is what keeps `security.noChildProcess` true.
+ */
+
+import { statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type { Finding } from "./findings.js";
+
+/**
+ * THE literal. `sil_doctor` reports this path and probes this path, the skill
+ * prose documents it, and `package.json#bin` maps it — one constant, so the
+ * reported path and the probed path cannot drift. A doctor that certifies a path
+ * it never probed is the same class of lie this module exists to kill.
+ */
+export const CREATION_ENTRYPOINT_RELATIVE = "scripts/create-shopper.mjs";
+
+/** The creation entrypoint's sibling. It lives here for the same reason and by
+ * the same root: `wiring.tools_not_admitted` used to hand ClawHub operators a
+ * bare bin name too — doctor's own advice, unrunnable on the channel it
+ * diagnoses. One root derivation, one place. */
+export const ALLOWLIST_SCRIPT_RELATIVE = "scripts/allowlist-openclaw.mjs";
+
+const PLUGIN_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+export function resolveCreationEntrypoint(): string {
+  return join(PLUGIN_ROOT, CREATION_ENTRYPOINT_RELATIVE);
+}
+
+export function resolveAllowlistScript(): string {
+  return join(PLUGIN_ROOT, ALLOWLIST_SCRIPT_RELATIVE);
+}
+
+/** What a local read can honestly establish about the entrypoint. */
+export type CreationEntrypointVerdict = "present" | "missing" | "unresolvable";
+
+/**
+ * Probe the entrypoint — a local `stat`, so it stays determinate with the
+ * network down.
+ *
+ * `unresolvable` is not padding: ENOENT means the tarball shipped incomplete,
+ * while an unreadable parent or a non-file at the path means something else is
+ * wrong with the tree. They are the same severity but not the same sentence, and
+ * the operator's next move depends on which one it is.
+ */
+export function probeCreationEntrypoint(
+  entrypoint: string = resolveCreationEntrypoint(),
+): CreationEntrypointVerdict {
+  try {
+    return statSync(entrypoint).isFile() ? "present" : "unresolvable";
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === "ENOENT"
+      ? "missing"
+      : "unresolvable";
+  }
+}
+
+/**
+ * A singleton subsystem check, so it reports EVERY run and says `ok` when
+ * healthy — `fixed → re-run → ok` needs the id to still be there after the fix.
+ * Hence a `Finding`, never `Finding | null`: an advisory-only builder could not
+ * tell "reachable" from "never checked".
+ *
+ * Pure — the caller does the I/O and hands in the verdict. That is what makes the
+ * no-bare-bin guarantee cheap to assert totally, over every verdict.
+ *
+ * `warn`, not `critical`: by the doctor's ladder critical means the core path is
+ * broken, and a plugin that broken could not run a tool to say so. The plugin
+ * runs fine here — one flow cannot. `warn` is also the load-bearing half: it is
+ * what makes `healthy` false.
+ */
+export function buildCreationEntrypointFinding(
+  entrypoint: string,
+  verdict: CreationEntrypointVerdict,
+): Finding {
+  const id = "creation.entrypoint_present";
+
+  if (verdict === "present") {
+    return {
+      id,
+      severity: "info",
+      status: "ok",
+      detected: `The shopper-creation entrypoint ${entrypoint} is present and runnable.`,
+      suggestedAction: null,
+      appliedAction: null,
+    };
+  }
+
+  return {
+    id,
+    severity: "warn",
+    status: "advisory",
+    detected:
+      verdict === "missing"
+        ? `The shopper-creation entrypoint ${entrypoint} is missing, so creating`
+          + " a shopper would fail at its last step."
+        : `The shopper-creation entrypoint ${entrypoint} could not be read as a`
+          + " file, so creating a shopper would fail at its last step.",
+    // Never a bare bin name and never a PATH edit: this diagnoses an incomplete
+    // plugin tree, and the recovery must be runnable on the channel it is being
+    // read on. `openclaw` itself is always on PATH — that is the whole premise.
+    suggestedAction:
+      "Reinstall the sil plugin through OpenClaw's own plugin install path (for"
+      + " example `openclaw plugins install @4gpts/sil`), then reload — the"
+      + " plugin tree is incomplete. sil never reinstalls itself.",
+    appliedAction: null,
+  };
+}

--- a/src/lib/host-wiring.ts
+++ b/src/lib/host-wiring.ts
@@ -30,6 +30,7 @@ import { fileURLToPath } from "node:url";
 
 import type { PluginAPI } from "openclaw/plugin-sdk";
 
+import { resolveAllowlistScript } from "./creation-entrypoint.js";
 import type { Finding } from "./findings.js";
 
 /** The shipped manifest, resolved relative to this module — two levels up from
@@ -281,10 +282,16 @@ function buildToolsNotAdmittedFinding(
     // overwrite-only on 2026.6.9, so following such a "fix" would silently
     // un-admit every other plugin already in the array. A fix that breaks klodi
     // to fix sil is not a fix — and the user would discover it later, in a
-    // different plugin, with no trail back to us. The shipped bin is additive
+    // different plugin, with no trail back to us. The shipped script is additive
     // and idempotent across all three trust surfaces.
+    //
+    // By absolute path via `node`, NEVER the bare `sil-openclaw-allowlist` name:
+    // that name reaches PATH only through a global npm-style install's bin
+    // linking, which the plugin-install channel does not do. An operator who is
+    // already broken, follows this advice, and gets "command not found" learns
+    // that the doctor cannot be trusted.
     suggestedAction:
-      `Run the shipped \`sil-openclaw-allowlist\` bin — it admits "${facts.id}"`
+      `Run \`node "${resolveAllowlistScript()}"\` — it admits "${facts.id}"`
       + ` additively, preserving every other trusted plugin — then reload`
       + ` OpenClaw. The edit takes effect on the next reload, and sil never`
       + ` writes host config or reloads the gateway itself.`,

--- a/src/tools/doctor.ts
+++ b/src/tools/doctor.ts
@@ -41,6 +41,11 @@ import type { PluginAPI } from "openclaw/plugin-sdk";
 import { Type } from "typebox";
 
 import {
+  buildCreationEntrypointFinding,
+  probeCreationEntrypoint,
+  resolveCreationEntrypoint,
+} from "../lib/creation-entrypoint.js";
+import {
   DIR_MODE,
   getConfigPath,
   getDataDir,
@@ -95,6 +100,14 @@ export interface DoctorReport {
   /** Report CONTEXT, not a finding: WHICH install is being diagnosed. Local, so
    * never conditional on the probe. */
   installedVersion: string;
+  /** The absolute shopper-creation entrypoint — a path, never a secret, and the
+   * datum the creation flow is documented to RUN. It rides the report rather
+   * than a finding string because a finding is six flat fields of prose: an
+   * agent would have to regex a path out of it at the payoff moment. The
+   * VERDICT on this path is an ordinary finding (`creation.entrypoint_present`);
+   * this is the datum. Reported unconditionally — a path we cannot reach is
+   * still the path we mean, and suppressing it would hide the diagnosis. */
+  creationEntrypoint: string;
   counts: { info: number; warn: number; critical: number };
   findings: Finding[];
 }
@@ -139,6 +152,15 @@ export function registerDoctorTools(
       const compat = buildGatewayCompatFinding(readHostVersion(api));
       if (compat !== null) findings.push(compat);
 
+      // The creation entrypoint: resolved ONCE, then both reported and probed —
+      // so the path the report hands the agent to run is, by construction, the
+      // path the verdict is about. A local stat, so it still answers offline.
+      const creationEntrypoint = resolveCreationEntrypoint();
+      findings.push(buildCreationEntrypointFinding(
+        creationEntrypoint,
+        probeCreationEntrypoint(creationEntrypoint),
+      ));
+
       const installedVersion = readInstalledVersion();
       const behind = buildVersionBehindFinding(
         installedVersion,
@@ -146,7 +168,12 @@ export function registerDoctorTools(
       );
       if (behind !== null) findings.push(behind);
 
-      return jsonResult(buildDoctorReport({ dataDir, installedVersion, findings }));
+      return jsonResult(buildDoctorReport({
+        dataDir,
+        installedVersion,
+        creationEntrypoint,
+        findings,
+      }));
     },
   });
 }
@@ -156,9 +183,10 @@ export function registerDoctorTools(
 export function buildDoctorReport(input: {
   dataDir: string;
   installedVersion: string;
+  creationEntrypoint: string;
   findings: Finding[];
 }): DoctorReport {
-  const { dataDir, installedVersion, findings } = input;
+  const { dataDir, installedVersion, creationEntrypoint, findings } = input;
   const sorted = sortFindings(findings);
   const counts = { info: 0, warn: 0, critical: 0 };
   for (const f of sorted) counts[f.severity] += 1;
@@ -167,6 +195,7 @@ export function buildDoctorReport(input: {
     healthy: counts.warn === 0 && counts.critical === 0,
     dataDir,
     installedVersion,
+    creationEntrypoint,
     counts,
     findings: sorted,
   };


### PR DESCRIPTION
## Card

`cards/creation-bin-unreachable-on-clawhub-installs.md` (local-only — `cards/` is gitignored
in this repo; the card lives in the `card/creation-bin-unreachable-on-clawhub-installs`
worktree and carries the full intent, founder rulings, and handoffs).

## The bug

On a **ClawHub install** (`openclaw plugins install @4gpts/sil`) the shopper-creation flow
died at its **last step** — after the interview, after the user said "yes, create it". The
skill documented the bare bin `sil-openclaw-create-shopper`, which reaches PATH only via a
global npm-style install's **bin linking**. `openclaw plugins install` just extracts the
tarball. Blast radius: every ClawHub-channel install, not just our fleet.

## Why the obvious fix would have made it worse

The original direction was `node <plugin-root>/scripts/create-shopper.mjs`, with the root
derived from the skill's own location. Discovery **falsified** that on live
`alpine/openclaw:2026.6.9` + `openclaw/openclaw:2026.7.1`: the host publishes plugin skills as
**symlinks** into `<CONFIG_DIR>/plugin-skills/` and hands the agent the symlink path
deliberately, and `node` strips a `..` hop off it **lexically**:

| same path string | result |
|---|---|
| `cat  <skilldir>/../scripts/create-shopper.mjs` | works |
| `node <skilldir>/../scripts/create-shopper.mjs` | **MODULE_NOT_FOUND** |

That trades `command not found` for `Cannot find module` — same silent-late failure, at the
same step, and it would have broken npm-global too. `cat` and `ls` certify it as working.

## The fix — `sil_doctor` becomes the path oracle

The plugin process is the only party that knows its own root, and already does it
(`version-advisory.ts`). So it reports the path and the agent runs it:

- **NEW `src/lib/creation-entrypoint.ts`** — root from `import.meta.url` (never cwd/PATH/home/
  hardcode), **THE literal** for `scripts/create-shopper.mjs`, a `stat` probe, and a **pure**
  finding builder.
- **`DoctorReport.creationEntrypoint`** — top-level absolute path (report CONTEXT, like
  `dataDir`), plus the `creation.entrypoint_present` singleton finding: `warn` when
  unreachable, which makes `healthy` false. Local + unconditional — it answers offline.
- **The skill's "one command" rewritten clean** — `sil_doctor` → read `creationEntrypoint` →
  write the spec to a **0600 temp file** → `node "<it>" --spec <file>` → remove it. No heredoc,
  no bare bin, no `<plugin-root>` placeholder to guess.
- **Founder ruling 2** — `wiring.tools_not_admitted`'s `suggestedAction` and `SKILL.md:38` told
  ClawHub operators to run the same dead bare bin, **inside the doctor itself**. Same resolver,
  now `node "<root>/scripts/allowlist-openclaw.mjs"`.

**No drift is possible by construction:** `resolveCreationEntrypoint()` is called once in
`execute()`; that one value is both reported and probed. The field cannot describe a path it
never checked — the exact class of lie this card kills.

## Constraints held

- **Zero `child_process` in `dist/`** (grep-clean after a real build) — reachability is a
  `stat`, never a spawn. `security.noChildProcess` intact.
- **No new tool, no new group** — `openclaw.plugin.json#contracts.tools` byte-identical, so
  none of the seven tool-set mirrors fire.
- **`package.json#bin` byte-identical** — retained for npm-global users.
- Every guard moved **add-only**; no exact set was loosened to pass.

## Test plan

- [x] **1342 passing / 0 failing.** (`repo-scaffold.integration.test.ts`'s 10 reds are the
      known worktree artefact — gitignored `docs/`+`CLAUDE.md`, untouched by this diff.)
- [x] Typecheck + build clean.
- [x] **ClawHub channel reproduced**: the bin invoked with sil bins **off PATH**, asserting the
      bare name exits **127** in that same shell (the test proves its own premise).
- [x] Reachability asserted by an **actual `node` load**, never `existsSync` (the `cat`-lies trap).
- [x] qa proved every guard **bites** by mutation in a scratch copy — incl. a
      `PLUGIN_ROOT = process.cwd()` variant that **39 of 40 unit tests happily passed**.
- [x] **Live-verified from the built `dist/`, network down**: healthy → `info`/`ok`; broken
      tree → `warn`/`healthy:false` naming the path; repair → re-run → same id back to `ok`.
- [x] The documented command run from a foreign cwd with a spec full of quotes/backticks/`$`/
      newlines: bytes reached the validator intact.

## Not closed here

Per **founder ruling 4**, true channel parity + agent path-following land as e2e in the
**`sil-stage`** sibling (its boot already does `openclaw plugins install --link` — no npm
bin-linking, the ClawHub channel's defining property). That companion card is **not yet filed**.
This PR is unit + integration only and does not pretend to close the e2e claim.

## Distillation target

Knowledge capture happens **after Review PASS** in the `distilling` stage — `solutions-architect`
runs in this same worktree and pushes here. Queued: the **plugin-skills symlink + lexical-`..`**
host invariant (`docs/knowledge/` — reusable by every sibling shipping an OpenClaw plugin), and
`docs/decisions/create-shopper-bin.md`, whose invocation claim this PR makes stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)