### PR TITLE
chore: retire the three wall-clock upper-bound assertions in tests

### DIFF
--- a/src/__tests__/doctor.integration.test.ts
+++ b/src/__tests__/doctor.integration.test.ts
@@ -1507,16 +1507,13 @@ describe("AC6c — the probe is bounded, fail-soft, and SILENT on failure", () =
         }),
     );
 
-    const started = Date.now();
     const report = await runDoctor();
-    const elapsed = Date.now() - started;
 
-    // The probe carried a real AbortSignal, and it really fired.
+    // The abort IS the bound here, not a stopwatch: this fake settles only via
+    // its own `abort` listener, so a probe that never aborts never returns and
+    // fails on `testTimeout: 10_000` — loudly, and without a wall-clock proxy.
     expect(sawSignal).toBeDefined();
     expect(sawSignal!.aborted).toBe(true);
-    // Bounded well inside the suite's 10s timeout — a user-invoked diagnostic
-    // must not sit on a blackholed socket.
-    expect(elapsed).toBeLessThan(8_000);
     // Fail-soft to SILENCE, with the full local report intact.
     expect(versionFindings(report)).toEqual([]);
     expect(report.status).toBe("ok");

--- a/src/__tests__/lib/version-advisory.test.ts
+++ b/src/__tests__/lib/version-advisory.test.ts
@@ -330,7 +330,33 @@ describe("probeLatestVersion — bounded by a DEADLINE, not merely by an abort",
     // The null came FROM the deadline (timers never fire early), so it is a
     // bound — not a probe that happens to give up on its own.
     expect(elapsed).toBeGreaterThanOrEqual(250);
-    expect(elapsed).toBeLessThan(2_000);
+  });
+
+  it("fires the CALLER's deadline and no other — nothing at 299ms, null at 300ms", async () => {
+    // The bracket, on the TEST's clock: the assertion above pins only that a
+    // deadline fired, never WHICH. `setTimeout(…, PROBE_TIMEOUT_MS)` — the
+    // caller's argument ignored — survives every other assertion in this file,
+    // all of them comfortably inside `testTimeout: 10_000`.
+    vi.useFakeTimers();
+    try {
+      let settled = false;
+      const probe = probeLatestVersion(blackhole, 300).then((v) => {
+        settled = true;
+        return v;
+      });
+
+      await vi.advanceTimersByTimeAsync(299);
+      expect(settled).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      // The flag is read BEFORE the await deliberately: under every mutant this
+      // test kills, the promise never settles, so awaiting first would turn an
+      // instant red into a 10s hang.
+      expect(settled).toBe(true);
+      await expect(probe).resolves.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("is not vacuous — the same probe returns a REAL version from a channel that answers", async () => {
@@ -354,21 +380,11 @@ describe("probeLatestVersion — bounded by a DEADLINE, not merely by an abort",
     expect(signal!.aborted).toBe(true);
   });
 
-  it("does NOT wait for the deadline when the channel answers promptly", async () => {
-    // A race won by the deadline on every run would make `sil_doctor` cost its
-    // full timeout each time. With a 30s deadline, an implementation that awaits
-    // it fails by suite timeout rather than passing slowly.
-    const started = Date.now();
-
-    await expect(probeLatestVersion(okChannel("9.9.9"), 30_000)).resolves.toBe("9.9.9");
-
-    expect(Date.now() - started).toBeLessThan(5_000);
-  });
-
-  it("clears the deadline timer once the request wins — no dangling handle", async () => {
-    // A 30s timer left armed after `execute()` returns holds the host's event
-    // loop open — the same class of failure as the register()-opens-nothing
-    // invariant, one layer down.
+  it("resolves on the channel's answer, not the deadline — and leaves no timer armed", async () => {
+    // Two failures, one shape. A race won by the deadline every run would cost
+    // `sil_doctor` its full 30s; a 30s timer still armed after `execute()`
+    // returns holds the host's event loop open. Time is FROZEN here, so an
+    // implementation that awaits its deadline cannot resolve at all.
     vi.useFakeTimers();
     try {
       await expect(probeLatestVersion(okChannel("9.9.9"), 30_000)).resolves.toBe("9.9.9");

--- a/src/__tests__/lib/version-advisory.test.ts
+++ b/src/__tests__/lib/version-advisory.test.ts
@@ -359,6 +359,29 @@ describe("probeLatestVersion — bounded by a DEADLINE, not merely by an abort",
     }
   });
 
+  it("fires the DEFAULT 3s budget when the caller names none — nothing at 2999ms, null at 3000ms", async () => {
+    // `doctor.ts:167` is the only production caller and passes no `timeoutMs`,
+    // so this constant IS the shipped budget. Every other test here names its
+    // own deadline, leaving a regression to e.g. 9s green under `testTimeout`.
+    vi.useFakeTimers();
+    try {
+      let settled = false;
+      const probe = probeLatestVersion(blackhole).then((v) => {
+        settled = true;
+        return v;
+      });
+
+      await vi.advanceTimersByTimeAsync(2_999);
+      expect(settled).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(settled).toBe(true); // flag before the await — see the test above
+      await expect(probe).resolves.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("is not vacuous — the same probe returns a REAL version from a channel that answers", async () => {
     // Without this, a `probeLatestVersion` that simply `return null`ed would pass
     // every assertion above. `null` must mean "bounded/failed", never "always".


### PR DESCRIPTION
## Card

`cards/retire-the-three-wall-clock-upper-bound-assertions.md` (gitignored — local to the card worktree).

## Summary

Three tests asserted an **upper bound on wall-clock elapsed time** as a proxy for a bound already proven by other means. Elapsed time is a property of how busy the box is, not of the code under test — and one of the three had already gone red under CPU contention (**8419 ms** against `elapsed < 8_000`) with an empty diff against its last-known-good commit.

The structural point: the suite already has exactly **one** wall-clock upper bound — `vitest.config.ts`'s central `testTimeout: 10_000`. Three ad-hoc thresholds *below* it were strictly weaker duplicates of a guard that already exists.

| Site | Was | Now |
|---|---|---|
| `doctor.integration.test.ts:1519` | `expect(elapsed).toBeLessThan(8_000)` | **deleted** — companion `expect(sawSignal!.aborted).toBe(true)` already pins it; the fake settles *only* via abort, so an unaborted probe still fails loudly on `testTimeout` |
| `version-advisory.test.ts:333` | `expect(elapsed).toBeLessThan(2_000)` | **replaced**, not deleted — a fake-timer test pins *which* deadline fired (299 ms ⇒ not settled, 300 ms ⇒ `null`) |
| `version-advisory.test.ts:365` | `expect(Date.now() - started).toBeLessThan(5_000)` | **folded** into the existing fake-timer test, which proves the same property more strongly: under frozen time an implementation that awaits its deadline cannot resolve at all |

Site 2 is a replacement rather than a bare deletion because no companion pinned the upper half of that bracket: a `setTimeout(…, PROBE_TIMEOUT_MS)` mutant that ignores the caller's argument survives **every other assertion in the file**.

Net test count is unchanged (−1 / +1). No `src/lib/` or `src/tools/` file is modified — those were mutation targets only, every mutant reverted.

## Test plan

**Success signal** — `grep -rnE 'toBeLessThan' src/__tests__/ | grep -E 'elapsed|Date\.now\(\)'` returns nothing (exit 1).

**Non-vacuity — six mutants, all RED, all reverted** (run in an isolated copy, never in the worktree):

| Mutant in `src/lib/version-advisory.ts` | Test that bit | Shape |
|---|---|---|
| `setTimeout(…, timeoutMs)` → `PROBE_TIMEOUT_MS` | site-2 replacement — **1 failed \| 47 passed** | 18 ms, named |
| `Promise.race([request, deadline])` → `await request` | site-2 replacement + 2 legacy | **10 ms** vs 10 s |
| drop `controller.abort()` | **site 1** `sawSignal.aborted` | 3 015 ms, named |
| drop `resolve(null)` | site-2 replacement | **11 ms** on the flag |
| `→ await deadline` | site-3 fold | testTimeout |
| `clearTimeout` → no-op | site-3 fold, only it | 13 ms, `expected 1 to be +0` |

The `1 failed | 47 passed` result is the proof that nothing else caught the parameter-ignored mutant. The `settled` flag is asserted **before** the `await` deliberately — under every mutant these tests kill the promise never settles, so awaiting first would turn a ~15 ms named red into a 10 s hang.

**Merge gate — 7 full-suite runs, every one exit `0`, 1536/1536:**

- [x] solo `0 / 24s`, `0 / 24s`
- [x] **concurrent** (overlapping a second `vitest run`) `0 / 29s`, `0 / 29s` — the condition that produced the original red
- [x] solo `0 / 24s`
- [x] **saturated** (3 vitest loops + 16 spinners on 16 cores) `0 / 110s` @ loadavg 44, `0 / 109s` @ loadavg 51

**The flake did not reproduce, and that sharpens the case.** A 6-round two-arm A/B (pre-fix vs post-fix test files, identical saturation, loadavg 46–64) was 0/6 vs 0/6. Measuring the quantity `elapsed < 8_000` actually thresholded: **3011–3014 ms solo, 3034–3360 ms at loadavg 56** — dominated by the real 3 s `PROBE_TIMEOUT_MS`, with contention adding ≤360 ms. The observed 8419 ms is therefore a fat-tail scheduling stall roughly 5.4 s above a p100 that could not be pushed past 3.4 s — not smooth degradation. No threshold is simultaneously tight enough to catch a hang and loose enough to survive that tail, which is why widening it was correctly ruled out.

**Base drift:** branch was cut at `203eb0d`; fast-forwarded onto `cfb02c7` (PR #76, `sil_domain_find`). Neither touched file overlaps it, and #76 introduces no new wall-clock assertions. The gate ran on the merged tree.

## Distillation target

`docs/knowledge/an-abortcontroller-alone-does-not-bound-a-probe.md` currently **prescribes** the assertion this PR retires — its worked snippet teaches `expect(Date.now() - t0).toBeLessThan(2_000)` as the pattern "any future bounded outbound call inherits". Leave it standing and the assertion regrows on the next probe someone writes. Rewriting it to the fake-timer bracket plus the state proofs it already names (`signal.aborted`, `getTimerCount() === 0`) is a deliverable of the distilling stage, not optional.