### PR TITLE
bug: the suite rewrites dist/ while the bin imports it — one build per run, installed atomically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ coverage/
 # Build outputs
 dist/
 build/
+# Suite build scratch (.tmp-dist-{build,target,load}-*) — a killed run would leave an
+# untracked tree, and `pnpm release` fails closed on its clean-tree check.
+.tmp-dist-*/
 *.egg-info/
 target/
 out/

--- a/scripts/create-shopper.mjs
+++ b/scripts/create-shopper.mjs
@@ -121,21 +121,24 @@ const SOUL_SIL_RULES =
 const CREATED_EVENT = "sil_shopper_created";
 const FAILED_EVENT = "sil_shopper_create_failed";
 
-/** Emit one structured NDJSON line in sil's marker style: `{event, level, ...}`. */
-function logMarker(stream, level, event, fields) {
-  stream.write(JSON.stringify({ event, level, ...fields }) + "\n");
+/** Emit one structured NDJSON line in sil's marker style: `{event, level, ...}`,
+ * straight to the fd: `process.stdout.write` is async on a pipe, so the line that
+ * overflows the buffer is exactly the one the following `process.exit()` discards
+ * — and `created` echoes an unbounded `name`. */
+function logMarker(fd, level, event, fields) {
+  writeFileSync(fd, JSON.stringify({ event, level, ...fields }) + "\n");
 }
 
 /** Terminal success emit — one `created` object on stdout, exit 0. */
 function emitCreated(fields) {
-  logMarker(process.stdout, "info", CREATED_EVENT, { status: "created", ...fields });
+  logMarker(1, "info", CREATED_EVENT, { status: "created", ...fields });
   process.exit(0);
 }
 
 /** Terminal failure emit — one object on stderr carrying the taxonomy `status`,
  * exit 1. Never carries persona/userSpec text. */
 function emitFailure(status, fields) {
-  logMarker(process.stderr, "error", FAILED_EVENT, { status, ...fields });
+  logMarker(2, "error", FAILED_EVENT, { status, ...fields });
   process.exit(1);
 }
 

--- a/src/__tests__/create-shopper.integration.test.ts
+++ b/src/__tests__/create-shopper.integration.test.ts
@@ -39,9 +39,9 @@
  *
  * The bin imports the COMPILED libs (`dist/lib/profile-store.js`) and shells the
  * `sil-openclaw-allowlist` bin (which imports `dist/lib/openclaw-allowlist.js`), so
- * beforeAll builds dist FROM THE CURRENT SOURCE — never a possibly-stale dist (a
- * stale dist silently tests old logic). The build is the same `tsc -p
- * tsconfig.build.json` the bin's `../dist` import needs.
+ * dist is built FROM THE CURRENT SOURCE — never a possibly-stale dist (a stale dist
+ * silently tests old logic). That build is `globalSetup`'s (`helpers/build-dist.ts`):
+ * once per run, installed by rename, so no bin ever reads a half-emitted module.
  *
  * THE fake `openclaw` shim is a faithful test double of the EXTERNAL host CLI: it
  * answers `agents list` / `agents add` / `config set` / `config validate` (and the
@@ -60,11 +60,10 @@ import {
   describe,
   it,
   expect,
-  beforeAll,
   beforeEach,
   afterEach,
 } from "vitest";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import {
   mkdtempSync,
   rmSync,
@@ -73,6 +72,8 @@ import {
   writeFileSync,
   mkdirSync,
   chmodSync,
+  openSync,
+  closeSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
@@ -115,7 +116,13 @@ interface RunResult {
   status: number;
   stdout: string;
   stderr: string;
+  /** Non-null only if the child was KILLED — i.e. it never terminated on its own. */
+  signal: NodeJS.Signals | null;
 }
+
+/** Hard bound on a single bin run (~1 s in practice). Not a latency budget — a hang
+ * detector, so a bin that waits on an open handle fails the run instead of wedging it. */
+const RUN_TIMEOUT_MS = 20_000;
 
 /** The endorsed create-shopper spec. `agentId` is NOT a field — the bin derives it
  * from `name` (`deriveAgentId`), so the user authors ONE friendly display name. */
@@ -322,23 +329,6 @@ let emptyHome: string; // guaranteed-empty HOME so no real ~/.openclaw resolves
 let logPath: string; // shim invocation log
 let configPath: string;
 
-beforeAll(() => {
-  // The bin imports dist/lib/profile-store.js and shells the allowlist bin
-  // (dist/lib/openclaw-allowlist.js) — build the libs from the CURRENT source so
-  // the integration tier exercises what the dev wrote, never a stale dist. We
-  // invoke the TypeScript compiler's real JS entry (node_modules/.bin/tsc is a
-  // shell wrapper `node` cannot run directly).
-  execFileSync("node", ["node_modules/typescript/bin/tsc", "-p", "tsconfig.build.json"], {
-    cwd: REPO_ROOT,
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-  for (const rel of ["dist/lib/profile-store.js", "dist/lib/openclaw-allowlist.js"]) {
-    if (!existsSync(join(REPO_ROOT, rel))) {
-      throw new Error(`build did not emit ${rel} — the bin's import would 404`);
-    }
-  }
-}, 120_000);
-
 beforeEach(() => {
   workdir = mkdtempSync(join(tmpdir(), "sil-create-it-"));
   dataDir = mkdtempSync(join(tmpdir(), "sil-create-data-"));
@@ -421,25 +411,13 @@ interface RunOpts {
   fail?: string[];
   /** Override the resolved config env (for the "no config" fail-closed case). */
   env?: Record<string, string>;
+  /** Redirect the child's stdout/stderr to real FILES instead of pipes. */
+  toFiles?: boolean;
 }
 
-/** Spawn the bin as a child process with a hermetic, explicit env. */
-function runBin(opts: RunOpts = {}): RunResult {
-  const args = [SCRIPT];
-  let input = "";
-  if (opts.stdin !== undefined) {
-    input = opts.stdin;
-  } else if (opts.spec) {
-    if (opts.viaSpecFile) {
-      const specPath = join(workdir, "spec.json");
-      writeFileSync(specPath, JSON.stringify(opts.spec));
-      args.push("--spec", specPath);
-    } else {
-      input = JSON.stringify(opts.spec);
-    }
-  }
-
-  const env: Record<string, string> = {
+/** The hermetic, explicit env every spawn of the bin runs under. */
+function binEnv(opts: RunOpts = {}): Record<string, string> {
+  return {
     PATH: `${binDir}:${process.env["PATH"] ?? "/usr/bin:/bin"}`,
     HOME: emptyHome,
     OPENCLAW_CONFIG_PATH: configPath,
@@ -448,27 +426,76 @@ function runBin(opts: RunOpts = {}): RunResult {
     ...(opts.fail && opts.fail.length ? { OPENCLAW_SHIM_FAIL: opts.fail.join(",") } : {}),
     ...(opts.env ?? {}),
   };
+}
 
+/** `[SCRIPT, …]` plus the stdin body, per the chosen input channel. */
+function binArgs(opts: RunOpts): { args: string[]; input: string } {
+  const args = [SCRIPT];
+  if (opts.stdin !== undefined) return { args, input: opts.stdin };
+  if (!opts.spec) return { args, input: "" };
+  if (!opts.viaSpecFile) return { args, input: JSON.stringify(opts.spec) };
+  const specPath = join(workdir, "spec.json");
+  writeFileSync(specPath, JSON.stringify(opts.spec));
+  args.push("--spec", specPath);
+  return { args, input: "" };
+}
+
+/** Spawn the bin as a child process with a hermetic, explicit env. */
+function runBin(opts: RunOpts = {}): RunResult {
+  const { args, input } = binArgs(opts);
+  const env = binEnv(opts);
+
+  const outPath = join(workdir, "bin-stdout.txt");
+  const errPath = join(workdir, "bin-stderr.txt");
+  const fds = opts.toFiles ? [openSync(outPath, "w"), openSync(errPath, "w")] : null;
+
+  // `spawnSync`, never `execFileSync`: the latter returns ONLY stdout on success, so
+  // the whole success path was blind to a child that crashed and still exited 0 — the
+  // diagnostic hole this card's root cause hid behind for a day.
+  // `process.execPath`, never the bare "node": the ClawHub-channel tests below hand
+  // this an env whose PATH holds ONLY the `openclaw` shim, and a PATH lookup for the
+  // interpreter itself would fail there for a reason unrelated to what they prove.
   try {
-    // `process.execPath`, never the bare "node": the ClawHub-channel tests below
-    // hand this an env whose PATH holds ONLY the `openclaw` shim, and a PATH lookup
-    // for the interpreter itself would fail there for a reason that has nothing to
-    // do with what those tests are proving.
-    const stdout = execFileSync(process.execPath, args, {
+    const r = spawnSync(process.execPath, args, {
       input,
       env,
       encoding: "utf8",
-      stdio: ["pipe", "pipe", "pipe"],
+      stdio: fds ? ["pipe", fds[0]!, fds[1]!] : ["pipe", "pipe", "pipe"],
+      timeout: RUN_TIMEOUT_MS,
+      // Generous: the >64 KB-marker test emits ~500 KB. An ENOBUFS truncation would
+      // read exactly like the marker truncation under test.
+      maxBuffer: 32 * 1024 * 1024,
     });
-    return { status: 0, stdout, stderr: "" };
-  } catch (err: unknown) {
-    const e = err as { status?: number; stdout?: Buffer | string; stderr?: Buffer | string };
+    if (r.error && (r.error as NodeJS.ErrnoException).code !== "ETIMEDOUT") {
+      throw new Error(`spawning the bin failed outright: ${r.error.message}`);
+    }
     return {
-      status: e.status ?? 1,
-      stdout: (e.stdout ?? "").toString(),
-      stderr: (e.stderr ?? "").toString(),
+      status: r.status ?? 1,
+      stdout: fds ? readFileSync(outPath, "utf8") : (r.stdout ?? ""),
+      stderr: fds ? readFileSync(errPath, "utf8") : (r.stderr ?? ""),
+      signal: r.signal,
     };
+  } finally {
+    for (const fd of fds ?? []) closeSync(fd);
   }
+}
+
+/** Run the bin with a real PTY on fd 1/2 (util-linux `script`). A terminal merges the
+ * two streams, so this returns ONE `merged` text — never split it back apart. */
+function runBinOnPty(spec: Spec): { status: number; signal: NodeJS.Signals | null; merged: string } {
+  const specPath = join(workdir, "pty-spec.json");
+  writeFileSync(specPath, JSON.stringify(spec));
+  const command = [process.execPath, SCRIPT, "--spec", specPath].map((a) => `'${a}'`).join(" ");
+  const r = spawnSync("script", ["-q", "-e", "-c", command, "/dev/null"], {
+    env: binEnv(),
+    encoding: "utf8",
+    stdio: ["pipe", "pipe", "pipe"],
+    timeout: RUN_TIMEOUT_MS,
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  if (r.error) throw new Error(`spawning \`script\` failed outright: ${r.error.message}`);
+  // The pty line discipline maps \n → \r\n; that \r is the terminal's, not the bin's.
+  return { status: r.status ?? 1, signal: r.signal, merged: (r.stdout ?? "").replace(/\r\n/g, "\n") };
 }
 
 /** Parse the single NDJSON marker the bin emits on the given stream. */
@@ -514,8 +541,6 @@ describe("created — one valid run wires every surface and returns the identity
     // … and the agentId is the lower-kebab id DERIVED from it — a concrete literal,
     // never echoed from an input (agentId is no longer a spec field).
     expect(m["agentId"]).toBe("my-shopper");
-    // No failure marker on stderr for a clean create.
-    expect(r.stderr.includes("sil_shopper_create_failed")).toBe(false);
   });
 
   it("materializes the sil artefacts — shared user_spec.md (frontmatter name), NO manifest, NO domains at create", () => {
@@ -1200,16 +1225,22 @@ describe("no PII/secret leakage — the markers never echo the persona or userSp
   it("neither stdout nor stderr contains the persona/userSpec secrets, on created OR on failure", () => {
     writeConfig(freshConfig());
 
+    // BOTH streams of BOTH runs: until this card `runBin` hardcoded `stderr: ""` on
+    // the success path, so this check could only ever see half the output.
     const ok = runBin({ spec: validSpec() });
     expect(ok.status).toBe(0);
-    expect(ok.stdout).not.toContain(PERSONA_SECRET);
-    expect(ok.stdout).not.toContain(USERSPEC_SECRET);
+    for (const stream of [ok.stdout, ok.stderr]) {
+      expect(stream).not.toContain(PERSONA_SECRET);
+      expect(stream).not.toContain(USERSPEC_SECRET);
+    }
 
     // A forced failure carries a path + cause — still never the persona/userSpec.
     const fail = runBin({ spec: validSpec({ name: "Leak Check" }), fail: ["config-validate"] });
     expect(fail.status).not.toBe(0);
-    expect(fail.stderr).not.toContain(PERSONA_SECRET);
-    expect(fail.stderr).not.toContain(USERSPEC_SECRET);
+    for (const stream of [fail.stdout, fail.stderr]) {
+      expect(stream).not.toContain(PERSONA_SECRET);
+      expect(stream).not.toContain(USERSPEC_SECRET);
+    }
   });
 });
 
@@ -1686,4 +1717,156 @@ describe("AC C1 — shell metacharacters round-trip verbatim via --spec", () => 
     expect(parseMarker(r.stdout)["status"]).toBe("created");
     expect(readFileSync(join(spec.workspace, "SOUL.md"), "utf8")).toContain(`'"'"'`);
   });
+});
+
+// ===========================================================================
+// THE OUTPUT CONTRACT — exactly ONE complete NDJSON line on the correct stream,
+// the other stream byte-empty, and the exit code that line claims. Card:
+// create-shopper-bin-dies-on-its-exit-path (`docs/decisions/create-shopper-bin.md`
+// §3). Content and code are pinned TOGETHER on purpose: "no crash banner" and
+// "the other stream is empty" both pass for free against a bin that emits nothing.
+// ===========================================================================
+
+/** The `created` marker echoes an unbounded `name` ~5× (name, agentId, and agentId twice
+ * more in the manual-bind warning), so 64 KiB of it makes the line ~328 KB — 5× a Linux
+ * pipe buffer. Measured on the pre-fix bin: truncated 10/10 at this size (still exit 0,
+ * no trailing newline), 2/6 at 50 k, 0/6 at 20 k. Bounded above too: the derived agentId
+ * goes to `openclaw agents add` as ONE argv element, and Linux caps that at
+ * MAX_ARG_STRLEN (32 pages) — past it the bin fails closed with `persistence_failed` and
+ * never reaches `emitCreated`, testing E2BIG instead of the pipe. 2× headroom either way. */
+const OVERFLOW_NAME_LEN = 65_536;
+
+/** The tails Node prints when it dies of an uncaught exception — the exact bytes that
+ * made `parseMarker` throw `Unexpected token 'N', "Node.js v24.19.0"`. */
+function assertNoCrashDump(...streams: string[]): void {
+  for (const text of streams) {
+    expect(text).not.toContain("Node.js v");
+    expect(text).not.toMatch(/^\s+at .+:\d+:\d+/m);
+    expect(text).not.toContain("throw er;");
+  }
+}
+
+/** The non-empty lines a stream carries. */
+function lines(text: string): string[] {
+  return text.split("\n").filter(Boolean);
+}
+
+describe("output contract — one whole line, one empty stream, the exit code it claims", () => {
+  it("created: stdout is EXACTLY one \\n-terminated created line, stderr is byte-empty, exit 0", () => {
+    writeConfig(freshConfig());
+
+    const r = runBin({ spec: validSpec() });
+
+    expect(r.status).toBe(0);
+    expect(r.signal).toBeNull();
+    // Byte-empty, not "carries no failure marker": until this card, runBin hardcoded
+    // `stderr: ""` on the success path, so a child that dumped a stack and still
+    // exited 0 was invisible to every assertion in this file.
+    expect(r.stderr).toBe("");
+    expect(r.stdout.endsWith("\n")).toBe(true);
+    expect(lines(r.stdout)).toHaveLength(1);
+    // Parsed from the WHOLE stream, not `parseMarker`'s last line — anything else on
+    // stdout is a contract violation, not something to skip past.
+    const m = JSON.parse(r.stdout) as Record<string, unknown>;
+    expect(m["event"]).toBe("sil_shopper_created");
+    expect(m["status"]).toBe("created");
+    assertNoCrashDump(r.stdout, r.stderr);
+  });
+
+  it("invalid_request: stderr is EXACTLY one line naming the field, stdout byte-empty, exit 1", () => {
+    writeConfig(freshConfig());
+
+    const r = runBin({ spec: { ...validSpec(), name: "   " } });
+
+    expect(r.status).toBe(1);
+    expect(r.signal).toBeNull();
+    expect(r.stdout).toBe("");
+    expect(r.stderr.endsWith("\n")).toBe(true);
+    expect(lines(r.stderr)).toHaveLength(1);
+    const m = JSON.parse(r.stderr) as Record<string, unknown>;
+    expect(m["event"]).toBe("sil_shopper_create_failed");
+    expect(m["status"]).toBe("invalid_request");
+    expect(m["field"]).toBe("name");
+    // The measured symptom: Node's dump landing AFTER the bin's own line, which made
+    // `parseMarker` take the banner as the marker and throw on 'N'.
+    assertNoCrashDump(r.stdout, r.stderr);
+  });
+
+  it("a created marker past the pipe buffer still arrives WHOLE — on a pipe, a file, and a pty", () => {
+    const spec = validSpec({ name: "N".repeat(OVERFLOW_NAME_LEN) });
+    // The derived agentId is as long as the name, so the default workspace path would
+    // be ENAMETOOLONG. The bin never puts the id in a path; this fixture must not either.
+    spec.workspace = join(workdir, "overflow-workspace");
+
+    writeConfig(freshConfig());
+    const onPipe = runBin({ spec });
+
+    expect(onPipe.status).toBe(0);
+    expect(onPipe.stderr).toBe("");
+    // Anti-vacuity: the whole point is a line the pipe buffer cannot hold in one go.
+    // If the bin ever bounds the echoed `name`, this is the assertion that should fail.
+    expect(onPipe.stdout.length).toBeGreaterThan(64 * 1024);
+    expect(lines(onPipe.stdout)).toHaveLength(1);
+    expect((JSON.parse(onPipe.stdout) as Record<string, unknown>)["name"]).toBe(spec.name);
+
+    // A file redirect and a terminal are the other two channels the shipped bin runs
+    // on (`node <creationEntrypoint>` from an agent's bash tool, or by hand).
+    rmSync(dataDir, { recursive: true, force: true });
+    mkdirSync(dataDir, { recursive: true });
+    writeConfig(freshConfig());
+    const toFile = runBin({ spec, toFiles: true });
+
+    expect(toFile.status).toBe(0);
+    expect(toFile.stderr).toBe("");
+    expect(lines(toFile.stdout)).toHaveLength(1);
+    expect((JSON.parse(toFile.stdout) as Record<string, unknown>)["name"]).toBe(spec.name);
+
+    rmSync(dataDir, { recursive: true, force: true });
+    mkdirSync(dataDir, { recursive: true });
+    writeConfig(freshConfig());
+    // Anti-vacuity for the channel itself: prove `script` really hands the child a tty,
+    // or this leg silently re-tests the pipe.
+    const ttyProbe = spawnSync(
+      "script",
+      ["-q", "-e", "-c", `'${process.execPath}' -e 'process.stdout.write(String(process.stdout.isTTY))'`, "/dev/null"],
+      { env: binEnv(), encoding: "utf8", timeout: RUN_TIMEOUT_MS },
+    );
+    expect(ttyProbe.stdout.trim()).toBe("true");
+
+    const onPty = runBinOnPty(spec);
+
+    expect(onPty.status).toBe(0);
+    expect(lines(onPty.merged)).toHaveLength(1);
+    expect((JSON.parse(onPty.merged) as Record<string, unknown>)["name"]).toBe(spec.name);
+
+    assertNoCrashDump(onPipe.stdout, onPipe.stderr, toFile.stdout, toFile.stderr, onPty.merged);
+  }, 60_000);
+
+  it("every terminal outcome exits on its own — never killed, never waiting on a handle", () => {
+    // The hang the `process.exitCode` + natural-exit direction invites. For the sole
+    // caller — a synchronous bash tool — a bin that never returns is worse than a
+    // wrong exit code, and no other test here would notice: `runBin`'s timeout kills
+    // it and every assertion then reads a plain non-zero status.
+    const outcomes: Array<[string, () => RunResult, number]> = [
+      ["created", () => runBin({ spec: validSpec() }), 0],
+      ["invalid_request", () => runBin({ stdin: "" }), 1],
+      ["collision", () => { seedExistingShopper(); return runBin({ spec: validSpec() }); }, 1],
+      ["persistence_failed", () => runBin({ spec: validSpec(), fail: ["agents-add"] }), 1],
+    ];
+
+    for (const [label, run, expected] of outcomes) {
+      rmSync(dataDir, { recursive: true, force: true });
+      mkdirSync(dataDir, { recursive: true });
+      writeConfig(freshConfig());
+
+      const r = run();
+
+      expect(r.signal, `${label}: the bin was KILLED, so it never terminated on its own`).toBeNull();
+      expect(r.status, `${label}: exit code must match the marker's claim`).toBe(expected);
+      // Anti-vacuity: a bin that emitted nothing would satisfy both of the above.
+      const marker = JSON.parse(expected === 0 ? r.stdout : r.stderr) as Record<string, unknown>;
+      expect(marker["status"]).toBe(label);
+      assertNoCrashDump(r.stdout, r.stderr);
+    }
+  }, 60_000);
 });

--- a/src/__tests__/dist-build-choreography.integration.test.ts
+++ b/src/__tests__/dist-build-choreography.integration.test.ts
@@ -1,0 +1,88 @@
+/**
+ * INTEGRATION — who builds `dist/`, and when (tier: integration — reads what this run's
+ * `globalSetup` provided, the real `dist/` it produced, and every test file's source).
+ *
+ * Card: create-shopper-bin-dies-on-its-exit-path. `create-shopper.integration.test.ts`
+ * and `openclaw-allowlist.integration.test.ts` each drove the build compiler in a
+ * `beforeAll`, emitting NON-atomically into the one shared `dist/` — while their own
+ * spawned bins were statically importing `../dist/lib/*.js`. A bin that started mid-emit
+ * read a truncated module and died at ESM instantiation (stdout empty, exit 1). Measured
+ * 1 anomaly in 2,365 spawns under 6-way parallel vitest; 32 in ~24,000 against a
+ * compiler storm; `dist/lib/profile-store.js` read 0 bytes on 11 of 811,224 reads.
+ *
+ * The fix has two halves and neither closes it alone: ONE build per vitest process
+ * (`globalSetup`, finished before any test file runs) kills the intra-run race, and an
+ * ATOMIC rename install kills the cross-process one (4 parallel `vitest run`s each
+ * build; run A's tests race run B's emit). These guards pin the MECHANISM — a
+ * probabilistic race cannot be a suite assertion under `no-ci-by-design.md`.
+ *
+ * THESE ASSERTIONS ARE THE SPEC. Do NOT weaken them to match the config.
+ */
+
+import { describe, it, expect, inject } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { distEntriesTheBinsImport, DIST_DIR, REPO_ROOT, TSC_ENTRY, TSC_PROJECT } from "./helpers/build-dist";
+
+const TESTS_DIR = join(REPO_ROOT, "src", "__tests__");
+
+/** The ONE test file allowed to drive the build compiler itself: it plants a stale
+ * artifact and rebuilds over it in a private outDir to prove stale-dist immunity —
+ * that isolated build is the entire point of the file. Add-only; never loosen. */
+const TEST_FILES_THAT_MAY_COMPILE = ["compiled-artifact-load.integration.test.ts"];
+
+function testFiles(): string[] {
+  return readdirSync(TESTS_DIR, { recursive: true, encoding: "utf8" })
+    .filter((p) => p.endsWith(".test.ts"))
+    .sort();
+}
+
+/** Value exports (not `type`/`interface`) declared by a TypeScript source. */
+function valueExports(tsSource: string): string[] {
+  return [...tsSource.matchAll(/^export\s+(?:async\s+)?(?:function|const|class|let|var)\s+([A-Za-z0-9_$]+)/gm)]
+    .map((m) => m[1]!)
+    .sort();
+}
+
+describe("dist/ is built once per vitest run, before any test file executes", () => {
+  it("globalSetup runs the shared build helper, and the dist/ it produced matches CURRENT source", async () => {
+    // Behavioural, not a config grep: only `helpers/build-dist.ts#setup` provides this
+    // key, and vitest resolves `globalSetup` before it loads a single test file. Absent
+    // ⇒ the wiring is gone, whatever `vitest.config.ts` happens to say.
+    expect(inject("distBuild")).toEqual(distEntriesTheBinsImport());
+
+    // Anti-vacuity, and the measured failure itself: `does not provide an export named
+    // getShopperArtefactDir` was a bin reading a dist/ that did NOT match its source.
+    // Runtime export names, not a text grep — a half-written module cannot fake these.
+    const libEntries = distEntriesTheBinsImport().filter((e) => e.startsWith("lib/"));
+    expect(libEntries.length).toBeGreaterThan(1);
+    for (const rel of libEntries) {
+      const compiled = await import(pathToFileURL(join(DIST_DIR, rel)).href);
+      const source = readFileSync(join(REPO_ROOT, "src", rel.replace(/\.js$/, ".ts")), "utf8");
+      expect(Object.keys(compiled).sort()).toEqual(valueExports(source));
+    }
+  });
+
+  it("no test file compiles into dist/ — a re-added beforeAll build reopens the race", () => {
+    // The failure mode nothing else catches: `globalSetup` can be wired and correct
+    // while a per-file `beforeAll` still rewrites the shared dist/ under running bins.
+    const drivers = testFiles().filter((rel) => {
+      const source = readFileSync(join(TESTS_DIR, rel), "utf8");
+      return source.includes(TSC_ENTRY) || source.includes(TSC_PROJECT);
+    });
+
+    expect(drivers.map((p) => p.split("/").at(-1))).toEqual(TEST_FILES_THAT_MAY_COMPILE);
+
+    for (const rel of drivers) {
+      const source = readFileSync(join(TESTS_DIR, rel), "utf8");
+      expect(source).toContain("--outDir");
+      // …and that outDir is a private scratch dir, never the shared dist/.
+      expect(source).not.toMatch(/--outDir["'\s,]+["'`]?dist/);
+    }
+
+    // Anti-vacuity: the exact set above means nothing if the walk found no files.
+    expect(testFiles().length).toBeGreaterThan(20);
+  });
+});

--- a/src/__tests__/helpers/build-dist.ts
+++ b/src/__tests__/helpers/build-dist.ts
@@ -1,0 +1,87 @@
+/**
+ * Build `dist/` ONCE per vitest run (vitest.config.ts `globalSetup`) and install it
+ * with `renameSync` only. The operator bins statically import `../dist/lib/*.js`, so a
+ * `tsc` emitting straight into the shared `dist/` lets a bin spawned mid-emit read a
+ * truncated module and die at ESM instantiation. `rename(2)` is atomic: every reader
+ * sees one whole version. Card: create-shopper-bin-dies-on-its-exit-path.
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, renameSync, rmSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+/** …/src/__tests__/helpers → the checkout root. */
+export const REPO_ROOT = join(HERE, "..", "..", "..");
+export const DIST_DIR = join(REPO_ROOT, "dist");
+
+/** The compiler's real JS entry — `node_modules/.bin/tsc` is a shell wrapper `node`
+ * cannot run directly. */
+export const TSC_ENTRY = "node_modules/typescript/bin/tsc";
+export const TSC_PROJECT = "tsconfig.build.json";
+
+/** Every `../dist/**.js` an operator bin statically imports. Derived, not listed, so a
+ * new bin import cannot silently escape the emitted-entries check. */
+export function distEntriesTheBinsImport(): string[] {
+  const scripts = join(REPO_ROOT, "scripts");
+  const found = new Set<string>(["index.js"]);
+  for (const file of readdirSync(scripts)) {
+    if (!file.endsWith(".mjs")) continue;
+    const source = readFileSync(join(scripts, file), "utf8");
+    for (const m of source.matchAll(/["']\.\.\/dist\/([^"']+\.js)["']/g)) found.add(m[1]!);
+  }
+  return [...found].sort();
+}
+
+/** Move every emitted file over `distDir`, one atomic `rename(2)` each. */
+function installTree(from: string, to: string): void {
+  mkdirSync(to, { recursive: true });
+  for (const entry of readdirSync(from, { withFileTypes: true })) {
+    const src = join(from, entry.name);
+    const dst = join(to, entry.name);
+    if (entry.isDirectory()) installTree(src, dst);
+    else renameSync(src, dst);
+  }
+}
+
+export interface BuildDistOptions {
+  /** Unit-tier seam: run the compiler with this argv. Defaults to the real `tsc`. */
+  compile?: (argv: string[]) => void;
+  /** Unit-tier seam: install target. Defaults to the checkout's real `dist/`. */
+  distDir?: string;
+}
+
+export function buildDist(opts: BuildDistOptions = {}): void {
+  const distDir = opts.distDir ?? DIST_DIR;
+  const compile = opts.compile ?? ((argv) => {
+    execFileSync("node", argv, { cwd: REPO_ROOT, stdio: ["ignore", "pipe", "pipe"] });
+  });
+  // Under REPO_ROOT, never the OS tmpdir: `rename(2)` across filesystems is EXDEV, and
+  // /tmp is routinely a different one.
+  const outDir = mkdtempSync(join(REPO_ROOT, ".tmp-dist-build-"));
+  try {
+    compile([TSC_ENTRY, "-p", TSC_PROJECT, "--outDir", outDir]);
+    for (const rel of distEntriesTheBinsImport()) {
+      if (!existsSync(join(outDir, rel))) {
+        throw new Error(`build did not emit ${rel} — an operator bin's import would 404`);
+      }
+    }
+    installTree(outDir, distDir);
+  } finally {
+    rmSync(outDir, { recursive: true, force: true });
+  }
+}
+
+declare module "vitest" {
+  export interface ProvidedContext {
+    /** What this run's ONE build installed. Absent ⇒ `globalSetup` never ran. */
+    distBuild: string[];
+  }
+}
+
+/** vitest `globalSetup` — runs once per vitest process, before any test file. */
+export function setup(project: { provide: (key: "distBuild", value: string[]) => void }): void {
+  buildDist();
+  project.provide("distBuild", distEntriesTheBinsImport());
+}

--- a/src/__tests__/lib/build-dist.test.ts
+++ b/src/__tests__/lib/build-dist.test.ts
@@ -1,0 +1,180 @@
+/**
+ * UNIT — the shared `dist/` build helper (`src/__tests__/helpers/build-dist.ts`).
+ *
+ * Card: create-shopper-bin-dies-on-its-exit-path. `tsc` emitting straight into the one
+ * shared `dist/` let a bin spawned mid-emit read a truncated module and die at ESM
+ * instantiation (`does not provide an export named …`, exit 1, stdout empty). The
+ * helper's whole job is that emit never being observable: compile to a temp `--outDir`,
+ * then install by `rename(2)`, which is atomic — a concurrent reader sees the whole old
+ * file or the whole new one, never a half-written one.
+ *
+ * The compiler is the injected seam (a real `tsc` is a 15 s integration cost); the
+ * INSTALL is the real code path, exercised against a real temp `dist/`. Atomicity is
+ * asserted by INODE IDENTITY, not by a spy: `rename(2)` moves the inode, every copying
+ * install (`copyFileSync`, `writeFileSync`, `cp -a`) allocates a new one. A spy on
+ * `renameSync` would prove it was called, not that nothing else did the work.
+ *
+ * THESE ASSERTIONS ARE THE SPEC. Do NOT weaken them to match the helper.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+
+import {
+  buildDist,
+  distEntriesTheBinsImport,
+  DIST_DIR,
+  REPO_ROOT,
+  TSC_ENTRY,
+  TSC_PROJECT,
+} from "../helpers/build-dist";
+
+/** A file the bins do NOT import, nested one level deeper — proves the install walks
+ * the whole emitted tree, not just the entries it checks for. */
+const EXTRA_EMIT = "tools/catalog.js";
+
+let distDir: string;
+/** Every argv the injected compiler was handed, in call order. */
+let compileCalls: string[][];
+/** `dist/lib/profile-store.js` as the compiler saw it, per call. */
+let distDuringCompile: (string | null)[];
+/** Inode of each file the compiler emitted, keyed by path relative to the outDir. */
+let emittedInodes: Map<string, number>;
+/** outDirs the helper asked the compiler to emit into. */
+let outDirs: string[];
+
+/** Stand-in for `tsc`: reads `--outDir` off the argv and plants a realistic emit tree
+ * there — every entry the bins import, plus one nested extra. */
+function fakeCompile(argv: string[]): void {
+  compileCalls.push(argv);
+  const outDir = argv[argv.indexOf("--outDir") + 1]!;
+  outDirs.push(outDir);
+  const seen = join(distDir, "lib", "profile-store.js");
+  distDuringCompile.push(existsSync(seen) ? readFileSync(seen, "utf8") : null);
+
+  for (const rel of [...distEntriesTheBinsImport(), EXTRA_EMIT]) {
+    const target = join(outDir, rel);
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, `// fresh ${rel}\n`);
+    emittedInodes.set(rel, statSync(target).ino);
+  }
+}
+
+beforeEach(() => {
+  // Under REPO_ROOT, not the OS tmpdir: /tmp is a different filesystem here, and
+  // `rename(2)` across filesystems is EXDEV — the same constraint the helper is
+  // written to, so a target elsewhere would test a path the helper never takes.
+  distDir = mkdtempSync(join(REPO_ROOT, ".tmp-dist-target-"));
+  compileCalls = [];
+  distDuringCompile = [];
+  emittedInodes = new Map();
+  outDirs = [];
+});
+
+// No sweep of stray `.tmp-dist-build-*` here: `buildDist` removes its own in a
+// `finally`, and a blind sweep would delete a PARALLEL vitest run's in-flight outDir.
+afterEach(() => {
+  rmSync(distDir, { recursive: true, force: true });
+});
+
+/** Seed the target with a previous build so "the compiler never wrote here" is
+ * observable rather than vacuous against an empty directory. */
+function seedPreviousBuild(): void {
+  mkdirSync(join(distDir, "lib"), { recursive: true });
+  writeFileSync(join(distDir, "lib", "profile-store.js"), "// STALE\n");
+}
+
+describe("buildDist — compiles to a temp outDir and installs by rename only", () => {
+  it("never names dist/ as an output path, and every emitted file lands there by rename (same inode)", () => {
+    seedPreviousBuild();
+
+    buildDist({ compile: fakeCompile, distDir });
+
+    expect(compileCalls).toHaveLength(1);
+    const argv = compileCalls[0]!;
+    expect(argv[0]).toBe(TSC_ENTRY);
+    expect(argv).toContain("-p");
+    expect(argv).toContain(TSC_PROJECT);
+
+    // No compiler output path IS dist/, or lives under it — the emit must be
+    // unobservable to a bin importing dist/ while it runs.
+    const outDir = outDirs[0]!;
+    expect(outDir).not.toBe(distDir);
+    expect(relative(distDir, outDir).startsWith("..")).toBe(true);
+    for (const arg of argv) {
+      const asPath = resolve(REPO_ROOT, arg);
+      expect(asPath).not.toBe(distDir);
+      expect(relative(distDir, asPath).startsWith("..")).toBe(true);
+    }
+    // …and the install runs strictly AFTER the compile: mid-compile, dist/ still
+    // held the previous build byte-for-byte.
+    expect(distDuringCompile).toEqual(["// STALE\n"]);
+
+    // The whole emitted tree arrived, each file by rename — a copying install would
+    // allocate a fresh inode for every one of these.
+    for (const [rel, ino] of emittedInodes) {
+      expect(existsSync(join(distDir, rel))).toBe(true);
+      expect(statSync(join(distDir, rel)).ino).toBe(ino);
+    }
+    expect(emittedInodes.has(EXTRA_EMIT)).toBe(true);
+
+    // The scratch outDir is gone — no orphan build tree under the checkout root.
+    expect(existsSync(outDir)).toBe(false);
+  });
+
+  it("throws instead of installing when the build misses an entry a bin imports", () => {
+    // The failure mode no other test catches: a partial emit installed into dist/ ships
+    // a shopper whose `../dist/lib/*.js` import 404s at ESM load — green suite, dead bin.
+    seedPreviousBuild();
+    const missing = distEntriesTheBinsImport().find((e) => e.startsWith("lib/"))!;
+    const partialCompile = (argv: string[]): void => {
+      fakeCompile(argv);
+      rmSync(join(outDirs.at(-1)!, missing), { force: true });
+    };
+
+    expect(() => buildDist({ compile: partialCompile, distDir })).toThrow(missing);
+
+    expect(readFileSync(join(distDir, "lib", "profile-store.js"), "utf8")).toBe("// STALE\n");
+    expect(existsSync(join(distDir, EXTRA_EMIT))).toBe(false);
+    expect(existsSync(outDirs[0]!)).toBe(false);
+  });
+});
+
+describe("distEntriesTheBinsImport — derived from the bins, never a hand-list", () => {
+  it("names every ../dist/*.js an operator script statically imports, plus the plugin entry", () => {
+    const entries = distEntriesTheBinsImport();
+
+    const fromSource = new Set<string>(["index.js"]);
+    for (const file of readdirSync(join(REPO_ROOT, "scripts"))) {
+      if (!file.endsWith(".mjs")) continue;
+      const source = readFileSync(join(REPO_ROOT, "scripts", file), "utf8");
+      for (const m of source.matchAll(/from\s+["']\.\.\/dist\/([^"']+\.js)["']/g)) fromSource.add(m[1]!);
+    }
+
+    expect(entries).toEqual([...fromSource].sort());
+    // Anti-vacuity: an empty or single-entry derivation would satisfy the equality
+    // above while checking nothing, and these two are the imports that actually broke.
+    expect(entries).toContain("lib/profile-store.js");
+    expect(entries).toContain("lib/openclaw-allowlist.js");
+  });
+});
+
+describe("the default install target is the directory the bins actually import", () => {
+  it("DIST_DIR is where `../dist/lib/profile-store.js` resolves from scripts/", () => {
+    // Anti-vacuity for the seam: every assertion above runs against an INJECTED
+    // distDir, so a default pointing somewhere else would go unnoticed. Derived from
+    // the bin's own import specifier, never restated from the helper.
+    const asTheBinResolvesIt = resolve(REPO_ROOT, "scripts", "../dist/lib/profile-store.js");
+    expect(join(DIST_DIR, "lib", "profile-store.js")).toBe(asTheBinResolvesIt);
+  });
+});

--- a/src/__tests__/openclaw-allowlist.integration.test.ts
+++ b/src/__tests__/openclaw-allowlist.integration.test.ts
@@ -21,10 +21,10 @@
  *   AC8 — config-path precedence (OPENCLAW_CONFIG_PATH wins) + missing-config
  *         fail-closed (no write, no parent dir created, structured error, exit 1).
  *
- * The script imports the COMPILED lib (`dist/lib/openclaw-allowlist.js`), so the
- * suite builds the lib once in beforeAll FROM THE CURRENT SOURCE — never relying
- * on a possibly-stale dist (a stale dist would silently test old logic). The
- * build is the same `tsc -p tsconfig.build.json` the script's `dist` import needs.
+ * The script imports the COMPILED lib (`dist/lib/openclaw-allowlist.js`), built FROM
+ * THE CURRENT SOURCE by `globalSetup` (`helpers/build-dist.ts`) — once per run and
+ * installed by rename, so a stale dist cannot silently test old logic and a
+ * half-emitted one cannot kill a spawned script at ESM load.
  *
  * The two invariants this suite defends (product-owner): AC6 (idempotent) and the
  * additive half of AC1 (klodi survives). Every other case guards those two.
@@ -38,7 +38,6 @@ import {
   describe,
   it,
   expect,
-  beforeAll,
   beforeEach,
   afterEach,
 } from "vitest";
@@ -138,21 +137,6 @@ function freshConfig(): unknown {
 
 let workdir: string;
 let configPath: string;
-
-beforeAll(() => {
-  // The script imports dist/lib/openclaw-allowlist.js — build the lib from the
-  // CURRENT source so the integration tier exercises what the dev actually
-  // wrote, never a stale dist. Fails loud if the build breaks. We invoke the
-  // TypeScript compiler's real JS entry (node_modules/.bin/tsc is a shell
-  // wrapper that `node` cannot run directly).
-  execFileSync("node", ["node_modules/typescript/bin/tsc", "-p", "tsconfig.build.json"], {
-    cwd: REPO_ROOT,
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-  if (!existsSync(join(REPO_ROOT, "dist", "lib", "openclaw-allowlist.js"))) {
-    throw new Error("build did not emit dist/lib/openclaw-allowlist.js — script import would 404");
-  }
-}, 60_000);
 
 beforeEach(() => {
   workdir = mkdtempSync(join(tmpdir(), "sil-allowlist-it-"));

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,9 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     include: ['src/__tests__/**/*.test.ts'],
+    // dist/ is built ONCE here, before any test file runs, and installed by rename —
+    // a per-file `beforeAll` tsc rewrote the shared dist/ under running bins.
+    globalSetup: ['./src/__tests__/helpers/build-dist.ts'],
     environment: 'node',
     testTimeout: 10_000,
     pool: 'forks',


### PR DESCRIPTION
## Card
`cards/create-shopper-bin-dies-on-its-exit-path.md` (worktree-local — this repo is gitignored-mode, so the card body is not in the diff).

## Summary
`scripts/create-shopper.mjs` statically imports `../dist/lib/*.js`, and the suite **rewrote that same `dist/` while tests were running** — `create-shopper.integration.test.ts` and `openclaw-allowlist.integration.test.ts` each ran `tsc -p tsconfig.build.json` in a `beforeAll`, emitting non-atomically into the one shared directory. A bin spawned mid-emit read a truncated module and died at ESM instantiation: stdout empty, exit `1`, a Node dump on stderr. That is one event with two faces — a happy-path test reading `expected 1 to be +0`, and an `invalid_request` test whose `parseMarker` threw `Unexpected token 'N', "Node.js v24.19.0"`.

- **`src/__tests__/helpers/build-dist.ts` (new)** — builds `dist/` once, compiling to a scratch `--outDir` under the repo root (never `/tmp`: `rename(2)` across filesystems is EXDEV), checking the entries the bins import, then installing each file with `renameSync`. Atomic, so every reader sees one whole version.
- **`vitest.config.ts`** — `globalSetup` runs it, once per vitest process, before any test file.
- **Both `beforeAll` builds deleted**, not guarded. Neither half of the fix closes the race alone: `globalSetup` kills the intra-run race, `rename(2)` the cross-process one (4 parallel `vitest run`s each build).
- **`runBin` uses `spawnSync`** — the success path returns the child's *real* stderr instead of a hardcoded `""`, plus the kill signal and a hang bound.
- **`scripts/create-shopper.mjs`** — `logMarker` writes to the fd (`writeFileSync(1|2, line)`). `process.stdout.write` is async on a pipe, so `process.exit()` discarded the `created` marker past the buffer; the marker echoes an unbounded `name`.

`compiled-artifact-load.integration.test.ts` is untouched — its isolated temp `outDir` build is that file's whole point.

## Test plan
- [x] +10 tests, 1386 → 1396. Every acceptance criterion proven RED first, in `cp -a` copies: 5 helper mutations, both files restored to `dev`, a stderr-dirtying bin (RED with the new `runBin`, GREEN with the old one), a 40 %-truncated `dist/lib/profile-store.js`, and the pre-fix bin truncating 10/10 at a 328 KB marker.
- [x] A/B on the mechanism, outside the suite — 4 concurrent builders against a tight ESM-import loop: non-atomic `tsc` into `dist/` **4 anomalies in 3,575 spawns**, atomic rename install **0 in 4,653**.
- [x] The card's repro (4 parallel `vitest run` of the file) 5/5 clean rounds.
- [x] Full suite **5× exit 0, 1396/1396**; `pnpm typecheck` clean. Suite wall-clock ~65 s → ~30 s.

## Distillation target
Knowledge capture happens **after Review PASS** in the `distilling` stage — `solutions-architect` runs in this same worktree, commits to this same branch, and pushes here so the PR ends up containing implementation + tests + distillation in one mergeable unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)