### PR TITLE
chore: retire the card, board and Obsidian layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,12 @@
 # cc-setup harness — local-only in this PUBLIC repo. The whole orchestration
 # harness is gitignored so none of it ships in the public plugin repo: the
 # .claude/ tree (skills, agents, hooks, commands, settings, worktrees,
-# agent-memory, logs), the kanban board + cards, the Obsidian vault, the
-# distilled docs, the contributor/agent instructions, and the MCP config.
-# The files live on-disk locally; the board runs from there.
+# agent-memory, logs), the distilled docs, the contributor/agent instructions,
+# and the MCP config. The files live on-disk locally.
 # To untrack anything committed before this rule: git rm -r --cached <path>
 .claude/
 *.worktree
 .mcp.json
-cards/
-BOARD.md
-INDEX.base
-.obsidian/
 docs/
 CLAUDE.md
 


### PR DESCRIPTION
## What

Retires the kanban card harness from this repo: `cards/`, `BOARD.md`, `INDEX.base` and the Obsidian vault. The board is replaced by one goal document per goal in `mission-control-sil`.

## Why

The card layer is harness state, not product. Nothing in the code reads it — the guards that mention `cards/` only ever **exclude** it, never enumerate it, which is what makes the deletion safe.

## Verification

`pnpm test` — **64 files, 1609 tests**, exit 0.

## Notes

`cards/`, `BOARD.md`, `INDEX.base` and `.obsidian/` were gitignored here, so they were never tracked — this commit only removes the now-dangling ignore rules. The files are deleted from disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)