### PR TITLE
bug: an unlistable directory reads as not_found on the agent surface — one presence classifier, prove or abstain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,28 @@ release (`clawhub package publish --changelog`). See [README](./README.md#releas
   No alias and no deprecation stub — a shopper that called it was getting an
   error, and now gets a tool that simply is not there.
 
+### Fixed
+
+- **A directory sil cannot list no longer reads as an absent document.**
+  `sil_doc_read` / `sil_doc_write` / `sil_doc_remove` decided absence with
+  `existsSync` — a boolean over a stat that swallows every errno, so an
+  unlistable `briefs/` (or an unstat-able store root) answered `not_found` for a
+  Brief sitting on disk, while `sil_doc_find` reported that same directory in
+  `unreadable[]` in the same breath. `not_found`'s own message names
+  `sil_doc_write (mode: create)`, so the answer *was* the re-mint instruction and
+  the buyer's own words went with it; on `sil_doc_remove` it claimed a delete
+  that never happened. Every gate that decides absence now runs one probe —
+  **ENOENT alone is absence**; every other errno leaves presence unknown, and
+  unknown is stated as `unreadable` (`recovery: "inspect_document"`), never
+  guessed. Real absence is unchanged, so a first Brief on a fresh machine still
+  mints, and a directory that will not list but whose file reads still hands the
+  document over. `sil_doctor` inherits the new `unreadable[]` entries, so the
+  operator and agent surfaces describe one state — including the store root at
+  mode `0o400`, which until now no surface saw at all. The `sil_doc_read` /
+  `sil_doc_remove` descriptions and the `sil-shopping` bundle now state
+  `not_found` only with its qualifier: sil listed the containing directory and
+  the document was not in it.
+
 ## [0.4.6] - 2026-07-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -189,9 +189,9 @@ Everything the shopper knows lives in markdown under `$SIL_DATA_DIR/shopper/`: o
 | Tool | What it does |
 |---|---|
 | `sil_doc_find` | List what your shopper has — the shopper document and every Brief, as **coordinates only** (ref, title, status, the job's items), never bodies. Optional `kind`, `domain` (a path prefix over the Briefs' items), `status` and free-text `query`, all composable; the bare call is the whole overview. A file with malformed frontmatter is reported as `unreadable` and keeps its place. |
-| `sil_doc_read` | Read ONE whole document body plus its frontmatter, by `ref`. An absent document is `not_found`; a present-but-corrupt one is `unreadable`, which the agent inspects rather than overwrites. |
+| `sil_doc_read` | Read ONE whole document body plus its frontmatter, by `ref`. `not_found` is answered only when sil could list the directory that would hold the document and it was not in it. A directory sil could **not** list is `unreadable`, as is a present-but-corrupt document — and `unreadable` is inspected and repaired, never overwritten, because your own words may still be recoverable. |
 | `sil_doc_write` | Write ONE document — `body` is always the **whole** reconciled markdown, so a correction rewrites the line it changes instead of stacking a contradicting one. `mode: create` refuses if the ref already exists; `mode: replace` refuses if it does not. Atomic and owner-only. |
-| `sil_doc_remove` | Forget ONE Brief. Never a cascade, and the shopper document itself is not removable — correct it with a `replace` instead. The agent confirms with you first; removing something already gone is a safe no-op. |
+| `sil_doc_remove` | Forget ONE Brief. Never a cascade, and the shopper document itself is not removable — correct it with a `replace` instead. The agent confirms with you first. |
 
 ---
 

--- a/sil-shopping/references/domain_and_brief.md
+++ b/sil-shopping/references/domain_and_brief.md
@@ -180,8 +180,10 @@ as `unreadable` and keeps its place, never half-read.
   status and `## Items` rows. `domain` is a path prefix; `query` is a substring over slugs
   and titles; filters compose; the bare call is *"what does my shopper have?"*.
 - **`sil_doc_read { ref }`** — one whole body plus frontmatter. **Read before every
-  write** — reconcile from the real current body, never from memory. An absent document is
-  `not_found`; a present-but-corrupt one is `unreadable`, which is **never written over**.
+  write** — reconcile from the real current body, never from memory. `not_found` is
+  reported **only** when sil could list the directory that would hold the document and it
+  was not in it; a directory sil could not list is `unreadable`, as is a
+  present-but-corrupt document — and `unreadable` is **never written over**.
 - **`sil_doc_write { ref, mode, body, … }`** — `mode: create` fails if the ref exists,
   `mode: replace` fails if it does not. `body` is always the **whole reconciled markdown**
   — no append, no section patch, so a correction can never stack a row contradicting the

--- a/sil-shopping/references/domain_and_brief.md
+++ b/sil-shopping/references/domain_and_brief.md
@@ -180,10 +180,10 @@ as `unreadable` and keeps its place, never half-read.
   status and `## Items` rows. `domain` is a path prefix; `query` is a substring over slugs
   and titles; filters compose; the bare call is *"what does my shopper have?"*.
 - **`sil_doc_read { ref }`** — one whole body plus frontmatter. **Read before every
-  write** — reconcile from the real current body, never from memory. `not_found` is
-  reported **only** when sil could list the directory that would hold the document and it
-  was not in it; a directory sil could not list is `unreadable`, as is a
-  present-but-corrupt document — and `unreadable` is **never written over**.
+  write** — reconcile from the real current body, never from memory.
+  `not_found` means sil listed the containing directory and the document was not in it;
+  a directory sil could **not** list is `unreadable`, as is a present-but-corrupt one —
+  and `unreadable` is **never written over**.
 - **`sil_doc_write { ref, mode, body, … }`** — `mode: create` fails if the ref exists,
   `mode: replace` fails if it does not. `body` is always the **whole reconciled markdown**
   — no append, no section patch, so a correction can never stack a row contradicting the

--- a/src/__tests__/doc-store-boundary.integration.test.ts
+++ b/src/__tests__/doc-store-boundary.integration.test.ts
@@ -572,11 +572,10 @@ describe("the CONTAINING directory — an unlistable `briefs/` is UNREADABLE, ne
  * refusal to shop. A shopper who has simply never written a Brief must never be told
  * their store is corrupt.
  *
- * AC7 — a miss inside a LISTABLE, non-empty `briefs/` — has no bar here, for the same
- * reason AC14 has none: `tools/doc-surface.test.ts` G4 already reads
- * `brief:never-existed` out of a populated `briefs/` and pins `not_found`, at this same
- * registered-tool boundary. Measured, not assumed — an over-broad read gate turns G4
- * red alongside AC8 / AC9 / AC23. Do not re-add it.
+ * AC7 (a miss inside a LISTABLE, non-empty `briefs/`) has no bar here, for AC14's
+ * reason: `tools/doc-surface.test.ts` G4 pins `not_found` on `brief:never-existed`
+ * inside a populated `briefs/`, at this same boundary. Measured — an over-broad read
+ * gate reds G4 beside AC8 / AC9 / AC23. Do not re-add it.
  */
 describe("…and real absence still reads as absence", () => {
   it("AC8 — an ABSENT `briefs/` is the normal mintable state: `not_found` on read, `ok` on create (beat 1, fresh machine)", async () => {

--- a/src/__tests__/doc-store-boundary.integration.test.ts
+++ b/src/__tests__/doc-store-boundary.integration.test.ts
@@ -1,5 +1,5 @@
 /**
- * INTEGRATION — `doc-store.ts:52`'s standing invariant: THE STORE NEVER THROWS
+ * INTEGRATION — `doc-store.ts`'s standing invariant: THE STORE NEVER THROWS
  * ACROSS THE TOOL BOUNDARY. Real filesystem, real store, driven through the
  * REGISTERED tools, because an exception's entire cost is paid at `execute()` —
  * calling the store function directly would test a path production never takes.
@@ -14,6 +14,9 @@
  * store through the very scan that throws.
  *
  * THESE ASSERTIONS ARE THE SPEC. Do NOT weaken one to match the store.
+ *
+ * The two describes below name the contract by its SYMBOL, never by a line number: a
+ * `:52` anchor is a claim nothing verifies, and one added import silently made it a lie.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
@@ -206,7 +209,7 @@ afterEach(() => {
   rmSync(dataDir, { recursive: true, force: true });
 });
 
-describe("`doc-store.ts:52` — a store the OS will not let us list is REPORTED, never thrown", () => {
+describe("`doc-store.ts`'s never-throws boundary — a store the OS will not let us list is REPORTED, never thrown", () => {
   it("`briefs` present as a FILE (ENOTDIR): sil_doc_find answers, names it, and still reports the shopper", async () => {
     // `existsSync(briefsDir)` passes on a file, and the very next `readdirSync`
     // raises ENOTDIR straight out of `execute()`. The shopper clause is what
@@ -321,10 +324,10 @@ describe("`doc-store.ts:52` — a store the OS will not let us list is REPORTED,
  * The FOURTH listing site — the store root — and a different failure than the three
  * above. An unlistable `shopper/` throws NOTHING: `existsSync` on every child of it
  * answers false, so the store reads a present store as an ABSENT one. That is the
- * conflation `doc-store.ts:69` forbids in as many words, and it is the more dangerous
- * shape, because a throw at least stops the agent.
+ * conflation `doc-store.ts`'s `Unreadable` forbids in as many words, and it is the more
+ * dangerous shape, because a throw at least stops the agent.
  */
-describe("`doc-store.ts:69` — an unlistable store ROOT is UNREADABLE, never absent", () => {
+describe("`doc-store.ts`'s `Unreadable` contract — an unlistable store ROOT is UNREADABLE, never absent", () => {
   it.skipIf(AS_ROOT)("sil_doc_read {ref: shopper} answers `unreadable` — `not_found` steers a re-mint over the buyer's own words", async () => {
     // The whole cost is the recovery: `not_found`'s message names sil_doc_write
     // (mode: create), and the shopper document is the one `sil_doc_remove` refuses to
@@ -568,21 +571,14 @@ describe("the CONTAINING directory — an unlistable `briefs/` is UNREADABLE, ne
  * answer that STOPS the agent: a false one is not a cosmetic wrong answer, it is a
  * refusal to shop. A shopper who has simply never written a Brief must never be told
  * their store is corrupt.
+ *
+ * AC7 — a miss inside a LISTABLE, non-empty `briefs/` — has no bar here, for the same
+ * reason AC14 has none: `tools/doc-surface.test.ts` G4 already reads
+ * `brief:never-existed` out of a populated `briefs/` and pins `not_found`, at this same
+ * registered-tool boundary. Measured, not assumed — an over-broad read gate turns G4
+ * red alongside AC8 / AC9 / AC23. Do not re-add it.
  */
 describe("…and real absence still reads as absence", () => {
-  it("AC7 — a real miss INSIDE a listable `briefs/` is still `not_found`", async () => {
-    seedShopper();
-    seedBrief();
-
-    // Guard-of-the-guard: the directory is real, listable and non-empty, so the miss
-    // below is a miss and not an empty store.
-    const found = await call("sil_doc_find");
-    expect(found["unreadable"]).toEqual([]);
-    expect((found["briefs"] as unknown[]).length).toBe(1);
-
-    expect((await call("sil_doc_read", { ref: "brief:never-written" }))["status"]).toBe("not_found");
-  });
-
   it("AC8 — an ABSENT `briefs/` is the normal mintable state: `not_found` on read, `ok` on create (beat 1, fresh machine)", async () => {
     seedShopper();
     expect(existsSync(briefsDir())).toBe(false); // guard-of-the-guard

--- a/src/__tests__/doc-store-boundary.integration.test.ts
+++ b/src/__tests__/doc-store-boundary.integration.test.ts
@@ -24,6 +24,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -104,11 +105,49 @@ function seedShopper(): void {
   write(join(shopperDir(), "user_spec.md"), artefact({ name: "Ioannis" }, "## Who\nBuys once and keeps it.\n"));
 }
 
-function seedBrief(slug = "chamonix"): void {
+function seedBrief(slug = "chamonix", body = "## Items\n"): void {
   write(
     join(briefsDir(), `${slug}.md`),
-    artefact({ slug, title: "Chamonix", status: "active", updated_at: "2026-08-01" }, "## Items\n"),
+    artefact({ slug, title: "Chamonix", status: "active", updated_at: "2026-08-01" }, body),
   );
+}
+
+/**
+ * Take a reading with `path` at `mode`, and RESTORE before any expectation runs — a
+ * bar that fails mid-fault must not leave an unreadable tree for the next one (or
+ * for `afterEach`'s rm). `0o000`, `0o400` and `0o300` are three DIFFERENT states of
+ * the same directory and no one of them stands in for another.
+ */
+async function underMode<T>(path: string, mode: number, take: () => Promise<T>): Promise<T> {
+  chmodSync(path, mode);
+  try {
+    return await take();
+  } finally {
+    chmodSync(path, 0o700);
+  }
+}
+
+interface DoctorFinding {
+  id: string;
+  severity: string;
+  detected: string;
+}
+
+/** `sil_doctor` through its REGISTERED tool, version probe doubled as up-to-date so
+ * the only thing a finding can come from is the store on disk. */
+async function runDoctor(): Promise<{ healthy: boolean; findings: DoctorFinding[] }> {
+  const doctor = createMockPluginApi();
+  registerDoctorTools(doctor, async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      package: { name: "@4gpts/sil", latestVersion: INSTALLED, tags: { latest: INSTALLED } },
+      owner: { handle: "4gpts" },
+    }),
+  }));
+  return JSON.parse(
+    (await getTool(doctor, "sil_doctor").execute("c", {})).content[0]?.text as string,
+  ) as { healthy: boolean; findings: DoctorFinding[] };
 }
 
 /** Replace a directory with a FILE of the same name — `existsSync` still passes,
@@ -260,23 +299,6 @@ describe("`doc-store.ts:52` — a store the OS will not let us list is REPORTED,
     // through `sil_doc_*`. A guard placed in `doc.ts`'s `execute()` passes every
     // bar above and leaves the one surface whose job is to diagnose a broken store
     // dying on it — with `dir.usable` true, because the DATA dir is fine.
-    const doctor = createMockPluginApi();
-    registerDoctorTools(doctor, async () => ({
-      ok: true,
-      status: 200,
-      json: async () => ({
-        package: { name: "@4gpts/sil", latestVersion: INSTALLED, tags: { latest: INSTALLED } },
-        owner: { handle: "4gpts" },
-      }),
-    }));
-    const runDoctor = async (): Promise<{
-      healthy: boolean;
-      findings: Array<{ id: string; detected: string }>;
-    }> =>
-      JSON.parse(
-        (await getTool(doctor, "sil_doctor").execute("c", {})).content[0]?.text as string,
-      ) as { healthy: boolean; findings: Array<{ id: string; detected: string }> };
-
     seedShopper();
     seedBrief();
 
@@ -415,5 +437,381 @@ describe("`doc-store.ts:69` — an unlistable store ROOT is UNREADABLE, never ab
     chmodSync(shopperDir(), 0o700);
     expect(existsSync(join(briefsDir(), "chamonix.md"))).toBe(true);
     expect((await call("sil_doc_remove", { ref: "brief:chamonix" }))["status"]).toBe("removed");
+  });
+});
+
+/**
+ * THE CONTAINING-DIRECTORY RULE, one level down from the root. `briefs/` is the only
+ * other containing directory in the ref grammar, and the root's probe never fires for
+ * it: `readdirSync(shopper)` succeeds, so every ref-addressed verb falls straight to
+ * `existsSync(briefs/<slug>.md)` — a boolean over a `stat()` that swallows EVERY errno.
+ * `false` means ENOENT **or** "I was not allowed to look", and the store records the
+ * second as the first.
+ *
+ * A ref-addressed verb may answer `not_found` ONLY when it listed the directory that
+ * would contain the document and the document was not in it. When that listing fails,
+ * present-or-absent is unknown — and unknown is STATED, never guessed as absence.
+ */
+describe("the CONTAINING directory — an unlistable `briefs/` is UNREADABLE, never absent", () => {
+  it.skipIf(AS_ROOT)("AC1 — sil_doc_read answers `unreadable`; `not_found`'s own message IS the re-mint instruction", async () => {
+    seedShopper();
+    seedBrief();
+
+    // Guard-of-the-guard: listable, this exact ref reads back — so the answer below is
+    // about the LOCK, not a Brief that never existed.
+    expect((await call("sil_doc_read", { ref: "brief:chamonix" }))["status"]).toBe("ok");
+
+    const read = await underMode(briefsDir(), 0o000, () =>
+      call("sil_doc_read", { ref: "brief:chamonix" }),
+    );
+
+    expect(read["status"]).toBe("unreadable");
+    expect(read["recovery"]).toBe("inspect_document");
+    // …and it says WHERE it could not look. The store's OTHER `unreadable` reads
+    // "malformed or absent frontmatter", which is nonsense for a chmod fault and
+    // steers the repair at a file that is perfectly fine.
+    expect(String(read["message"])).toContain("briefs");
+    expect(String(read["message"])).not.toMatch(/malformed/i);
+  });
+
+  it.skipIf(AS_ROOT)("AC2 — sil_doc_write {mode: replace} answers `unreadable`, never \"mint it with mode: create first\"", async () => {
+    seedShopper();
+    seedBrief();
+
+    // Guard-of-the-guard: listable, this same replace lands on this same store.
+    expect(
+      (await call("sil_doc_write", { ref: "brief:chamonix", mode: "replace", title: "Chamonix", body: "## Items\n" }))["status"],
+    ).toBe("ok");
+
+    const replaced = await underMode(briefsDir(), 0o000, () =>
+      call("sil_doc_write", { ref: "brief:chamonix", mode: "replace", title: "Chamonix", body: "## Items\n" }),
+    );
+
+    expect(replaced["status"]).toBe("unreadable");
+    expect(replaced["recovery"]).toBe("inspect_document");
+    expect(String(replaced["message"])).not.toMatch(/mode: create/);
+  });
+
+  it.skipIf(AS_ROOT)("AC3 — a `create` over a slug that IS on disk answers `unreadable` and leaves the bytes exactly as they were", async () => {
+    seedShopper();
+    seedBrief();
+    const path = join(briefsDir(), "chamonix.md");
+    // Reading the bytes here is also the guard-of-the-guard: the document is on disk
+    // and readable before the lock goes on.
+    const before = readFileSync(path, "utf8");
+
+    const created = await underMode(briefsDir(), 0o000, () =>
+      call("sil_doc_write", { ref: "brief:chamonix", mode: "create", title: "Chamonix", body: "## Items\n| new | | open |\n" }),
+    );
+
+    expect(created["status"]).toBe("unreadable");
+    // NOT `persistence_failed` / `fix_data_dir`: that blames the data directory for a
+    // store whose documents are intact, and sends the buyer to repair the wrong thing.
+    expect(created["recovery"]).toBe("inspect_document");
+    expect(readFileSync(path, "utf8")).toBe(before);
+  });
+
+  it.skipIf(AS_ROOT)("AC4 — a `create` for a slug that is NOT on disk also abstains: \"a mint never clobbers\" cannot be upheld over a directory it cannot enumerate", async () => {
+    seedShopper();
+    seedBrief();
+
+    // Guard-of-the-guard: listable, a mint at a free slug lands — so the answer below
+    // is the lock, not a rejected slug.
+    expect(
+      (await call("sil_doc_write", { ref: "brief:new-job", mode: "create", title: "New", body: "## Items\n" }))["status"],
+    ).toBe("ok");
+
+    const created = await underMode(briefsDir(), 0o000, () =>
+      call("sil_doc_write", { ref: "brief:another-job", mode: "create", title: "Another", body: "## Items\n" }),
+    );
+
+    expect(created["status"]).toBe("unreadable");
+    expect(created["recovery"]).toBe("inspect_document");
+  });
+
+  it.skipIf(AS_ROOT)("AC5 — sil_doc_remove answers `unreadable` and the Brief is still on disk — \"(already gone)\" said of a document that is not", async () => {
+    seedShopper();
+    seedBrief();
+    const path = join(briefsDir(), "chamonix.md");
+
+    // Guard-of-the-guard: listable, that exact ref is present and readable.
+    expect((await call("sil_doc_read", { ref: "brief:chamonix" }))["status"]).toBe("ok");
+
+    const removed = await underMode(briefsDir(), 0o000, () =>
+      call("sil_doc_remove", { ref: "brief:chamonix" }),
+    );
+
+    expect(removed["status"]).toBe("unreadable");
+    expect(removed["recovery"]).toBe("inspect_document");
+    // `not_found` here reads as "your delete already happened", so the agent stops
+    // asking — and the Brief it reported deleted is still sitting here.
+    expect(existsSync(path)).toBe(true);
+  });
+
+  it("AC6 — `briefs` present as a regular FILE (ENOTDIR) reaches the same answer through a different mechanism", async () => {
+    // EACCES and ENOTDIR are distinct: an `isDirectory()` guard passes one and not the
+    // other. The agent-facing answer must not depend on which one the store hit.
+    seedShopper();
+    seedBrief();
+    expect((await call("sil_doc_read", { ref: "brief:chamonix" }))["status"]).toBe("ok");
+
+    replaceDirWithFile(briefsDir());
+
+    const read = await call("sil_doc_read", { ref: "brief:chamonix" });
+    expect(read["status"]).toBe("unreadable");
+    expect(read["recovery"]).toBe("inspect_document");
+  });
+});
+
+/**
+ * THE OTHER DIRECTION, and the more expensive one to get wrong. `unreadable` is the
+ * answer that STOPS the agent: a false one is not a cosmetic wrong answer, it is a
+ * refusal to shop. A shopper who has simply never written a Brief must never be told
+ * their store is corrupt.
+ */
+describe("…and real absence still reads as absence", () => {
+  it("AC7 — a real miss INSIDE a listable `briefs/` is still `not_found`", async () => {
+    seedShopper();
+    seedBrief();
+
+    // Guard-of-the-guard: the directory is real, listable and non-empty, so the miss
+    // below is a miss and not an empty store.
+    const found = await call("sil_doc_find");
+    expect(found["unreadable"]).toEqual([]);
+    expect((found["briefs"] as unknown[]).length).toBe(1);
+
+    expect((await call("sil_doc_read", { ref: "brief:never-written" }))["status"]).toBe("not_found");
+  });
+
+  it("AC8 — an ABSENT `briefs/` is the normal mintable state: `not_found` on read, `ok` on create (beat 1, fresh machine)", async () => {
+    seedShopper();
+    expect(existsSync(briefsDir())).toBe(false); // guard-of-the-guard
+
+    expect((await call("sil_doc_read", { ref: "brief:chamonix" }))["status"]).toBe("not_found");
+    expect(
+      (await call("sil_doc_write", { ref: "brief:chamonix", mode: "create", title: "Chamonix", body: "## Items\n" }))["status"],
+    ).toBe("ok");
+  });
+
+  it("AC9 — a genuinely empty store is an ANSWERED emptiness, never a fault", async () => {
+    mkdirSync(shopperDir(), { recursive: true, mode: 0o700 });
+
+    expect((await call("sil_doc_read", { ref: "shopper" }))["status"]).toBe("not_found");
+
+    const found = await call("sil_doc_find");
+    expect(found["status"]).toBe("ok");
+    expect(found).not.toHaveProperty("shopper");
+    expect(found["briefs"]).toEqual([]);
+    expect(found["unreadable"]).toEqual([]);
+  });
+
+  it.skipIf(AS_ROOT)("AC10 — at `briefs/` 0o300 the probe fires on the MISS, not on the directory: the read is `ok`, and find still names it", async () => {
+    seedShopper();
+    seedBrief("chamonix", "## Items\n| skis |  | open |\n\n### skis\nthe buyer's own words\n");
+
+    const [read, found] = await underMode(briefsDir(), 0o300, async () => [
+      await call("sil_doc_read", { ref: "brief:chamonix" }),
+      await call("sil_doc_find"),
+    ]);
+
+    // The store CAN hand this document over. A probe on the DIRECTORY downgrades it to
+    // `unreadable` and sends the buyer to repair a store that works.
+    expect(read["status"]).toBe("ok");
+    expect(String(read["body"])).toContain("the buyer's own words");
+    // …while enumeration stays honestly partial. This is also the fault-injection
+    // proof: over a listable `briefs/` the same call reports nothing.
+    expect(reported(found)).toContain("briefs");
+  });
+});
+
+describe("scope and agreement — one fault, one state, three surfaces", () => {
+  it.skipIf(AS_ROOT)("AC11 — one broken directory never blacks out a ref it does not contain", async () => {
+    seedShopper();
+    seedBrief();
+
+    const read = await underMode(briefsDir(), 0o000, async () => {
+      // Guard-of-the-guard: the fault is REALLY injected — this is the listing the
+      // store is about to fail at.
+      expect(() => readdirSync(briefsDir())).toThrow();
+      return call("sil_doc_read", { ref: "shopper" });
+    });
+
+    expect(read["status"]).toBe("ok");
+    expect(read["fields"]).toMatchObject({ name: "Ioannis" });
+    expect(String(read["body"])).toContain("Buys once and keeps it.");
+  });
+
+  it.skipIf(AS_ROOT)("AC12 — the two AGENT verbs describe one state: find names `briefs`, and read does not call the document absent", async () => {
+    seedShopper();
+    seedBrief();
+
+    const [found, read] = await underMode(briefsDir(), 0o000, async () => [
+      await call("sil_doc_find"),
+      await call("sil_doc_read", { ref: "brief:chamonix" }),
+    ]);
+
+    expect(reported(found)).toContain("briefs");
+    // Sharper than the operator/agent split: `not_found` here would have the same
+    // surface contradict itself inside one call pair.
+    expect(read["status"]).not.toBe("not_found");
+  });
+
+  it.skipIf(AS_ROOT)("AC13 — the OPERATOR and AGENT surfaces agree: sil_doctor is unhealthy about `shopper/briefs`, and the read does not call the document absent", async () => {
+    seedShopper();
+    seedBrief();
+
+    // Guard-of-the-guard: with a real `briefs/` the doctor is quiet and healthy, so
+    // the finding below is caused by the fault and nothing else.
+    const before = await runDoctor();
+    expect(before.healthy).toBe(true);
+
+    const [report, read] = await underMode(briefsDir(), 0o000, async () => [
+      await runDoctor(),
+      await call("sil_doc_read", { ref: "brief:chamonix" }),
+    ]);
+
+    expect(report.findings.filter((f) => f.id === "fs.unreadable_dir:shopper/briefs")).toEqual([
+      expect.objectContaining({ severity: "warn" }),
+    ]);
+    expect(report.healthy).toBe(false);
+    expect(read["status"]).not.toBe("not_found");
+  });
+});
+
+/**
+ * THE ROOT'S OWN TWO DOORS — neither of which `briefs/` reaches, and both of which
+ * survive `shopperDirError()`. It early-outs on `!existsSync(shopper)`, so an
+ * un-stat-able `$SIL_DATA_DIR` is recorded as "there is no store"; and at `shopper/`
+ * 0o400 its `readdirSync` probe SUCCEEDS while every child stat EACCESes — the state a
+ * listability probe cannot see, and the only one where the operator surface is blind
+ * too.
+ */
+describe("the ROOT's own two doors — an un-stat-able data dir, and a `shopper/` that lists but does not traverse", () => {
+  it.skipIf(AS_ROOT)("AC17 — with `$SIL_DATA_DIR` itself at 0o000, sil_doc_read {ref: shopper} answers `unreadable`", async () => {
+    seedShopper();
+    expect((await call("sil_doc_read", { ref: "shopper" }))["status"]).toBe("ok"); // guard-of-the-guard
+
+    const read = await underMode(dataDir, 0o000, () => call("sil_doc_read", { ref: "shopper" }));
+
+    expect(read["status"]).toBe("unreadable");
+    expect(read["recovery"]).toBe("inspect_document");
+  });
+
+  it.skipIf(AS_ROOT)("AC18 — …and sil_doc_find names the store rather than answering a CLEAN empty one", async () => {
+    seedShopper();
+    seedBrief();
+
+    const healthy = await call("sil_doc_find");
+    expect(healthy["unreadable"]).toEqual([]); // guard-of-the-guard
+
+    const found = await underMode(dataDir, 0o000, () => call("sil_doc_find"));
+
+    expect(found["status"]).toBe("ok");
+    // A clean empty result is what `checkStore()` turns into zero findings — the
+    // doctor believing a locked store is a healthy one.
+    expect(found["unreadable"]).not.toEqual([]);
+    expect(reported(found)).toContain("shopper");
+  });
+
+  it.skipIf(AS_ROOT)("AC19 — at `shopper/` 0o400 the listing SUCCEEDS and every child stat EACCESes: the read answers `unreadable`", async () => {
+    seedShopper();
+    expect((await call("sil_doc_read", { ref: "shopper" }))["status"]).toBe("ok"); // guard-of-the-guard
+
+    const read = await underMode(shopperDir(), 0o400, async () => {
+      // The state's whole signature, asserted so this bar cannot pass on the wrong
+      // fault: the directory lists (a listability probe sees nothing) while
+      // `existsSync` on the document sitting right there answers false.
+      expect(readdirSync(shopperDir())).toContain("user_spec.md");
+      expect(existsSync(join(shopperDir(), "user_spec.md"))).toBe(false);
+      return call("sil_doc_read", { ref: "shopper" });
+    });
+
+    expect(read["status"]).toBe("unreadable");
+    expect(read["recovery"]).toBe("inspect_document");
+  });
+
+  it.skipIf(AS_ROOT)("AC20 — …and sil_doc_find names BOTH the shopper and `briefs` in unreadable[]", async () => {
+    seedShopper();
+    seedBrief();
+
+    const healthy = await call("sil_doc_find");
+    expect(healthy["unreadable"]).toEqual([]); // guard-of-the-guard
+
+    const found = await underMode(shopperDir(), 0o400, () => call("sil_doc_find"));
+
+    expect(found["status"]).toBe("ok");
+    const ids = (found["unreadable"] as Array<{ id: string }>).map((u) => u.id);
+    expect(ids).toContain("shopper");
+    expect(ids.filter((id) => id.includes("briefs"))).not.toEqual([]);
+  });
+
+  it.skipIf(AS_ROOT)("AC21 — sil_doctor is `healthy: false` with a store.unreadable finding — today the ONE state no surface sees", async () => {
+    seedShopper();
+    seedBrief();
+
+    // Guard-of-the-guard: healthy and silent about the store beforehand. The walk's
+    // per-entry `lstat` EACCES is swallowed as the vanished-tmp-file race and
+    // `tightenMode` ignores a too-TIGHT mode, so `find` is the only reporter left.
+    const before = await runDoctor();
+    expect(before.healthy).toBe(true);
+    expect(before.findings.filter((f) => f.id.startsWith("store.unreadable:"))).toEqual([]);
+
+    const report = await underMode(shopperDir(), 0o400, () => runDoctor());
+
+    expect(report.findings.filter((f) => f.id.startsWith("store.unreadable:"))).not.toEqual([]);
+    expect(report.healthy).toBe(false);
+  });
+
+  it.skipIf(AS_ROOT)("AC22 — the create-shopper bin's singleton pre-flight fails CLOSED at `shopper/` 0o400, over a buyer it cannot see", () => {
+    seedShopper();
+    const specPath = join(shopperDir(), "user_spec.md");
+    const before = readFileSync(specPath, "utf8");
+
+    // Guard-of-the-guard: readable, this same store makes the bin REFUSE — proof it
+    // reaches the pre-flight and reads this person.
+    expect(runCreateShopper().marker["status"]).toBe("collision");
+
+    chmodSync(shopperDir(), 0o400);
+    const locked = runCreateShopper();
+    // Restored first: a failed assertion must not poison the afterEach cleanup.
+    chmodSync(shopperDir(), 0o700);
+
+    expect(locked.status).not.toBe(0);
+    expect(locked.stdout).not.toContain("sil_shopper_created");
+    expect(locked.marker["status"]).toBe("persistence_failed");
+    // It fails HERE, at the store it could not read — not two steps later at the host
+    // CLI. `path` is the only field that tells those two apart.
+    expect(locked.marker["path"]).toBe(shopperDir());
+    expect(String(locked.marker["cause"])).toMatch(/degraded/);
+    // The person is exactly as they were — no second shopper minted over them.
+    expect(readFileSync(specPath, "utf8")).toBe(before);
+  });
+
+  it("AC23 — with NO `shopper/` at all: an empty store, `not_found`, and a mint that lands (the bar that stops the fix bricking onboarding)", async () => {
+    expect(existsSync(shopperDir())).toBe(false); // guard-of-the-guard: a fresh machine
+
+    const found = await call("sil_doc_find");
+    expect(found["status"]).toBe("ok");
+    expect(found).not.toHaveProperty("shopper");
+    expect(found["briefs"]).toEqual([]);
+    expect(found["unreadable"]).toEqual([]);
+
+    expect((await call("sil_doc_read", { ref: "shopper" }))["status"]).toBe("not_found");
+
+    // The bin's singleton gate OPENS on "nothing yet": it walks PAST the store
+    // pre-flight and dies at the host CLI, which is absent from PATH by design — so
+    // `path` is the config it could not drive, never the store, and the cause is not
+    // the degraded-store refusal. (The end-to-end mint from this same baseline is
+    // `create-shopper.integration.test.ts`'s happy path.)
+    const fresh = runCreateShopper();
+    expect(fresh.marker["status"]).toBe("persistence_failed");
+    expect(fresh.marker["path"]).toBe(join(dataDir, "openclaw.json"));
+    expect(String(fresh.marker["cause"])).not.toMatch(/degraded/);
+
+    // …and the mint itself lands: `create` over an absent store directory is beat 1,
+    // not a fault.
+    expect(
+      (await call("sil_doc_write", { ref: "shopper", mode: "create", name: "Ioannis", body: "## Who\nnew here\n" }))["status"],
+    ).toBe("ok");
   });
 });

--- a/src/__tests__/doc-store-migration.integration.test.ts
+++ b/src/__tests__/doc-store-migration.integration.test.ts
@@ -318,9 +318,9 @@ describe("G6 — the one-hop migration off `domains/<slug>/{method.md, prds/*.md
 
   it("G6 — a legacy directory name carrying a regex metacharacter migrates through a structural probe, and never throws across the tool boundary", async () => {
     // A slug interpolated into `new RegExp(...)` is a SyntaxError waiting on a live
-    // disk: `foo(bar` makes every `sil_doc_*` call throw for that store, forever,
-    // against `doc-store.ts:52` ("the store never throws across the tool boundary").
-    // A line-equality probe cannot throw and needs no escaping.
+    // disk: `foo(bar` makes every `sil_doc_*` call throw for that store, forever, against
+    // `doc-store.ts`'s standing invariant that the store never throws across the tool
+    // boundary. A line-equality probe cannot throw and needs no escaping.
     write(join(shopperDir(), "user_spec.md"), artefact({ name: "Ioannis" }, "## Who\nBuys once.\n"));
     write(
       join(legacyDir("foo(bar"), "method.md"),

--- a/src/__tests__/helpers/honesty-vocabulary.ts
+++ b/src/__tests__/helpers/honesty-vocabulary.ts
@@ -214,6 +214,73 @@ export function overTriggerOffenders(body: string): string[] {
 }
 
 /**
+ * The FOURTH honesty state, and the one that lives on the document surface:
+ * `not_found`. It is a POSITIVE claim — sil listed the directory that would hold
+ * the document and it was not in it — and the agent acts on it by minting a fresh
+ * document, or by believing a delete landed. Stated bare, it is the re-mint
+ * instruction: over a directory sil merely could not read, the buyer's own words
+ * are gone in one call.
+ *
+ * Same shape as the scanners above (sentence scope, the offending sentence
+ * returned), and the same reason for it: an agent reads the sentence on its own,
+ * so a qualifier three sentences away does not reach it.
+ *
+ * NOT a clause match. The qualifier is matched as a listing verb NEXT TO a
+ * container noun, in either order, so any wording that says sil could (or could
+ * not) list the directory holding the document satisfies it — the rule is pinned,
+ * the sentence is free.
+ */
+const NOT_FOUND_TOKEN = /\bnot_found\b/i;
+
+/** What `not_found` is being said to MEAN. */
+const ABSENCE_CLAIM =
+  /\b(absent|already[ -]gone|gone|missing|does\s+not\s+exist|doesn'?t\s+exist|isn'?t\s+there|no\s+such|never\s+written|nothing\s+(?:is\s+)?there)\b/i;
+
+/** What that meaning LICENSES — the two acts this rule exists to gate. */
+const ABSENCE_LICENCE =
+  /\b(mints?|minting|creates?|re-?mint\w*|write\s+a\s+fresh|fresh\s+(?:one|document)|repeat\s+call|safe|deleted|removed|delete\s+landed)\b/i;
+
+/**
+ * `store` is deliberately NOT a container noun here: this prose says "the sil
+ * shopper's store" constantly, so accepting it would let an unrelated "list what
+ * you have" clear the very sentence being guarded.
+ */
+const LISTED_QUALIFIER =
+  /\b(?:list\w*|enumerat\w+|scan\w*)\b[^.;]{0,30}\b(?:director\w+|folder|briefs|containing|would\s+hold)\b|\b(?:director\w+|folder|briefs|containing)\b[^.;]{0,30}\b(?:list\w*|enumerat\w+|scan\w*)\b|\bunlistable\b/i;
+
+/**
+ * This rule needs a CLAIM and its QUALIFIER in one unit, so unlike the scanners
+ * above it cannot treat a physical line break as a unit break: the bundle's prose
+ * is hard-wrapped, and the agent reads the rendered sentence, not the column
+ * width. Wrapped lines are joined; a blank line and a new bullet are still real
+ * boundaries.
+ */
+function unwrapped(body: string): string[] {
+  return sentences(body.replace(/\n(?!\s*\n)(?!\s*[-*•]\s)/g, " "));
+}
+
+/**
+ * Sentences that state `not_found` as a bare licence to mint, or as proof a
+ * delete landed. Empty ⇒ every such sentence carries the listing qualifier.
+ */
+export function notFoundLicenceOffenders(body: string): string[] {
+  return unwrapped(body)
+    .filter(
+      (s) =>
+        NOT_FOUND_TOKEN.test(s)
+        && (ABSENCE_CLAIM.test(s) || ABSENCE_LICENCE.test(s))
+        && !LISTED_QUALIFIER.test(s),
+    )
+    .map((s) => s.replace(/\s+/g, " "));
+}
+
+/** Does this body teach `not_found` WITH its qualifier at all? The forbid-scan
+ * above passes vacuously over prose that simply deleted the vocabulary. */
+export function statesQualifiedNotFound(body: string): boolean {
+  return unwrapped(body).some((s) => NOT_FOUND_TOKEN.test(s) && LISTED_QUALIFIER.test(s));
+}
+
+/**
  * Vocabulary the v0 contract retired, as TEXT — every entry is a dead string
  * that cannot appear innocently in English prose, so a blanket forbid is right.
  *

--- a/src/__tests__/lib/honesty-vocabulary.test.ts
+++ b/src/__tests__/lib/honesty-vocabulary.test.ts
@@ -19,9 +19,11 @@
 import { describe, it, expect } from "vitest";
 import {
   honestyExclusionOffenders,
+  notFoundLicenceOffenders,
   overPromiseOffenders,
   overTriggerOffenders,
   retiredV0Offenders,
+  statesQualifiedNotFound,
   RETIRED_V0_TOKENS,
 } from "../helpers/honesty-vocabulary.js";
 
@@ -256,4 +258,91 @@ describe("retiredV0Offenders — the pre-v0 contract's dead strings", () => {
       expect(retiredV0Offenders(description)).toEqual([]);
     },
   );
+});
+
+/**
+ * The needle AC15 (tool descriptions) and AC16 (bundle prose) both read. Without a
+ * bite proof an unmatchable qualifier would leave BOTH of them green over prose
+ * that still hands the agent the licence — the failure neither of them can catch
+ * about itself.
+ *
+ * The spare rows are deliberately worded UNLIKE the descriptions they will run
+ * over: the rule is "state the listing condition", not "use this sentence".
+ */
+describe("notFoundLicenceOffenders — `not_found` is a positive claim, never a bare licence", () => {
+  const MUST_BITE: [string, string][] = [
+    ["sil_doc_read's shipped line, verbatim", "An absent document answers not_found."],
+    [
+      "sil_doc_remove's shipped line, verbatim — `not_found` as proof a delete landed",
+      "An already-gone document answers not_found, so a repeat call is safe.",
+    ],
+    [
+      "the bundle's shipped line, verbatim",
+      "An absent document is `not_found`; a present-but-corrupt one is `unreadable`.",
+    ],
+    [
+      "the re-mint instruction spelled out",
+      "If a Brief reads not_found, mint a fresh one with sil_doc_write (mode: create).",
+    ],
+    [
+      "the delete believed to have landed",
+      "A repeat sil_doc_remove answers not_found, which is proof the document is gone.",
+    ],
+    [
+      "sentence scope — a qualifier in the NEXT sentence does not reach it",
+      "not_found means the Brief is gone. sil reports it only when it could list the directory.",
+    ],
+    [
+      "bullet scope — a qualifier in the bullet BELOW does not reach it either",
+      "- An absent document answers not_found\n- sil could list the directory that would hold it",
+    ],
+  ];
+
+  it.each(MUST_BITE)("bites: %s", (_label, prose) => {
+    expect(notFoundLicenceOffenders(prose)).not.toEqual([]);
+  });
+
+  const MUST_SPARE: [string, string][] = [
+    [
+      "the condition stated plainly",
+      "not_found is reported only when sil could list the directory that would hold the document"
+        + " and it was not in it.",
+    ],
+    [
+      "the same rule from the other side — different words, same fact",
+      "not_found never means an unreadable directory: it is what sil answers when the folder"
+        + " listed cleanly and the document was gone.",
+    ],
+    [
+      "the negative form, naming the state it excludes",
+      "not_found is never returned for an unlistable directory, so an absent answer is a real"
+        + " absence.",
+    ],
+    [
+      "an enumeration of the wire's statuses claims nothing about absence",
+      "The store answers ok, not_found, unreadable or invalid_request.",
+    ],
+    [
+      "a HARD-WRAPPED sentence is one sentence — the rule is not a column-width rule",
+      "`not_found` is reported only when sil could list the\ndirectory that would hold the document"
+        + "\nand it was not in it.",
+    ],
+  ];
+
+  it.each(MUST_SPARE)("spares: %s", (_label, prose) => {
+    expect(notFoundLicenceOffenders(prose)).toEqual([]);
+  });
+
+  it("statesQualifiedNotFound separates teaching the rule from deleting the vocabulary", () => {
+    // The cheapest way to pass a forbid-scan is to stop naming `not_found` at all,
+    // which leaves the agent reading a status nothing explains. AC15/AC16 use this
+    // as their floor, so it has to be false on the bare form.
+    expect(
+      statesQualifiedNotFound(
+        "not_found is reported only when sil could list the directory that would hold it.",
+      ),
+    ).toBe(true);
+    expect(statesQualifiedNotFound("An absent document answers not_found.")).toBe(false);
+    expect(statesQualifiedNotFound("The document surface is local-only.")).toBe(false);
+  });
 });

--- a/src/__tests__/skill-bundle-contract.integration.test.ts
+++ b/src/__tests__/skill-bundle-contract.integration.test.ts
@@ -25,9 +25,11 @@ import {
 import { perNicheExpertOffenders } from "./helpers/per-niche-expert.js";
 import {
   honestyExclusionOffenders,
+  notFoundLicenceOffenders,
   overPromiseOffenders,
   overTriggerOffenders,
   retiredV0Offenders,
+  statesQualifiedNotFound,
   RETIRED_V0_TOKENS,
 } from "./helpers/honesty-vocabulary.js";
 // The bundle's reading + SCOPING primitives, shared with
@@ -221,6 +223,23 @@ describe("sil-shopping skill bundle — load-bearing contract (not prose)", () =
       for (const s of overTriggerOffenders(body)) offenders.push(`${rel}: ${s}`);
     }
     expect(offenders).toEqual([]);
+  });
+
+  it("AC16 — the bundle states `not_found` as a claim from a listing, never as a bare licence to mint", () => {
+    // AC15's other surface, through the ONE shared needle
+    // (`helpers/honesty-vocabulary.ts`): the skill is what the agent reads before it
+    // ever sees a tool description, so a perfectly qualified `sil_doc_read`
+    // description is undone by a reference file that still says "an absent document
+    // is not_found". Two guards, one rule — the same discipline that keeps the
+    // honesty scans from drifting apart.
+    const offenders: string[] = [];
+    for (const rel of bundleFiles()) {
+      for (const s of notFoundLicenceOffenders(read(rel))) offenders.push(`${rel}: ${s}`);
+    }
+    expect(offenders).toEqual([]);
+    // Guard-of-the-guard: deleting the vocabulary passes the scan above vacuously.
+    // The bundle documents the document surface, so it must still teach the rule.
+    expect(bundleFiles().filter((rel) => statesQualifiedNotFound(read(rel)))).not.toEqual([]);
   });
 
   it("guard-of-the-guard: the scanned corpus is non-trivial", () => {

--- a/src/__tests__/tools/tool-schema-contract.unit.test.ts
+++ b/src/__tests__/tools/tool-schema-contract.unit.test.ts
@@ -45,9 +45,11 @@ import {
 import { perNicheExpertOffenders } from "../helpers/per-niche-expert.js";
 import {
   honestyExclusionOffenders,
+  notFoundLicenceOffenders,
   overPromiseOffenders,
   overTriggerOffenders,
   retiredV0Offenders,
+  statesQualifiedNotFound,
   RETIRED_V0_TOKENS,
 } from "../helpers/honesty-vocabulary.js";
 
@@ -518,6 +520,35 @@ describe("AC G8 — each document tool carries its DOMAINS §8 discipline clause
       }
     }
     expect(missing).toEqual([]);
+  });
+});
+
+describe("AC15 — `not_found` is stated as a claim sil can only make from a listing", () => {
+  it("AC15 — no registered description hands out the re-mint licence, and the two doc verbs still teach the rule", () => {
+    // The agent decides whether to re-mint from these descriptions alone, and
+    // `not_found` is the one status that instructs it to. Over a directory the store
+    // merely could not read, that instruction costs the buyer's own words in one
+    // call — the same loss the `unreadable` contract exists to prevent, arriving
+    // through prose instead of through code.
+    //
+    // Runs over the WHOLE registered surface (descriptions AND parameter
+    // descriptions), derived from the live registration, so a fifth verb that learns
+    // the habit is caught for free.
+    const api = allRegisteredTools();
+    const offenders: string[] = [];
+    for (const [name, text] of wholeSurface(api)) {
+      for (const sentence of notFoundLicenceOffenders(text)) offenders.push(`${name}: ${sentence}`);
+    }
+    expect(offenders).toEqual([]);
+
+    // Guard-of-the-guard: the cheapest way to pass a forbid-scan is to stop naming
+    // `not_found` anywhere, which leaves the agent reading a wire status no
+    // description explains. The two verbs that can answer it must still state the
+    // condition under which sil is entitled to.
+    const qualified = wholeSurface(api)
+      .filter(([, text]) => statesQualifiedNotFound(text))
+      .map(([name]) => name);
+    expect(qualified).toEqual(expect.arrayContaining(["sil_doc_read", "sil_doc_remove"]));
   });
 });
 

--- a/src/lib/doc-store.ts
+++ b/src/lib/doc-store.ts
@@ -74,6 +74,9 @@ interface NotFound {
 interface Unreadable {
   ok: false;
   kind: "unreadable";
+  /** "<path>: <cause>" — what the log line needs to tell a chmod fault from a parse
+   * failure. Internal: the agent-facing envelope carries `message`. */
+  detail: string;
   message: string;
 }
 
@@ -100,6 +103,7 @@ function unreadable(path: string): Unreadable {
   return {
     ok: false,
     kind: "unreadable",
+    detail: path + ": malformed or absent frontmatter",
     message:
       path + ": the document is present but corrupt (malformed or absent frontmatter)"
         + " — inspect / repair, do NOT overwrite (it may still be recoverable).",
@@ -175,6 +179,7 @@ function presenceUnreadable(path: string, cause: string): Unreadable {
   return {
     ok: false,
     kind: "unreadable",
+    detail: path + ": " + cause,
     message: path + ": " + presenceError(cause)
       + ". The document may still be on disk, so do NOT mint a fresh one over it.",
   };

--- a/src/lib/doc-store.ts
+++ b/src/lib/doc-store.ts
@@ -171,11 +171,11 @@ function presenceError(cause: string): string {
 }
 
 /** An unsettled presence as a verb-facing variant — `unreadable`, never `not_found`. */
-function storeUnreadable(path: string, error: string): Unreadable {
+function presenceUnreadable(path: string, cause: string): Unreadable {
   return {
     ok: false,
     kind: "unreadable",
-    message: path + ": " + error
+    message: path + ": " + presenceError(cause)
       + ". The document may still be on disk, so do NOT mint a fresh one over it.",
   };
 }
@@ -554,7 +554,7 @@ export function readDocument(ref: unknown): ReadDocResult {
   const target = resolveRef(ref);
   if ("ok" in target) return target;
   const at = probe(target.path);
-  if (at.state === "unknown") return storeUnreadable(target.path, presenceError(at.error));
+  if (at.state === "unknown") return presenceUnreadable(target.path, at.error);
   if (at.state === "absent") {
     return notFound(
       "No document at " + JSON.stringify(target.ref) + " — list what exists with"
@@ -636,7 +636,7 @@ function preflightMode(
   mode: WriteMode,
 ): { ok: true; existing: Artefact | null } | InvalidRequest | NotFound | Unreadable {
   const at = probe(target.path);
-  if (at.state === "unknown") return storeUnreadable(target.path, presenceError(at.error));
+  if (at.state === "unknown") return presenceUnreadable(target.path, at.error);
   const present = at.state === "present";
   if (mode === "create") {
     if (!present) return { ok: true, existing: null };
@@ -703,7 +703,7 @@ export function removeDocument(ref: unknown): RemoveDocResult {
     );
   }
   const at = probe(target.path);
-  if (at.state === "unknown") return storeUnreadable(target.path, presenceError(at.error));
+  if (at.state === "unknown") return presenceUnreadable(target.path, at.error);
   if (at.state === "absent") {
     return notFound("No document at " + JSON.stringify(target.ref) + " to remove (already gone).");
   }

--- a/src/lib/doc-store.ts
+++ b/src/lib/doc-store.ts
@@ -14,6 +14,7 @@ import {
   renameSync,
   rmSync,
   rmdirSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import type { Dirent } from "node:fs";
@@ -66,9 +67,10 @@ interface NotFound {
   message: string;
 }
 
-/** PRESENT but unreadable — a document that will not parse, or a store directory the
- * OS will not list. Never conflated with `not_found`: an agent that reads "absent"
- * over a corrupt document re-mints and the buyer's own words are gone. */
+/** NOT KNOWN TO BE ABSENT — a document that will not parse, a store directory the OS
+ * will not list, or a path the OS would not let us stat at all. Never conflated with
+ * `not_found`: an agent that reads "absent" over a corrupt document re-mints and the
+ * buyer's own words are gone. */
 interface Unreadable {
   ok: false;
   kind: "unreadable";
@@ -125,9 +127,9 @@ function errCause(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
-/** `readdirSync` is the store's one fs call that throws where `existsSync` already
- * said yes — EACCES, or a directory present as a FILE (the read is ENOTDIR). Every
- * listing goes through here so a broken tree is REPORTED, never thrown at a tool. */
+/** `readdirSync` throws where the probe already settled presence — EACCES, or a
+ * directory present as a FILE (the read is ENOTDIR). Every listing goes through here
+ * so a broken tree is REPORTED, never thrown at a tool. */
 function listDir(dir: string): { entries: Dirent[]; error: string | null } {
   try {
     return { entries: readdirSync(dir, { withFileTypes: true }), error: null };
@@ -141,24 +143,53 @@ function listingError(cause: string): string {
     + " — repair it by hand (it may be unreadable, or a file where a directory belongs)";
 }
 
-/** With `shopper/` ITSELF unlistable (EACCES, or a file in its place) every child
- * `existsSync` answers false — so an absent store and a locked one read identically,
- * and `not_found` would steer the agent to re-mint over documents still on disk. */
-function shopperDirError(): string | null {
-  const dir = getShopperArtefactDir();
-  if (!existsSync(dir)) return null;
-  const { error } = listDir(dir);
-  return error === null ? null : listingError(error);
+/** ONE primitive for every gate that decides absence. `existsSync` is a boolean over a
+ * stat that swallows every errno, so its `false` means ENOENT *or* "I was not allowed to
+ * look" — the conflation `Unreadable` forbids. A throw here leaves presence UNKNOWN, and
+ * unknown is stated, never guessed as absence. */
+type Presence =
+  | { state: "present" }
+  | { state: "absent" }
+  | { state: "unknown"; error: string };
+
+function probe(path: string): Presence {
+  try {
+    statSync(path);
+    return { state: "present" };
+  } catch (err) {
+    // ENOENT alone is proof of absence (a dangling symlink included). `throwIfNoEntry`
+    // is NOT the classifier: it also swallows ENOTDIR, which is a broken tree.
+    return (err as NodeJS.ErrnoException).code === "ENOENT"
+      ? { state: "absent" }
+      : { state: "unknown", error: errCause(err) };
+  }
 }
 
-/** The root's failure as a verb-facing variant — `unreadable`, never `not_found`. */
-function storeUnreadable(error: string): Unreadable {
+function presenceError(cause: string): string {
+  return "presence could not be determined: " + cause
+    + " — repair it by hand (it may be unreadable, or a file where a directory belongs)";
+}
+
+/** An unsettled presence as a verb-facing variant — `unreadable`, never `not_found`. */
+function storeUnreadable(path: string, error: string): Unreadable {
   return {
     ok: false,
     kind: "unreadable",
-    message: getShopperArtefactDir() + ": " + error
-      + ". The documents underneath may be intact — do NOT mint a fresh one over them.",
+    message: path + ": " + error
+      + ". The document may still be on disk, so do NOT mint a fresh one over it.",
   };
+}
+
+/** The root as `findDocuments` alone needs it: the whole store sits behind this one
+ * directory, so its fault is reported once for every query. Enumeration IS the operation
+ * here — the ref-addressed verbs probe the path they were asked about instead. */
+function shopperDirError(): string | null {
+  const dir = getShopperArtefactDir();
+  const at = probe(dir);
+  if (at.state === "absent") return null;
+  if (at.state === "unknown") return presenceError(at.error);
+  const { error } = listDir(dir);
+  return error === null ? null : listingError(error);
 }
 
 /** Names only, `.md` only, sorted — a scan's stable order. A DIRECTORY named `x.md`
@@ -283,7 +314,6 @@ function stripLeadingFrontmatter(body: string): string {
 }
 
 function readArtefactFile(path: string): Artefact | null {
-  if (!existsSync(path)) return null;
   let raw: string;
   try {
     raw = readFileSync(path, "utf8");
@@ -436,7 +466,12 @@ function findShopper(filters: FindFilters, unreadable: UnreadableDocs): ShopperC
     && filters.status === undefined;
   if (!wanted) return undefined;
   const path = join(getShopperArtefactDir(), USER_SPEC_FILE);
-  if (!existsSync(path)) return undefined;
+  const at = probe(path);
+  if (at.state === "absent") return undefined;
+  if (at.state === "unknown") {
+    unreadable.push({ id: "shopper", error: presenceError(at.error) });
+    return undefined;
+  }
   const parsed = readArtefactFile(path);
   if (parsed === null) {
     unreadable.push({ id: "shopper", error: USER_SPEC_FILE + " has malformed or absent frontmatter" });
@@ -457,7 +492,12 @@ function findShopper(filters: FindFilters, unreadable: UnreadableDocs): ShopperC
 
 function findBriefs(filters: FindFilters, unreadable: UnreadableDocs): BriefCoord[] {
   const dir = join(getShopperArtefactDir(), BRIEFS_SUBDIR);
-  if (!existsSync(dir)) return [];
+  const at = probe(dir);
+  if (at.state === "absent") return [];
+  if (at.state === "unknown") {
+    unreadable.push({ id: BRIEFS_SUBDIR, error: presenceError(at.error) });
+    return [];
+  }
   const listing = listDir(dir);
   if (listing.error !== null) {
     unreadable.push({ id: BRIEFS_SUBDIR, error: listingError(listing.error) });
@@ -513,9 +553,9 @@ export type ReadDocResult =
 export function readDocument(ref: unknown): ReadDocResult {
   const target = resolveRef(ref);
   if ("ok" in target) return target;
-  const rootError = shopperDirError();
-  if (rootError !== null) return storeUnreadable(rootError);
-  if (!existsSync(target.path)) {
+  const at = probe(target.path);
+  if (at.state === "unknown") return storeUnreadable(target.path, presenceError(at.error));
+  if (at.state === "absent") {
     return notFound(
       "No document at " + JSON.stringify(target.ref) + " — list what exists with"
         + " sil_doc_find, or write it with sil_doc_write (mode: create).",
@@ -589,14 +629,15 @@ export function writeDocument(spec: WriteSpec): WriteDocResult {
 
 /** The mode gate, and the only read of what is already on disk: create fails if the
  * ref exists, replace fails if it does not — and replace over a corrupt document is
- * refused, because reconciling needs the words that are still in there. */
+ * refused, because reconciling needs the words that are still in there. Both guarantees
+ * need presence SETTLED, so an unsettled one abstains rather than guesses. */
 function preflightMode(
   target: ResolvedRef,
   mode: WriteMode,
 ): { ok: true; existing: Artefact | null } | InvalidRequest | NotFound | Unreadable {
-  const rootError = shopperDirError();
-  if (rootError !== null) return storeUnreadable(rootError);
-  const present = existsSync(target.path);
+  const at = probe(target.path);
+  if (at.state === "unknown") return storeUnreadable(target.path, presenceError(at.error));
+  const present = at.state === "present";
   if (mode === "create") {
     if (!present) return { ok: true, existing: null };
     return invalid(
@@ -661,9 +702,9 @@ export function removeDocument(ref: unknown): RemoveDocResult {
         + " written from. Correct it with sil_doc_write (mode: replace) instead.",
     );
   }
-  const rootError = shopperDirError();
-  if (rootError !== null) return storeUnreadable(rootError);
-  if (!existsSync(target.path)) {
+  const at = probe(target.path);
+  if (at.state === "unknown") return storeUnreadable(target.path, presenceError(at.error));
+  if (at.state === "absent") {
     return notFound("No document at " + JSON.stringify(target.ref) + " to remove (already gone).");
   }
   try {
@@ -687,12 +728,14 @@ export interface ShopperIdentity {
 }
 
 export function readShopperIdentity(): ShopperIdentity {
-  const rootError = shopperDirError();
+  const userSpecPath = join(getShopperArtefactDir(), USER_SPEC_FILE);
+  const at = probe(userSpecPath);
   // Inconclusive, not empty — the create-shopper bin reads an empty answer as "no
   // shopper yet" and would mint a second person over the one it could not see.
-  if (rootError !== null) return { ok: true, unreadable: [{ id: SHOPPER_SUBDIR, error: rootError }] };
-  const userSpecPath = join(getShopperArtefactDir(), USER_SPEC_FILE);
-  if (!existsSync(userSpecPath)) return { ok: true, unreadable: [] };
+  if (at.state === "unknown") {
+    return { ok: true, unreadable: [{ id: USER_SPEC_FILE, error: presenceError(at.error) }] };
+  }
+  if (at.state === "absent") return { ok: true, unreadable: [] };
   const parsed = readArtefactFile(userSpecPath);
   if (parsed === null) {
     return {

--- a/src/tools/doc.ts
+++ b/src/tools/doc.ts
@@ -109,10 +109,12 @@ function registerRead(api: PluginAPI): void {
       + " `ref` is \"shopper\" (the person — their body facts, fit, shopping taste,"
       + " constraints and past purchases) or \"brief:<slug>\" (one shopping job — its"
       + " items, buying guide, hard constraints, preferences and open questions)."
-      + " Discover refs with sil_doc_find. An absent document answers not_found; a"
-      + " present but corrupt one answers unreadable — inspect and repair it, never"
-      + " write a fresh document over it, because the buyer's own words may still be"
-      + " recoverable. A ref that is not lower-kebab, or names a kind this version does"
+      + " Discover refs with sil_doc_find. not_found is reported ONLY when sil could"
+      + " list the directory that would hold the document and it was not in it — a"
+      + " directory sil could not list answers unreadable instead, as does a present but"
+      + " corrupt document: inspect and repair it, never write a fresh document over it,"
+      + " because the buyer's own words may still be recoverable."
+      + " A ref that is not lower-kebab, or names a kind this version does"
       + " not address, answers invalid_request. Local-only, no network.",
     parameters: Type.Object({
       ref: Type.String({
@@ -207,8 +209,10 @@ function registerRemove(api: PluginAPI): void {
       + " by sil_doctor rather than followed. Destructive, so confirm with the buyer"
       + " first. Only a Brief is removable; the shopper document is the person every"
       + " Brief was written from, so it answers invalid_request — correct it with"
-      + " sil_doc_write (mode: replace) instead. An already-gone document answers"
-      + " not_found, so a repeat call is safe. Local-only, no network.",
+      + " sil_doc_write (mode: replace) instead. not_found is reported ONLY when sil"
+      + " could list the directory that would hold the document and it was not in it;"
+      + " a directory sil could not list answers unreadable instead, and is never proof"
+      + " that the delete landed. Local-only, no network.",
     parameters: Type.Object({
       ref: Type.String({
         description: 'The document ref to remove: "brief:<slug>" (lower-kebab, not "main").',

--- a/src/tools/doc.ts
+++ b/src/tools/doc.ts
@@ -244,9 +244,10 @@ function mapFailure(api: PluginAPI, tool: string, result: StoreFailure) {
     return jsonResult({ status: "not_found", message: result.message });
   }
   if (result.kind === "unreadable") {
-    // A present-but-corrupt document — steer the agent to inspect/repair, NEVER write
-    // over it (silent loss of a recoverable document). Distinct from not_found.
-    api.logger.warn(tool + "_unreadable", {});
+    // NOT KNOWN TO BE ABSENT — presence unsettled, or a body that will not parse. Steer
+    // the agent to inspect/repair, NEVER write over it (silent loss of a recoverable
+    // document). Distinct from not_found.
+    api.logger.warn(tool + "_unreadable", { detail: result.detail });
     return jsonResult({ status: "unreadable", message: result.message, recovery: "inspect_document" });
   }
   api.logger.error(tool + "_persistence_failed", { error: result.error });


### PR DESCRIPTION
## Card

`cards/an-unlistable-store-root-reads-as-not-found-on-the.md` (gitignored here — it lives in the `card/…` worktree; see its body for the full intent + handoffs).

## Summary

`existsSync` cannot say "absent". It is a boolean over a `stat()` that swallows every errno, so `false` means ENOENT **or** "I was not allowed to look" — the exact conflation `doc-store.ts`'s `Unreadable` interface forbids in its own comment. The store decided absence with it at eight read-path gates, so an unlistable `briefs/`, an untraversable `$SIL_DATA_DIR`, and a `0o400` `shopper/` all answered `not_found` for documents that are on disk — and `not_found`'s own message names `sil_doc_write (mode: create)`, so it *is* the re-mint instruction.

- **One primitive replaces all eight** — `probe(path)` → `present` / `absent` / `unknown`, off a bare `statSync` classified on the errno: `ENOENT` alone is proof of absence, every other throw leaves presence unknown, and unknown is **stated** (`unreadable`), never guessed.
- **The eager root probe is deleted from the four ref-addressed verbs**, not doubled up. `shopperDirError()` survives only in `findDocuments`, where enumeration *is* the operation. A fault scoped to one directory no longer blacks out a ref it does not contain, and `briefs/` at `0o300` now hands back a Brief the store can actually read.
- **`sil_doc_find` keeps its `{ok: true, …, unreadable[]}` contract** and reports under the existing ids, so `sil_doctor` inherits `store.unreadable:*` → `healthy: false` with no change to `doctor.ts`.
- **Agent-facing prose** (`sil_doc_read`, `sil_doc_remove`, the `sil-shopping` bundle) no longer states `not_found` as a bare licence to mint or as proof a delete landed.

No tool added, removed or renamed — no exact-set fan-out. `existsSync` survives only in the migration gates, whose writes fail closed under the same errno.

## Test plan

- [x] 35 new bars, one per acceptance criterion (AC1–AC13, AC15–AC23; AC14 is a no-new-test regression bar). Real fs, registered tools, real `chmod` injection, `it.skipIf(AS_ROOT)`.
- [x] The five pre-existing root-case bars pass **unchanged and un-duplicated**.
- [x] `tsc --noEmit` and `tsc -p tsconfig.build.json` clean.
- [x] Full suite exit `0` on **5 back-to-back runs** — 61 files, 1578 tests (`repo-scaffold` excluded: it stats gitignored `CLAUDE.md` / `docs/`, a known worktree artefact).
- [x] Live-verified against the built `dist/` on a real seeded store: all 23 AC states walked end to end, including the one that corrected Discovery (below).

## One measured correction to Discovery

Discovery specified `statSync(p, { throwIfNoEntry: false })` and recorded that it *throws* on ENOTDIR. It does not — on Node v24.19.0 it returns `undefined` for **ENOTDIR as well as ENOENT**, so that classifier answers `not_found` for AC6 (`briefs` present as a regular file). Measured, then replaced with the errno-keyed form.

## Distillation target

Knowledge capture happens **after Review PASS** in the `distilling` stage — `solutions-architect` runs in this same worktree, commits to this same branch, and pushes here so the PR ends up containing implementation + tests + distillation in one mergeable unit.