### PR TITLE
feature: sil_domain_find — the fifth catalog tool, so the read route is reachable

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -12,6 +12,7 @@
     "tools": [
       "sil_doctor",
       "sil_domain_create",
+      "sil_domain_find",
       "sil_learn",
       "sil_product_get",
       "sil_profile_get",

--- a/sil-shopping/SKILL.md
+++ b/sil-shopping/SKILL.md
@@ -87,7 +87,7 @@ while setup is incomplete; it sheds once a shopper exists.
 | re-read the shortlist before deciding (≤5 refs from a prior result) | `sil_product_get` | — |
 | "where can I buy this?" / does the pick ship to me | `sil_stores` | — |
 | a buy intent whose category has no settled registry path — or `sil_search` refused the domain, or refused a predicate and you cannot tell which | `sil_domain_find` | [`method_and_prds.md`](references/method_and_prds.md) |
-| `sil_domain_find` returned no adoptable match and `capped: false`, after research | `sil_domain_create` | [`method_and_prds.md`](references/method_and_prds.md) |
+| a `sil_domain_find` **discovery** read (`q`) came back `matches: []` with `capped: false`, after research — a `path` probe never licenses a mint | `sil_domain_create` | [`method_and_prds.md`](references/method_and_prds.md) |
 | "set up an agent that shops for me" / "create my shopper" | (onboarding, then the engine) | [`agent_creation_engine.md`](references/agent_creation_engine.md) |
 | "what does my shopper know?" / "which domains / PRDs?" | `sil_profile_search` | [`method_and_prds.md`](references/method_and_prds.md) |
 | "show me the &lt;niche&gt; domain" (method or one PRD) | `sil_profile_get` | [`method_and_prds.md`](references/method_and_prds.md) |

--- a/sil-shopping/SKILL.md
+++ b/sil-shopping/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sil-shopping
-description: 'Use when the user explicitly asks to shop with sil or manage their sil shopper: register or check their sil account, search sil in one registry domain, re-read results by ref, list a pick''s sellers and where to buy, add a new category to the registry, set up their one shopper (a two-touchpoint, endorsement-gated onboarding), view or forget what it has learned (domains/PRDs), or — running as that shopper — execute the six-beat Spec-Driven Shopping loop and record a fact or taste it surfaced. Drives sil_register, sil_whoami, sil_search, sil_product_get, sil_stores, sil_domain_create, sil_profile_materialize, sil_profile_search, sil_profile_get, sil_profile_remove, sil_learn, sil_doctor.'
+description: 'Use when the user explicitly asks to shop with sil or manage their sil shopper: register or check their sil account, search sil in one registry domain, re-read results by ref, list a pick''s sellers and where to buy, read the registry for a category before coining one and add a new category to it, set up their one shopper (a two-touchpoint, endorsement-gated onboarding), view or forget what it has learned (domains/PRDs), or — running as that shopper — execute the six-beat Spec-Driven Shopping loop and record a fact or taste it surfaced. Drives sil_register, sil_whoami, sil_search, sil_product_get, sil_stores, sil_domain_find, sil_domain_create, sil_profile_materialize, sil_profile_search, sil_profile_get, sil_profile_remove, sil_learn, sil_doctor.'
 metadata:
   openclaw:
     emoji: "\U0001F6D2"
@@ -28,15 +28,17 @@ it knows, view or forget a domain, refine it.
   `serviceability: unknown` are ordinary answers that KEEP their subject. Present
   the result and name the gap; never drop a result or a seller for carrying one,
   and never read an `unset` cost as zero or free.
-- **Buy-intent in an unlearned niche ⇒ mint first — and there are TWO mints, for
-  two different stores.** *Your* method is local: a niche you have not learned is a
-  MISS, `sil_profile_search` returns it with `next_step: sil_learn`, and you
-  research the buying guide and `sil_learn create` the method before shopping.
-  *sil's* category is global: `sil_search` takes one registry `domain` and refuses a
-  path the registry does not hold, which is a routing signal — not a failure and not
-  an empty shelf. Answer it with `sil_domain_create` at the path you actually meant,
-  then re-issue the search. Never coin a shallower or re-spelled path to dodge a
-  refusal: the registry is shared by every shopper and nothing can undo a mint.
+- **Buy-intent in an unlearned niche ⇒ TWO shelves, and each is READ before it is
+  written.** One symmetry, stated once. *Your* method is local: a niche you have
+  not learned is a MISS, `sil_profile_search` returns it with
+  `next_step: sil_learn`, and you research the buying guide and `sil_learn create`
+  the method before shopping. *sil's* category is global: `sil_domain_find` reads
+  the registry in the buyer's own words, and only when that read names no adoptable
+  match — and states the answer was complete (`capped: false`) — do you coin one
+  with `sil_domain_create` and re-issue the search. `sil_search` refusing a path the
+  registry does not hold is a routing signal, not a failure and not an empty shelf.
+  Never coin a shallower or re-spelled path to dodge a refusal: the registry is
+  shared by every shopper and nothing can undo a mint.
 - **Every pick comes out of a sil tool.** A product, price, seller or buy URL that
   did not come back from `sil_search` / `sil_product_get` / `sil_stores` never
   enters the shortlist — never from the open web, even when sil returns nothing and
@@ -66,8 +68,9 @@ shopper set up — any `domains`?).
 
 - **No identity** ⇒ guide the user to register.
 - **No shopper / no domains** ⇒ a one-off search still works, but it is never bare:
-  `sil_search` needs a registry `domain`, so settle the category first (and coin it
-  with `sil_domain_create` when sil refuses it). Offer the setup path alongside.
+  `sil_search` needs a registry `domain`, so settle the category first.
+  `sil_domain_find` is HOW you settle it; `sil_domain_create` is what you do only
+  when that read named nothing to adopt. Offer the setup path alongside.
 - **Shopper present** ⇒ shop through what you know about the person via the loop.
 
 [`references/setup_onboarding.md`](references/setup_onboarding.md) owns the setup
@@ -83,7 +86,8 @@ while setup is incomplete; it sheds once a shopper exists.
 | "find X" / "search for X" in one settled category | `sil_search` | — |
 | re-read the shortlist before deciding (≤5 refs from a prior result) | `sil_product_get` | — |
 | "where can I buy this?" / does the pick ship to me | `sil_stores` | — |
-| `sil_search` refused the domain as unregistered, after research | `sil_domain_create` | — |
+| a buy intent whose category has no settled registry path — or `sil_search` refused the domain, or refused a predicate and you cannot tell which | `sil_domain_find` | [`method_and_prds.md`](references/method_and_prds.md) |
+| `sil_domain_find` returned no adoptable match and `capped: false`, after research | `sil_domain_create` | [`method_and_prds.md`](references/method_and_prds.md) |
 | "set up an agent that shops for me" / "create my shopper" | (onboarding, then the engine) | [`agent_creation_engine.md`](references/agent_creation_engine.md) |
 | "what does my shopper know?" / "which domains / PRDs?" | `sil_profile_search` | [`method_and_prds.md`](references/method_and_prds.md) |
 | "show me the &lt;niche&gt; domain" (method or one PRD) | `sil_profile_get` | [`method_and_prds.md`](references/method_and_prds.md) |

--- a/sil-shopping/references/method_and_prds.md
+++ b/sil-shopping/references/method_and_prds.md
@@ -69,8 +69,11 @@ sil holds is what a predicate can be evaluated against; a synonym (`speed_mbps` 
     `specs` keys into `## Search vocabulary`, coin nothing.
   - **descend** — a guide describing a *broader* category ⇒ the only mint permitted is
     a **descendant** of that path, never a sibling and never a re-rooted one.
-  - **mint licensed** — no returned match states `exists: true` **and** `capped` is
-    `false` ⇒ research, probe, coin.
+  - **mint licensed** — a **`q` discovery read** came back `matches: []` beside
+    `capped: false` ⇒ research, probe, coin. Only that read licenses a mint: a `path`
+    probe never licenses one — it answers about the path you already guessed, and its
+    `exists: false` is silent about the standing path under a different parent, the
+    fork this route exists to prevent.
   - **narrow** — `capped: true` ⇒ the answer was bounded and the standing path may sit
     just past it. Sharpen the ask, read once more; the mint is **not** licensed.
 - **One concept, one spelling — take the key sil already holds.** A domain in the
@@ -91,7 +94,10 @@ sil holds is what a predicate can be evaluated against; a synonym (`speed_mbps` 
   reach: settle the read, never coin around it. And when `sil_search` refuses, its two
   refusals read alike, so `path`-probe the domain you submitted and let the stated
   `exists` decide — `true` means fix the predicate and re-issue, `false` means the
-  domain was the problem. A permanent global write is never entered off refusal prose.
+  domain was the problem. `false` ends the probe's job, not the discipline: read again
+  in the buyer's own words (`q`), and coin only if that discovery read returns
+  `matches: []` with `capped: false`. A permanent global write is never entered off
+  refusal prose, and never off a probe.
 - **A provisional match (`validated_at: null`) is adopted like any other.** It keeps its
   place in the answer, and re-minting it earns a refusal. Its first answers come from
   the web while sil catches up — say that to the buyer; every result and seller it

--- a/sil-shopping/references/method_and_prds.md
+++ b/sil-shopping/references/method_and_prds.md
@@ -12,9 +12,11 @@ fill. Three paths.
 ## LOAD — the hot path (HIT, fresh)
 
 A plain revisit **LOADS**: `sil_profile_get(domain)` reads the durable method body
-— **no research**. This is the default on every revisit; the method is
-**recovered, never rebuilt**. Loading its `## Search vocabulary` brings that domain's
-spec keys into context for Beat 4.
+— **no research, and no registry read**. This is the default on every revisit; the
+method is **recovered, never rebuilt**. Loading its `## Search vocabulary` brings that
+domain's spec keys into context for Beat 4. A method that already records a settled
+registry path is searched with **no `sil_domain_find` call at all** — the registry read
+is the cold path's first move, never a per-search toll.
 
 ## MINT — cold (MISS)
 
@@ -31,6 +33,12 @@ guide generalises**: `earbuds` serves gym, commute, and office; the gym specific
 in the gym PRD, not a `wireless-gym-earbuds` method. Folding the use-context into the
 domain forks a near-duplicate method per intent and kills reuse.
 
+**sil's registry is the first place you explore — before the web.** It is the cheapest
+read you have, and what it returns is what every other shopper already agreed to call
+things. `sil_domain_find` runs *while* `## Search vocabulary` is being composed, so an
+adopted path and its keys are recorded at creation rather than retrofitted afterwards;
+the block below owns the detail.
+
 Persist with **`sil_learn create`** (`target: "method"`, domain + name + body) — the
 file **is** the registration (it errors if the method already exists: a revisit LOADs,
 a stale one REFRESHes with `write`). Never the setup-only `sil_profile_materialize`.
@@ -45,23 +53,54 @@ carries these sections, and only these:
   `user_spec` (omit until something durable is known).
 - **`## Volatility`** — the volatile axis + a rough refresh cadence.
 
-**The registry owns the spelling — this block records it.** A `key` sil holds is what
-a predicate can be evaluated against; a synonym (`speed_mbps` vs
+**The registry owns the spelling, and `sil_domain_find` is how you read it.** A `key`
+sil holds is what a predicate can be evaluated against; a synonym (`speed_mbps` vs
 `transfer_speed_mbps`) is simply outside the resolved vocabulary and comes back
 `applied: false` — a named gap, never a filter. So:
 
+- **Read in the buyer's own words, not a path guess.** `sil_domain_find`'s `q` is
+  matched against each standing category's path text *and* its buying guide, so prose
+  reaches a settled path that a path-shaped guess walks straight past. Budget: **at
+  most 2 discovery reads** — the buyer's ask verbatim, then the plain category name
+  only if the first returned nothing — **plus 1 `path` probe**. The probe asks a
+  different question and does **not** count against the two: **≤2 + 1**.
+- **Judge fit on the returned `guide`, never on how a path reads.** Four verdicts:
+  - **adopt** — a guide describing *this* category ⇒ take that path verbatim, copy its
+    `specs` keys into `## Search vocabulary`, coin nothing.
+  - **descend** — a guide describing a *broader* category ⇒ the only mint permitted is
+    a **descendant** of that path, never a sibling and never a re-rooted one.
+  - **mint licensed** — no returned match states `exists: true` **and** `capped` is
+    `false` ⇒ research, probe, coin.
+  - **narrow** — `capped: true` ⇒ the answer was bounded and the standing path may sit
+    just past it. Sharpen the ask, read once more; the mint is **not** licensed.
 - **One concept, one spelling — take the key sil already holds.** A domain in the
   registry resolves its own vocabulary; write those keys down here verbatim rather
   than coining beside them.
 - **Coining is `sil_domain_create`'s job, once, for a NEW category** — its `specs` are
-  the first keys of a path sil did not have. An existing path is refused and nothing is
-  written; never coin a near-path variant to route around that refusal.
+  the first keys of a path sil did not have. `path`-probe the exact path you are about
+  to coin and write **only the keys it does not already inherit**: on `exists: false`
+  the probe still returns the vocabulary that path would inherit, and the mint answers
+  with the keys you handed it, so a skipped probe re-coins `brand` or `weight` off the
+  root and forks the vocabulary on your first predicate. An existing path is refused
+  and nothing is written; never coin a near-path variant to route around that refusal.
 - **Common attribute → conventional name.** When you are coining a new category's first
   keys, a widely-shared attribute (screen size, weight, RAM, waterproof rating,
   material…) takes its **conventional** name. Coin fresh only for a genuinely niche one.
+- **A read that did not return is not a read that returned nothing.** Any non-`ok`
+  status — `invalid_request`, a transient, `not_registered` — leaves the mint out of
+  reach: settle the read, never coin around it. And when `sil_search` refuses, its two
+  refusals read alike, so `path`-probe the domain you submitted and let the stated
+  `exists` decide — `true` means fix the predicate and re-issue, `false` means the
+  domain was the problem. A permanent global write is never entered off refusal prose.
+- **A provisional match (`validated_at: null`) is adopted like any other.** It keeps its
+  place in the answer, and re-minting it earns a refusal. Its first answers come from
+  the web while sil catches up — say that to the buyer; every result and seller it
+  named stays on the table.
 
 Naming is never a gate — an unresolved key costs precision, never blocks a search — and
-it is **silent to the buyer**: never surface key plumbing.
+it is **silent to the buyer**: never surface key plumbing. Only the **keys** are
+adopted: the registry's `guide` is the evidence you judge fit on, while
+`## How it's bought` stays your own research.
 
 ## REFRESH — signal-driven (HIT, stale)
 

--- a/src/__tests__/catalog-domain-find.integration.test.ts
+++ b/src/__tests__/catalog-domain-find.integration.test.ts
@@ -1,0 +1,502 @@
+/**
+ * INTEGRATION — `sil_domain_find` wired end to end over a mocked `fetch`.
+ *
+ * THE VERB IS THE WHOLE SAFETY PROPERTY. `/catalog/domains` is the first sil-api
+ * path served by two verbs, and the two could not be further apart: `GET` reads
+ * the registry and writes nothing, `POST` performs v0's ONE permanent,
+ * un-undoable global write. A read that used the wrong verb would turn a
+ * discovery call into a mint — so the shared double buckets by METHOD, and every
+ * assertion below reads `router.domainFind` (the read) and `router.domains` (the
+ * mint) as separate lists. A read that reached the mint bucket fails loudly here
+ * rather than being narrated as safe.
+ *
+ * TWO ANSWERS CARRY THE PRODUCT WEIGHT, and they are the two an ordinary "did it
+ * return 200" test cannot tell apart:
+ *
+ *   - `matches: []` beside `capped: false` is a SUCCESS and the ONLY thing that
+ *     licenses the mint. Read as a failure — or as an absence — the agent is back
+ *     to the cold-start behaviour this card exists to delete.
+ *   - the payload passes through VERBATIM. `inherited` and `defined_at` are what
+ *     let an agent coin only the keys a path does not already inherit; a
+ *     projector that dropped them would leave that rule unexecutable while every
+ *     status assertion here stayed green.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { registerCatalogTools } from "../tools/catalog.js";
+import { setApiUrl, setWebUrl, getApiUrl } from "../lib/config.js";
+import { readTokens } from "../lib/credentials.js";
+import { createMockPluginApi, getTool, type MockPluginAPI } from "./helpers/mock-plugin-api.js";
+import {
+  SIL_API,
+  SIL_WEB,
+  bearerToken,
+  infoMarkerCount,
+  installRouter,
+  logBlob,
+  ok,
+  payloadOf,
+  queryOf,
+  rotated,
+  seedTokens,
+} from "./helpers/v0-harness.js";
+import {
+  AUTH,
+  FIND_400_BOTH,
+  FIND_400_NEITHER,
+  GOLDEN_DOMAINS,
+  domainFindCapped,
+  domainFindEmpty,
+  domainFindGolden,
+  domainFindProbeMiss,
+  matchFor,
+} from "./helpers/v0-wire.js";
+
+const TOOL = "sil_domain_find";
+const ACCESS = "at-live-token";
+const REFRESH = "rt-live-token";
+
+const ASK = { q: "ski boots for a heavy aggressive skier" };
+const PROBE = { path: "product.sports.winter.ski.boots.freeride" };
+
+let api: MockPluginAPI;
+let dataDir: string;
+let priorDataDir: string | undefined;
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), "sil-v0-find-"));
+  priorDataDir = process.env["SIL_DATA_DIR"];
+  process.env["SIL_DATA_DIR"] = dataDir;
+  setWebUrl(SIL_WEB);
+  setApiUrl(SIL_API);
+  api = createMockPluginApi();
+  registerCatalogTools(api);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  setWebUrl("");
+  setApiUrl("");
+  if (priorDataDir === undefined) delete process.env["SIL_DATA_DIR"];
+  else process.env["SIL_DATA_DIR"] = priorDataDir;
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+async function run(
+  params: Record<string, unknown> = ASK,
+  callId = "call-1",
+): Promise<Record<string, unknown>> {
+  return payloadOf(await getTool(api, TOOL).execute(callId, params));
+}
+
+/** The double, answering the read with `body` and everything else with `{}`. */
+function serve(body: unknown = domainFindGolden()) {
+  return installRouter((kind) => (kind === "domainFind" ? ok(body) : ok({})));
+}
+
+describe("one route, one request — and the write is never entered", () => {
+  it("GETs `/catalog/domains?q=…` with a Bearer, exactly once", async () => {
+    seedTokens(ACCESS, REFRESH);
+    const router = serve();
+    await run();
+
+    expect(router.domainFind).toHaveLength(1);
+    const [request] = router.domainFind;
+    expect(request.method).toBe("GET");
+    expect(request.url.startsWith(`${getApiUrl()}/catalog/domains?`)).toBe(true);
+    expect([...queryOf(request).keys()]).toEqual(["q"]);
+    expect(queryOf(request).get("q")).toBe(ASK.q);
+    expect(bearerToken(request)).toBe(ACCESS);
+  });
+
+  it("the GET carries NO body and NO content-type — it is a read", async () => {
+    // A GET body is at best ignored and in strict fetch environments throws; the
+    // principal comes from the Bearer JWT, never from a request body.
+    seedTokens(ACCESS, REFRESH);
+    const router = serve();
+    await run();
+    expect(router.domainFind[0].hasBody).toBe(false);
+    expect(router.domainFind[0].body).toBeNull();
+  });
+
+  it("the MINT bucket stays empty — a read never performs the global write", async () => {
+    // The structural half of BR-1. `POST /catalog/domains` and
+    // `GET /catalog/domains` are separate buckets in the double precisely so
+    // this is an assertion rather than a claim.
+    seedTokens(ACCESS, REFRESH);
+    const router = serve();
+    await run();
+    expect(router.domains).toEqual([]);
+  });
+
+  it("no other route is touched, and nothing lands unrouted", async () => {
+    seedTokens(ACCESS, REFRESH);
+    const router = serve();
+    await run();
+    expect(router.search).toEqual([]);
+    expect(router.lookup).toEqual([]);
+    expect(router.stores).toEqual([]);
+    expect(router.refresh).toEqual([]);
+    expect(router.other).toEqual([]);
+    expect(router.all).toHaveLength(1);
+  });
+
+  it("a `path` probe GETs the same route with exactly `?path=`", async () => {
+    seedTokens(ACCESS, REFRESH);
+    const router = serve(domainFindProbeMiss(PROBE.path));
+    await run(PROBE);
+    expect(router.domainFind).toHaveLength(1);
+    expect([...queryOf(router.domainFind[0]).keys()]).toEqual(["path"]);
+    expect(queryOf(router.domainFind[0]).get("path")).toBe(PROBE.path);
+    expect(router.domains).toEqual([]);
+  });
+
+  it("the token never reaches a log line or the result", async () => {
+    seedTokens(ACCESS, REFRESH);
+    serve();
+    const payload = await run();
+    expect(logBlob(api)).not.toContain(ACCESS);
+    expect(logBlob(api)).not.toContain(REFRESH);
+    expect(JSON.stringify(payload)).not.toContain(ACCESS);
+  });
+
+  it("the buyer's ask does not leak into a log line either", async () => {
+    // The ask is the buyer's own words. It travels to sil-api as the read's
+    // evidence; it is not operator telemetry.
+    seedTokens(ACCESS, REFRESH);
+    serve();
+    await run();
+    expect(logBlob(api)).not.toContain(ASK.q);
+  });
+
+  it("the read is NOT written to the search-results buffer — it holds no products", async () => {
+    const { getSearchResult, __resetSearchResultsStore } = await import(
+      "../lib/search-results-store.js"
+    );
+    __resetSearchResultsStore();
+    seedTokens(ACCESS, REFRESH);
+    serve();
+    await run(ASK, "call-find-buffer");
+    expect(getSearchResult("call-find-buffer", "")).toBeNull();
+  });
+});
+
+describe("the answer crosses the tool boundary whole", () => {
+  beforeEach(() => {
+    seedTokens(ACCESS, REFRESH);
+    serve();
+  });
+
+  it("`status: ok` beside the wire body, unprojected", async () => {
+    const payload = await run();
+    const wire = domainFindGolden();
+    expect(payload["status"]).toBe("ok");
+    expect(payload["matches"]).toEqual(wire["matches"]);
+    expect(payload["capped"]).toEqual(wire["capped"]);
+  });
+
+  it("`capped: false` is PRESENT, not stripped as a falsy nothing", async () => {
+    // Half the mint licence. A dropped `capped` reads as "the list was complete"
+    // to an agent that cannot see it was never told.
+    const payload = await run();
+    expect(payload).toHaveProperty("capped");
+    expect(payload["capped"]).toBe(false);
+  });
+
+  it("`capped` survives JSON serialization as `false`, not as an absent key", async () => {
+    const raw = (await getTool(api, TOOL).execute("call-raw", ASK)).content[0].text as string;
+    expect(raw).toContain('"capped"');
+    expect(JSON.parse(raw)).toHaveProperty("capped", false);
+  });
+
+  it("every `DomainSpecWire` field arrives — including the two BR-4 is computed from", async () => {
+    // `inherited` and `defined_at` are what let an agent coin ONLY the keys a
+    // path does not already inherit. A projector that dropped them would leave
+    // that rule unexecutable while every status assertion in this file stayed
+    // green — which is why this is asserted field by field, on a real body.
+    const payload = await run();
+    const match = matchFor(payload, GOLDEN_DOMAINS.validated);
+    const specs = match["specs"] as Record<string, unknown>[];
+    expect(specs.length).toBeGreaterThan(0);
+    for (const spec of specs) {
+      expect(Object.keys(spec).sort()).toEqual([
+        "allowed_values",
+        "data_type",
+        "defined_at",
+        "display_name",
+        "inherited",
+        "key",
+        "level",
+        "unit",
+        "value_set",
+      ]);
+    }
+  });
+
+  it("the INHERITED key keeps its ancestor's `defined_at` — the shadow rule, made visible", async () => {
+    const payload = await run();
+    const specs = matchFor(payload, GOLDEN_DOMAINS.validated)["specs"] as Record<
+      string,
+      unknown
+    >[];
+    const brand = specs.find((s) => s["key"] === "brand");
+    expect(brand?.["inherited"]).toBe(true);
+    expect(brand?.["defined_at"]).toBe("product");
+    expect(brand?.["value_set"]).toBe("brands");
+    const flex = specs.find((s) => s["key"] === "flex_index");
+    expect(flex?.["inherited"]).toBe(false);
+    expect(flex?.["unit"]).toBe("count");
+  });
+
+  it("a NULL field is a stated fact, not a dropped key", async () => {
+    // `unit: null` on an enum and `allowed_values: null` on a number are the
+    // answer, and an omitted key is a different one.
+    const payload = await run();
+    const specs = matchFor(payload, GOLDEN_DOMAINS.validated)["specs"] as Record<
+      string,
+      unknown
+    >[];
+    const brand = specs.find((s) => s["key"] === "brand");
+    expect(brand).toHaveProperty("unit", null);
+    expect(brand).toHaveProperty("allowed_values", null);
+    const soleNorm = specs.find((s) => s["key"] === "sole_norm");
+    expect(soleNorm?.["allowed_values"]).toEqual(["gripwalk", "alpine"]);
+    expect(soleNorm).toHaveProperty("value_set", null);
+  });
+
+  it("the `guide` is verbatim and untruncated — it is what fit is judged on", async () => {
+    // A shortened guide reads as a complete one, and adopting a domain that is
+    // not the buyer's pollutes silently — harder to see than a duplicate mint.
+    const payload = await run();
+    const wire = matchFor(domainFindGolden(), GOLDEN_DOMAINS.validated);
+    expect(matchFor(payload, GOLDEN_DOMAINS.validated)["guide"]).toBe(wire["guide"]);
+  });
+
+  it("a FENCED match keeps its place, with the fence stated", async () => {
+    // `validated_at: null` means minted but not yet validated. It is a real
+    // domain, it is adopted like any other, and re-minting it earns a 409 —
+    // so it must be returned, never quietly held back.
+    const payload = await run();
+    const fenced = matchFor(payload, GOLDEN_DOMAINS.fenced);
+    expect(fenced).toHaveProperty("validated_at", null);
+    expect(fenced["exists"]).toBe(true);
+  });
+
+  it("`exists` is present on every match", async () => {
+    const payload = await run();
+    for (const match of payload["matches"] as Record<string, unknown>[]) {
+      expect(typeof match["exists"]).toBe("boolean");
+    }
+  });
+});
+
+describe("the empty answer is the MINT SIGNAL, and it is a success", () => {
+  beforeEach(() => seedTokens(ACCESS, REFRESH));
+
+  it("`matches: []` with `capped: false` reaches the agent as `ok`", async () => {
+    serve(domainFindEmpty());
+    const payload = await run();
+    expect(payload["status"]).toBe("ok");
+    expect(payload["matches"]).toEqual([]);
+    expect(payload["capped"]).toBe(false);
+  });
+
+  it("the empty answer is never framed as a failure or an absence", async () => {
+    serve(domainFindEmpty());
+    const payload = await run();
+    for (const failure of ["not_found", "invalid_request", "retryable", "must_reregister", "error"]) {
+      expect(payload["status"]).not.toBe(failure);
+    }
+    expect(payload).not.toHaveProperty("recovery");
+  });
+
+  it("`matches: []` survives serialization as an empty array, not an absent key", async () => {
+    serve(domainFindEmpty());
+    const raw = (await getTool(api, TOOL).execute("call-empty", ASK)).content[0].text as string;
+    expect(raw).toContain('"matches"');
+    expect(JSON.parse(raw)).toHaveProperty("matches", []);
+  });
+
+  it("`capped: true` crosses intact — a bounded list is not an empty one", async () => {
+    // The one that re-creates the whole defect if it is lost: an agent that
+    // reads a bounded list, sees nothing fit and mints, while the standing path
+    // sat just past the bound.
+    serve(domainFindCapped());
+    const payload = await run();
+    expect(payload["status"]).toBe("ok");
+    expect(payload["capped"]).toBe(true);
+  });
+});
+
+describe("the probe answers about ONE path, and states both facts", () => {
+  it("`exists: false` arrives beside the vocabulary the path WOULD inherit", async () => {
+    seedTokens(ACCESS, REFRESH);
+    serve(domainFindProbeMiss(PROBE.path));
+    const payload = await run(PROBE);
+    expect(payload["status"]).toBe("ok");
+    const [match] = payload["matches"] as Record<string, unknown>[];
+    expect(match["path"]).toBe(PROBE.path);
+    expect(match["exists"]).toBe(false);
+    expect(match).toHaveProperty("guide", null);
+    expect((match["specs"] as unknown[]).length).toBeGreaterThan(0);
+  });
+
+  it("a probe MISS is NOT an empty answer — `matches` carries one element", async () => {
+    // The distinction BR-4 rests on: a probe answers only about the path already
+    // guessed, so its miss can shape a mint but must never license one.
+    seedTokens(ACCESS, REFRESH);
+    serve(domainFindProbeMiss(PROBE.path));
+    const payload = await run(PROBE);
+    expect((payload["matches"] as unknown[]).length).toBe(1);
+  });
+});
+
+describe("the refusals", () => {
+  beforeEach(() => seedTokens(ACCESS, REFRESH));
+
+  it.each([
+    ["neither", FIND_400_NEITHER, {}],
+    ["both", FIND_400_BOTH, { q: "ski boots", path: "product.sports.winter.ski.boots" }],
+  ])("a 400 for %s surfaces the route's own message VERBATIM", async (_label, body, params) => {
+    installRouter((kind) => (kind === "domainFind" ? { status: 400, body } : ok({})));
+    const payload = await run(params);
+    expect(payload["status"]).toBe("invalid_request");
+    expect(payload["error"]).toBe("invalid_request");
+    expect(payload["message"]).toBe(body.message);
+    // No `recovery` on a 400: auth is fine, and re-sending the same querystring
+    // cannot succeed.
+    expect(payload).not.toHaveProperty("recovery");
+  });
+
+  it("a refusal carries NO `matches` the agent could read as an empty shelf", async () => {
+    // BR-2, at the tool boundary: a read that did not return is not a read that
+    // returned nothing.
+    installRouter((kind) =>
+      kind === "domainFind" ? { status: 400, body: FIND_400_NEITHER } : ok({}),
+    );
+    const payload = await run({});
+    expect(payload).not.toHaveProperty("matches");
+    expect(payload).not.toHaveProperty("capped");
+  });
+
+  it("a transient failure carries no `matches` either, and asks for a retry", async () => {
+    installRouter((kind) => (kind === "domainFind" ? { status: 503, body: {} } : ok({})));
+    const payload = await run();
+    expect(payload["status"]).toBe("retryable");
+    expect(payload).not.toHaveProperty("matches");
+    expect(payload["recovery"]).not.toBe("sil_register");
+  });
+
+  it("a network failure is `retryable`, and exactly one request was attempted", async () => {
+    const router = installRouter((kind) => (kind === "domainFind" ? "network-error" : ok({})));
+    const payload = await run();
+    expect(payload["status"]).toBe("retryable");
+    expect(router.domainFind).toHaveLength(1);
+  });
+
+  it("a 200 the gate refuses is `retryable`, never a false `ok`", async () => {
+    // A body that cannot state `capped` cannot support the mint decision, so it
+    // is unusable rather than degraded.
+    const body = domainFindGolden();
+    delete body["capped"];
+    serve(body);
+    expect((await run())["status"]).toBe("retryable");
+  });
+});
+
+describe("A9 — the 401 choreography is the shared one", () => {
+  beforeEach(() => seedTokens(ACCESS, REFRESH));
+
+  it("a first 401 recovers silently — one refresh, one retry, the agent sees `ok`", async () => {
+    const router = installRouter((kind, nth) => {
+      if (kind === "domainFind") {
+        return nth === 0 ? { status: 401, body: AUTH.unauthorized } : ok(domainFindGolden());
+      }
+      if (kind === "refresh") return rotated("at-rotated", "rt-rotated");
+      return ok({});
+    });
+    const payload = await run();
+    expect(payload["status"]).toBe("ok");
+    expect(router.refresh).toHaveLength(1);
+    expect(router.domainFind).toHaveLength(2);
+    expect(bearerToken(router.domainFind[1])).toBe("at-rotated");
+    // The operator's only view of an otherwise-invisible recovery. Logs-only —
+    // it adds no field to the agent-facing payload.
+    expect(infoMarkerCount(api, "sil_domain_find_refreshed")).toBe(1);
+    expect(payload).not.toHaveProperty("refreshed");
+  });
+
+  it("the retry re-sends the SAME querystring — a recovery never re-asks a different question", async () => {
+    const router = installRouter((kind, nth) => {
+      if (kind === "domainFind") {
+        return nth === 0 ? { status: 401, body: AUTH.unauthorized } : ok(domainFindGolden());
+      }
+      if (kind === "refresh") return rotated("at-rotated", "rt-rotated");
+      return ok({});
+    });
+    await run();
+    expect(queryOf(router.domainFind[1]).get("q")).toBe(queryOf(router.domainFind[0]).get("q"));
+    expect([...queryOf(router.domainFind[1]).keys()]).toEqual(["q"]);
+  });
+
+  it("a SECOND 401 clears the tokens and is terminal `must_reregister`", async () => {
+    const router = installRouter((kind) => {
+      if (kind === "domainFind") return { status: 401, body: AUTH.unauthorized };
+      if (kind === "refresh") return rotated("at-rotated", "rt-rotated");
+      return ok({});
+    });
+    const payload = await run();
+    expect(payload["status"]).toBe("must_reregister");
+    expect(payload["recovery"]).toBe("sil_register");
+    expect(readTokens()).toBeNull();
+    expect(router.refresh).toHaveLength(1);
+    expect(router.domainFind).toHaveLength(2);
+  });
+
+  it("a refresh 5xx is `retryable`, the tokens SURVIVE, and no retry is made", async () => {
+    const router = installRouter((kind) => {
+      if (kind === "domainFind") return { status: 401, body: AUTH.unauthorized };
+      if (kind === "refresh") return { status: 503, body: { error: "unavailable" } };
+      return ok({});
+    });
+    const payload = await run();
+    expect(payload["status"]).toBe("retryable");
+    expect(readTokens()?.access_token).toBe(ACCESS);
+    expect(router.domainFind).toHaveLength(1);
+  });
+
+  it("403 `user_not_provisioned` clears the tokens; `principal_mismatch` does not", async () => {
+    installRouter((kind) =>
+      kind === "domainFind" ? { status: 403, body: AUTH.principalMismatch } : ok({}),
+    );
+    expect((await run(ASK, "call-a"))["reason"]).toBe("principal_mismatch");
+    expect(readTokens()?.access_token).toBe(ACCESS);
+
+    vi.restoreAllMocks();
+    installRouter((kind) =>
+      kind === "domainFind" ? { status: 403, body: AUTH.userNotProvisioned } : ok({}),
+    );
+    expect((await run(ASK, "call-b"))["reason"]).toBe("user_not_provisioned");
+    expect(readTokens()).toBeNull();
+  });
+
+  it("no 401 path ever reaches the MINT route", async () => {
+    // The worst available failure on this surface: a recovery that retried the
+    // wrong verb would perform the permanent write while recovering from an
+    // expired session.
+    const router = installRouter((kind, nth) => {
+      if (kind === "domainFind") {
+        return nth === 0 ? { status: 401, body: AUTH.unauthorized } : ok(domainFindGolden());
+      }
+      if (kind === "refresh") return rotated("at-rotated", "rt-rotated");
+      return ok({});
+    });
+    await run();
+    expect(router.domains).toEqual([]);
+    expect(router.other).toEqual([]);
+  });
+});

--- a/src/__tests__/cross-tool-401-parity.integration.test.ts
+++ b/src/__tests__/cross-tool-401-parity.integration.test.ts
@@ -2,7 +2,7 @@
  * INTEGRATION — A9: the 401 choreography is UNIFORM across every sil-api-calling
  * tool, and it is one shared helper, never a per-tool handler.
  *
- * Six tools reach sil-api with a Bearer: the four v0 catalog tools plus
+ * Six tools reach sil-api with a Bearer: the FIVE v0 catalog tools plus
  * `sil_whoami`. Each drives `refreshAndRetryOnce` — at most one refresh, at most
  * one retry, no loop. The failure this file forecloses is DRIFT: a tool that
  * refreshes twice, retries a dead token, clears credentials on a transient blip,
@@ -37,7 +37,13 @@ import {
   type RouteKind,
   type Router,
 } from "./helpers/v0-harness.js";
-import { AUTH, mintGolden, resultGolden, storesGolden } from "./helpers/v0-wire.js";
+import {
+  AUTH,
+  domainFindGolden,
+  mintGolden,
+  resultGolden,
+  storesGolden,
+} from "./helpers/v0-wire.js";
 
 const ACCESS = "at-live-token";
 const REFRESH = "rt-live-token";
@@ -67,6 +73,15 @@ const BEARER_TOOLS = [
     route: "domains" as const,
     params: { path: "product.sports.winter.ski.boots", guide: "how they are bought", specs: [] },
     success: (): unknown => mintGolden(),
+  },
+  {
+    // The read, on the mint's own path with the opposite verb — so `route` here
+    // is `domainFind`, NOT `domains`. Pointing it at the mint bucket would make
+    // this matrix drive the permanent write while claiming to test the read.
+    tool: "sil_domain_find",
+    route: "domainFind" as const,
+    params: { q: "ski boots" },
+    success: (): unknown => domainFindGolden(),
   },
   {
     tool: "sil_whoami",
@@ -274,12 +289,19 @@ describe("guard-of-the-guard: the matrix actually covers the surface", () => {
     // Deriving the expected set from the registered one closes that.
     const registered = [...api._tools.keys()];
     const silApiTools = registered.filter((name) =>
-      ["sil_search", "sil_product_get", "sil_stores", "sil_domain_create", "sil_whoami"].includes(name),
+      [
+        "sil_search",
+        "sil_product_get",
+        "sil_stores",
+        "sil_domain_create",
+        "sil_domain_find",
+        "sil_whoami",
+      ].includes(name),
     );
     expect(silApiTools.sort()).toEqual(BEARER_TOOLS.map((s) => s.tool).sort());
   });
 
-  it("each scenario really drove all five tools", () => {
-    expect(BEARER_TOOLS).toHaveLength(5);
+  it("each scenario really drove all six tools", () => {
+    expect(BEARER_TOOLS).toHaveLength(6);
   });
 });

--- a/src/__tests__/fixtures/README.md
+++ b/src/__tests__/fixtures/README.md
@@ -14,6 +14,7 @@ named one — and certify a wire that does not exist.
 |---|---|---|
 | `catalog-result-response.golden.json` | `sil-services` `dev` @ **`6a2b5ba`** — `services/sil-api/src/handlers/../__tests__/response-schema-contract.unit.test.ts`'s `SEARCH_RESPONSE`, the wire spec written as an instance | validates against `packages/schemas/schema/catalog-result-response.schema.json` |
 | `catalog-stores-response.golden.json` | `sil-services` `dev` @ **`6a2b5ba`** — assembled to `packages/db/src/stores.ts#buildStore`'s emission (all three serviceability states, `policy_evidence` on the negative one only) | validates against `packages/schemas/schema/catalog-stores-response.schema.json` |
+| `catalog-domain-find-response.golden.json` | `sil-services` `dev` @ **`0f72be5`** — assembled to `services/sil-api/src/handlers/domains.ts#toMatch` × `packages/db/src/registry.ts#toAgentSpec`'s emission, over the vocabulary `domain-find.db.integration.test.ts` seeds (the leaf's five coined specs plus the root's inherited `brand`, with `weight` shadowing) | validates against `packages/schemas/schema/catalog-domains-response.schema.json` |
 
 ## What makes them load-bearing
 
@@ -26,6 +27,14 @@ veto is computable from it, so a projection that drops any input is caught.
 `catalog-stores-response.golden.json` carries `serviceable` · `unknown` · `not_serviceable`
 in one body — `unknown` is the state the whole product turns on, and it is the one a
 filtering consumer would silently drop.
+
+`catalog-domain-find-response.golden.json` carries **both sides of every `DomainSpecWire`
+field that is nullable**: a `unit` set beside a null one, an inline `allowed_values` beside a
+named `value_set` beside neither, a `level` of `product` beside `variant` beside null, and
+`inherited: true` (`defined_at` an ancestor) beside `false`. All four `data_type`s appear, and
+the second match is **fenced** (`validated_at: null`) beside the first's timestamp. Those are
+exactly the fields BR-4's "coin only the keys this path does not already inherit" is computed
+from, so a projector that drops any of them is caught rather than merely suspected.
 
 ## When the sibling's contract moves
 

--- a/src/__tests__/fixtures/catalog-domain-find-response.golden.json
+++ b/src/__tests__/fixtures/catalog-domain-find-response.golden.json
@@ -1,0 +1,120 @@
+{
+  "matches": [
+    {
+      "path": "product.sports.winter.ski.boots",
+      "exists": true,
+      "validated_at": "2026-08-14T09:12:03.000Z",
+      "guide": "Hard-shell alpine ski boots that clamp into a binding. Fit comes first: last width in millimetres decides which shells can be made to work at all, then flex index for the skier's weight and aggression, then the shell shape itself. Sizing is mondopoint, and a liner that can be heat-moulded buys about half a size of adjustment.",
+      "specs": [
+        {
+          "key": "brand",
+          "display_name": "Brand",
+          "data_type": "enum",
+          "unit": null,
+          "allowed_values": null,
+          "value_set": "brands",
+          "level": "product",
+          "defined_at": "product",
+          "inherited": true
+        },
+        {
+          "key": "flex_index",
+          "display_name": "Flex index",
+          "data_type": "number",
+          "unit": "count",
+          "allowed_values": null,
+          "value_set": null,
+          "level": null,
+          "defined_at": "product.sports.winter.ski.boots",
+          "inherited": false
+        },
+        {
+          "key": "heat_moldable",
+          "display_name": "Heat mouldable",
+          "data_type": "boolean",
+          "unit": null,
+          "allowed_values": null,
+          "value_set": null,
+          "level": "product",
+          "defined_at": "product.sports.winter.ski.boots",
+          "inherited": false
+        },
+        {
+          "key": "msrp",
+          "display_name": "MSRP",
+          "data_type": "money",
+          "unit": null,
+          "allowed_values": null,
+          "value_set": null,
+          "level": "variant",
+          "defined_at": "product.sports.winter.ski.boots",
+          "inherited": false
+        },
+        {
+          "key": "sole_norm",
+          "display_name": "Sole norm",
+          "data_type": "enum",
+          "unit": null,
+          "allowed_values": ["gripwalk", "alpine"],
+          "value_set": null,
+          "level": "variant",
+          "defined_at": "product.sports.winter.ski.boots",
+          "inherited": false
+        },
+        {
+          "key": "weight",
+          "display_name": "Weight",
+          "data_type": "number",
+          "unit": "g",
+          "allowed_values": null,
+          "value_set": null,
+          "level": "variant",
+          "defined_at": "product.sports.winter.ski.boots",
+          "inherited": false
+        }
+      ]
+    },
+    {
+      "path": "product.sports.winter.ski.boots.race",
+      "exists": true,
+      "validated_at": null,
+      "guide": "Race-plate alpine boots: FIS-legal shells run narrower and stiffer than the recreational line, and the sole norm is fixed by the discipline rather than chosen.",
+      "specs": [
+        {
+          "key": "brand",
+          "display_name": "Brand",
+          "data_type": "enum",
+          "unit": null,
+          "allowed_values": null,
+          "value_set": "brands",
+          "level": "product",
+          "defined_at": "product",
+          "inherited": true
+        },
+        {
+          "key": "flex_index",
+          "display_name": "Flex index",
+          "data_type": "number",
+          "unit": "count",
+          "allowed_values": null,
+          "value_set": null,
+          "level": null,
+          "defined_at": "product.sports.winter.ski.boots",
+          "inherited": true
+        },
+        {
+          "key": "weight",
+          "display_name": "Weight",
+          "data_type": "number",
+          "unit": "g",
+          "allowed_values": null,
+          "value_set": null,
+          "level": "variant",
+          "defined_at": "product.sports.winter.ski.boots",
+          "inherited": true
+        }
+      ]
+    }
+  ],
+  "capped": false
+}

--- a/src/__tests__/helpers/v0-harness.ts
+++ b/src/__tests__/helpers/v0-harness.ts
@@ -1,14 +1,33 @@
 /**
- * The shared v0 catalog test harness — ONE `fetch` double for the four routes.
+ * The shared v0 catalog test harness — ONE `fetch` double for the five routes.
  *
  * The pre-v0 suite carried a near-identical `installRouter` in each of its
  * catalog integration files; four copies of a router is four places for the
- * origin/path assertions to drift apart, and the whole point of the four tools
- * being 1:1 with four routes is that they share one origin, one Bearer, one 401
+ * origin/path assertions to drift apart, and the whole point of the tools being
+ * 1:1 with the routes is that they share one origin, one Bearer, one 401
  * choreography and one error envelope. So the double is shared and the routing
- * is BY PATH, exhaustively — an unrouted request lands in `other`, which every
- * "exactly one fetch, to exactly its own path" assertion reads as a failure
- * rather than silently ignoring.
+ * is exhaustive — an unrouted request lands in `other`, which every "exactly one
+ * fetch, to exactly its own path" assertion reads as a failure rather than
+ * silently ignoring.
+ *
+ * ROUTING IS BY METHOD **AND** PATHNAME, because `/catalog/domains` is the first
+ * sil-api path served by two verbs: `GET` is the read (`domainFind`), `POST` is
+ * the mint (`domains`). Path alone cannot express that, and the two cheap
+ * alternatives are both wrong:
+ *
+ *   - matching the raw URL by suffix drops the read entirely —
+ *     `…/catalog/domains?q=ski+boots` does not END WITH `/catalog/domains`, so
+ *     it lands in `other` and reads as an unrouted request;
+ *   - loosening the suffix match to ignore the querystring is worse — the read
+ *     and the mint would then share ONE bucket, silently disarming the mint's
+ *     "exactly ONE write is attempted" bar and its `nthOfKind` sequencing.
+ *
+ * So the verb branch goes BEFORE the `ROUTE_PATH` loop, and `ROUTE_PATH` stays a
+ * 1:1 name→path map (it cannot express two kinds on one path). The split is what
+ * makes "a discovery read never performs the un-undoable global write" a
+ * STRUCTURAL assertion rather than a narrated one: a read that used the wrong
+ * verb lands in the mint bucket, and a mint that used the wrong verb lands in
+ * the read bucket. Both directions fail loudly.
  *
  * `fetch` is the ONLY thing mocked. The real sil-client, the real credentials
  * module, the real `refreshAndRetryOnce` and the real tools run above it.
@@ -21,10 +40,14 @@ import type { MockPluginAPI } from "./mock-plugin-api.js";
 
 /** The auth origin. Every catalog assertion pins it as the host that must NOT be hit. */
 export const SIL_WEB = "https://sil-web.test.example.com";
-/** The catalog origin — all four v0 routes, at their bare paths. */
+/** The catalog origin — every v0 route, at its bare path. */
 export const SIL_API = "https://sil-api.test.example.com";
 
-/** The four v0 routes, at the bare paths the architecture pins (no `/api/v1`). */
+/**
+ * The four POST-with-a-body routes, at the bare paths the architecture pins (no
+ * `/api/v1`). A 1:1 name→path map, which is exactly why the GET read is NOT in
+ * it: `/catalog/domains` carries two kinds, and one map key cannot hold both.
+ */
 export const ROUTE_PATH = {
   search: "/catalog/search",
   lookup: "/catalog/lookup",
@@ -32,7 +55,14 @@ export const ROUTE_PATH = {
   domains: "/catalog/domains",
 } as const;
 
-export type RouteKind = keyof typeof ROUTE_PATH | "refresh" | "other";
+/**
+ * `GET /catalog/domains` — the registry read, sharing the mint's path. Kept as
+ * its own constant beside `ROUTE_PATH` rather than inside it so the read and the
+ * mint can never collapse into one bucket by a careless map edit.
+ */
+export const DOMAIN_FIND_ROUTE = { method: "GET", path: "/catalog/domains" } as const;
+
+export type RouteKind = keyof typeof ROUTE_PATH | "domainFind" | "refresh" | "other";
 
 /** One recorded outbound request. */
 export interface Recorded {
@@ -51,7 +81,10 @@ export interface Router {
   search: Recorded[];
   lookup: Recorded[];
   stores: Recorded[];
+  /** `POST /catalog/domains` — the MINT bucket, and only the mint. */
   domains: Recorded[];
+  /** `GET /catalog/domains` — the READ bucket. Never the same list as `domains`. */
+  domainFind: Recorded[];
   refresh: Recorded[];
   /** Anything that matched no known path. Always assert this is empty. */
   other: Recorded[];
@@ -61,8 +94,9 @@ export interface Router {
  * Install the double. `reply(kind, nthOfKind, req)` decides each response.
  *
  * `/auth/refresh` is checked FIRST so a future shared path cannot be misrouted
- * onto a catalog bucket, and the catalog paths are matched by their exact bare
- * suffix so `/catalog/search` can never satisfy a `/catalog/stores` assertion.
+ * onto a catalog bucket. Then the verb split on `/catalog/domains`. Then the
+ * four bare paths, matched on the PATHNAME (never the raw URL) so a querystring
+ * cannot make a known route look unrouted.
  */
 export function installRouter(
   reply: (kind: RouteKind, nthOfKind: number, req: Recorded) => Reply,
@@ -73,6 +107,7 @@ export function installRouter(
     lookup: [],
     stores: [],
     domains: [],
+    domainFind: [],
     refresh: [],
     other: [],
   };
@@ -94,11 +129,14 @@ export function installRouter(
     const req: Recorded = { url, method, bearer, body, hasBody };
     router.all.push(req);
 
+    const path = pathnameOf(url);
     let kind: RouteKind = "other";
     if (url.includes("/auth/refresh")) kind = "refresh";
-    else {
-      for (const [name, path] of Object.entries(ROUTE_PATH)) {
-        if (url.endsWith(path)) {
+    else if (method === DOMAIN_FIND_ROUTE.method && path.endsWith(DOMAIN_FIND_ROUTE.path)) {
+      kind = "domainFind";
+    } else {
+      for (const [name, routePath] of Object.entries(ROUTE_PATH)) {
+        if (path.endsWith(routePath)) {
           kind = name as keyof typeof ROUTE_PATH;
           break;
         }
@@ -120,6 +158,28 @@ export function installRouter(
   });
 
   return router;
+}
+
+/**
+ * The path half of a request URL, querystring and fragment removed. Split by
+ * hand rather than through `new URL` so a relative or malformed URL a broken
+ * client emitted is still ROUTED (into `other`) instead of throwing inside the
+ * double — a fetch double that throws reports the wrong defect.
+ */
+function pathnameOf(url: string): string {
+  return url.split("#")[0].split("?")[0];
+}
+
+/**
+ * The request's querystring, parsed. Read the KEYS, not just the values: an
+ * emitted `q=` and an omitted `q` are DIFFERENT requests to `/catalog/domains`
+ * (the route answers "`q` must not be shorter than 1 character" for the first
+ * and "you sent neither" for the second), so a test that only reads values
+ * cannot tell them apart.
+ */
+export function queryOf(req: Recorded): URLSearchParams {
+  const [, search = ""] = req.url.split("#")[0].split("?");
+  return new URLSearchParams(search);
 }
 
 /** Parse a ToolResult's single text part as JSON. */

--- a/src/__tests__/helpers/v0-wire.ts
+++ b/src/__tests__/helpers/v0-wire.ts
@@ -35,6 +35,14 @@ export function storesGolden(): Record<string, unknown> {
   return read("catalog-stores-response.golden.json") as Record<string, unknown>;
 }
 
+/**
+ * `GET /catalog/domains`'s 200 — a DISCOVERY read (`?q=`) that named two domains.
+ * Fresh clone per call.
+ */
+export function domainFindGolden(): Record<string, unknown> {
+  return read("catalog-domain-find-response.golden.json") as Record<string, unknown>;
+}
+
 /** The mint's 200, which the route builds by hand — three fields, no more. */
 export function mintGolden(): Record<string, unknown> {
   return {
@@ -110,6 +118,82 @@ export function resultFor(
   return (body["results"] as Record<string, unknown>[]).find((r) => r["ref"] === ref);
 }
 
+/** The find golden with one top-level key deleted — the two-key envelope gate. */
+export function domainFindMissing(key: string): Record<string, unknown> {
+  const body = domainFindGolden();
+  delete body[key];
+  return body;
+}
+
+/** The find golden with `mutate` applied to `matches[0]` — the per-match gate. */
+export function domainFindWithMatch0(
+  mutate: (match: Record<string, unknown>) => void,
+): Record<string, unknown> {
+  const body = domainFindGolden();
+  mutate((body["matches"] as Record<string, unknown>[])[0]);
+  return body;
+}
+
+/**
+ * The MINT SIGNAL: the registry genuinely holds nothing for this ask, stated
+ * completely. `matches: []` beside `capped: false` is a SUCCESS — the one answer
+ * that licenses a permanent, un-undoable global write, which is why it has to be
+ * distinguishable from every failure by presence, never by length.
+ */
+export function domainFindEmpty(): Record<string, unknown> {
+  return { matches: [], capped: false };
+}
+
+/**
+ * The BOUNDED answer: K matches and more past the bound. `capped: true` is not a
+ * smaller success — an agent that reads a bounded list, sees nothing fit and
+ * mints while the standing path sat just past the bound has done exactly what
+ * this route exists to prevent, and only this field tells it.
+ */
+export function domainFindCapped(): Record<string, unknown> {
+  return { ...domainFindGolden(), capped: true };
+}
+
+/**
+ * A `?path=` PROBE of a path with no row — the shape BR-4 is computed from, and
+ * the one no text search can produce. Two facts that are never conflated:
+ * `exists: false` (there is no domain here) beside a non-empty `specs` (the
+ * vocabulary this path WOULD INHERIT if it were minted). `guide` is `null`
+ * because there is no row to carry one.
+ */
+export function domainFindProbeMiss(path = "product.sports.winter.ski.boots.freeride"): Record<
+  string,
+  unknown
+> {
+  const inherited = (
+    (domainFindGolden()["matches"] as Record<string, unknown>[])[0]["specs"] as Record<
+      string,
+      unknown
+    >[]
+  ).filter((spec) => spec["inherited"] === true);
+  return {
+    matches: [{ path, exists: false, validated_at: null, guide: null, specs: inherited }],
+    capped: false,
+  };
+}
+
+/** The match for `path`, or a legible throw naming what IS present. */
+export function matchFor(body: Record<string, unknown>, path: string): Record<string, unknown> {
+  const matches = body["matches"] as Record<string, unknown>[];
+  const found = matches.find((m) => m["path"] === path);
+  if (found === undefined) {
+    const paths = matches.map((m) => String(m["path"])).join(", ");
+    throw new Error(`no match for "${path}". Present: ${paths || "(none)"}`);
+  }
+  return found;
+}
+
+/** The two paths the find golden carries — one validated, one fenced. */
+export const GOLDEN_DOMAINS = {
+  validated: "product.sports.winter.ski.boots",
+  fenced: "product.sports.winter.ski.boots.race",
+} as const;
+
 /** The two refs the result golden carries — one catalog, one web. */
 export const GOLDEN_REFS = {
   catalog: "variant:0198f2a1-4c3d-7000-8000-0000000000a1",
@@ -157,6 +241,47 @@ export const STORES_404 = {
 export const MINT_409 = {
   error: "domain_exists",
   message: 'domain "product.sports.winter.ski.boots" already exists',
+} as const;
+
+/**
+ * The read's refusals, verbatim from `handlers/domains.ts` — its `QUERY_CONTRACT`
+ * constant, its handler branch (`— you sent ${neither|both}.`) and its
+ * `queryError` formatter, composed exactly as `server.ts`'s error handler emits
+ * them (`{ error: err.code, message: err.message }` — there is no `statusCode`
+ * or `error: "Bad Request"` member on this wire).
+ *
+ * PINNED AS LITERALS, never derived from the sibling's source. The plugin
+ * surfaces the message VERBATIM and matches on none of it, so what these fixtures
+ * prove is exactly that: the agent's whole recourse to a refusal reaches it
+ * unrewritten.
+ *
+ * `neither` and `both` are each other's control: one constant sentence cannot
+ * satisfy both, which is what makes "the message crossed intact" a real bar
+ * rather than an echo of the boilerplate every refusal shares.
+ */
+const FIND_QUERY_CONTRACT =
+  "GET /catalog/domains takes exactly one of `q` (a buyer ask) or `path` (an exact ltree path)";
+
+export const FIND_400_NEITHER = {
+  error: "invalid_request",
+  message: `${FIND_QUERY_CONTRACT} — you sent neither.`,
+} as const;
+
+export const FIND_400_BOTH = {
+  error: "invalid_request",
+  message: `${FIND_QUERY_CONTRACT} — you sent both.`,
+} as const;
+
+/**
+ * The VALIDATOR's arm of the same 400, through the route's own
+ * `schemaErrorFormatter`: an unsupported knob is refused BY NAME rather than
+ * silently ignored. The plugin can never send one (its schema declares `q` and
+ * `path` and nothing else) — which is the point: if this body ever reaches the
+ * tool, the message naming the offender is what makes that legible.
+ */
+export const FIND_400_UNSUPPORTED = {
+  error: "invalid_request",
+  message: `unsupported query parameter \`limit\` — ${FIND_QUERY_CONTRACT}.`,
 } as const;
 
 /**

--- a/src/__tests__/helpers/v0-wire.ts
+++ b/src/__tests__/helpers/v0-wire.ts
@@ -286,8 +286,12 @@ export const FIND_400_UNSUPPORTED = {
 
 /**
  * The auth plugin's shared bodies, verbatim from `middleware/auth.ts` — the SAME
- * four across all four routes. `error` is the machine-readable code (there is no
- * `reason` field on the wire; the plugin's `reason` is lifted FROM `error`).
+ * four across every v0 route, the registry read included: it registers inside the
+ * auth plugin's guarded scope, so an unauthenticated read is refused before the
+ * registry is reached (the resolved registry is sil's accumulating asset, and an
+ * unauthenticated read of it is a free scrape). `error` is the machine-readable
+ * code (there is no `reason` field on the wire; the plugin's `reason` is lifted
+ * FROM `error`).
  */
 export const AUTH = {
   unauthorized: { error: "unauthorized", message: "Authentication required" },

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -128,14 +128,16 @@ describe("plugin entry — registration contract", () => {
     // register() runs the real tool groups (no mock), so it populates the
     // api with exactly the real tools and NO example stub. This pins the
     // wiring AND the card's "absence" goal: sil_ping / sil_echo gone.
-    // The four-v0-tools card ADDS sil_stores + sil_domain_create to the existing
-    // catalog group (10 → 12, add-only). They join `registerCatalogTools`, so
-    // src/index.ts needs no new wiring — and no new hand-registering guard entry.
+    // The four-v0-tools card ADDED sil_stores + sil_domain_create to the existing
+    // catalog group (10 → 12); the read-before-mint card ADDS sil_domain_find to
+    // that same group (12 → 13, add-only). All three join `registerCatalogTools`,
+    // so src/index.ts needs no new wiring — and no new hand-registering guard entry.
     const api = createMockPluginApi();
     capturedRegisterFn!(api);
     expect([...api._tools.keys()].sort()).toEqual([
       "sil_doctor",
       "sil_domain_create",
+      "sil_domain_find",
       "sil_learn",
       "sil_product_get",
       "sil_profile_get",

--- a/src/__tests__/lib/catalog-client.test.ts
+++ b/src/__tests__/lib/catalog-client.test.ts
@@ -1,10 +1,15 @@
 /**
- * UNIT — the four v0 call functions (tier: unit — `fetch` doubled, no host, no
+ * UNIT — the five v0 call functions (tier: unit — `fetch` doubled, no host, no
  * filesystem, no credentials module).
  *
  * One route each, one request each, at the BARE path on the sil-api origin. This
  * is A8's client half: the tool half (that no tool's parameters can select
  * another's route) lives in `catalog-*.integration.test.ts`.
+ *
+ * FOUR POST A BODY; `findDomains` GETs a querystring — and it shares
+ * `/catalog/domains` with `mintDomain`, so at this layer the VERB is the only
+ * thing separating a read from the one write the product cannot undo. It
+ * therefore gets its own cases rather than a row in the POST table.
  *
  * The three things pinned here that nothing else can see:
  *   - the request BODY is what the agent asked for, with no plugin-invented
@@ -19,8 +24,16 @@ import {
   lookupCatalog,
   readStores,
   mintDomain,
+  findDomains,
 } from "../../lib/sil-client.js";
-import { MINT_409, STORES_404, mintGolden, resultGolden, storesGolden } from "../helpers/v0-wire.js";
+import {
+  MINT_409,
+  STORES_404,
+  domainFindGolden,
+  mintGolden,
+  resultGolden,
+  storesGolden,
+} from "../helpers/v0-wire.js";
 
 const API = "https://sil-api.test.example.com";
 const TOKEN = "at-secret-do-not-leak";
@@ -104,16 +117,51 @@ describe("each call hits exactly its OWN bare path, once, on the sil-api origin"
     expect(sent[0].bearer).toBe(`Bearer ${TOKEN}`);
   });
 
-  it("no call reaches `/api/v1` — the v0 routes are at the bare path", () => {
+  it("findDomains → GET /catalog/domains?… — the same path, the OPPOSITE verb", async () => {
+    // `mintDomain` POSTs this exact path. If the read ever emitted a POST it
+    // would coin a category as a side effect of looking one up, with no undo —
+    // so the method is asserted here, at the layer that decides it.
+    respond(200, domainFindGolden());
+    await findDomains(API, TOKEN, { q: "ski boots" });
+    expect(sent).toHaveLength(1);
+    expect(sent[0].method).toBe("GET");
+    expect(sent[0].url).toBe(`${API}/catalog/domains?q=ski+boots`);
+    expect(sent[0].bearer).toBe(`Bearer ${TOKEN}`);
+    // A GET body is at best ignored and in strict fetch environments throws.
+    expect(sent[0].body).toBeNull();
+  });
+
+  it("no call reaches `/api/v1` — the v0 routes are at the bare path", async () => {
     // The pre-v0 identity leg lives under `/api/v1` on the OTHER origin; a bare
     // path is the thing that keeps the two apart.
-    expect(sent.every((s) => !s.url.includes("/api/v1"))).toBe(true);
+    //
+    // DRIVEN, not observed. `sent` is reset per test, so asserting over it
+    // without issuing a call passes vacuously — which is how this guard sat
+    // green while proving nothing. Every call function is exercised first.
+    respond(200, resultGolden());
+    await searchCatalog(API, TOKEN, SEARCH_PARAMS);
+    await lookupCatalog(API, TOKEN, ["variant:abc"]);
+    respond(200, storesGolden());
+    await readStores(API, TOKEN, { ref: "variant:abc" });
+    respond(200, mintGolden());
+    await mintDomain(API, TOKEN, MINT_PARAMS);
+    respond(200, domainFindGolden());
+    await findDomains(API, TOKEN, { path: "product.sports.winter.ski.boots" });
+
+    expect(sent).toHaveLength(5);
+    expect(sent.filter((s) => s.url.includes("/api/v1"))).toEqual([]);
   });
 
   it("a trailing slash on the configured origin does not produce a double slash", async () => {
     respond(200, resultGolden());
     await searchCatalog(`${API}/`, TOKEN, SEARCH_PARAMS);
     expect(sent[0].url).toBe(`${API}/catalog/search`);
+  });
+
+  it("a trailing slash survives the querystring join too", async () => {
+    respond(200, domainFindGolden());
+    await findDomains(`${API}/`, TOKEN, { q: "ski boots" });
+    expect(sent[0].url).toBe(`${API}/catalog/domains?q=ski+boots`);
   });
 });
 
@@ -197,6 +245,7 @@ describe("token privacy and transport failure", () => {
     ["lookupCatalog", () => lookupCatalog(API, TOKEN, ["variant:a"])],
     ["readStores", () => readStores(API, TOKEN, { ref: "variant:a" })],
     ["mintDomain", () => mintDomain(API, TOKEN, MINT_PARAMS)],
+    ["findDomains", () => findDomains(API, TOKEN, { q: "ski boots" })],
   ])("%s maps a network failure to `retryable`, never a fabricated ok", async (_n, call) => {
     failNetwork();
     expect((await call()).kind).toBe("retryable");
@@ -236,6 +285,20 @@ describe("each call runs its OWN classifier — the route-specific statuses reac
   it("a search 409 is NOT `already_exists` — that status belongs to the mint alone", async () => {
     respond(409, MINT_409);
     expect((await searchCatalog(API, TOKEN, SEARCH_PARAMS)).kind).toBe("retryable");
+  });
+
+  it("a find 409 is NOT `already_exists` either — a read collides with nothing", async () => {
+    // The read shares the mint's PATH, so this is the one place the two could be
+    // conflated: reusing the mint's classifier would give the read a status for a
+    // state it cannot reach, and `already_exists` reads as "the category is
+    // already there" — a licence to stop looking.
+    respond(409, MINT_409);
+    expect((await findDomains(API, TOKEN, { q: "ski boots" })).kind).toBe("retryable");
+  });
+
+  it("a find 404 is NOT `not_found` — an absent domain is a 200 stating `exists: false`", async () => {
+    respond(404, { error: "not_found", message: "nope" });
+    expect((await findDomains(API, TOKEN, { path: "product.absent" })).kind).toBe("retryable");
   });
 
   it("a lookup 404/409 is likewise generic — one route, one extra status", async () => {

--- a/src/__tests__/lib/domain-find-classify.test.ts
+++ b/src/__tests__/lib/domain-find-classify.test.ts
@@ -1,0 +1,348 @@
+/**
+ * UNIT — `classifyDomainFindResponse` (tier: unit, <100 ms, no I/O).
+ *
+ * THE READ IS WHAT LICENSES THE MINT, so its 200 gate is not hygiene — it is the
+ * load-bearing half of BR-1. The agent is allowed to perform v0's ONE permanent,
+ * un-undoable global registry write only when a discovery read came back with no
+ * match stating `exists: true` AND `capped: false`. Both of those are read off
+ * the body. A gate that admits a body which cannot state them hands the agent a
+ * verdict it has no evidence for, under a `status: "ok"` that looks clean.
+ *
+ * Three failures are therefore refused as `retryable`, never `ok`:
+ *
+ *   - `capped` absent or non-boolean. `capped: false` is FALSY, so the gate must
+ *     test `typeof === "boolean"` and never truthiness. A dropped `capped` lets
+ *     the agent mint past a bound it never saw — the exact defect this route
+ *     exists to prevent.
+ *   - `exists` absent or non-boolean. It is STATED and never inferable: a path
+ *     with no row still resolves its ancestors' vocabulary, so a non-empty
+ *     `specs` says nothing, and `guide === null` says nothing either
+ *     (`@sil/schemas` `domain-find.ts:20-24`).
+ *   - `validated_at` neither a string nor `null`. The fence IS the column; a
+ *     body that cannot date it cannot say whether this domain's first answers
+ *     come from the web.
+ *
+ * And ONE success is refused the other way round: `matches: []` beside
+ * `capped: false` is `ok` — PRESENCE, never length, the same rule `results: []`
+ * follows. Mapping the empty answer to a failure (or to a `not_found` arm) would
+ * re-create the "empty shelf sent straight to the mint" behaviour this whole card
+ * exists to delete.
+ *
+ * The read has NO 404 and NO 409 arm: it holds nothing that can be absent (an
+ * absent domain is a 200 stating `exists: false`) and it writes nothing that can
+ * collide.
+ */
+
+import { describe, it, expect } from "vitest";
+import { classifyDomainFindResponse } from "../../lib/sil-client.js";
+import {
+  AUTH,
+  FIND_400_BOTH,
+  FIND_400_NEITHER,
+  FIND_400_UNSUPPORTED,
+  GOLDEN_DOMAINS,
+  domainFindCapped,
+  domainFindEmpty,
+  domainFindGolden,
+  domainFindMissing,
+  domainFindProbeMiss,
+  domainFindWithMatch0,
+  matchFor,
+} from "../helpers/v0-wire.js";
+
+describe("the 200 — the payload crosses whole, and the empty answer is a SUCCESS", () => {
+  it("classifies `ok` and carries the body verbatim", () => {
+    const wire = domainFindGolden();
+    const outcome = classifyDomainFindResponse(200, wire);
+    expect(outcome.kind).toBe("ok");
+    if (outcome.kind !== "ok") throw new Error("unreachable");
+    expect(outcome.found).toEqual(wire);
+  });
+
+  it("returns the ORIGINAL object, not a copy or a projection", () => {
+    // The identity check is the anti-projection guard: a gate that rebuilt the
+    // envelope would pass every deep-equal above while silently dropping the
+    // fields it does not declare.
+    const wire = domainFindGolden();
+    const outcome = classifyDomainFindResponse(200, wire);
+    if (outcome.kind !== "ok") throw new Error("expected ok");
+    expect(outcome.found as unknown).toBe(wire);
+  });
+
+  it("`matches: []` with `capped: false` is `ok` — the MINT SIGNAL, never a failure", () => {
+    const outcome = classifyDomainFindResponse(200, domainFindEmpty());
+    expect(outcome.kind).toBe("ok");
+    if (outcome.kind !== "ok") throw new Error("unreachable");
+    expect(outcome.found.matches).toEqual([]);
+    expect(outcome.found.capped).toBe(false);
+  });
+
+  it("the empty answer is NOT mapped to any absence arm", () => {
+    // A `not_found` here would be a SECOND empty-shelf signal, and the two would
+    // disagree about whether a mint is licensed.
+    const kind = classifyDomainFindResponse(200, domainFindEmpty()).kind;
+    expect(kind).not.toBe("not_found");
+    expect(kind).not.toBe("invalid_request");
+    expect(kind).not.toBe("retryable");
+  });
+
+  it("`capped: true` is still `ok` — a bounded answer is an answer, and it is STATED", () => {
+    const outcome = classifyDomainFindResponse(200, domainFindCapped());
+    expect(outcome.kind).toBe("ok");
+    if (outcome.kind !== "ok") throw new Error("unreachable");
+    expect(outcome.found.capped).toBe(true);
+  });
+
+  it("a `?path=` probe MISS crosses whole — `exists: false` beside the vocabulary it WOULD inherit", () => {
+    // The two facts are independent and are never conflated: no row here, and a
+    // non-empty inherited vocabulary. BR-4 is computed from exactly this shape,
+    // so a gate that rejected it (or an outcome that flattened it) would leave
+    // the pre-mint probe unusable.
+    const wire = domainFindProbeMiss();
+    const outcome = classifyDomainFindResponse(200, wire);
+    expect(outcome.kind).toBe("ok");
+    if (outcome.kind !== "ok") throw new Error("unreachable");
+    const [match] = outcome.found.matches;
+    expect(match.exists).toBe(false);
+    expect(match.guide).toBeNull();
+    expect(match.specs.length).toBeGreaterThan(0);
+  });
+
+  it("a FENCED match keeps its place — `validated_at: null` is adopted like any other", () => {
+    const outcome = classifyDomainFindResponse(200, domainFindGolden());
+    if (outcome.kind !== "ok") throw new Error("expected ok");
+    const fenced = matchFor(
+      outcome.found as unknown as Record<string, unknown>,
+      GOLDEN_DOMAINS.fenced,
+    );
+    expect(fenced["validated_at"]).toBeNull();
+    expect(fenced["exists"]).toBe(true);
+  });
+});
+
+describe("the `capped` gate — `false` is FALSY and must still pass", () => {
+  it("an explicit `capped: false` passes the gate", () => {
+    // The named bug class: a truthiness test drops the one value that means
+    // "this list is complete", which is half of the mint licence.
+    expect(classifyDomainFindResponse(200, { matches: [], capped: false }).kind).toBe("ok");
+  });
+
+  it.each([
+    ["absent", domainFindMissing("capped")],
+    ["a string 'false'", { ...domainFindGolden(), capped: "false" }],
+    ["a string 'true'", { ...domainFindGolden(), capped: "true" }],
+    ["null", { ...domainFindGolden(), capped: null }],
+    ["a number 0", { ...domainFindGolden(), capped: 0 }],
+    ["a number 1", { ...domainFindGolden(), capped: 1 }],
+  ])("a 200 whose `capped` is %s is `retryable`, never `ok`", (_label, body) => {
+    expect(classifyDomainFindResponse(200, body)).toEqual({ kind: "retryable" });
+  });
+});
+
+describe("the `matches` gate — the envelope's other half", () => {
+  it.each([
+    ["absent", domainFindMissing("matches")],
+    ["an object", { matches: {}, capped: false }],
+    ["a string", { matches: "product.sports", capped: false }],
+    ["null", { matches: null, capped: false }],
+    ["carrying a non-object element", { matches: ["product.sports"], capped: false }],
+    ["carrying null", { matches: [null], capped: false }],
+  ])("a 200 whose `matches` is %s is `retryable`, never `ok`", (_label, body) => {
+    expect(classifyDomainFindResponse(200, body)).toEqual({ kind: "retryable" });
+  });
+});
+
+describe("the per-match gate — every field a business rule reads is checked", () => {
+  it.each([
+    ["`exists` omitted", (m: Record<string, unknown>) => delete m["exists"]],
+    ["`exists` a string 'true'", (m: Record<string, unknown>) => (m["exists"] = "true")],
+    ["`exists` null", (m: Record<string, unknown>) => (m["exists"] = null)],
+    ["`exists` a number 1", (m: Record<string, unknown>) => (m["exists"] = 1)],
+    ["`path` omitted", (m: Record<string, unknown>) => delete m["path"]],
+    ["`path` not a string", (m: Record<string, unknown>) => (m["path"] = 7)],
+    ["`validated_at` omitted", (m: Record<string, unknown>) => delete m["validated_at"]],
+    ["`validated_at` a number", (m: Record<string, unknown>) => (m["validated_at"] = 1755158400)],
+    ["`validated_at` a boolean", (m: Record<string, unknown>) => (m["validated_at"] = false)],
+    ["`guide` omitted", (m: Record<string, unknown>) => delete m["guide"]],
+    ["`guide` an object", (m: Record<string, unknown>) => (m["guide"] = { text: "…" })],
+    ["`specs` omitted", (m: Record<string, unknown>) => delete m["specs"]],
+    ["`specs` an object", (m: Record<string, unknown>) => (m["specs"] = {})],
+  ])("a 200 with %s is `retryable`, never `ok`", (_label, mutate) => {
+    expect(classifyDomainFindResponse(200, domainFindWithMatch0(mutate))).toEqual({
+      kind: "retryable",
+    });
+  });
+
+  it("`validated_at: null` and `guide: null` are VALID — the fence and the absent row", () => {
+    // The nullable pair the gate must NOT reject: null is the stated fact here,
+    // not a missing field, and rejecting it would make every fenced domain and
+    // every probe miss unreadable.
+    const outcome = classifyDomainFindResponse(
+      200,
+      domainFindWithMatch0((m) => {
+        m["validated_at"] = null;
+        m["guide"] = null;
+      }),
+    );
+    expect(outcome.kind).toBe("ok");
+  });
+
+  it("an EMPTY `specs` on an existing domain is still `ok` — presence, never length", () => {
+    // A domain with an empty vocabulary still exists (`domain-find.ts:20-24`).
+    const outcome = classifyDomainFindResponse(
+      200,
+      domainFindWithMatch0((m) => (m["specs"] = [])),
+    );
+    expect(outcome.kind).toBe("ok");
+  });
+
+  it("a LATER match's malformation bites too — the gate walks every element", () => {
+    // A gate that checked only `matches[0]` would pass a body whose second match
+    // cannot state `exists`, and the agent reads all of them.
+    const body = domainFindGolden();
+    delete (body["matches"] as Record<string, unknown>[])[1]["exists"];
+    expect(classifyDomainFindResponse(200, body)).toEqual({ kind: "retryable" });
+  });
+
+  it("an unrelated ADDITIVE field on a match is still `ok` — the gate is not a whitelist", () => {
+    // An additive server field must reach the agent unreviewed; rejecting the
+    // unknown reinstates the projector this contract deletes.
+    const outcome = classifyDomainFindResponse(
+      200,
+      domainFindWithMatch0((m) => (m["notice"] = "an additive member")),
+    );
+    expect(outcome.kind).toBe("ok");
+  });
+});
+
+describe("the 200 that is not a body at all", () => {
+  it.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["an array", []],
+    ["a string", "product.sports.winter.ski.boots"],
+    ["a number", 1],
+    ["a boolean", true],
+  ])("a 200 that is %s is `retryable`", (_label, body) => {
+    expect(classifyDomainFindResponse(200, body)).toEqual({ kind: "retryable" });
+  });
+});
+
+/**
+ * The shared reserved-key refusal. `mapFindOutcome` spreads this body into
+ * `{ status: "ok", ...outcome.found, ...wiringAdvisories(api) }`, so a body
+ * declaring `status` would replace the plugin's dispatch key and one declaring
+ * `advisories` would drop the plugin's own field. The reservation is the SHARED
+ * one (`declaresEnvelopeKey`) — the fifth route inherits it rather than
+ * re-deriving it, and this file proves the fifth route actually got it.
+ */
+describe("the reserved ENVELOPE keys — a body declaring one is refused, never merged", () => {
+  it.each([
+    ["status", "partial"],
+    ["advisories", [{ id: "route.side_channel", severity: "warn" }]],
+  ])("a 200 declaring a top-level `%s` is `retryable`, never `ok`", (key, value) => {
+    expect(classifyDomainFindResponse(200, { ...domainFindGolden(), [key]: value })).toEqual({
+      kind: "retryable",
+    });
+  });
+
+  it.each(["status", "advisories"])("PRESENCE bites — a falsy `%s` is refused too", (key) => {
+    for (const value of [null, ""]) {
+      expect(classifyDomainFindResponse(200, { ...domainFindGolden(), [key]: value })).toEqual({
+        kind: "retryable",
+      });
+    }
+  });
+
+  it("guard-of-the-guard: the SAME body WITHOUT the reserved key is `ok`", () => {
+    expect(classifyDomainFindResponse(200, { ...domainFindGolden() }).kind).toBe("ok");
+  });
+
+  it("an unrelated additive TOP-LEVEL key is STILL `ok` — two reserved names, not a whitelist", () => {
+    expect(
+      classifyDomainFindResponse(200, { ...domainFindGolden(), notice: "an additive member" }).kind,
+    ).toBe("ok");
+  });
+});
+
+describe("the 400 — BOTH refusal paths surface verbatim, and neither is rewritten", () => {
+  it.each([
+    ["neither `q` nor `path`", FIND_400_NEITHER],
+    ["both `q` and `path`", FIND_400_BOTH],
+    ["an unsupported knob, named by the validator", FIND_400_UNSUPPORTED],
+  ])("a 400 for %s carries `{ error, message }` verbatim", (_label, body) => {
+    expect(classifyDomainFindResponse(400, body)).toEqual({
+      kind: "invalid_request",
+      error: body.error,
+      message: body.message,
+    });
+  });
+
+  it("the two mode refusals stay DISTINGUISHABLE — the message is the agent's whole recourse", () => {
+    // Each is the other's control: a classifier that synthesised its own message
+    // (or truncated to the shared contract sentence) would collapse them into
+    // one, and the agent could no longer tell "you sent nothing" from "you sent
+    // two things".
+    const neither = classifyDomainFindResponse(400, FIND_400_NEITHER);
+    const both = classifyDomainFindResponse(400, FIND_400_BOTH);
+    if (neither.kind !== "invalid_request" || both.kind !== "invalid_request") {
+      throw new Error("expected invalid_request");
+    }
+    expect(neither.message).not.toBe(both.message);
+    expect(neither.message).toContain("you sent neither");
+    expect(both.message).toContain("you sent both");
+  });
+
+  it("a 400 carries NO recovery hint and NO retry hint", () => {
+    // Re-sending the same querystring cannot succeed, and auth is fine.
+    const outcome = classifyDomainFindResponse(400, FIND_400_NEITHER);
+    expect(outcome).not.toHaveProperty("recovery");
+    expect(outcome).not.toHaveProperty("source");
+    expect(outcome.kind).not.toBe("retryable");
+  });
+});
+
+describe("the shared arms — identical to the other four sil-api routes", () => {
+  it("401 → unauthorized; 403 → forbidden with the reason; 503 → retryable", () => {
+    expect(classifyDomainFindResponse(401, AUTH.unauthorized)).toEqual({ kind: "unauthorized" });
+    expect(classifyDomainFindResponse(403, AUTH.userNotProvisioned)).toEqual({
+      kind: "forbidden",
+      reason: "user_not_provisioned",
+    });
+    expect(classifyDomainFindResponse(403, AUTH.principalMismatch)).toEqual({
+      kind: "forbidden",
+      reason: "principal_mismatch",
+    });
+    expect(classifyDomainFindResponse(503, AUTH.serviceUnavailable).kind).toBe("retryable");
+  });
+
+  it.each([500, 502, 504])("%d → retryable", (status) => {
+    expect(classifyDomainFindResponse(status, { error: "boom" }).kind).toBe("retryable");
+  });
+
+  it("a 5xx naming a degraded SOURCE carries the attribution", () => {
+    expect(
+      classifyDomainFindResponse(503, {
+        error: "source_unavailable",
+        source: "registry",
+        message: "registry read timed out",
+      }),
+    ).toEqual({ kind: "retryable", source: "registry", detail: "registry read timed out" });
+  });
+
+  it("a 404 is `retryable` and NOT an absence — this route has no `not_found` arm", () => {
+    // An absent domain is a 200 stating `exists: false`. A 404 here means the
+    // route itself is not there, which is a deployment fact, not an answer about
+    // the registry — and reading it as "nothing stands here" would license a
+    // mint off a missing route.
+    expect(classifyDomainFindResponse(404, { error: "not_found", message: "no route" })).toEqual({
+      kind: "retryable",
+    });
+  });
+
+  it("a 409 is `retryable` — the read writes nothing, so it can collide with nothing", () => {
+    expect(classifyDomainFindResponse(409, { error: "domain_exists", message: "x" })).toEqual({
+      kind: "retryable",
+    });
+  });
+});

--- a/src/__tests__/lib/openclaw-allowlist.test.ts
+++ b/src/__tests__/lib/openclaw-allowlist.test.ts
@@ -54,14 +54,20 @@ import {
 // unit core takes them as an argument so the test pins behaviour, not wiring).
 const SIL: SilAllowlistFacts = {
   id: "sil",
-  // The real 10-tool set after the retire-the-dead-sil-specs-tool card removed
-  // sil_specs (POST /catalog/specs is gone from sil-services; nothing replaces
-  // it), beside the five profile verbs and the four other core tools. (This
-  // carrier is the SILENT one — a stale entry stays GREEN here, because the loop
-  // below only asserts each name is ABSENT from a fresh config — so it is bumped
-  // for hygiene in lockstep with the mirrors that bite.)
+  // The real 13-tool set — the five v0 catalog tools, the five profile verbs,
+  // the two identity tools and the doctor.
+  //
+  // THIS CARRIER IS THE SILENT ONE, and it had already gone stale: it claimed
+  // "the real 10-tool set" while the four-v0-tools card had taken the surface to
+  // 12 (sil_stores + sil_domain_create were missing). Nothing here goes RED on a
+  // stale entry — the loop below only asserts each name is ABSENT from a fresh
+  // config, which a shorter list satisfies just as well — so a fixture that lies
+  // about the canonical set can sit here indefinitely. Repaired to the true set
+  // and bumped in lockstep with the mirrors that do bite.
   tools: [
     "sil_doctor",
+    "sil_domain_create",
+    "sil_domain_find",
     "sil_learn",
     "sil_product_get",
     "sil_profile_get",
@@ -70,6 +76,7 @@ const SIL: SilAllowlistFacts = {
     "sil_profile_search",
     "sil_register",
     "sil_search",
+    "sil_stores",
     "sil_whoami",
   ],
   skill: "./sil-shopping",

--- a/src/__tests__/manifest-contract.integration.test.ts
+++ b/src/__tests__/manifest-contract.integration.test.ts
@@ -29,12 +29,14 @@
  *     `contracts.tools` string array;
  *   - the real tool groups register exactly the tools named there (and
  *     the manifest names exactly the tools they register) — the set on
- *     both sides equals { sil_doctor, sil_domain_create, sil_learn,
- *     sil_product_get, sil_profile_get, sil_profile_materialize,
+ *     both sides equals { sil_doctor, sil_domain_create, sil_domain_find,
+ *     sil_learn, sil_product_get, sil_profile_get, sil_profile_materialize,
  *     sil_profile_remove, sil_profile_search, sil_register, sil_search,
- *     sil_stores, sil_whoami } (12 tools, after the four-v0-tools card ADDED
- *     sil_stores + sil_domain_create to the existing catalog group so the four
- *     v0 tools sit 1:1 with the four sil-services catalog routes).
+ *     sil_stores, sil_whoami } (13 tools: the four-v0-tools card ADDED
+ *     sil_stores + sil_domain_create to the existing catalog group, and the
+ *     read-before-mint card ADDS sil_domain_find, so the v0 catalog tools sit
+ *     1:1 with the sil-services catalog routes — `/catalog/domains` being the
+ *     first served by two verbs, one tool per verb).
  */
 
 import { describe, it, expect } from "vitest";
@@ -130,14 +132,16 @@ describe("manifest ↔ code drift guard (set-equality, BOTH directions)", () => 
     // The card's spine: after removing the skeleton examples, the manifest
     // AND the code both name exactly the real tools. Pinned by literal
     // so a re-introduced sil_ping/sil_echo (on either side) flips this RED,
-    // not just the symmetric drift check above. Now 12 tools — the
-    // four-v0-tools card ADDS sil_stores + sil_domain_create to the existing
-    // catalog group (10 → 12, add-only). Both new tools live in
-    // `registerCatalogTools`, which `codeRegisteredNames()` already calls, so
-    // this guard picks them up for free — a NEW group would not have been.
+    // not just the symmetric drift check above. Now 13 tools — the
+    // four-v0-tools card ADDED sil_stores + sil_domain_create (10 → 12) and the
+    // read-before-mint card ADDS sil_domain_find (12 → 13, add-only). All three
+    // live in `registerCatalogTools`, which `codeRegisteredNames()` already
+    // calls, so this guard picks them up for free — a NEW group would not have
+    // been.
     const expected = [
       "sil_doctor",
       "sil_domain_create",
+      "sil_domain_find",
       "sil_learn",
       "sil_product_get",
       "sil_profile_get",
@@ -191,6 +195,17 @@ describe("manifest ↔ code drift guard (set-equality, BOTH directions)", () => 
     // openclaw.plugin.json#contracts.tools.
     expect(codeRegisteredNames().has("sil_product_get")).toBe(true);
     expect(manifestToolNames().has("sil_product_get")).toBe(true);
+  });
+
+  it("sil_domain_find is BOTH registered by register() and declared in contracts.tools", () => {
+    // The read-before-mint card's fifth catalog tool — `GET /catalog/domains`,
+    // the verb twin of the mint's POST. It joins the EXISTING
+    // `registerCatalogTools` group, which `codeRegisteredNames()` already calls,
+    // so the code side is picked up dynamically; step 3 (the manifest entry) is
+    // the half that is not, and forgetting it flips the set-equality RED here
+    // before merge. That asymmetry is the whole point of this guard.
+    expect(codeRegisteredNames().has("sil_domain_find")).toBe(true);
+    expect(manifestToolNames().has("sil_domain_find")).toBe(true);
   });
 
   it("sil_profile_materialize is BOTH registered by register() and declared in contracts.tools", () => {
@@ -294,5 +309,21 @@ describe("the drift guard actually bites (failure-direction proof)", () => {
     const manifestPlusGhost = new Set(manifestToolNames());
     manifestPlusGhost.add("sil_tool_declared_but_unwired");
     expect(sorted(manifestPlusGhost)).not.toEqual(sorted(code));
+  });
+
+  // The same proof aimed at THE tool this card adds, in both directions. These
+  // are non-vacuous by construction: if `sil_domain_find` were missing from both
+  // sides, each `delete` would be a no-op, the two sets would still be equal, and
+  // the `not.toEqual` below would FAIL. So they cannot pass by the tool's absence.
+  it("FAILS if `sil_domain_find` is dropped from the manifest side", () => {
+    const manifestMinus = new Set(manifestToolNames());
+    manifestMinus.delete("sil_domain_find");
+    expect(sorted(manifestMinus)).not.toEqual(sorted(codeRegisteredNames()));
+  });
+
+  it("FAILS if `sil_domain_find` is dropped from the code side", () => {
+    const codeMinus = new Set(codeRegisteredNames());
+    codeMinus.delete("sil_domain_find");
+    expect(sorted(codeMinus)).not.toEqual(sorted(manifestToolNames()));
   });
 });

--- a/src/__tests__/openclaw-allowlist.integration.test.ts
+++ b/src/__tests__/openclaw-allowlist.integration.test.ts
@@ -63,13 +63,15 @@ const SCRIPT = join(REPO_ROOT, "scripts", "allowlist-openclaw.mjs");
 
 // sil's real facts (asserted against, sourced from the manifest the script reads).
 const SIL_ID = "sil";
-// The real 12-tool set: the four-v0-tools card added sil_stores +
-// sil_domain_create to the catalog group (10 → 12, add-only). Drives
+// The real 13-tool set: the four-v0-tools card added sil_stores +
+// sil_domain_create to the catalog group (10 → 12) and the read-before-mint card
+// adds sil_domain_find (12 → 13, add-only). Drives
 // `tools_added === SIL_TOOLS.length` and the per-tool not-enumerated-into-config
 // scan below.
 const SIL_TOOLS = [
   "sil_doctor",
   "sil_domain_create",
+  "sil_domain_find",
   "sil_learn",
   "sil_product_get",
   "sil_profile_get",

--- a/src/__tests__/plugin-load.integration.test.ts
+++ b/src/__tests__/plugin-load.integration.test.ts
@@ -161,13 +161,15 @@ describe("plugin load — data dir is created by the FULL real register() (card 
       .mock.calls.filter(([marker]) => marker === "sil_plugin_loaded");
     expect(markerCalls).toHaveLength(1);
     // The full real tool set — the data-dir creation does not add/drop a tool.
-    // 12 tools: the four-v0-tools card ADDS sil_stores + sil_domain_create to
-    // the existing catalog group (10 → 12, add-only). The set is exact in BOTH
-    // directions on purpose — loosening it to `toContain` stops it catching a
-    // silent removal, which is how a shipped tool disappears under a green suite.
+    // 13 tools: the four-v0-tools card ADDED sil_stores + sil_domain_create to
+    // the existing catalog group (10 → 12), and the read-before-mint card ADDS
+    // sil_domain_find (12 → 13, add-only). The set is exact in BOTH directions on
+    // purpose — loosening it to `toContain` stops it catching a silent removal,
+    // which is how a shipped tool disappears under a green suite.
     expect([...api._tools.keys()].sort()).toEqual([
       "sil_doctor",
       "sil_domain_create",
+      "sil_domain_find",
       "sil_learn",
       "sil_product_get",
       "sil_profile_get",

--- a/src/__tests__/search-results-method.integration.test.ts
+++ b/src/__tests__/search-results-method.integration.test.ts
@@ -913,11 +913,12 @@ describe("registration shape (C5) and log privacy", () => {
   // sil_* add or removal must bump it, count in the title included. It went
   // undocumented for a release because nobody greps a "…-method…" file for tool
   // tests; see docs/knowledge/adding-a-sil-tool-fans-out-to-exact-set-mirrors.md.
-  it("registering the gateway method does not change the tool set (still 12)", () => {
+  it("registering the gateway method does not change the tool set (still 13)", () => {
     const api = registerPlugin();
     expect([...api._tools.keys()].sort()).toEqual([
       "sil_doctor",
       "sil_domain_create",
+      "sil_domain_find",
       "sil_learn",
       "sil_product_get",
       "sil_profile_get",

--- a/src/__tests__/skill-bundle-contract.integration.test.ts
+++ b/src/__tests__/skill-bundle-contract.integration.test.ts
@@ -276,6 +276,36 @@ const routingRows = (): string[] =>
     .body.split("\n")
     .filter((line) => line.trimStart().startsWith("|"));
 
+/** The corpus cut into STATEMENTS — one bullet, one table row, one sentence. The
+ * bundle is hard-wrapped, so a line is not a statement; a bullet or a row is.
+ * Scoping matters more than the regexes it feeds: a corpus-wide `probe` + `not
+ * licensed` pair passes on the very wording this block rejects, because both
+ * strings already sit three lines apart in `method_and_prds.md` and the second is
+ * about the CAPPED branch. */
+const statements = (): string[] =>
+  bundleFiles().flatMap((rel) =>
+    // Per FILE, never over the joined corpus: a unit that straddles a file boundary
+    // could pair one file's `probe` with the next file's denial.
+    read(rel)
+      .split(/\n\s*(?:[-*+]\s|\|)|(?<=[.!?])\s+/)
+      .map((s) => s.replace(/\s+/g, " ").trim())
+      .filter(Boolean),
+  );
+
+/** Withholds the licence: "never licenses", "does not license", or the exclusivity
+ * form the tool itself uses ("only a `q` read licenses one"). Direction is
+ * load-bearing — the denial must PRECEDE the licence word, or "**mint licensed** —
+ * no returned match states…" satisfies it and the bar is born vacuous. */
+const DENIES_LICENCE = /\b(?:never|not|cannot|can'?t|no|only)\b[\s\S]*?licen/i;
+/** An EMPTY match list — the one thing a probe cannot produce. */
+const EMPTY_MATCH_LIST =
+  /matches:?\s*\[\s*\]|\bmatches\b[^.]{0,40}\bempty\b|\bempty\b[^.]{0,40}\bmatches\b/i;
+
+/** `[]` when some candidate satisfies the rule, else the candidates themselves — so
+ * a red PRINTS the statements the writer has to fix, not "0 is not greater than 0". */
+const unsatisfied = (candidates: string[], rule: (s: string) => boolean): string[] =>
+  candidates.some(rule) ? [] : candidates;
+
 describe("read before mint — the bundle's half of the card", () => {
   it("S2 — NO file reaches the global write without also naming the read", () => {
     // The card's spine, asserted structurally rather than by wording: a file that
@@ -356,6 +386,29 @@ describe("read before mint — the bundle's half of the card", () => {
     const corpus = bundleCorpus();
     expect(corpus).toMatch(/capped:?\s*`?true/i);
     expect(corpus).toMatch(/narrow|sharpen|read (once more|again)/i);
+  });
+
+  it("S4/BR-1b — the licence is an EMPTY `q` read, and a `path` probe never grants it", () => {
+    // The clause the plugin cannot enforce, and the one the bundle stated more
+    // weakly than the tool did. A probe MISS is not an empty answer: it returns a
+    // match carrying `exists: false` (`helpers/v0-wire.ts#domainFindProbeMiss`), so
+    // an `exists`-only licence test is SATISFIED by the single read that must never
+    // license a mint — and the agent coins a sibling of a path already standing
+    // under a different parent. That write is permanent, global and un-undoable, and
+    // `exists: false` at a guessed path is silent about it. Two halves, because
+    // either alone leaves the door: what the probe does NOT buy, and what the
+    // licence actually costs.
+    const units = statements();
+
+    const probeUnits = units.filter((s) => /probe/i.test(s));
+    expect(probeUnits.length).toBeGreaterThan(0); // guard-of-the-guard: an empty scan passes
+    expect(unsatisfied(probeUnits, (s) => DENIES_LICENCE.test(s))).toEqual([]);
+
+    const licenceUnits = units.filter((s) => /licen/i.test(s));
+    expect(licenceUnits.length).toBeGreaterThan(0); // guard-of-the-guard
+    expect(
+      unsatisfied(licenceUnits, (s) => EMPTY_MATCH_LIST.test(s) && /capped/i.test(s)),
+    ).toEqual([]);
   });
 
   it("S5 — the adoption discipline names its mechanism and says the keys travel VERBATIM", () => {

--- a/src/__tests__/skill-bundle-contract.integration.test.ts
+++ b/src/__tests__/skill-bundle-contract.integration.test.ts
@@ -36,8 +36,15 @@ const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const BUNDLE = join(REPO_ROOT, "sil-shopping");
 // The always-loaded router must name the whole v0 journey, not half of it: the
 // agent picks a tool by name at the moment of use, and a beat whose tool is
-// unnamed in SKILL.md is a beat it will improvise around. Add-only (4 → 6) with
-// the four-v0-tools card.
+// unnamed in SKILL.md is a beat it will improvise around. Add-only (4 → 6 with
+// the four-v0-tools card, 6 → 7 with the read-before-mint card).
+//
+// This list is HAND-MAINTAINED and separate from the dynamic "every registered
+// tool appears somewhere in the corpus" scan below: it is what forces a name into
+// `SKILL.md` ITSELF rather than into some `references/` file the agent may never
+// load. `sil_domain_find` has to be here, not merely in the corpus — the read is
+// the first move of the cold path, and a router that names only the mint sends an
+// empty shelf straight at the one write the product cannot undo.
 const CORE_TOOLS = [
   "sil_register",
   "sil_whoami",
@@ -45,6 +52,7 @@ const CORE_TOOLS = [
   "sil_product_get",
   "sil_stores",
   "sil_domain_create",
+  "sil_domain_find",
 ];
 // Tokens retired by the single-shopper + SDS-redesign pivots — no path, no doc,
 // no compat alias may resurrect them anywhere in the bundle. Each names a thing
@@ -138,9 +146,18 @@ describe("sil-shopping skill bundle — load-bearing contract (not prose)", () =
     expect(registeredTools().filter((n) => !corpus.includes(n))).toEqual([]);
   });
 
-  it("the four core tools are named in SKILL.md itself (the always-loaded router)", () => {
+  it("every core tool is named in SKILL.md itself (the always-loaded router)", () => {
     const src = skillSrc();
     expect(CORE_TOOLS.filter((t) => !src.includes(t))).toEqual([]);
+  });
+
+  it("the frontmatter description enumerates the read, not just the mint", () => {
+    // The description is what the host shows BEFORE the body is loaded, so it is
+    // the only text that decides whether the skill is reached at all. A trigger
+    // list that names the mint but not the read advertises the write half of a
+    // read-then-write discipline.
+    const { description } = frontmatter();
+    expect(description).toContain("sil_domain_find");
   });
 
   it("every references/ and examples/ link in the bundle resolves to a real file", () => {

--- a/src/__tests__/skill-bundle-contract.integration.test.ts
+++ b/src/__tests__/skill-bundle-contract.integration.test.ts
@@ -244,7 +244,7 @@ describe("sil-shopping skill bundle — load-bearing contract (not prose)", () =
     expect(src).toMatch(/open[ -]web/i); // never sourced from the open web
   });
 
-  it("the Beat-2 naming discipline survives the sil_specs excision", () => {
+  it("the Beat-2 naming discipline survives the sil_domain_find arrival", () => {
     // The removal's collateral-damage guard (retire-the-dead-sil-specs-tool). What
     // died is the registry ROUND TRIP, not the vocabulary hygiene: Beat 4 still
     // sends these coined names verbatim as sil_search.filters.specs, so a synonym
@@ -253,8 +253,147 @@ describe("sil-shopping skill bundle — load-bearing contract (not prose)", () =
     // TWO tokens, deliberately not a re-pinning of the wording (the 1 341-line
     // prose test was deleted for a reason).
     const src = read("references/method_and_prds.md");
-    expect(src).toContain("one spelling"); // reuse the exact ns.key you coined
+    expect(src).toContain("one spelling"); // reuse the exact key you coined
     expect(src).toContain("conventional name"); // take the Schelling-point name
+  });
+});
+
+// ===========================================================================
+// Card: sil-domain-find — READ BEFORE MINT, as the bundle states it.
+//
+// The tool alone does not close this card. `sil_domain_create` performs v0's ONE
+// permanent, un-undoable global registry write, and nothing in the plugin can
+// stop an agent reaching it — the discipline lives entirely in prose, so prose is
+// what has to be guarded. Each bar below holds a DECISION that changes the
+// shopper's behaviour if it is lost, never a sentence: the 1341-line prose test
+// this suite deleted stayed green through a live behavioural bug precisely
+// because it pinned wording instead.
+// ===========================================================================
+
+/** The router's table rows — what the agent matches an intent against. */
+const routingRows = (): string[] =>
+  frontmatter()
+    .body.split("\n")
+    .filter((line) => line.trimStart().startsWith("|"));
+
+describe("read before mint — the bundle's half of the card", () => {
+  it("S2 — NO file reaches the global write without also naming the read", () => {
+    // The card's spine, asserted structurally rather than by wording: a file that
+    // teaches the mint and never mentions the read is a door to a permanent write
+    // with the discipline missing. Derived from the corpus on disk, so a new
+    // reference file inherits the rule for free.
+    const offenders = bundleFiles().filter(
+      (rel) => read(rel).includes("sil_domain_create") && !read(rel).includes("sil_domain_find"),
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  it("S2 — guard-of-the-guard: some file DOES name the mint (an empty scan passes)", () => {
+    expect(bundleFiles().filter((rel) => read(rel).includes("sil_domain_create")).length)
+      .toBeGreaterThan(0);
+  });
+
+  it("S2 — the router's read row sits ABOVE its mint row, and the mint row names the read", () => {
+    // Reading order, mechanised. The agent matches top-down; a mint row above the
+    // read row is a mint row it reaches first.
+    const rows = routingRows();
+    const readRow = rows.findIndex((r) => r.includes("sil_domain_find"));
+    const mintRow = rows.findIndex((r) => r.includes("sil_domain_create"));
+    expect(readRow).toBeGreaterThanOrEqual(0);
+    expect(mintRow).toBeGreaterThanOrEqual(0);
+    expect(readRow).toBeLessThan(mintRow);
+    // The mint row states what must have happened first — otherwise the trigger
+    // reads as "a cold category" and the read becomes optional.
+    expect(rows[mintRow]).toMatch(/sil_domain_find|\bread\b/);
+  });
+
+  it("S2 — a read that did NOT return is not a read that returned nothing", () => {
+    // BR-2. Without this the natural repair for a transient failure is to mint and
+    // move on — a permanent global write entered off a network blip.
+    const corpus = bundleCorpus();
+    expect(corpus).toMatch(/invalid_request/);
+    expect(corpus).toMatch(
+      /did not return|not a read that returned nothing|never coin around|leaves the mint (out of reach|unreachable)/i,
+    );
+  });
+
+  it("S2/BR-8 — an ambiguous `sil_search` refusal is settled by a PROBE, never by a mint", () => {
+    // The two refusals carry the same `invalid_request` on the wire and the plugin
+    // matches on no prose, so the refusal text alone cannot tell them apart. The
+    // stated `exists` decides — a global write is never entered off refusal prose.
+    const corpus = bundleCorpus();
+    expect(corpus).toMatch(/read alike|cannot tell|indistinguishable|same .*invalid_request/i);
+    expect(corpus).toMatch(/probe/i);
+    expect(corpus).toMatch(/exists/);
+  });
+
+  it("S3 — the read's input is the buyer's PROSE, and the bundle says why a guess is wrong", () => {
+    // `q` is matched against a domain's guide as well as its path text, so a
+    // path-shaped guess misses exactly the domains the read exists to surface.
+    const corpus = bundleCorpus();
+    expect(corpus).toMatch(/own words/i);
+    expect(corpus).toMatch(/path[- ]shaped guess|not a path guess|rather than a path guess/i);
+    expect(corpus).toMatch(/guide/i);
+  });
+
+  it("S4 — all four branch verdicts are present, and `capped` is one of them", () => {
+    // Dropping the `capped` branch ALONE re-creates the exact defect the route
+    // exists to prevent: minting while the standing path sat just past the bound.
+    const corpus = bundleCorpus();
+    const verdicts: [string, RegExp][] = [
+      ["adopt", /\badopt/i],
+      ["descend", /\bdescend/i],
+      ["mint licensed", /licens/i],
+      ["narrow on capped", /\bcapped\b/],
+    ];
+    expect(verdicts.filter(([, re]) => !re.test(corpus)).map(([name]) => name)).toEqual([]);
+    // The descend rule's whole content: a sibling or re-rooted path for a category
+    // that already stands is never coined, because the mint would ACCEPT it.
+    expect(corpus).toMatch(/never a sibling|not a sibling|sibling.*re-?rooted/i);
+  });
+
+  it("S4 — `capped: true` withholds the licence rather than shrinking the answer", () => {
+    const corpus = bundleCorpus();
+    expect(corpus).toMatch(/capped:?\s*`?true/i);
+    expect(corpus).toMatch(/narrow|sharpen|read (once more|again)/i);
+  });
+
+  it("S5 — the adoption discipline names its mechanism and says the keys travel VERBATIM", () => {
+    // "take the key sil already holds" was unreachable advice until this tool
+    // existed: nothing in the surface could read a standing domain's vocabulary.
+    const src = read("references/method_and_prds.md");
+    expect(src).toContain("sil_domain_find");
+    expect(src).toContain("## Search vocabulary");
+    expect(src).toMatch(/verbatim/i);
+  });
+
+  it("S5 — the read budget is stated as a NUMBER, and the probe is outside it", () => {
+    // Open question 9. An agent left to infer whether the probe counts against the
+    // bound either forfeits it — forking the vocabulary — or takes a third
+    // discovery read. Write the arithmetic; do not imply it.
+    const src = read("references/method_and_prds.md");
+    expect(src).toMatch(/\b2\b|\btwo\b/);
+    expect(src).toMatch(/probe/i);
+    expect(src).toMatch(/does\s*\*{0,2}not\*{0,2}\s*count|≤\s*2\s*\+\s*1|2 \+ 1/i);
+  });
+
+  it("S6 — a fenced match is ADOPTED, and the fence explains the result rather than removing one", () => {
+    // `validated_at: null` means minted but not yet validated by the pass. The
+    // sentence carrying this is exactly the shape `honestyExclusionOffenders`
+    // scans (an exclusion verb beside a maturity claim), and that scan runs over
+    // the whole bundle above — so this bar only has to pin the DECISION.
+    const corpus = bundleCorpus();
+    expect(corpus).toMatch(/validated_at/);
+    expect(corpus).toMatch(/adopted like any other|like any other match|a real (category|domain)/i);
+    expect(corpus).toMatch(/stays on the table|every result and seller/i);
+  });
+
+  it("S7 — a held path is the cold path's memory, not a per-search toll", () => {
+    // Without this the card ships a latency and spend regression on every warm
+    // search, which no other bar here would catch.
+    const corpus = bundleCorpus();
+    expect(corpus).toMatch(/no `?sil_domain_find`? call|without a read|no registry read|not re-?read/i);
+    expect(corpus).toMatch(/cold path'?s first move|never a per-search toll|already records/i);
   });
 });
 

--- a/src/__tests__/tools/domain-find.test.ts
+++ b/src/__tests__/tools/domain-find.test.ts
@@ -1,0 +1,333 @@
+/**
+ * UNIT — `sil_domain_find`'s agent-facing surface (tier: unit — mock api, temp
+ * data dir, `fetch` spied).
+ *
+ * THE READ IS WHAT MAKES THE MINT SAFE, so this tool's surface carries an unusual
+ * weight: it is the only door through which an agent can learn that a category
+ * already stands before it performs v0's ONE permanent, un-undoable global write.
+ * Three properties of the surface decide whether that works, and all three are
+ * pinned here:
+ *
+ *   - THE QUERYSTRING IS THE CONTRACT. `?q=` and `?path=` are different
+ *     questions, exactly one per call, and an EMITTED `q=` is a different request
+ *     from an OMITTED `q` (the route answers "`q` must not be shorter than 1
+ *     character" for the first and "you sent neither" for the second). So the URL
+ *     must carry only the keys actually present, and it must be built with
+ *     `URLSearchParams` — a string-concatenated value could inject a second
+ *     parameter and turn a discovery read into a probe of the attacker's path.
+ *
+ *   - `q` CARRIES PROSE, NOT A PATH. The route matches `q` against each domain's
+ *     path text AND its guide, which is the only way a buyer's ask reaches
+ *     `product.sports.winter.ski.boots`. A `q` that inherited the path pattern
+ *     would be refused BY THE HOST — "ski boots" has a space — and the discovery
+ *     door would be silently dead while every other test stayed green.
+ *
+ *   - NOTHING IS REFUSED LOCALLY. The route names the offending parameter in its
+ *     own message; a second validator here would only be a surface to drift, and
+ *     it would fire exclusively on the agent-error path where the route's named
+ *     message beats a synthesized one. Both/neither go on the wire.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { registerCatalogTools } from "../../tools/catalog.js";
+import { setApiUrl, setWebUrl, getApiUrl } from "../../lib/config.js";
+import { getDataDir, getTokensPath } from "../../lib/credentials.js";
+import { createMockPluginApi, getTool, type MockPluginAPI } from "../helpers/mock-plugin-api.js";
+import {
+  honestyExclusionOffenders,
+  overPromiseOffenders,
+  overTriggerOffenders,
+} from "../helpers/honesty-vocabulary.js";
+import { domainFindGolden } from "../helpers/v0-wire.js";
+
+const TOOL = "sil_domain_find";
+const API = "https://sil-api.test.example.com";
+
+let api: MockPluginAPI;
+let dataDir: string;
+let priorDataDir: string | undefined;
+
+/** The spied global, typed — `.mock.calls[n][0]` is the URL the tool built. */
+const fetchSpy = (): ReturnType<typeof vi.mocked<typeof globalThis.fetch>> =>
+  vi.mocked(globalThis.fetch);
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), "sil-find-unit-"));
+  priorDataDir = process.env["SIL_DATA_DIR"];
+  process.env["SIL_DATA_DIR"] = dataDir;
+  setApiUrl(API);
+  setWebUrl("https://sil-web.test.example.com");
+  vi.spyOn(globalThis, "fetch");
+  api = createMockPluginApi();
+  registerCatalogTools(api);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  setApiUrl("");
+  setWebUrl("");
+  if (priorDataDir === undefined) delete process.env["SIL_DATA_DIR"];
+  else process.env["SIL_DATA_DIR"] = priorDataDir;
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+function schema(): Record<string, unknown> {
+  return getTool(api, TOOL).parameters as unknown as Record<string, unknown>;
+}
+
+function props(): Record<string, Record<string, unknown>> {
+  return schema()["properties"] as Record<string, Record<string, unknown>>;
+}
+
+const description = (): string => getTool(api, TOOL).description ?? "";
+
+/** Seed a token pair so the tool proceeds past the not-registered gate. */
+function seedTokens(): void {
+  mkdirSync(getDataDir(), { recursive: true });
+  writeFileSync(getTokensPath(), JSON.stringify({ access_token: "at", refresh_token: "rt" }), {
+    mode: 0o600,
+  });
+}
+
+/** Answer every call with one 200, so the tool reaches the wire and stops. */
+function answerOk(body: unknown = domainFindGolden()): void {
+  fetchSpy().mockImplementation(() =>
+    Promise.resolve(
+      new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    ),
+  );
+}
+
+/** The URL of the nth outbound request, as the tool built it. */
+function urlOf(nth = 0): URL {
+  const raw = fetchSpy().mock.calls[nth]?.[0];
+  if (raw === undefined) throw new Error(`no request at index ${nth}`);
+  return new URL(String(raw));
+}
+
+/** Run the tool and hand back the URL it called. */
+async function callWith(params: Record<string, unknown>): Promise<URL> {
+  seedTokens();
+  answerOk();
+  await getTool(api, TOOL).execute("call-1", params);
+  return urlOf();
+}
+
+describe("registration and schema", () => {
+  it("registers `sil_domain_find` with a description and an object schema", () => {
+    expect(getTool(api, TOOL).name).toBe(TOOL);
+    expect(description().length).toBeGreaterThan(0);
+    expect(getTool(api, TOOL).label ?? "").not.toBe("");
+    expect(schema()["type"]).toBe("object");
+  });
+
+  it("declares exactly `{ q, path }`, and NEITHER is required", () => {
+    // Both optional is what lets the ROUTE own the both/neither refusal. Making
+    // either required would move that refusal into the host, which answers with
+    // a schema pointer that names no parameter.
+    expect(Object.keys(props()).sort()).toEqual(["path", "q"]);
+    expect(schema()).not.toHaveProperty("required");
+  });
+
+  it("`q` is a 1–200 string — the bound the route's own matcher is costed at", () => {
+    expect(props()["q"]["type"]).toBe("string");
+    expect(props()["q"]["minLength"]).toBe(1);
+    expect(props()["q"]["maxLength"]).toBe(200);
+  });
+
+  it("`q` carries NO pattern — a buyer's ask is prose, and prose has spaces", () => {
+    // The trap this forecloses: copying `path`'s registry pattern onto `q` makes
+    // the host refuse "ski boots" before the route is reached. The discovery
+    // door would be dead while every other assertion on this surface stayed
+    // green — and discovery is the only mode that can license a mint.
+    expect(props()["q"]).not.toHaveProperty("pattern");
+    expect(props()["q"]).not.toHaveProperty("enum");
+  });
+
+  it("`path` carries the same registry pattern `sil_search`'s `domain` does", () => {
+    const searchDomain = (
+      (getTool(api, "sil_search").parameters as unknown as Record<string, unknown>)[
+        "properties"
+      ] as Record<string, Record<string, unknown>>
+    )["domain"];
+    // One pattern, three tools. A probe whose grammar differs from search's lets
+    // an agent probe a path it can then never search — and the route's `::ltree`
+    // cast is only unreachable-by-construction because the pattern holds.
+    expect(props()["path"]["pattern"]).toBe(searchDomain["pattern"]);
+    expect(props()["path"]["maxLength"]).toBe(255);
+  });
+
+  it("declares NO knob the route refuses — no limit, no cursor, no validated filter", () => {
+    // `GET /catalog/domains` refuses `limit` / `after` / `validated` BY NAME
+    // rather than ignoring them. A knob declared here that the route rejects
+    // reads to the agent as a capability, and every call using it 400s.
+    const declared = Object.keys(props());
+    const refused = ["limit", "after", "validated", "cursor", "n", "k", "top_k", "page"];
+    expect(declared.filter((p) => refused.includes(p))).toEqual([]);
+  });
+
+  it("every parameter carries a non-empty description", () => {
+    const missing = Object.entries(props())
+      .filter(([, p]) => ((p["description"] as string | undefined) ?? "").trim().length === 0)
+      .map(([name]) => name);
+    expect(missing).toEqual([]);
+  });
+});
+
+describe("the clauses the description must carry", () => {
+  it("states that exactly ONE of `q` or `path` travels per call", () => {
+    const d = description();
+    expect(d).toMatch(/exactly one of|one of .*(q|path).*(q|path)|never both/i);
+    expect(d).toContain("q");
+    expect(d).toContain("path");
+  });
+
+  it("says `q` carries the buyer's OWN WORDS, not a path guess", () => {
+    // The whole reason the discovery mode exists: `q` is matched against a
+    // domain's guide as well as its path text, so a path-shaped guess misses
+    // exactly the domains the read was built to surface.
+    const d = description().toLowerCase();
+    expect(d).toMatch(/own words|buyer'?s? (own )?(words|ask)|what the buyer asked/);
+  });
+
+  it("says an EMPTY `matches` is what licenses the mint, and names the mint tool", () => {
+    const d = description();
+    expect(d).toMatch(/matches/);
+    expect(d).toMatch(/\[\]|empty|nothing/i);
+    expect(d).toContain("sil_domain_create");
+  });
+
+  it("says `exists` is STATED — never inferred from a guide or a vocabulary", () => {
+    const d = description();
+    expect(d).toMatch(/exists/);
+    expect(d.toLowerCase()).toMatch(/stated|never infer|not inferred|do not infer|read it/);
+  });
+
+  it("says what `capped` means — the answer was bounded, so the mint is NOT licensed", () => {
+    // Dropping this one clause alone re-creates the exact defect the route
+    // exists to prevent: minting while the standing path sat just past the bound.
+    const d = description();
+    expect(d).toMatch(/capped/);
+    expect(d.toLowerCase()).toMatch(/narrow|again|more|past the|not complete/);
+  });
+
+  it("does not claim a general capability — a tool named `_find` is the one at risk", () => {
+    // `/\bfind\s+any(?:thing)?\b/` is a banned over-trigger and this tool is
+    // literally named `sil_domain_find`.
+    expect(overTriggerOffenders(description())).toEqual([]);
+  });
+
+  it("out-promises nothing and frames no honesty field as an exclusion", () => {
+    // A fenced domain (`validated_at: null`) is RETURNED and adopted like any
+    // other; prose that reads as "skip the unvalidated ones" would undo the
+    // route's own decision one layer up.
+    expect(overPromiseOffenders(description())).toEqual([]);
+    expect(honestyExclusionOffenders(description())).toEqual([]);
+  });
+
+  it("guard-of-the-guard: the description is substantial enough for the scans above", () => {
+    expect(description().trim().length).toBeGreaterThan(200);
+  });
+});
+
+describe("before the network", () => {
+  it("with no stored tokens the tool is terminal `not_registered` and calls NO fetch", async () => {
+    const result = await getTool(api, TOOL).execute("call-1", { q: "ski boots" });
+    const payload = JSON.parse(result.content[0].text as string) as Record<string, unknown>;
+    expect(payload["status"]).toBe("not_registered");
+    expect(payload["recovery"]).toBe("sil_register");
+    expect(fetchSpy()).not.toHaveBeenCalled();
+  });
+
+  it("the unauthenticated refusal carries NO empty match list the agent could act on", async () => {
+    // A `matches: []` on a failure would license a mint off a call that never
+    // reached the registry — BR-2's shape, at the tool boundary.
+    const result = await getTool(api, TOOL).execute("call-2", { q: "ski boots" });
+    const payload = JSON.parse(result.content[0].text as string) as Record<string, unknown>;
+    expect(payload).not.toHaveProperty("matches");
+    expect(payload).not.toHaveProperty("capped");
+  });
+});
+
+describe("the querystring is the contract", () => {
+  it("`q` alone emits exactly `?q=<value>` and NO `path` key", async () => {
+    const url = await callWith({ q: "ski boots" });
+    expect(url.origin + url.pathname).toBe(`${getApiUrl()}/catalog/domains`);
+    expect([...url.searchParams.keys()]).toEqual(["q"]);
+    expect(url.searchParams.get("q")).toBe("ski boots");
+    expect(url.searchParams.has("path")).toBe(false);
+  });
+
+  it("`path` alone emits exactly `?path=<value>` and NO `q` key", async () => {
+    const url = await callWith({ path: "product.sports.winter.ski.boots" });
+    expect([...url.searchParams.keys()]).toEqual(["path"]);
+    expect(url.searchParams.get("path")).toBe("product.sports.winter.ski.boots");
+    expect(url.searchParams.has("q")).toBe(false);
+  });
+
+  it("NEITHER emits NO query parameters at all — an empty `q=` is a different request", async () => {
+    // The route answers "`q` must not be shorter than 1 character" for `?q=` and
+    // "you sent neither" for no parameters. Both are 400s, and they are the
+    // agent's whole recourse — a plugin that emitted `q=` would trade the one
+    // message that diagnoses the real mistake for one that diagnoses a
+    // fabricated one.
+    const url = await callWith({});
+    expect([...url.searchParams.keys()]).toEqual([]);
+    expect(url.search).toBe("");
+  });
+
+  it("BOTH are forwarded — the plugin refuses nothing locally", async () => {
+    // The route's 400 names the offender ("you sent both"); a local refusal would
+    // have to invent its own message, which would then differ from the route's.
+    const url = await callWith({ q: "ski boots", path: "product.sports.winter.ski.boots" });
+    expect([...url.searchParams.keys()].sort()).toEqual(["path", "q"]);
+    expect(url.searchParams.get("q")).toBe("ski boots");
+    expect(url.searchParams.get("path")).toBe("product.sports.winter.ski.boots");
+  });
+
+  it("the value is URL-ENCODED, never concatenated", async () => {
+    const url = await callWith({ q: "50/50 boots & poles, 130 flex?" });
+    expect(url.searchParams.get("q")).toBe("50/50 boots & poles, 130 flex?");
+    expect([...url.searchParams.keys()]).toEqual(["q"]);
+  });
+
+  it("a `q` that LOOKS like a second parameter cannot become one", async () => {
+    // The concatenation trap, stated as an attack: `&path=` inside the ask must
+    // arrive as part of the ask, never as a probe of somebody else's path — a
+    // probe answers a different question and can never license a mint.
+    const url = await callWith({ q: "boots&path=product.evil.node" });
+    expect([...url.searchParams.keys()]).toEqual(["q"]);
+    expect(url.searchParams.get("q")).toBe("boots&path=product.evil.node");
+    expect(url.searchParams.has("path")).toBe(false);
+  });
+
+  it("an empty-string `q` is forwarded AS an empty `q=` — the plugin drops no key it was given", async () => {
+    // The host's `minLength: 1` makes this unreachable in production, which is
+    // exactly why it is asserted: the plugin must not start filling or dropping
+    // keys on its own account, because a dropped key silently converts one
+    // route message into another.
+    const url = await callWith({ q: "" });
+    expect([...url.searchParams.keys()]).toEqual(["q"]);
+    expect(url.searchParams.get("q")).toBe("");
+    expect(url.search).toBe("?q=");
+  });
+
+  it("calls the BARE path on the sil-api origin — no `/api/v1`, no trailing slash", async () => {
+    const url = await callWith({ q: "ski boots" });
+    expect(url.pathname).toBe("/catalog/domains");
+    expect(url.toString()).not.toContain("/api/v1");
+    expect(url.origin).toBe(API);
+  });
+
+  it("issues exactly ONE request per call", async () => {
+    await callWith({ q: "ski boots" });
+    expect(fetchSpy()).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/tools/search.test.ts
+++ b/src/__tests__/tools/search.test.ts
@@ -186,6 +186,22 @@ describe("the description carries what only it can carry", () => {
     expect(d).toMatch(/registr(y|ies)|registered|unregistered/i);
   });
 
+  it("routes the refusal at the READ first, and reaches the mint only through it", () => {
+    // The route out of a cold category now has TWO steps, and the order is the
+    // whole safety property: the refusal is ambiguous (an unregistered domain and
+    // a rejected predicate are the same code on the wire), so the read is what
+    // settles which one it was. Naming only the mint — which the assertion above
+    // is satisfied by on its own — would send an ambiguous refusal straight at a
+    // permanent, un-undoable global write.
+    //
+    // ORDER, not mere presence: this is the assertion the mint-name check cannot
+    // make, and without it a future edit could delete `sil_domain_find` from this
+    // description under a fully green suite.
+    const d = description();
+    expect(d).toContain("sil_domain_find");
+    expect(d.indexOf("sil_domain_find")).toBeLessThan(d.indexOf("sil_domain_create"));
+  });
+
   it("the `domain` PARAMETER's own description names the remedy too", () => {
     // A parameter description is read in isolation, at the moment the agent is
     // choosing what to put in that field — which is exactly where a refused path
@@ -193,6 +209,13 @@ describe("the description carries what only it can carry", () => {
     // registry tool" leaves the tool description technically compliant while
     // deleting the pointer at the point of use.
     expect(props()["domain"]["description"]).toContain("sil_domain_create");
+    // …and the read that must precede it, in that order — a parameter description
+    // that names only the write teaches the write at the point of use.
+    const domainDescription = props()["domain"]["description"] as string;
+    expect(domainDescription).toContain("sil_domain_find");
+    expect(domainDescription.indexOf("sil_domain_find")).toBeLessThan(
+      domainDescription.indexOf("sil_domain_create"),
+    );
   });
 
   it("the `domain` description forbids guessing a shallower path around the refusal", () => {

--- a/src/__tests__/tools/tool-schema-contract.unit.test.ts
+++ b/src/__tests__/tools/tool-schema-contract.unit.test.ts
@@ -236,8 +236,28 @@ describe("registered tool descriptions carry NO per-niche-expert vocabulary (who
  * `lib/honesty-vocabulary.test.ts`.
  * ------------------------------------------------------------------------- */
 
-/** The four v0 catalog tools, by SC6's own names — verbatim, not renamed. */
-const V0_TOOLS = ["sil_search", "sil_product_get", "sil_stores", "sil_domain_create"] as const;
+/**
+ * The v0 catalog tools, by SC6's own names — verbatim, not renamed.
+ *
+ * FIVE, not four. SC6 says "four tools" and that wording is now literally false:
+ * the design rule is 1:1 with the routes and never flags on one another, and
+ * `/catalog/domains` is served by TWO verbs — `GET` reads the registry, `POST`
+ * performs the one write nothing can undo. Shrinking the tool count to preserve
+ * SC6's sentence would put the read behind a `mode` flag on the write, which is
+ * the exact shape the rule forbids.
+ *
+ * This list is HAND-MAINTAINED and it drives three `it.each` guards below (the
+ * no-flags rule, the retired-parameter scan, and the discipline clause). It bites
+ * nothing when a tool is omitted — the registration check below is a SUBSET test —
+ * so an omission here silently narrows all three rather than going RED.
+ */
+const V0_TOOLS = [
+  "sil_search",
+  "sil_product_get",
+  "sil_stores",
+  "sil_domain_find",
+  "sil_domain_create",
+] as const;
 
 /** A tool's description plus every one of its parameter descriptions. */
 function agentFacingText(api: MockPluginAPI, name: string): string {
@@ -259,8 +279,8 @@ function wholeSurface(api: MockPluginAPI): [string, string][] {
   return [...api._tools.keys()].map((name) => [name, agentFacingText(api, name)]);
 }
 
-describe("v0 — the four tools are registered under SC6's names, 1:1 with the four routes", () => {
-  it("all four exist, spelled exactly as the goal names them", () => {
+describe("v0 — the tools are registered under SC6's names, 1:1 with the routes", () => {
+  it("all five exist, spelled exactly as the goal names them", () => {
     const names = registeredToolNames(allRegisteredTools());
     expect(V0_TOOLS.filter((t) => !names.has(t))).toEqual([]);
   });
@@ -424,6 +444,12 @@ describe("v0 — each of the four carries its discipline clause (R6.2.1)", () =>
     sil_product_get: [/shortlist/i, /live/i, /top-?k|top offers/i],
     sil_stores: [/three states/i, /unknown/i, /serviceab/i],
     sil_domain_create: [/\bNEW\b/, /research|read(ing)? up/i, /never[^.]*change|not to change/i],
+    // The read's discipline is a BUDGET and a mode rule: the two doors answer
+    // different questions, and a cold category is settled in at most two
+    // discovery reads plus one probe of the exact path about to be coined. An
+    // agent left to infer whether the probe counts against the bound either
+    // forfeits it (forking the vocabulary) or takes a third discovery read.
+    sil_domain_find: [/\b(2|two)\b/, /probe/i, /never both|exactly one of/i],
   };
 
   it.each(V0_TOOLS)("%s's description carries every load-bearing token of its clause", (name) => {

--- a/src/__tests__/v0-journey.integration.test.ts
+++ b/src/__tests__/v0-journey.integration.test.ts
@@ -1,20 +1,30 @@
 /**
  * INTEGRATION — the whole v0 journey over ONE scripted `fetch`: a cold category
- * refused, researched, minted, searched, shortlisted and handed off.
+ * refused, READ, researched, minted, searched, shortlisted and handed off.
  *
- *   sil_search (400, unregistered) → sil_domain_create → sil_search
- *     → sil_product_get → sil_stores → one handoff URL
+ *   sil_search (400, unregistered) → sil_domain_find (matches: []) →
+ *     sil_domain_create → sil_search → sil_product_get → sil_stores
+ *     → one handoff URL
+ *
+ * THE READ IS PART OF THE CHAIN, and that is this file's newest claim. Before it
+ * existed the cold start ran refusal → mint, so the only thing standing between
+ * an empty shelf and a permanent, un-undoable global write was the agent's
+ * judgement. The read is what turns that into a step: the mint is entered only
+ * after a discovery read named nothing to adopt.
  *
  * SCOPE, deliberately. This is the TOOL CHAIN, not the agent. What the agent
  * SAYS — the mint announcement, the veto's three buckets, the dating of a
  * `stored` price — is not testable in this repo at any tier: it belongs to the
  * skill card and to sil-stage. There is no e2e tier here and none is invented
- * (CLAUDE.md: one `vitest run` is the whole gate).
+ * (CLAUDE.md: one `vitest run` is the whole gate). Nor can this file prove the
+ * agent WAITED for the read; what it proves is that the tools compose that way
+ * and that no tool performs another's job.
  *
  * What IS testable, and what this file exists to prove:
- *   - the four tools compose into a terminating journey with no fifth call and
- *     no tool standing in for another;
- *   - each hop calls exactly its own route, once;
+ *   - the tools compose into a terminating journey with no extra call and no
+ *     tool standing in for another;
+ *   - each hop calls exactly its own route, once — and the read and the mint,
+ *     which share a PATH, are told apart by their VERB;
  *   - the journey ENDS at one URL that came out of a sil tool result — every
  *     product, price, seller and URL presented is traceable to a tool response,
  *     never to anything the plugin invented.
@@ -42,6 +52,7 @@ import {
   GOLDEN_REFS,
   SEARCH_400,
   clone,
+  domainFindEmpty,
   mintGolden,
   resultGolden,
   storeFor,
@@ -86,6 +97,10 @@ function scriptTheJourney(): Router {
     if (kind === "search") {
       return nth === 0 ? { status: 400, body: SEARCH_400.unknownDomain } : ok(resultGolden());
     }
+    // The read answers with the MINT SIGNAL: the registry genuinely holds
+    // nothing for this ask, and says so completely (`capped: false`). That is
+    // the only answer that licenses the mint below.
+    if (kind === "domainFind") return ok(domainFindEmpty());
     if (kind === "domains") return ok(mintGolden());
     if (kind === "lookup") return ok(resultGolden());
     if (kind === "stores") return ok(storesGolden());
@@ -103,15 +118,29 @@ describe("the cold-start journey terminates at one handoff URL", () => {
   it("runs beat A → E, each tool once per beat, ending at a URL that came from sil", async () => {
     const router = scriptTheJourney();
 
-    // Beat A — the front door refuses. This IS the cold-start beat: there is no
-    // `GET /catalog/domains` at v0, so the refusal is how the agent learns the
-    // category is new.
+    // Beat A — the front door refuses. The refusal is a ROUTING SIGNAL, and on
+    // this wire it is ambiguous by design: an unregistered domain and a rejected
+    // predicate carry the same `invalid_request`. So it routes to the read, not
+    // to the mint.
     const refused = await call("sil_search", { domain: DOMAIN, query: "ski boots", n: 8 }, "j1");
     expect(refused["status"]).toBe("invalid_request");
     expect(refused["message"]).toContain("mint it first");
 
-    // Beat A′ — the mint, at the path the agent actually meant. (The research
-    // that produces `guide` is the agent's web work, outside the tool surface.)
+    // Beat A′ — the READ, in the buyer's own words. `matches: []` beside
+    // `capped: false` is a real answer and the one thing that licenses the write
+    // below; anything else (a match to adopt, a bounded list, a failed read)
+    // ends the cold start here.
+    const read = await call("sil_domain_find", { q: "ski boots" }, "j2");
+    expect(read["status"]).toBe("ok");
+    expect(read["matches"]).toEqual([]);
+    expect(read["capped"]).toBe(false);
+    // The read touched the registry's READ verb and nothing else — the write is
+    // still un-entered at this point in the journey.
+    expect(router.domains).toEqual([]);
+
+    // Beat A″ — the mint, at the path the agent actually meant, now that the
+    // read has named nothing to adopt. (The research that produces `guide` is
+    // the agent's web work, outside the tool surface.)
     const minted = await call(
       "sil_domain_create",
       {
@@ -119,7 +148,7 @@ describe("the cold-start journey terminates at one handoff URL", () => {
         guide: "Ski boots are bought by fit first: last width, then flex, then shell shape.",
         specs: [{ key: "flex_index", display_name: "Flex index", data_type: "number", unit: "index" }],
       },
-      "j2",
+      "j3",
     );
     expect(minted["status"]).toBe("ok");
     expect(minted["path"]).toBe(DOMAIN);
@@ -129,7 +158,7 @@ describe("the cold-start journey terminates at one handoff URL", () => {
     const results = await call(
       "sil_search",
       { domain: DOMAIN, query: "ski boots", n: 8, predicates: [{ key: "flex_index", op: "gte", value: 110 }] },
-      "j3",
+      "j4",
     );
     expect(results["status"]).toBe("ok");
     const shortlist = (results["results"] as Record<string, unknown>[]).map((r) => r["ref"] as string);
@@ -137,13 +166,13 @@ describe("the cold-start journey terminates at one handoff URL", () => {
 
     // Beat C — the shortlist re-read, by the refs sil returned, ≤5.
     expect(shortlist.length).toBeLessThanOrEqual(5);
-    const reread = await call("sil_product_get", { refs: shortlist }, "j4");
+    const reread = await call("sil_product_get", { refs: shortlist }, "j5");
     expect(reread["status"]).toBe("ok");
 
     // Beat D — the pick's sellers. The pick is a ref sil returned, not a
     // product the agent named.
     const pick = shortlist[0];
-    const stores = await call("sil_stores", { ref: pick, destination: "DE" }, "j5");
+    const stores = await call("sil_stores", { ref: pick, destination: "DE" }, "j6");
     expect(stores["status"]).toBe("ok");
 
     // Beat E — one URL, named for what it is.
@@ -155,12 +184,17 @@ describe("the cold-start journey terminates at one handoff URL", () => {
     // Each route hit exactly as many times as the journey has beats on it, and
     // nothing reached an unrouted path.
     expect(router.search).toHaveLength(2);
+    expect(router.domainFind).toHaveLength(1);
     expect(router.domains).toHaveLength(1);
     expect(router.lookup).toHaveLength(1);
     expect(router.stores).toHaveLength(1);
     expect(router.refresh).toEqual([]);
     expect(router.other).toEqual([]);
-    expect(router.all).toHaveLength(5);
+    expect(router.all).toHaveLength(6);
+    // The two `/catalog/domains` calls are ONE read and ONE write, told apart by
+    // the verb — never two of either.
+    expect(router.domainFind[0].method).toBe("GET");
+    expect(router.domains[0].method).toBe("POST");
   });
 
   it("every URL, price and seller presented came out of a sil tool result", async () => {
@@ -235,12 +269,27 @@ describe("no tool stands in for another, across the whole journey", () => {
     expect(router.all).toHaveLength(1);
   });
 
-  it("`sil_domain_create` never searches to check first — read-before-mint has no route at v0", async () => {
-    // The v0 substitute for read-before-mint is the 400/409 pair. A plugin-side
-    // pre-check would be a second, invented contract.
+  it("`sil_domain_create` performs NO read of its own — the read is the agent's step", async () => {
+    // Read-before-mint is a DISCIPLINE the agent follows across two tool calls,
+    // never a pre-check the mint runs for itself. A mint that silently read first
+    // would make the discipline unobservable — the agent could skip it and the
+    // chain would look identical — and it would hide a second round trip inside
+    // the one call that cannot be undone.
     const router = scriptTheJourney();
     await call("sil_domain_create", { path: DOMAIN, guide: "g", specs: [] }, "m5");
     expect(router.search).toEqual([]);
+    expect(router.domainFind).toEqual([]);
+    expect(router.all).toHaveLength(1);
+  });
+
+  it("`sil_domain_find` never mints — the read and the write share a path, not a verb", async () => {
+    // The inverse, and the more dangerous direction: a read that reached the
+    // POST would coin a category as a side effect of looking one up, with no
+    // undo and nothing downstream able to detect it.
+    const router = scriptTheJourney();
+    await call("sil_domain_find", { q: "ski boots" }, "m6");
+    expect(router.domains).toEqual([]);
+    expect(router.domainFind).toHaveLength(1);
     expect(router.all).toHaveLength(1);
   });
 });

--- a/src/lib/sil-client.ts
+++ b/src/lib/sil-client.ts
@@ -1,6 +1,6 @@
 /**
  * Typed HTTP wrappers for every endpoint the plugin calls — the two sil-web auth
- * endpoints, the sil-api identity read and the four v0 catalog routes — each
+ * endpoints, the sil-api identity read and the five v0 catalog routes — each
  * returning a DISCRIMINATED UNION over the documented outcomes so the status
  * taxonomy lives in exactly one place and the caller switches on `kind` rather
  * than re-deriving meaning from `res.status` at every site.
@@ -42,9 +42,12 @@
  *     403 { error: user_not_provisioned | principal_mismatch } → forbidden (terminal)
  *     5xx / network / abort                               → retryable
  *
- * Wire contract for the FOUR v0 catalog routes (SAME origin as the identity read —
- * sil-api, bare paths, NOT /api/v1). All four take the same Bearer, share one auth
- * plugin (401 / 403 / 503) and one error envelope `{ error, message }`:
+ * Wire contract for the FIVE v0 catalog routes (SAME origin as the identity read —
+ * sil-api, bare paths, NOT /api/v1). All five take the same Bearer, share one auth
+ * plugin (401 / 403 / 503) and one error envelope `{ error, message }`. Four are
+ * POSTs carrying a body; the fifth is a bodyless GET — and `/catalog/domains` is
+ * the one path served by TWO VERBS, so the METHOD, not the path, decides whether a
+ * call reads the registry or writes to it permanently:
  *
  *   POST <silApiUrl>/catalog/search   body { domain, query, n, predicates?, destination? }
  *     200 SearchResponse                             → ok
@@ -68,6 +71,20 @@
  *     409 { error:"domain_exists", message }         → already_exists (NOT a failure:
  *         the vocabulary is usable — re-issue the search on the SAME path)
  *
+ *   GET  <silApiUrl>/catalog/domains?q=<ask> | ?path=<ltree>   (no body, no content-type)
+ *     200 DomainFindResponse { matches, capped }     → ok. `matches: []` is a genuine
+ *         empty answer and a SUCCESS — it is what LICENSES a mint, so mapping it to a
+ *         failure would recreate the collision this route exists to delete. `capped`
+ *         says the list was bounded, which is the difference between "nothing stands
+ *         here" and "nothing stands here that I was shown".
+ *     400 { error:"invalid_request", message }       → invalid_request. Exactly one of
+ *         `q` / `path` per call, checked in the route's HANDLER (not a schema `oneOf`)
+ *         so the message NAMES the parameter at fault — which is why the plugin
+ *         forwards what it was given and refuses nothing locally. The refusal costs
+ *         one round trip and touches no registry row.
+ *     There is no 404 and no 409 arm: a path with no row is a 200 stating
+ *     `exists: false`, and a read collides with nothing.
+ *
  * SEARCH AND LOOKUP ANSWER WITH THE SAME OBJECT, by contract (`@sil/schemas`
  * `search.ts:1-30`) — hence ONE {@link CatalogResultOutcome} and one classifier for
  * both. They differ in what they were asked and in what they spend, never in what
@@ -85,10 +102,11 @@
  * tool envelope's own keys, so spreading such a payload would overwrite the agent's
  * dispatch key or swallow the server's field; the gate takes `retryable` instead.
  *
- * Wire types are MIRRORED from `@sil/schemas` (`packages/schemas/src/{search,stores}.ts`),
- * never imported — no cross-repo dependency, and `@ucp-js/sdk` carries zero catalog
- * types. The v0 result body is deliberately NOT a UCP shape: a UCP variant carries
- * one merchant's price, which would delete the price spread that IS the answer.
+ * Wire types are MIRRORED from `@sil/schemas`
+ * (`packages/schemas/src/{search,stores,domain-find}.ts`), never imported — no
+ * cross-repo dependency, and `@ucp-js/sdk` carries zero catalog types. The v0 result
+ * body is deliberately NOT a UCP shape: a UCP variant carries one merchant's price,
+ * which would delete the price spread that IS the answer.
  *
  * The VERB is load-bearing: sil-api's `POST /identity` is the agent enrich-STUB
  * ({kind, verified, subject, ...} — no name/addresses); `GET /identity` is the
@@ -390,6 +408,48 @@ export interface DomainMintResult {
   specs: string[];
 }
 
+/** One entry of a domain's RESOLVED vocabulary — its own specs plus every
+ * ancestor's, nearest definition winning. `defined_at` + `inherited` are what let
+ * an agent coin only the keys a path does not already inherit; dropping either
+ * makes that diff uncomputable while everything still looks healthy. NULLABLE,
+ * never optional: an absent key is indistinguishable from a serialization bug. */
+export interface DomainSpecWire {
+  key: string;
+  display_name: string;
+  data_type: string;
+  unit: string | null;
+  allowed_values: string[] | null;
+  value_set: string | null;
+  level: string | null;
+  defined_at: string;
+  inherited: boolean;
+}
+
+/** One domain the read names — the SAME element in both query modes, so a caller
+ * handles a probe result with no branch. `guide` is the ONLY thing fit may be
+ * judged on: a path that merely reads like the category is not a match, and
+ * adopting a wrong one pollutes silently. On an `exists: false` probe, `specs` is
+ * the vocabulary this path WOULD inherit if minted. */
+export interface DomainMatch {
+  path: string;
+  /** STATED. Never inferable from a `null` `guide`, never from a non-empty
+   * `specs` — a path with no row still resolves its ancestors' vocabulary. */
+  exists: boolean;
+  /** The fence, as the column: `null` = minted but not yet validated by the pass. */
+  validated_at: string | null;
+  guide: string | null;
+  specs: DomainSpecWire[];
+}
+
+/** The `GET /catalog/domains` 200 body. `capped` is the anti-defect field: an
+ * agent that reads a bounded list, sees nothing fit and mints — while the standing
+ * path sat just past the bound — has done exactly what the route exists to
+ * prevent, and only `capped` tells it. */
+export interface DomainFindResponse {
+  matches: DomainMatch[];
+  capped: boolean;
+}
+
 /* ── request side. Object TYPE ALIASES, not interfaces: only an alias carries an
  * implicit index signature, and these are handed straight to `postJson`. ── */
 
@@ -438,6 +498,20 @@ export type DomainMintParams = {
   specs: SpecDefinitionInput[];
 };
 
+/** EXACTLY ONE of `q` / `path` per call — a rule the ROUTE owns, not the plugin.
+ * Both arms stay optional here so the agent's mistake travels intact and is
+ * refused by name; a local both/neither check would have to invent its own
+ * message, which would then differ from the one the agent actually acts on. */
+export type DomainFindParams = {
+  /** DISCOVERY: the buyer's ask, matched against each domain's path text AND its
+   * guide — the only mode that can surface a standing path the agent had no name
+   * for. `matches: []` here is the mint signal. */
+  q?: string;
+  /** PROBE: one exact ltree path. It answers about that path alone, so it can
+   * SHAPE a mint (which keys are already inherited) but never license one. */
+  path?: string;
+};
+
 /**
  * The outcome of `/catalog/search` AND `/catalog/lookup` — ONE union, because the
  * two routes answer with the same object by contract. `unauthorized` is the sole
@@ -471,6 +545,18 @@ export type MintOutcome =
   | { kind: "forbidden"; reason: string }
   | { kind: "invalid_request"; error: string; message: string }
   | { kind: "already_exists"; path: string; message: string }
+  | { kind: "retryable"; source?: string; detail?: string };
+
+/** `GET /catalog/domains` — the mint's own path read instead of written. It
+ * restates the four shared arms rather than reusing {@link CatalogResultOutcome}
+ * (whose `ok` carries a `SearchResponse`), and it adds NOTHING: there is no 404
+ * (a path with no row is a 200 stating `exists: false`) and no 409 (a read
+ * collides with nothing). Three similar unions beat a premature helper. */
+export type DomainFindOutcome =
+  | { kind: "ok"; found: DomainFindResponse }
+  | { kind: "unauthorized" }
+  | { kind: "forbidden"; reason: string }
+  | { kind: "invalid_request"; error: string; message: string }
   | { kind: "retryable"; source?: string; detail?: string };
 
 /**
@@ -537,6 +623,27 @@ export function classifyMintResponse(status: number, body: unknown, path: string
 
   const domain = gateMintResult(body);
   return domain === null ? { kind: "retryable" } : { kind: "ok", domain };
+}
+
+/**
+ * Classify a `GET /catalog/domains` response — the read before the mint.
+ *
+ * PRESENCE, never length: `matches: []` on a well-formed envelope is a genuine
+ * empty answer and a SUCCESS. It is also the one answer that licenses a permanent
+ * global write, so mapping it to a failure (or to a `not_found` this route cannot
+ * even produce) would rebuild the empty-shelf-straight-to-the-mint behaviour the
+ * read exists to delete.
+ *
+ * Pure and exported — unit-tested in isolation.
+ */
+export function classifyDomainFindResponse(status: number, body: unknown): DomainFindOutcome {
+  if (status === 400) return { kind: "invalid_request", ...extractApiError(body) };
+  if (status === 401) return { kind: "unauthorized" };
+  if (status === 403) return { kind: "forbidden", reason: extractForbiddenReason(body) };
+  if (status !== 200) return retryableFromBody(body);
+
+  const found = gateDomainFindResponse(body);
+  return found === null ? { kind: "retryable" } : { kind: "ok", found };
 }
 
 /**
@@ -787,6 +894,38 @@ export async function mintDomain(
     return { kind: "retryable" };
   }
   return classifyMintResponse(res.status, await readJsonBody(res), params.path);
+}
+
+/**
+ * `GET /catalog/domains` — the registry read that precedes the mint. Same path as
+ * {@link mintDomain}, opposite verb: a bodyless GET, so a wrong method here would
+ * turn a discovery call into the one write the product cannot undo.
+ *
+ * The querystring is built with `URLSearchParams` and carries ONLY the keys the
+ * agent actually sent. An empty `q=` is a DIFFERENT request from an omitted `q` —
+ * the route answers "`q` must NOT have fewer than 1 characters" for the first and
+ * "you sent neither" for the second, and each message is the agent's whole
+ * recourse. Nothing is filled in, nothing is dropped, and nothing is
+ * string-concatenated (an unencoded value could inject a second parameter).
+ */
+export async function findDomains(
+  silApiUrl: string,
+  token: string,
+  params: DomainFindParams,
+): Promise<DomainFindOutcome> {
+  const query = new URLSearchParams();
+  if (params.q !== undefined) query.set("q", params.q);
+  if (params.path !== undefined) query.set("path", params.path);
+  const search = query.toString();
+  const url =
+    `${stripTrailingSlash(silApiUrl)}/catalog/domains${search === "" ? "" : `?${search}`}`;
+  let res: Response;
+  try {
+    res = await getJson(url, { authorization: `Bearer ${token}` });
+  } catch {
+    return { kind: "retryable" };
+  }
+  return classifyDomainFindResponse(res.status, await readJsonBody(res));
 }
 
 /** Result of the high-level refresh orchestration (read → refresh → rotate). */
@@ -1056,6 +1195,49 @@ function gateMintResult(body: unknown): DomainMintResult | null {
   const specs = envelope["specs"];
   if (!Array.isArray(specs) || !specs.every((s) => typeof s === "string")) return null;
   return envelope as unknown as DomainMintResult;
+}
+
+/**
+ * The 200 gate for `GET /catalog/domains`. It covers the fields the agent's
+ * adopt / descend / mint / narrow verdict is computed from, and nothing below
+ * them: `capped` and, per match, `exists`, `guide`, `validated_at`, `path`.
+ *
+ * `typeof capped === "boolean"`, never truthiness — `capped: false` is falsy and
+ * is also the ONLY value that licenses a mint, so a truthy test would silently
+ * turn "the answer was complete" into "the field is missing". `exists` and
+ * `guide` are gated for the same reason they are on the wire: `exists` is stated
+ * rather than inferred, and `guide` is the sole basis for judging fit, so a body
+ * that cannot carry them is unusable rather than degraded → `retryable`.
+ *
+ * `specs[]` is checked for being an array and then left alone — its elements are
+ * what a valid first predicate is formed from, and re-validating them here would
+ * put a second, drifting copy of the vocabulary contract in the plugin. On
+ * success the ORIGINAL object is returned: no projection, no rename, no default.
+ */
+function gateDomainFindResponse(body: unknown): DomainFindResponse | null {
+  const envelope = asRecord(body);
+  if (envelope === null) return null;
+  if (declaresEnvelopeKey(envelope)) return null;
+  if (typeof envelope["capped"] !== "boolean") return null;
+  if (!Array.isArray(envelope["matches"])) return null;
+
+  for (const raw of envelope["matches"]) {
+    const match = asRecord(raw);
+    if (match === null) return null;
+    if (typeof match["path"] !== "string") return null;
+    if (typeof match["exists"] !== "boolean") return null;
+    if (!isStringOrNull(match["validated_at"])) return null;
+    if (!isStringOrNull(match["guide"])) return null;
+    if (!Array.isArray(match["specs"])) return null;
+  }
+  return envelope as unknown as DomainFindResponse;
+}
+
+/** A nullable wire string: present and a string, or present and exactly `null`.
+ * `undefined` fails — on this wire an absent key is a serialization bug, not an
+ * absent value. */
+function isStringOrNull(value: unknown): boolean {
+  return typeof value === "string" || value === null;
 }
 
 /** Pull the actionable reason out of a 403 body (`user_not_provisioned` /

--- a/src/tools/catalog.ts
+++ b/src/tools/catalog.ts
@@ -1,26 +1,31 @@
 /**
- * The four v0 catalog tools, 1:1 with the four sil-api routes: `sil_search`
- * (`/catalog/search`), `sil_product_get` (`/catalog/lookup`), `sil_stores`
- * (`/catalog/stores`) and `sil_domain_create` (`/catalog/domains`).
+ * The five v0 catalog tools, 1:1 with the five sil-api routes: `sil_search`
+ * (`POST /catalog/search`), `sil_product_get` (`POST /catalog/lookup`),
+ * `sil_stores` (`POST /catalog/stores`), `sil_domain_find` (`GET
+ * /catalog/domains`) and `sil_domain_create` (`POST /catalog/domains`).
  *
- * FOUR INTENTIONS, FOUR TOOLS, NEVER FLAGS ON ONE ANOTHER. No `mode`, no
+ * FIVE INTENTIONS, FIVE TOOLS, NEVER FLAGS ON ONE ANOTHER. No `mode`, no
  * `action`, no `include_stores`, no `refresh`, no `create_domain_if_missing`. A
  * model picks a tool by name at the moment of use; a flag hides the intention
- * inside a parameter it will not read — and one of these four performs a GLOBAL
- * registry write that nothing in the product can undo.
+ * inside a parameter it will not read — and one of these five performs a GLOBAL
+ * registry write that nothing in the product can undo. The read and that write
+ * share a PATH and are told apart by the VERB alone, which is precisely why they
+ * are two tools and not one: a `mode` on the mint would leave the undoable write
+ * one mistyped enum value away from a discovery call.
  *
  * THE TOOLS COMPUTE NO VERDICT. The agent's three-state veto (verified satisfies
  * · verified violates · not verified) is computed from `values[].state`,
- * `predicates[].applied` and `results[].maturity`. This layer's whole job is that
- * those three cross the boundary intact: the payload is gated structurally at its
- * top level and handed over VERBATIM. There is no projection here, deliberately —
- * a per-field projector drops exactly the fields the veto reads, and it would do
- * so while looking perfectly healthy.
+ * `predicates[].applied` and `results[].maturity`; the registry read's four-way
+ * verdict (adopt · descend · mint · narrow) is computed from `exists`, `guide`
+ * and `capped`. This layer's whole job is that they cross the boundary intact:
+ * the payload is gated structurally at its top level and handed over VERBATIM.
+ * There is no projection here, deliberately — a per-field projector drops exactly
+ * the fields a verdict reads, and it would do so while looking perfectly healthy.
  *
- * ONE GROUP, ONE FILE. All four share one origin, one Bearer, one 401
+ * ONE GROUP, ONE FILE. All five share one origin, one Bearer, one 401
  * choreography and one error envelope, and a new `registerXTools` group has to be
  * hand-wired into three guards or it silently NARROWS them (CLAUDE.md). The
- * envelope helpers at the bottom are tool-parameterised and shared by all four.
+ * envelope helpers at the bottom are tool-parameterised and shared by all five.
  *
  * `execute()` is the same shape in every tool:
  *   1. no stored tokens → terminal `not_registered`, ZERO network calls;
@@ -45,12 +50,15 @@ import { clearTokens, readConfig, readTokens } from "../lib/credentials.js";
 import { wiringAdvisories } from "../lib/host-wiring.js";
 import { putSearchResult } from "../lib/search-results-store.js";
 import {
+  findDomains,
   lookupCatalog,
   mintDomain,
   readStores,
   refreshAndRetryOnce,
   searchCatalog,
   type CatalogResultOutcome,
+  type DomainFindOutcome,
+  type DomainFindParams,
   type DomainMintParams,
   type MintOutcome,
   type SearchParams,
@@ -73,6 +81,9 @@ export function registerCatalogTools(api: PluginAPI): void {
   registerSearch(api);
   registerProductGet(api);
   registerStores(api);
+  // The read is registered before the write it licenses — the same order the
+  // agent is told to call them in.
+  registerDomainFind(api);
   registerDomainCreate(api);
 }
 
@@ -92,9 +103,11 @@ function registerSearch(api: PluginAPI): void {
       + " requirement reported `applied: false`, or a result whose value is"
       + " `unset`, is NOT VERIFIED — neither a match nor a miss: keep the result"
       + " and name the missing value. Discipline: at most 4 calls per item; widen"
-      + " soft requirements only; a hard requirement is never relaxed. If the"
-      + " domain is not in sil's registry the call is refused — research how the"
-      + " category is bought, then sil_domain_create at that same path.",
+      + " soft requirements only; a hard requirement is never relaxed. A refusal"
+      + " naming the domain and a refusal naming a predicate read alike on the"
+      + " wire, so settle which one it was with sil_domain_find — a `path` probe"
+      + " states whether the domain stands — and reach for sil_domain_create only"
+      + " once that read has named nothing to adopt.",
     parameters: Type.Object({
       domain: Type.String({
         pattern: DOMAIN_PATH_PATTERN,
@@ -102,8 +115,9 @@ function registerSearch(api: PluginAPI): void {
         description:
           "The registry path to search, dot-separated and lowercase (e.g."
           + " product.sports.winter.ski.boots). Exactly one domain per call. A path"
-          + " sil does not hold is refused — mint it with sil_domain_create rather"
-          + " than retrying or guessing a shallower path.",
+          + " sil does not hold is refused — read the registry with sil_domain_find"
+          + " for the path that already stands, and coin one with sil_domain_create"
+          + " only if none does. Never retry, and never guess a shallower path.",
       }),
       query: Type.String({
         minLength: 1,
@@ -353,15 +367,101 @@ function registerStores(api: PluginAPI): void {
   });
 }
 
+function registerDomainFind(api: PluginAPI): void {
+  api.registerTool({
+    name: "sil_domain_find",
+    label: "Read sil's registry before coining a category",
+    description:
+      "Read sil's shared registry before coining anything into it: send `q` (the"
+      + " buyer's own words) or `path` (one exact registry path) — exactly one of"
+      + " the two per call, never both. `q` is discovery: your words are matched"
+      + " against each standing"
+      + " category's path text AND its buying guide, so prose reaches a settled"
+      + " path that a path-shaped guess cannot. `path` probes that one path:"
+      + " `exists` is stated on every match, and where it is false the `specs`"
+      + " returned are the vocabulary that path WOULD inherit if coined. Then act"
+      + " on what came back. A match whose `guide` describes this category is"
+      + " ADOPTED: take its path verbatim and its spec keys as your search"
+      + " vocabulary, and coin nothing. A guide describing a BROADER category"
+      + " permits only a descendant of that path, never a sibling. `matches: []`"
+      + " with `capped: false` is a real answer and the one signal that licenses"
+      + " sil_domain_create. `capped: true` means the list was bounded and more may"
+      + " stand past it — narrow the ask and read again rather than coining. A"
+      + " provisional match (`validated_at: null`) is a real category, adopted like"
+      + " any other. Discipline: at most 2 discovery reads per category, plus one"
+      + " `path` probe of the exact path you are about to coin.",
+    parameters: Type.Object({
+      q: Type.Optional(
+        Type.String({
+          minLength: 1,
+          maxLength: 200,
+          description:
+            "The buyer's ask, in their own words — the discovery door. It is"
+            + " matched against each standing category's path text AND its buying"
+            + " guide, which is why prose reaches a settled path a path-shaped"
+            + " guess cannot. Send this or `path`, never both: the route refuses a"
+            + " call carrying both or neither and says which one you sent.",
+        }),
+      ),
+      path: Type.Optional(
+        Type.String({
+          pattern: DOMAIN_PATH_PATTERN,
+          maxLength: 255,
+          description:
+            "One exact registry path, dot-separated and lowercase (e.g."
+            + " product.sports.winter.ski.boots) — the probe door. It answers about"
+            + " that path alone: `exists` says whether it already stands, and when"
+            + " it does not, `specs` is the vocabulary it would inherit, so you coin"
+            + " only the keys it lacks. A probe SHAPES a mint; only a `q` read"
+            + " licenses one. Send this or `q`, never both.",
+        }),
+      ),
+    }),
+    async execute(_callId, params) {
+      const stored = readTokens();
+      if (stored === null) return notRegistered("sil_domain_find");
+
+      const query = readFindParams(params);
+      const first = await findDomains(getApiUrl(), stored.access_token, query);
+      const recovered = await refreshAndRetryOnce(
+        first,
+        (o): boolean => o.kind === "unauthorized",
+        (accessToken) => findDomains(getApiUrl(), accessToken, query),
+      );
+      switch (recovered.kind) {
+        case "result":
+          if (recovered.refreshed) api.logger.info("sil_domain_find_refreshed", {});
+          return mapFindOutcome(api, recovered.outcome);
+        case "must_reregister":
+          if (recovered.reason === "invalid_grant") clearTokens();
+          api.logger.info("sil_domain_find_must_reregister", { cause: recovered.reason });
+          return mustReregister("sil_domain_find");
+        case "second_unauthorized":
+          clearTokens();
+          api.logger.info("sil_domain_find_must_reregister", { cause: "retry_unauthorized" });
+          return mustReregister("sil_domain_find");
+        case "retryable":
+          api.logger.info("sil_domain_find_refresh_retryable", {});
+          return transient("sil_domain_find");
+      }
+    },
+  });
+}
+
 function registerDomainCreate(api: PluginAPI): void {
   api.registerTool({
     name: "sil_domain_create",
     label: "Add a new category to sil's shared registry",
     description:
       "Add a NEW category to sil's shared registry: its path, a buying guide"
-      + " written from research, and its first spec keys. Call it only after"
-      + " reading up on the web on how that category is actually bought (never on"
-      + " products), and only when sil's search refused the domain as unregistered."
+      + " written from research, and its first spec keys. Two things must both hold"
+      + " before you call it: sil_domain_find returned no adoptable match for this"
+      + " category and stated the answer was complete (`capped: false`), and you"
+      + " have read up on the web on how the category is actually bought (never on"
+      + " products). Probe the exact path with sil_domain_find as well, and coin"
+      + " only the keys that path does not already inherit — the response here"
+      + " echoes the keys you sent, so a skipped probe forks the vocabulary on your"
+      + " very first predicate."
       + " NEW nodes only — an existing path is refused and nothing is written; that"
       + " refusal means the category is already there, so re-issue the search on"
       + " the same path. Never mint a near-path variant to route around a refusal,"
@@ -524,6 +624,34 @@ function mapStoresOutcome(api: PluginAPI, ref: string, outcome: StoresOutcome) {
   }
 }
 
+/** Map a registry-read outcome to the agent-facing envelope. The `ok` arm logs
+ * the two numbers an operator needs to tell a licensed mint from an unlicensed
+ * one — how many domains the read named, and whether the list was bounded. The
+ * ask itself is never logged: it is the buyer's own words. */
+function mapFindOutcome(api: PluginAPI, outcome: DomainFindOutcome) {
+  switch (outcome.kind) {
+    case "ok":
+      api.logger.info("sil_domain_find_read", {
+        match_count: outcome.found.matches.length,
+        capped: outcome.found.capped,
+      });
+      return jsonResult({ status: "ok", ...outcome.found, ...wiringAdvisories(api) });
+    case "forbidden":
+      return forbiddenResult(api, "sil_domain_find", outcome.reason);
+    case "invalid_request":
+      api.logger.info("sil_domain_find_invalid_request", { error: outcome.error });
+      return invalidRequest(outcome.error, outcome.message);
+    case "retryable":
+      api.logger.info(
+        "sil_domain_find_retryable",
+        outcome.source ? { source: outcome.source } : {},
+      );
+      return transient("sil_domain_find", outcome.source, outcome.detail);
+    case "unauthorized":
+      return mustReregister("sil_domain_find");
+  }
+}
+
 function mapMintOutcome(api: PluginAPI, outcome: MintOutcome) {
   switch (outcome.kind) {
     case "ok":
@@ -581,6 +709,19 @@ function readStoresParams(params: Record<string, unknown>): StoresParams {
   return {
     ref: asString(params["ref"]),
     ...(typeof destination === "string" ? { destination } : {}),
+  };
+}
+
+/** Exactly what the agent sent, and only that. Both keys absent, one present or
+ * BOTH present all travel as read: the route owns the exactly-one-of rule and
+ * names the parameter at fault, and a local refusal would have to invent a second
+ * message that then drifts from the one the agent actually acts on. */
+function readFindParams(params: Record<string, unknown>): DomainFindParams {
+  const q = params["q"];
+  const path = params["path"];
+  return {
+    ...(typeof q === "string" ? { q } : {}),
+    ...(typeof path === "string" ? { path } : {}),
   };
 }
 

--- a/src/tools/catalog.ts
+++ b/src/tools/catalog.ts
@@ -106,8 +106,9 @@ function registerSearch(api: PluginAPI): void {
       + " soft requirements only; a hard requirement is never relaxed. A refusal"
       + " naming the domain and a refusal naming a predicate read alike on the"
       + " wire, so settle which one it was with sil_domain_find — a `path` probe"
-      + " states whether the domain stands — and reach for sil_domain_create only"
-      + " once that read has named nothing to adopt.",
+      + " states whether the domain stands. If it does not, read again with `q`,"
+      + " and reach for sil_domain_create only once that discovery read comes back"
+      + " `matches: []` with `capped: false`. A probe never licenses a mint.",
     parameters: Type.Object({
       domain: Type.String({
         pattern: DOMAIN_PATH_PATTERN,
@@ -455,13 +456,14 @@ function registerDomainCreate(api: PluginAPI): void {
     description:
       "Add a NEW category to sil's shared registry: its path, a buying guide"
       + " written from research, and its first spec keys. Two things must both hold"
-      + " before you call it: sil_domain_find returned no adoptable match for this"
-      + " category and stated the answer was complete (`capped: false`), and you"
-      + " have read up on the web on how the category is actually bought (never on"
-      + " products). Probe the exact path with sil_domain_find as well, and coin"
-      + " only the keys that path does not already inherit — the response here"
-      + " echoes the keys you sent, so a skipped probe forks the vocabulary on your"
-      + " very first predicate."
+      + " before you call it: a sil_domain_find DISCOVERY read — `q`, the buyer's own"
+      + " words — came back `matches: []` with `capped: false`, and you have read up"
+      + " on the web on how the category is actually bought (never on products). Then"
+      + " `path`-probe the exact path with sil_domain_find and coin only the keys that"
+      + " path does not already inherit — the response here echoes the keys you sent,"
+      + " so a skipped probe forks the vocabulary on your very first predicate. That"
+      + " probe SHAPES the mint and never licenses it: it answers only about the path"
+      + " you already guessed."
       + " NEW nodes only — an existing path is refused and nothing is written; that"
       + " refusal means the category is already there, so re-issue the search on"
       + " the same path. Never mint a near-path variant to route around a refusal,"


### PR DESCRIPTION
## Card

`cards/sil-domain-find-the-fifth-tool-so-the-read-route-i.md` (gitignored-mode — it lives only in the `card/…` worktree; see its body for the full intent + handoffs).

## Summary

sil-services shipped `GET /catalog/domains` (#94) and this plugin shipped its four v0 catalog tools (#75); neither knew about the other, so **read-before-mint was unreachable from an agent** and the skill sent an empty shelf straight at `sil_domain_create` — the one write in v0 that nothing can undo.

This adds the fifth tool, 1:1 with the route, in the **existing** `registerCatalogTools` group.

- **`src/lib/sil-client.ts`** — `DomainSpecWire` / `DomainMatch` / `DomainFindResponse` mirrored from `@sil/schemas` (never imported; not a UCP shape, not `/api/v1`), plus `DomainFindOutcome`, `classifyDomainFindResponse`, a 200 gate, and `findDomains()` reusing the module-private bodyless `getJson`.
- **`src/tools/catalog.ts`** — `sil_domain_find`, registered **before** the mint it licenses. `sil_search`'s and `sil_domain_create`'s descriptions re-pointed: a refusal routes to the READ, and the mint is reached only once that read named nothing to adopt.
- **`openclaw.plugin.json`** — `contracts.tools` 12 → 13 (step 3, the load-bearing half of the drift guard).
- **`sil-shopping/`** — the "TWO mints" bullet rewritten whole into *two shelves, each read before it is written*; a routing row for the read above the mint; and `references/method_and_prds.md`'s "take the key sil already holds" finally gains its mechanism (four verdicts, the descend rule, the pre-mint probe, budget stated as **≤2 discovery reads + 1 probe**).

### Three decisions worth reviewing

1. **No client-side `q`/`path` validator.** Both-or-neither is forwarded and refused by the route, which names the parameter at fault. A local refusal would have to invent a second message that then drifts from the one the agent acts on. Overturns the card's draft AC — reasoning in Discovery's "Alternatives ruled out".
2. **No projection.** The gate returns the ORIGINAL object; `inherited` / `defined_at` are what make "coin only the keys this path does not already inherit" computable at all.
3. **`guide` is gated** (one field beyond the card's enumerated list). The adopt-vs-descend verdict is computed from it, exactly as the search veto is computed from `values`/`predicates`/`maturity`.

## Test plan

- [x] `pnpm typecheck` clean.
- [x] Full suite **exit `0` on 5 back-to-back runs**, 1522/1522, stable count, clean tree (`--exclude repo-scaffold`; see below).
- [x] 3 new test files: `tools/domain-find.test.ts`, `lib/domain-find-classify.test.ts`, `catalog-domain-find.integration.test.ts`.
- [x] The 6 biting exact-set mirrors bumped 12 → 13 and the 3 silent carriers bumped by hand — **every change add-only**; no `.toEqual` loosened to `toContain`, no set weakened to a subset.
- [x] `helpers/v0-harness.ts` gains a fifth `domainFind` kind matched on **method + pathname** — `/catalog/domains` is the first path in this repo served by two verbs, and path-suffix routing alone could not express it without breaking the mint's "exactly ONE write is attempted" bar.
- [x] **Live-verified against the compiled `dist/`** over a real socket: 19/19 — one GET with a Bearer, bare path, `?q=` / `?path=` / both / neither each producing a distinct request, the payload unprojected, no token in any log line or result, and **zero POSTs to `/catalog/domains`** across the whole run.

**Known worktree artefact, not a regression:** `repo-scaffold.integration.test.ts` reports 10 failures in any card worktree because `docs/` and `CLAUDE.md` are gitignored and absent there. Full-suite tally with it included: 1524 passed / 10 failed.

## Distillation target

Knowledge capture happens **after Review PASS** in the `distilling` stage — `solutions-architect` runs in this same worktree, commits to this same branch, and pushes here so the PR ends up containing implementation + tests + distillation in one mergeable unit. Three known targets: `docs/knowledge/sil-api-catalog-contract.md:74` is now false ("There is no `GET /catalog/domains`"), the four-routes framing in that same doc, and the reusable method+pathname harness-routing pattern.
