### PR TITLE
fix: sil.search_results is unknown on a stock gateway — load sil at gateway startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ release (`clawhub package publish --changelog`). See [README](./README.md#releas
 
 ## [Unreleased]
 
+### Fixed
+
+- **`sil.search_results` now exists on a stock gateway.** `activation` gains
+  `onStartup: true` (alongside the existing `onCapabilities: ["tool"]`, the
+  posture bundled extensions already ship). 0.4.5 registered the method into the
+  gateway's request-local *tool-discovery* registry, which the host deliberately
+  never installs as active — so dispatch, which resolves from the active
+  registry, answered `unknown method` for every paired client, and Studio
+  rendered the degraded notice instead of product cards. Loading at gateway
+  startup puts the registration in the registry dispatch actually reads, and the
+  agent tool path then prefers that same registry — one module instance, so the
+  page `sil_search` stores is the page the method hands back.
+
 ## [0.4.5] - 2026-07-23
 
 ### Added

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -5,7 +5,8 @@
   "version": "0.4.5",
   "skills": ["./sil-shopping"],
   "activation": {
-    "onCapabilities": ["tool"]
+    "onCapabilities": ["tool"],
+    "onStartup": true
   },
   "contracts": {
     "tools": [

--- a/src/__tests__/compiled-artifact-load.integration.test.ts
+++ b/src/__tests__/compiled-artifact-load.integration.test.ts
@@ -65,7 +65,17 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import type { PluginAPI } from "openclaw/plugin-sdk";
-import { createMockPluginApi } from "./helpers/mock-plugin-api.js";
+// The SOURCE store instance — deliberately a DIFFERENT module instance from the
+// one inside the freshly-built dist. Used below to prove the compiled tool and
+// the compiled gateway method resolve each other through their OWN store, not
+// through a shared source module the harness dragged in.
+import { getSearchResult } from "../lib/search-results-store.js";
+import {
+  createMockPluginApi,
+  getTool,
+  callGatewayMethod,
+  registeredGatewayMethodNames,
+} from "./helpers/mock-plugin-api.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 /** Repo root of the checkout under test (…/src/__tests__ → root). */
@@ -244,5 +254,183 @@ describe("compiled-artifact load runs against a FRESH dist, never the planted st
       .mocked(api.logger.info)
       .mock.calls.filter(([marker]) => marker === "sil_plugin_loaded");
     expect(markerCalls).toHaveLength(1);
+  });
+});
+
+// ===========================================================================
+// AC2 — ONE register() on the COMPILED entry yields ONE store across BOTH
+// surfaces (the writer `sil_search` and the reader `sil.search_results`)
+// ===========================================================================
+
+const METHOD = "sil.search_results";
+const SIL_API = "https://sil-api.compiled.test.example.com";
+const ACCOUNT = "user-compiled";
+
+/** One real `SilCatalogProduct` off the sil-api wire — a required `source`, and a
+ * variant carrying a non-empty `checkout_url`. Anti-false-green: a `{stub:true}`
+ * echo carries none of these, so nothing below can pass against a placeholder. */
+function wireProduct(n: number): Record<string, unknown> {
+  return {
+    id: `gid://product/${n}`,
+    title: `Ergonomic Task Chair ${n}`,
+    description: { plain: `A height-adjustable task chair, model ${n}.` },
+    price_range: {
+      min: { amount: 100_000 + n, currency: "USD" },
+      max: { amount: 200_000 + n, currency: "USD" },
+    },
+    variants: [
+      {
+        id: `gid://variant/${n}-1`,
+        title: `Ergonomic Task Chair ${n} — Graphite`,
+        description: { plain: `A height-adjustable task chair, model ${n}.` },
+        price: { amount: 100_000 + n, currency: "USD" },
+        availability: { available: true, status: "in_stock" },
+        checkout_url: `https://buy.example.com/chair-${n}`,
+      },
+    ],
+    source: `merchant-${n}`,
+  };
+}
+
+/** A live sil session inside the per-test `$SIL_DATA_DIR`, written as FILES —
+ * never through the source `credentials` module, whose in-process state is not
+ * the one the compiled plugin reads. */
+function seedSession(): void {
+  writeFileSync(
+    join(tempDataDir, "tokens.json"),
+    JSON.stringify({ access_token: "compiled-at", refresh_token: "compiled-rt" }),
+    { mode: 0o600 },
+  );
+  writeFileSync(
+    join(tempDataDir, "config.json"),
+    JSON.stringify({ user: { id: ACCOUNT, name: "Compiled User" } }),
+    { mode: 0o600 },
+  );
+}
+
+/** The catalog-search boundary — the ONLY thing doubled. Records every outbound
+ * URL so "the compiled client, at the configured origin" is assertable by count. */
+function installSearchRouter(products: unknown[]): { urls: string[] } {
+  const urls: string[] = [];
+  vi.spyOn(globalThis, "fetch").mockImplementation((input: unknown) => {
+    const url = typeof input === "string" ? input : String(input);
+    urls.push(url);
+    const isSearch = url.includes("/catalog/search");
+    return Promise.resolve(
+      new Response(
+        JSON.stringify(
+          isSearch ? { products, pagination: { has_next_page: false } } : {},
+        ),
+        {
+          status: isSearch ? 200 : 500,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+    );
+  });
+  return { urls };
+}
+
+function payloadOf(result: { content: { text?: string }[] }): Record<string, unknown> {
+  const text = result.content[0]?.text;
+  if (typeof text !== "string") throw new Error("no tool payload");
+  return JSON.parse(text) as Record<string, unknown>;
+}
+
+describe("AC2 — one register() on dist/index.js ⇒ the sil_search WRITER and the sil.search_results READER share ONE store", () => {
+  // The gap 0.4.5's suite structurally could not close. Its ~30 assertions drove
+  // the SOURCE modules through a harness that imports the tool and the handler
+  // separately; nothing proved that the artefact a host actually loads yields one
+  // store across both surfaces. Here both come out of a SINGLE `register()` call
+  // on the freshly-built compiled entry — the strongest in-repo proof available
+  // that a page written by the tool is resolvable by the method.
+  //
+  // What this still cannot prove (and must not claim to): WHICH host process
+  // runs that register(). That is the manifest's `activation.onStartup` posture,
+  // pinned statically in `package-manifest.integration.test.ts` (AC3) and
+  // observed live on a real gateway (AC1/AC9). No plugin-side test can see the
+  // host's load plan.
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("resolves the page the COMPILED sil_search just wrote, under the same host callId", async () => {
+    const rec = installSearchRouter([wireProduct(1), wireProduct(2)]);
+    seedSession();
+
+    // ONE register() — the shipped posture. Both surfaces are captured off the
+    // SAME api, so nothing here can be satisfied by two independent loads.
+    const api = createMockPluginApi({ pluginConfig: { sil_api_url: SIL_API } });
+    capturedRegisterFn!(api);
+    expect(registeredGatewayMethodNames(api).has(METHOD)).toBe(true);
+
+    const CALL_ID = "call_compiled_hit";
+    const payload = payloadOf(
+      await getTool(api, "sil_search").execute(CALL_ID, { query: "office chair" }),
+    );
+    // Premise of the whole test: the search really succeeded and carries real
+    // projected products, not an error envelope the resolve could never store.
+    expect(payload["status"]).toBe("ok");
+    const products = payload["products"] as Record<string, unknown>[];
+    expect(products).toHaveLength(2);
+    expect(products[0]!["id"]).toBe("gid://product/1");
+    // The COMPILED config module resolved the pluginConfig override — the request
+    // went to the test origin, so this is the compiled client's own leg.
+    expect(rec.urls.filter((u) => u.startsWith(SIL_API))).toHaveLength(1);
+
+    const frames = await callGatewayMethod(api, METHOD, { callId: CALL_ID });
+    // Frame COUNT, not just the last frame: a handler that never responds leaves
+    // a client hanging forever, and that is zero frames, not a failure body.
+    expect(frames).toHaveLength(1);
+    expect(frames[0]!.ok).toBe(true);
+    const body = frames[0]!.payload as Record<string, unknown>;
+    expect(body["status"]).toBe("ok");
+    expect(body["products"]).toEqual(payload["products"]);
+  });
+
+  it("serves it from the COMPILED module's OWN store — the source store never saw the page", async () => {
+    // Cross-instance proof. If this file's assertions could be satisfied by the
+    // source `search-results-store` module (the one the sibling suites drive),
+    // the "one register(), one store" claim would be about the harness rather
+    // than the artefact. The compiled entry has its own module instance, so the
+    // source store must be EMPTY for a callId the compiled tool just stored.
+    installSearchRouter([wireProduct(7)]);
+    seedSession();
+
+    const api = createMockPluginApi({ pluginConfig: { sil_api_url: SIL_API } });
+    capturedRegisterFn!(api);
+
+    const CALL_ID = "call_compiled_instance";
+    const payload = payloadOf(
+      await getTool(api, "sil_search").execute(CALL_ID, { query: "office chair" }),
+    );
+    expect(payload["status"]).toBe("ok");
+
+    expect(getSearchResult(CALL_ID, ACCOUNT)).toBeNull();
+
+    const body = (await callGatewayMethod(api, METHOD, { callId: CALL_ID }))[0]!
+      .payload as Record<string, unknown>;
+    expect(body["status"]).toBe("ok");
+    expect((body["products"] as unknown[])).toHaveLength(1);
+  });
+
+  it("is NOT VACUOUS — the same compiled handler answers not_found for a callId it never stored", async () => {
+    // Without this, every `status:"ok"` above is equally satisfied by a handler
+    // that answers ok unconditionally — the assertion would be measuring the
+    // fixture, not the store.
+    installSearchRouter([wireProduct(1)]);
+    seedSession();
+
+    const api = createMockPluginApi({ pluginConfig: { sil_api_url: SIL_API } });
+    capturedRegisterFn!(api);
+
+    const frames = await callGatewayMethod(api, METHOD, { callId: "call_compiled_never" });
+    expect(frames).toHaveLength(1);
+    // Every outcome rides a SUCCESSFUL response carrying a structured body;
+    // `ok:false` is a transport fault a client would retry forever.
+    expect(frames[0]!.ok).toBe(true);
+    const body = frames[0]!.payload as Record<string, unknown>;
+    expect(body["status"]).toBe("not_found");
+    expect(body).not.toHaveProperty("products");
   });
 });

--- a/src/__tests__/package-manifest.integration.test.ts
+++ b/src/__tests__/package-manifest.integration.test.ts
@@ -57,7 +57,7 @@ interface Manifest {
   description?: string;
   version?: string;
   skills?: string[];
-  activation?: { onCapabilities?: string[] };
+  activation?: { onCapabilities?: string[]; onStartup?: boolean };
   contracts?: { tools?: string[] };
   configSchema?: { type?: string; properties?: Record<string, unknown> };
   security?: { packagingNote?: string; filesystemScope?: string[] };
@@ -150,6 +150,52 @@ describe("openclaw.plugin.json — manifest shape", () => {
     for (const name of manifest.contracts!.tools!) {
       expect(name.startsWith("klodi_")).toBe(false);
     }
+  });
+});
+
+describe("openclaw.plugin.json — activation posture: the key that decides whether the gateway surface EXISTS (AC3)", () => {
+  // 0.4.5 shipped `sil.search_results` under ~30 green handler assertions and the
+  // method did not exist on a single stock gateway. A gateway RPC method is
+  // dispatchable only from the registry the host INSTALLS as active, and the host
+  // admits a plugin to that (gateway-startup) load plan only when
+  // `activation.onStartup === true` — `shouldConsiderForGatewayStartup`,
+  // `vendor/openclaw/src/plugins/gateway-startup-plugin-ids.ts`. Every other load
+  // path builds a request-local snapshot nothing dispatches from, so the method
+  // was "registered where nobody looks".
+  //
+  // Nothing caught it because THIS file's `Manifest.activation` was typed
+  // `{ onCapabilities?: string[] }` — the load-bearing key was invisible to the
+  // repo's only manifest guard. Widening that type is half the fix; these
+  // assertions are the other half.
+  const manifest = readJson<Manifest>("openclaw.plugin.json");
+
+  it("declares activation.onStartup === true — the plugin loads in the GATEWAY process", () => {
+    const activation = manifest.activation;
+    expect(activation).toBeTypeOf("object");
+    // `toBe(true)` on a NON-optional read. A truthiness matcher or an
+    // `activation?.onStartup` optional chain passes for free on an ABSENT key —
+    // i.e. it passes on exactly the manifest that shipped the bug.
+    expect(activation!.onStartup).toBe(true);
+  });
+
+  it('keeps activation.onCapabilities containing "tool" — the agent-runtime posture is ADDED to, never replaced', () => {
+    // The gateway-startup load must not come at the cost of the capability
+    // declaration: bundled `google-meet` ships both keys together, and dropping
+    // one to add the other would be a silent posture swap rather than an addition.
+    const activation = manifest.activation;
+    expect(Array.isArray(activation!.onCapabilities)).toBe(true);
+    expect(activation!.onCapabilities).toContain("tool");
+  });
+
+  it("activation declares EXACTLY these two triggers (exact set, add-only)", () => {
+    // Set-equality, never a subset check: a renamed key (`onStart`, `startup`)
+    // parses fine, satisfies no host trigger, and would leave the surface inert
+    // again — the failure mode this card exists to kill. Adding a real third
+    // trigger means bumping this list deliberately.
+    expect(Object.keys(manifest.activation!).sort()).toEqual([
+      "onCapabilities",
+      "onStartup",
+    ]);
   });
 });
 

--- a/src/__tests__/plugin-load.integration.test.ts
+++ b/src/__tests__/plugin-load.integration.test.ts
@@ -33,6 +33,7 @@
 
 import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vitest";
 import {
+  chmodSync,
   existsSync,
   mkdtempSync,
   readFileSync,
@@ -292,6 +293,100 @@ describe("plugin load — an uncreatable data dir is a LOUD, fail-closed termina
     expect(existsSync(unwritableDataDir)).toBe(false);
   });
 });
+
+const AS_ROOT = typeof process.getuid === "function" && process.getuid() === 0;
+
+describe.skipIf(AS_ROOT)(
+  "plugin load — an uncreatable data dir registers NOTHING: no tool, and no gateway method (AC10)",
+  () => {
+    // The half 0.4.5 added and nothing pinned. `register()` now hands the host a
+    // SECOND surface (`sil.search_results`), and under the new `onStartup: true`
+    // posture it runs on the gateway's boot path. `ensureDataDir()` throws BEFORE
+    // any `registerXTools`/`registerSearchResultsMethod` call, so the fail-closed
+    // terminal must leave the api COMPLETELY untouched — a half-registered plugin
+    // would hand a paired client a gateway method backed by a store whose home
+    // does not exist.
+    //
+    // The fault is injected with REAL filesystem permissions (a `0o500` containing
+    // dir ⇒ EACCES on the recursive mkdir), never a synthetic production hook: a
+    // hook would test the hook. It is deliberately a DIFFERENT errno from the AC5
+    // block's ENOTDIR blocker-file, which is what makes the log assertion below
+    // non-vacuous — a `cause` hardcoded to "ENOTDIR" passes there and fails here.
+    // Root bypasses permission bits, hence the skip guard.
+    let containingDir: string;
+    let targetDataDir: string;
+    let priorSilDataDir: string | undefined;
+    let priorXdg: string | undefined;
+
+    beforeEach(() => {
+      containingDir = mkdtempSync(join(tmpdir(), "sil-datadir-ro-"));
+      targetDataDir = join(containingDir, "sil-data");
+      chmodSync(containingDir, 0o500);
+      priorSilDataDir = process.env["SIL_DATA_DIR"];
+      priorXdg = process.env["XDG_DATA_HOME"];
+      process.env["SIL_DATA_DIR"] = targetDataDir;
+    });
+
+    afterEach(() => {
+      if (priorSilDataDir === undefined) delete process.env["SIL_DATA_DIR"];
+      else process.env["SIL_DATA_DIR"] = priorSilDataDir;
+      if (priorXdg === undefined) delete process.env["XDG_DATA_HOME"];
+      else process.env["XDG_DATA_HOME"] = priorXdg;
+      chmodSync(containingDir, 0o700);
+      rmSync(containingDir, { recursive: true, force: true });
+    });
+
+    it("register() throws EACCES and registers NOTHING — not one tool, not the gateway method", () => {
+      // A null captured register would ALSO throw (TypeError) and leave the api
+      // empty, which would make both assertions below vacuous. Pin the premise.
+      expect(capturedRegisterFn).toBeTypeOf("function");
+      expect(getDataDir()).toBe(targetDataDir);
+
+      const api = createMockPluginApi();
+      // The throw is the OS one, not an incidental harness error.
+      expect(() => capturedRegisterFn!(api)).toThrow(/EACCES/);
+
+      expect([...api._tools.keys()]).toEqual([]);
+      expect([...api._gatewayMethods.keys()]).toEqual([]);
+    });
+
+    it("logs `sil_plugin_data_dir_failed` naming the path + the REAL OS cause, with no credential vocabulary", () => {
+      const api = createMockPluginApi();
+      try {
+        capturedRegisterFn!(api);
+      } catch {
+        // Expected — the log is emitted before the rethrow.
+      }
+      const failCalls = vi
+        .mocked(api.logger.error)
+        .mock.calls.filter(([marker]) => marker === "sil_plugin_data_dir_failed");
+      expect(failCalls).toHaveLength(1);
+      const detail = JSON.stringify(failCalls[0]![1]);
+      expect(detail).toContain(targetDataDir);
+      // EACCES, not ENOTDIR: the cause is read off the OS error, never a literal.
+      expect(detail).toContain("EACCES");
+      // Registration-time log: no credential material, on the loudest path.
+      expect(detail).not.toContain("access_token");
+      expect(detail).not.toContain("refresh_token");
+      expect(detail).not.toContain("Bearer");
+    });
+
+    it("is NOT VACUOUS — the SAME register() populates both surfaces once the dir is creatable", () => {
+      // Without this, "registers nothing" is satisfied by any throw at all —
+      // including a broken harness that never reaches the plugin. Same captured
+      // register, same api factory, only the directory mode changes.
+      chmodSync(containingDir, 0o700);
+
+      const api = createMockPluginApi();
+      expect(() => capturedRegisterFn!(api)).not.toThrow();
+      expect(api._tools.size).toBeGreaterThan(0);
+      // Count only — the method NAME is pinned by the single exact-set carrier in
+      // `search-results-method.integration.test.ts`; a second name mirror here
+      // would only add a place to forget to bump.
+      expect(api._gatewayMethods.size).toBe(1);
+    });
+  },
+);
 
 describe("plugin load — the register path is SOURCE-authoritative, immune to a stale on-disk dist (AC3)", () => {
   // The masked-regression instance the card exists to kill. PRE-FIX this file

--- a/src/lib/search-results-store.ts
+++ b/src/lib/search-results-store.ts
@@ -12,12 +12,15 @@
  * this map and answers over the paired `deviceToken` WS.
  *
  * The key is the HOST's `callId`, verbatim — never prefixed, hashed, or
- * re-minted. It is the one identifier that is reliably streamed (the client
- * already reads it off the tool identity frames as `data.itemId`), and
- * `execute()` receives it BEFORE any I/O, so a page can never be orphaned by a
- * failing search. Because that id is visible to anyone who can see the frames,
- * knowledge of a `callId` is NOT evidence of entitlement: the principal check
- * below is the only gate that matters.
+ * re-minted. `execute()` receives it BEFORE any I/O, so a page can never be
+ * orphaned by a failing search. A client joins on
+ * `data.toolCallId ?? data.itemId`, in that order: the id is the same string on
+ * every frame, but the FIELD NAME differs per family (`session.tool` carries
+ * only `toolCallId`, the `agent`/`stream:"item"` frames only `itemId`) and on
+ * the non-codex path `itemId` is `tool:`-prefixed — see
+ * `docs/decisions/search-results-pull-surface.md`. Because that id is visible to
+ * anyone who can see the frames, knowledge of a `callId` is NOT evidence of
+ * entitlement: the principal check below is the only gate that matters.
  *
  * In-memory, by choice. Process death is the strongest retention ceiling
  * available and costs nothing; an on-disk buffer would put prices, seller


### PR DESCRIPTION
## Card

`cards/sil-search-results-is-unknown-on-a-stock-gateway.md` (gitignored-mode — the card lives in
the `card/…` worktree, not this branch; see its body for the full intent + handoffs).

## Summary

`sil.search_results` shipped in 0.4.5 (#71) and **did not exist on any stock gateway** — every
paired client got `ok:false / INVALID_REQUEST: unknown method`, and every SIL Studio device
rendered the degraded notice with zero product cards.

The cause is **registry visibility, not process identity**. `register()` already ran in the
gateway process and already called `registerGatewayMethod` — but into the request-local
*tool-discovery* registry, which the host deliberately never installs as active
(`standalone-runtime-registry-loader.ts:96`). Dispatch resolves from the live *active* registry.
`unknown method` was never "not registered"; it was **"registered where nobody looks."**

`activation.onStartup: true` puts sil in the gateway-startup plan, whose registry IS installed as
active and gateway-bindable, and the agent tool path then prefers that same registry — one module
instance, one store.

- `openclaw.plugin.json` — `activation` gains `"onStartup": true` alongside `"onCapabilities": ["tool"]`
  (the posture bundled `google-meet` already ships). **No file under `src/` changes.**
- `CHANGELOG.md` — `## [Unreleased]`.
- Tests (qa): AC3 manifest-posture guard, AC2 compiled writer/reader single-store proof, AC10
  fail-closed no-registration on an uncreatable `$SIL_DATA_DIR`.

Observed at the host, before/after:

```
before  [gateway] http server listening (2 plugins: codex, memory-core; 0.7s)
after   [gateway] http server listening (3 plugins: codex, memory-core, sil; 1.2s)
```

## Test plan

- [x] `pnpm test` — **5 back-to-back runs, exit `0` each**; 51 files, 1444 tests
      (excluding `repo-scaffold.integration.test.ts`, which fails in every worktree by design)
- [x] `tsc --noEmit` and `tsc -p tsconfig.build.json` clean
- [x] AC3 proven non-vacuous — deleting the key turns exactly 2 assertions RED
- [x] **AC1 live vector** on `openclaw/openclaw:2026.7.1` with the locally packed tarball linked:
      paired Ed25519 device WS → real codex agent turn → `sil_search` → `callId` off the tool
      frames → `sil.search_results` returns `{"status":"ok","products":[…2…],"cursor":"…"}`,
      same ids in the same rank order as the tool's own result. Verbatim response is in the
      card's `## In Dev`. Reproduced 3×.
- [x] Store-split hazard falsified by measurement: 34 `tools.invoke` searches EVICT the agent
      turn's page (bounded at 32, lazy eviction on write) ⇒ one store, one module instance.

## Note for reviewers

The live wire carries the host's callId on `data.toolCallId` — **`data.itemId` is absent from
every `session.tool` frame** on 2026.7.1, contrary to the store's docstring and
`[[search-results-pull-surface]]`. No code change here (the key is opaque to the plugin), but the
docs are wrong and Studio's decoder must join on `toolCallId`. Flagged for distillation and for
the Studio card `card/align` (PR #13).

## Distillation target

Knowledge capture happens **after Review PASS** in the `distilling` stage — `solutions-architect`
runs in this same worktree, commits to this same branch, and pushes here so the PR ends up
containing implementation + tests + distillation in one mergeable unit.