### PR TITLE
sil v0 — four catalog tools 1:1 with the routes, and the skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,12 @@ release (`clawhub package publish --changelog`). See [README](./README.md#releas
 
 ### Fixed
 
+- **`create-shopper` attaches the skill where a 2026.8.1+ host looks.** The host's config
+  migration renamed `agents.list` (an array) to `agents.entries` (a map keyed by id), and
+  `openclaw agents add` writes that shape, so creation failed closed after the add on every
+  2026.8.1+ gateway. The script now reads both shapes and attaches the skill at
+  `agents.entries["<id>"].skills` (bracket-quoted for hyphenated ids) or `agents.list[<i>]`,
+  whichever the host uses; the two never coexist. Measured live on 2026.8.1 and 2026.9.2.
 - **A directory sil cannot list no longer reads as an absent document.**
   `sil_doc_read` / `sil_doc_write` / `sil_doc_remove` decided absence with
   `existsSync` — a boolean over a stat that swallows every errno, so an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,8 +113,13 @@ release (`clawhub package publish --changelog`). See [README](./README.md#releas
   migration renamed `agents.list` (an array) to `agents.entries` (a map keyed by id), and
   `openclaw agents add` writes that shape, so creation failed closed after the add on every
   2026.8.1+ gateway. The script now reads both shapes and attaches the skill at
-  `agents.entries["<id>"].skills` (bracket-quoted for hyphenated ids) or `agents.list[<i>]`,
-  whichever the host uses; the two never coexist. Measured live on 2026.8.1 and 2026.9.2.
+  `agents.entries["<id>"].skills` (bracket-quoted for hyphenated ids) or
+  `agents.list[<i>].skills`, whichever the host uses; the two never coexist. The attach
+  is then read back with `config get` and fails closed when the skill is not there —
+  a host that parses the path differently writes one literal key and still exits 0, and
+  that silent misattach is the state the fix exists to prevent. Measured live on
+  2026.8.1 and 2026.9.2; the wiring-drift detector reads both shapes too, so it no
+  longer goes blind on a migrated host.
 - **A directory sil cannot list no longer reads as an absent document.**
   `sil_doc_read` / `sil_doc_write` / `sil_doc_remove` decided absence with
   `existsSync` — a boolean over a stat that swallows every errno, so an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,13 +113,12 @@ release (`clawhub package publish --changelog`). See [README](./README.md#releas
   migration renamed `agents.list` (an array) to `agents.entries` (a map keyed by id), and
   `openclaw agents add` writes that shape, so creation failed closed after the add on every
   2026.8.1+ gateway. The script now reads both shapes and attaches the skill at
-  `agents.entries["<id>"].skills` (bracket-quoted for hyphenated ids) or
-  `agents.list[<i>].skills`, whichever the host uses; the two never coexist. The attach
-  is then read back with `config get` and fails closed when the skill is not there —
-  a host that parses the path differently writes one literal key and still exits 0, and
-  that silent misattach is the state the fix exists to prevent. Measured live on
-  2026.8.1 and 2026.9.2; the wiring-drift detector reads both shapes too, so it no
-  longer goes blind on a migrated host.
+  `agents.entries["<id>"].skills` or `agents.list[<i>].skills`, whichever the host uses;
+  the two never coexist. The attach is then re-read from `openclaw.json` and fails closed
+  when the skill is not there — a host that parses the path differently writes one
+  literal key and still exits 0, and that silent misattach is the state the fix exists to
+  prevent. Measured live on 2026.8.1 and 2026.9.2; the wiring-drift detector reads both
+  shapes too, so it no longer goes blind on a migrated host.
 - **A directory sil cannot list no longer reads as an absent document.**
   `sil_doc_read` / `sil_doc_write` / `sil_doc_remove` decided absence with
   `existsSync` — a boolean over a stat that swallows every errno, so an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ release (`clawhub package publish --changelog`). See [README](./README.md#releas
 
 ### Changed
 
+- **`openclaw.build.openclawVersion` / `pluginSdkVersion` record `2026.9.2`**, the host this
+  plugin is now verified against (the stage pins it). Diagnostics only on the host side; the
+  `compat` floor stays `>=2026.7.1` — nothing here needs a newer API.
 - **BREAKING — the shopper's store is FLAT, and the pre-0.5 layout migrates in one
   hop on first touch of a `sil_doc_*` tool.** `shopper/user_spec.md` +
   `shopper/briefs/<slug>.md` replace `shopper/domains/<slug>/{method.md,
@@ -117,8 +120,11 @@ release (`clawhub package publish --changelog`). See [README](./README.md#releas
   the two never coexist. The attach is then re-read from `openclaw.json` and fails closed
   when the skill is not there — a host that parses the path differently writes one
   literal key and still exits 0, and that silent misattach is the state the fix exists to
-  prevent. Measured live on 2026.8.1 and 2026.9.2; the wiring-drift detector reads both
-  shapes too, so it no longer goes blind on a migrated host.
+  prevent. The entries shape was measured live on 2026.8.1 (the fleet's hotfix) and on
+  2026.9.2 in an isolated container (`agents add` writes the map; the bracket path
+  round-trips through `config set` / `config get`); the attach and its read-back are
+  graded by the shimmed suite. The wiring-drift detector reads both shapes too, so it no
+  longer goes blind on a migrated host.
 - **A directory sil cannot list no longer reads as an absent document.**
   `sil_doc_read` / `sil_doc_write` / `sil_doc_remove` decided absence with
   `existsSync` — a boolean over a stat that swallows every errno, so an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ release (`clawhub package publish --changelog`). See [README](./README.md#releas
 
 ### Changed
 
-- **`openclaw.build.openclawVersion` / `pluginSdkVersion` record `2026.9.2`**, the host this
+- **`openclaw.build.openclawVersion` / `pluginSdkVersion` record `2026.9.3`**, the host this
   plugin is now verified against (the stage pins it). Diagnostics only on the host side; the
   `compat` floor stays `>=2026.7.1` — nothing here needs a newer API.
 - **BREAKING — the shopper's store is FLAT, and the pre-0.5 layout migrates in one
@@ -121,7 +121,7 @@ release (`clawhub package publish --changelog`). See [README](./README.md#releas
   when the skill is not there — a host that parses the path differently writes one
   literal key and still exits 0, and that silent misattach is the state the fix exists to
   prevent. The entries shape was measured live on 2026.8.1 (the fleet's hotfix) and on
-  2026.9.2 in an isolated container (`agents add` writes the map; the bracket path
+  2026.9.3 in an isolated container (`agents add` writes the map; the bracket path
   round-trips through `config set` / `config get`); the attach and its read-back are
   graded by the shimmed suite. The wiring-drift detector reads both shapes too, so it no
   longer goes blind on a migrated host.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ release (`clawhub package publish --changelog`). See [README](./README.md#releas
 
 ### Added
 
+- **`sil_domain_create` specs take an optional `axis: true`** — the ONE variant-level key
+  merchants sell the category by (a boot's mondopoint). At most one per category and
+  `level: variant` only; the route refuses both. sil keys a page's size selector on it
+  when the page names no key.
 - **`sil_doc_find` / `sil_doc_read` / `sil_doc_write` / `sil_doc_remove` — the
   shopper's documents, four operations over one ref scheme.** `ref` is `"shopper"`
   (the person) or `"brief:<slug>"` (one shopping job, many items, many domains).

--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
       "minGatewayVersion": ">=2026.7.1"
     },
     "build": {
-      "openclawVersion": "2026.9.2",
-      "pluginSdkVersion": "2026.9.2"
+      "openclawVersion": "2026.9.3",
+      "pluginSdkVersion": "2026.9.3"
     },
     "hostTargets": [
       "darwin-arm64",

--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
       "minGatewayVersion": ">=2026.7.1"
     },
     "build": {
-      "openclawVersion": "2026.7.1",
-      "pluginSdkVersion": "2026.7.1"
+      "openclawVersion": "2026.9.2",
+      "pluginSdkVersion": "2026.9.2"
     },
     "hostTargets": [
       "darwin-arm64",

--- a/scripts/create-shopper.mjs
+++ b/scripts/create-shopper.mjs
@@ -308,7 +308,7 @@ function existingAgentIds(config) {
  * there — or null when the agent sits in neither roster shape (the caller fails
  * closed). One resolver, so the write and its verification cannot target different
  * places. The entries key rides bracket-quoted (`JSON.stringify`): the host's parser
- * accepts that form for every key and it is escape-safe (dot-path.ts, 2026.9.2). */
+ * accepts that form for every key and it is escape-safe (dot-path.ts, 2026.9.3). */
 function skillSlot(config, agentId) {
   const entries = config?.agents?.entries;
   if (

--- a/scripts/create-shopper.mjs
+++ b/scripts/create-shopper.mjs
@@ -287,17 +287,40 @@ function readSkillAttachName() {
   return { name };
 }
 
-/** The agentId path-segment ids already registered in the host config's
- * `agents.list` — the authoritative, shim-independent clash source. */
+/** The agentId path-segment ids already registered in the host config — the
+ * authoritative, shim-independent clash source. Reads BOTH roster shapes: the
+ * `agents.entries` map (2026.8.1+) and the legacy `agents.list` array (<=2026.7.1);
+ * `openclaw agents add` writes whichever the running host uses, and the two never
+ * coexist on a live box (measured 2026-09-02). */
 function existingAgentIds(config) {
+  const ids = new Set();
   const list = Array.isArray(config?.agents?.list) ? config.agents.list : [];
-  return list.map((a) => a?.id).filter((id) => typeof id === "string");
+  for (const a of list) if (typeof a?.id === "string" && a.id) ids.add(a.id);
+  const entries = config?.agents?.entries;
+  if (entries && typeof entries === "object" && !Array.isArray(entries)) {
+    for (const id of Object.keys(entries)) if (id) ids.add(id);
+  }
+  return [...ids];
 }
 
-/** The index of `agentId` in `agents.list`, or -1 (used to target the skill attach). */
-function agentIndex(config, agentId) {
+/** The `openclaw config set` path for `agentId`'s skills array, in whichever roster
+ * shape the host uses: `agents.entries["<id>"].skills` on 2026.8.1+, or
+ * `agents.list[<idx>].skills` on <=2026.7.1. Returns null if the agent is in neither,
+ * so the caller fails closed. The bracket-quoted entries key is safe for hyphenated
+ * agent ids (e.g. `executive-shopper`) that a bare dot-path would split. */
+function skillAttachPath(config, agentId) {
+  const entries = config?.agents?.entries;
+  if (
+    entries &&
+    typeof entries === "object" &&
+    !Array.isArray(entries) &&
+    Object.prototype.hasOwnProperty.call(entries, agentId)
+  ) {
+    return `agents.entries[${JSON.stringify(agentId)}].skills`;
+  }
   const list = Array.isArray(config?.agents?.list) ? config.agents.list : [];
-  return list.findIndex((a) => a?.id === agentId);
+  const idx = list.findIndex((a) => a?.id === agentId);
+  return idx >= 0 ? `agents.list[${idx}].skills` : null;
 }
 
 /** True iff `openclaw config validate --json` reported `{valid:true}`. The host
@@ -563,15 +586,15 @@ function main() {
 
   // --- 8. Attach the sil skill + enable the sil plugin (value-mode, --strict-json) ---
   const postAddConfig = readConfig(configPath);
-  const idx = agentIndex(postAddConfig, agentId);
-  if (idx < 0) {
-    failAndTeardown(configPath, "the created agent " + JSON.stringify(agentId) + " is not in agents.list after `openclaw agents add`");
+  const skillsPath = skillAttachPath(postAddConfig, agentId);
+  if (skillsPath === null) {
+    failAndTeardown(configPath, "the created agent " + JSON.stringify(agentId) + " is in neither agents.entries nor agents.list after `openclaw agents add`");
   }
   // Attach the skill by its PUBLISHED name (`sil-shopping`), NOT the plugin id
   // (`sil`) — a skill and the plugin are two distinct host keys, and the per-agent
   // attach is the only skill surface, so the plugin id here would load no skill.
   const skillRes = runOpenclaw(
-    ["config", "set", `agents.list[${idx}].skills`, JSON.stringify([skillAttachName]), "--strict-json"],
+    ["config", "set", skillsPath, JSON.stringify([skillAttachName]), "--strict-json"],
     configPath,
   );
   if (!skillRes.ok) {

--- a/scripts/create-shopper.mjs
+++ b/scripts/create-shopper.mjs
@@ -34,8 +34,8 @@
  *   7. writeDocument               — REUSED; { ref: shopper, mode: create } ⇒ the shopper
  *                                    document user_spec.md (frontmatter carries the name);
  *                                    no manifest, no Brief written at create
- *   8. attach the sil skill + enable the sil plugin (config set, then a config get
- *      read-back — an exit-0 `config set` that wrote the wrong key is a silent misattach)
+ *   8. attach the sil skill + enable the sil plugin (config set, then re-read openclaw.json
+ *      — an exit-0 `config set` that wrote the wrong key is a silent misattach)
  *   9. sil-openclaw-allowlist      — REUSED whole; additive/idempotent/atomic three-surface
  *                                    trust merge (plugins.allow + tools.alsoAllow + plugins.entries.sil)
  *  10. bind the current channel    — FAIL-OPEN convenience, NOT fail-closed: resolve the channel
@@ -304,11 +304,12 @@ function existingAgentIds(config) {
   return [...ids];
 }
 
-/** The `openclaw config set` path for `agentId`'s skills array, or null when the
- * agent sits in neither roster shape (the caller fails closed). The entries key is
- * bracket-QUOTED because a bare dot-path splits a hyphenated id like
- * `executive-shopper` into two segments. */
-function skillAttachPath(config, agentId) {
+/** `agentId`'s skills slot — the `openclaw config set` path AND the value currently
+ * there — or null when the agent sits in neither roster shape (the caller fails
+ * closed). One resolver, so the write and its verification cannot target different
+ * places. The entries key is bracket-quoted: that is the host's own canonical form
+ * for a key it would not print bare (`appendConfigPathSegment`, 2026.9.2). */
+function skillSlot(config, agentId) {
   const entries = config?.agents?.entries;
   if (
     entries &&
@@ -316,11 +317,14 @@ function skillAttachPath(config, agentId) {
     !Array.isArray(entries) &&
     Object.prototype.hasOwnProperty.call(entries, agentId)
   ) {
-    return `agents.entries[${JSON.stringify(agentId)}].skills`;
+    return {
+      path: `agents.entries[${JSON.stringify(agentId)}].skills`,
+      skills: entries[agentId]?.skills,
+    };
   }
   const list = Array.isArray(config?.agents?.list) ? config.agents.list : [];
   const idx = list.findIndex((a) => a?.id === agentId);
-  return idx >= 0 ? `agents.list[${idx}].skills` : null;
+  return idx >= 0 ? { path: `agents.list[${idx}].skills`, skills: list[idx]?.skills } : null;
 }
 
 /** True iff `openclaw config validate --json` reported `{valid:true}`. The host
@@ -585,30 +589,29 @@ function main() {
   }
 
   // --- 8. Attach the sil skill + enable the sil plugin (value-mode, --strict-json) ---
-  const postAddConfig = readConfig(configPath);
-  const skillsPath = skillAttachPath(postAddConfig, agentId);
-  if (skillsPath === null) {
+  const slot = skillSlot(readConfig(configPath), agentId);
+  if (slot === null) {
     failAndTeardown(configPath, "the created agent " + JSON.stringify(agentId) + " is in neither agents.entries nor agents.list after `openclaw agents add`");
   }
   // Attach the skill by its PUBLISHED name (`sil-shopping`), NOT the plugin id
   // (`sil`) — a skill and the plugin are two distinct host keys, and the per-agent
   // attach is the only skill surface, so the plugin id here would load no skill.
   const skillRes = runOpenclaw(
-    ["config", "set", skillsPath, JSON.stringify([skillAttachName]), "--strict-json"],
+    ["config", "set", slot.path, JSON.stringify([skillAttachName]), "--strict-json"],
     configPath,
   );
   if (!skillRes.ok) {
     failAndTeardown(configPath, "attaching the sil skill failed: " + (skillRes.stderr || "non-zero exit"));
   }
-  // Read the attach back: a host that parses the path differently writes a LITERAL
-  // key and still exits 0 — a silent misattach, the loudest place to be wrong. The
-  // name's PRESENCE is the invariant; `config get --json`'s wrapper shape is not.
-  const skillReadBack = runOpenclaw(["config", "get", skillsPath, "--json"], configPath);
-  if (!skillReadBack.stdout.includes(skillAttachName)) {
+  // Verify against the FILE, never the CLI: a host that writes the path as a literal
+  // key still exits 0, and its own `config get` would read that same literal key back
+  // — the misattach would confirm itself. openclaw.json is what the gateway loads.
+  const attached = skillSlot(readConfig(configPath), agentId)?.skills;
+  if (!(Array.isArray(attached) && attached.includes(skillAttachName))) {
     failAndTeardown(
       configPath,
-      "the sil skill did not stick: `openclaw config set " + skillsPath + "` exited 0 but the "
-        + "read-back of that path does not carry " + JSON.stringify(skillAttachName),
+      "the sil skill did not stick: `openclaw config set " + slot.path + "` exited 0 but "
+        + slot.path + " in openclaw.json does not carry " + JSON.stringify(skillAttachName),
     );
   }
   // No per-agent `tools.deny` is set: the shopper inherits the host's default toolset

--- a/scripts/create-shopper.mjs
+++ b/scripts/create-shopper.mjs
@@ -29,12 +29,13 @@
  *      an INCONCLUSIVE read (degraded store / CLI error) fails closed — never fabricates
  *      a "no shopper" verdict, never proceeds to `agents add`
  *   4. snapshot openclaw.json      — the whole-file teardown anchor, taken BEFORE step 5
- *   5. openclaw agents add         — create the real agents.list entry + workspace bootstrap
+ *   5. openclaw agents add         — create the real host roster entry + workspace bootstrap
  *   6. write <workspace>/SOUL.md   — the persona (atomic tmp→rename); never a sil artefact
  *   7. writeDocument               — REUSED; { ref: shopper, mode: create } ⇒ the shopper
  *                                    document user_spec.md (frontmatter carries the name);
  *                                    no manifest, no Brief written at create
- *   8. attach the sil skill + enable the sil plugin (config set)
+ *   8. attach the sil skill + enable the sil plugin (config set, then a config get
+ *      read-back — an exit-0 `config set` that wrote the wrong key is a silent misattach)
  *   9. sil-openclaw-allowlist      — REUSED whole; additive/idempotent/atomic three-surface
  *                                    trust merge (plugins.allow + tools.alsoAllow + plugins.entries.sil)
  *  10. bind the current channel    — FAIL-OPEN convenience, NOT fail-closed: resolve the channel
@@ -46,7 +47,7 @@
  *  12. one { status, … } JSON result; exit 0 ONLY on `created`.
  *
  * Teardown on ANY failure after step 5 = whole-file snapshot-restore of
- * openclaw.json (reverses the agents.list entry + skill + plugin + trust in ONE
+ * openclaw.json (reverses the roster entry + skill + plugin + trust in ONE
  * atomic op, superseding the allowlist bin's inner `.bak`), plus removal of the
  * workspace dir (only if WE created it) and the singleton shopper dir (only if it
  * did not pre-exist — the singleton pre-flight guarantees it was ours). This
@@ -261,7 +262,7 @@ function readConfig(configPath) {
   }
 }
 
-/** Resolve the sil SKILL's published name to attach at `agents.list[i].skills`,
+/** Resolve the sil SKILL's published name to attach at the agent's `skills` array,
  * single-sourced from the shipped manifest (mirrors `allowlist-openclaw.mjs`'s
  * `readSilFacts`). A skill attaches by its PUBLISHED name = the skill-dir basename
  * = `basename(openclaw.plugin.json#skills[0])` (`sil-shopping`) — NOT the plugin id
@@ -291,7 +292,7 @@ function readSkillAttachName() {
  * authoritative, shim-independent clash source. Reads BOTH roster shapes: the
  * `agents.entries` map (2026.8.1+) and the legacy `agents.list` array (<=2026.7.1);
  * `openclaw agents add` writes whichever the running host uses, and the two never
- * coexist on a live box (measured 2026-09-02). */
+ * coexist on a live host (measured 2026-09-02). */
 function existingAgentIds(config) {
   const ids = new Set();
   const list = Array.isArray(config?.agents?.list) ? config.agents.list : [];
@@ -303,11 +304,10 @@ function existingAgentIds(config) {
   return [...ids];
 }
 
-/** The `openclaw config set` path for `agentId`'s skills array, in whichever roster
- * shape the host uses: `agents.entries["<id>"].skills` on 2026.8.1+, or
- * `agents.list[<idx>].skills` on <=2026.7.1. Returns null if the agent is in neither,
- * so the caller fails closed. The bracket-quoted entries key is safe for hyphenated
- * agent ids (e.g. `executive-shopper`) that a bare dot-path would split. */
+/** The `openclaw config set` path for `agentId`'s skills array, or null when the
+ * agent sits in neither roster shape (the caller fails closed). The entries key is
+ * bracket-QUOTED because a bare dot-path splits a hyphenated id like
+ * `executive-shopper` into two segments. */
 function skillAttachPath(config, agentId) {
   const entries = config?.agents?.entries;
   if (
@@ -521,7 +521,7 @@ function main() {
   if (existingAgentIds(preConfig).includes(agentId)) {
     emitFailure("collision", {
       cause: "the agentId " + JSON.stringify(agentId)
-        + " already exists in the host agents.list — refusing to overwrite an existing agent's persona or wiring.",
+        + " already exists in the host agent roster — refusing to overwrite an existing agent's persona or wiring.",
     });
   }
 
@@ -599,6 +599,17 @@ function main() {
   );
   if (!skillRes.ok) {
     failAndTeardown(configPath, "attaching the sil skill failed: " + (skillRes.stderr || "non-zero exit"));
+  }
+  // Read the attach back: a host that parses the path differently writes a LITERAL
+  // key and still exits 0 — a silent misattach, the loudest place to be wrong. The
+  // name's PRESENCE is the invariant; `config get --json`'s wrapper shape is not.
+  const skillReadBack = runOpenclaw(["config", "get", skillsPath, "--json"], configPath);
+  if (!skillReadBack.stdout.includes(skillAttachName)) {
+    failAndTeardown(
+      configPath,
+      "the sil skill did not stick: `openclaw config set " + skillsPath + "` exited 0 but the "
+        + "read-back of that path does not carry " + JSON.stringify(skillAttachName),
+    );
   }
   // No per-agent `tools.deny` is set: the shopper inherits the host's default toolset
   // untouched. A deny of the fs-mutators is inert here — codex brings its OWN shell

--- a/scripts/create-shopper.mjs
+++ b/scripts/create-shopper.mjs
@@ -307,8 +307,8 @@ function existingAgentIds(config) {
 /** `agentId`'s skills slot — the `openclaw config set` path AND the value currently
  * there — or null when the agent sits in neither roster shape (the caller fails
  * closed). One resolver, so the write and its verification cannot target different
- * places. The entries key is bracket-quoted: that is the host's own canonical form
- * for a key it would not print bare (`appendConfigPathSegment`, 2026.9.2). */
+ * places. The entries key rides bracket-quoted (`JSON.stringify`): the host's parser
+ * accepts that form for every key and it is escape-safe (dot-path.ts, 2026.9.2). */
 function skillSlot(config, agentId) {
   const entries = config?.agents?.entries;
   if (

--- a/sil-shopping/references/agent_creation_engine.md
+++ b/sil-shopping/references/agent_creation_engine.md
@@ -172,7 +172,7 @@ works) — surface it.
    "shopper" }` performs, atomically, with the name in its frontmatter. **Setup-only:
    no domain settled and no Brief opened.**
 7. **Attach skill + enable plugin** (value-mode `config set --strict-json`, measured on
-   `openclaw/openclaw:2026.9.2` and every pinned host before it):
+   `openclaw/openclaw:2026.9.3` and every pinned host before it):
    `agents.entries["<agentId>"].skills` ← `["sil-shopping"]` (bracket-quoted: the host's
    path parser accepts that form for every key; `agents.list[<idx>].skills` on
    ≤2026.7.1); `plugins.entries.sil.enabled` ← `true`. The attach is then **re-read from

--- a/sil-shopping/references/agent_creation_engine.md
+++ b/sil-shopping/references/agent_creation_engine.md
@@ -173,12 +173,12 @@ works) — surface it.
    no domain settled and no Brief opened.**
 7. **Attach skill + enable plugin** (value-mode `config set --strict-json`, the only
    mode the pinned `alpine/openclaw:2026.6.9` accepts):
-   `agents.entries["<agentId>"].skills` ← `["sil-shopping"]` (bracket-quoted — a bare
-   dot-path splits a hyphenated id; `agents.list[<idx>].skills` on ≤2026.7.1);
-   `plugins.entries.sil.enabled` ← `true`. The attach is **read back** with `config get`
-   — an exit-0 write that landed on the wrong key is a silent misattach, so it fails
-   closed instead. **No per-agent `tools.deny`** — the shopper inherits the host default
-   toolset.
+   `agents.entries["<agentId>"].skills` ← `["sil-shopping"]` (the bracket form the host
+   itself prints for a key it would not write bare; `agents.list[<idx>].skills` on
+   ≤2026.7.1); `plugins.entries.sil.enabled` ← `true`. The attach is then **re-read from
+   `openclaw.json`** — an exit-0 write that landed on the wrong key is a silent
+   misattach, so it fails closed instead. **No per-agent `tools.deny`** — the shopper
+   inherits the host default toolset.
 8. **Admit sil (plugin trust)** — the shipped **`scripts/allowlist-openclaw.mjs`** helper
    (which the script runs itself, by absolute path via `node` — never the bare name)
    additively merges the three trust surfaces (`plugins.allow` + `tools.alsoAllow` +

--- a/sil-shopping/references/agent_creation_engine.md
+++ b/sil-shopping/references/agent_creation_engine.md
@@ -173,8 +173,8 @@ works) — surface it.
    no domain settled and no Brief opened.**
 7. **Attach skill + enable plugin** (value-mode `config set --strict-json`, the only
    mode the pinned `alpine/openclaw:2026.6.9` accepts):
-   `agents.entries["<agentId>"].skills` ← `["sil-shopping"]` (the bracket form the host
-   itself prints for a key it would not write bare; `agents.list[<idx>].skills` on
+   `agents.entries["<agentId>"].skills` ← `["sil-shopping"]` (bracket-quoted: the host's
+   path parser accepts that form for every key; `agents.list[<idx>].skills` on
    ≤2026.7.1); `plugins.entries.sil.enabled` ← `true`. The attach is then **re-read from
    `openclaw.json`** — an exit-0 write that landed on the wrong key is a silent
    misattach, so it fails closed instead. **No per-agent `tools.deny`** — the shopper

--- a/sil-shopping/references/agent_creation_engine.md
+++ b/sil-shopping/references/agent_creation_engine.md
@@ -171,8 +171,8 @@ works) — surface it.
 6. **Write the shopper document** — the same `create` write `sil_doc_write { ref:
    "shopper" }` performs, atomically, with the name in its frontmatter. **Setup-only:
    no domain settled and no Brief opened.**
-7. **Attach skill + enable plugin** (value-mode `config set --strict-json`, the only
-   mode the pinned `alpine/openclaw:2026.6.9` accepts):
+7. **Attach skill + enable plugin** (value-mode `config set --strict-json`, measured on
+   `openclaw/openclaw:2026.9.2` and every pinned host before it):
    `agents.entries["<agentId>"].skills` ← `["sil-shopping"]` (bracket-quoted: the host's
    path parser accepts that form for every key; `agents.list[<idx>].skills` on
    ≤2026.7.1); `plugins.entries.sil.enabled` ← `true`. The attach is then **re-read from

--- a/sil-shopping/references/agent_creation_engine.md
+++ b/sil-shopping/references/agent_creation_engine.md
@@ -163,8 +163,9 @@ works) — surface it.
    already exists"); steer to opening a new Brief or correcting the current shopper,
    **never a second shopper**. An inconclusive read fails closed.
 3. **Snapshot `openclaw.json`** — the teardown anchor, before any write.
-4. **`openclaw agents add`** — the real `agents.list[]` entry + workspace bootstrap,
-   inheriting model + tools from `agents.defaults`.
+4. **`openclaw agents add`** — the real host roster entry (`agents.entries` on
+   2026.8.1+, `agents.list[]` on ≤2026.7.1) + workspace bootstrap, inheriting model +
+   tools from `agents.defaults`.
 5. **Write `SOUL.md`** = endorsed **persona + the standing "The sil way" creed block**
    (below).
 6. **Write the shopper document** — the same `create` write `sil_doc_write { ref:
@@ -172,8 +173,12 @@ works) — surface it.
    no domain settled and no Brief opened.**
 7. **Attach skill + enable plugin** (value-mode `config set --strict-json`, the only
    mode the pinned `alpine/openclaw:2026.6.9` accepts):
-   `agents.list[<idx>].skills` ← `["sil-shopping"]`; `plugins.entries.sil.enabled` ←
-   `true`. **No per-agent `tools.deny`** — the shopper inherits the host default toolset.
+   `agents.entries["<agentId>"].skills` ← `["sil-shopping"]` (bracket-quoted — a bare
+   dot-path splits a hyphenated id; `agents.list[<idx>].skills` on ≤2026.7.1);
+   `plugins.entries.sil.enabled` ← `true`. The attach is **read back** with `config get`
+   — an exit-0 write that landed on the wrong key is a silent misattach, so it fails
+   closed instead. **No per-agent `tools.deny`** — the shopper inherits the host default
+   toolset.
 8. **Admit sil (plugin trust)** — the shipped **`scripts/allowlist-openclaw.mjs`** helper
    (which the script runs itself, by absolute path via `node` — never the bare name)
    additively merges the three trust surfaces (`plugins.allow` + `tools.alsoAllow` +

--- a/sil-shopping/references/domain_and_brief.md
+++ b/sil-shopping/references/domain_and_brief.md
@@ -76,7 +76,7 @@ things.
   keys, a widely-shared attribute (screen size, weight, RAM, waterproof rating,
   material…) takes its **conventional** name. Coin fresh only for a genuinely niche one.
 - **Name the axis the category is sold by.** Where merchants price and stock by ONE
-  variant-level key — a boot's mondo point, a tyre's width — mark that spec `axis: true`
+  variant-level key — a boot's mondopoint, a tyre's width — mark that spec `axis: true`
   (it must be `level: variant`, and a category has at most one). sil keys a page's size
   selector on it when the page names no key; a colour or a fit is never the axis.
 - **A read that did not return is not a read that returned nothing.** Any non-`ok` status

--- a/sil-shopping/references/domain_and_brief.md
+++ b/sil-shopping/references/domain_and_brief.md
@@ -75,6 +75,10 @@ things.
 - **Common attribute → conventional name.** When you are coining a new category's first
   keys, a widely-shared attribute (screen size, weight, RAM, waterproof rating,
   material…) takes its **conventional** name. Coin fresh only for a genuinely niche one.
+- **Name the axis the category is sold by.** Where merchants price and stock by ONE
+  variant-level key — a boot's mondo point, a tyre's width — mark that spec `axis: true`
+  (it must be `level: variant`, and a category has at most one). sil keys a page's size
+  selector on it when the page names no key; a colour or a fit is never the axis.
 - **A read that did not return is not a read that returned nothing.** Any non-`ok` status
   — `invalid_request`, a transient, `not_registered` — leaves the mint out of reach:
   settle the read, never coin around it. And when `sil_search` refuses, its two refusals

--- a/src/__tests__/create-shopper.integration.test.ts
+++ b/src/__tests__/create-shopper.integration.test.ts
@@ -194,7 +194,7 @@ function writeCfg(c) { writeFileSync(cfgPath, JSON.stringify(c, null, 2) + "\n")
 function die(msg) { process.stderr.write("shim: " + msg + "\n"); process.exit(1); }
 
 // Tokenize a config path as the host does (vendor/openclaw src/shared/dot-path.ts,
-// 2026.9.2): a bracket segment is ONE key — [N] an array index, a quoted one a string
+// 2026.9.3): a bracket segment is ONE key — [N] an array index, a quoted one a string
 // key that may contain dots — and every other segment splits on dots. The shim dies on
 // a path it cannot fully consume (the host throws there too); it is looser than the host
 // on malformed separators such as agents..list, which no path the bin emits contains.

--- a/src/__tests__/create-shopper.integration.test.ts
+++ b/src/__tests__/create-shopper.integration.test.ts
@@ -152,7 +152,6 @@ interface Spec {
  *                            fail: config-set-literal ⇒ write the WHOLE path as ONE
  *                            literal key and still exit 0 — the silent misattach a host
  *                            that cannot parse the path performs]
- *   config get <path> --json → the value at <path>, or `null`. The attach read-back.
  *   config validate --json → {valid:true,path}                          [fail: config-validate
  *                            ⇒ {valid:false,path,issues,error}, exit 0]
  *   agents bind --agent <id> --bind <ch> --json
@@ -194,16 +193,26 @@ function readCfg() { return JSON.parse(readFileSync(cfgPath, "utf8")); }
 function writeCfg(c) { writeFileSync(cfgPath, JSON.stringify(c, null, 2) + "\n"); }
 function die(msg) { process.stderr.write("shim: " + msg + "\n"); process.exit(1); }
 
-// Split a config path into segments: dots, "[N]" indexes, and the bracket-QUOTED
-// keys 2026.8.1+ needs for hyphenated agent ids — "agents.list[0].skills",
-// "plugins.entries.sil.enabled", 'agents.entries["my-shopper"].skills'.
+// Tokenize a config path as the host does (vendor/openclaw src/shared/dot-path.ts,
+// 2026.9.2): a bracket segment is ONE key — [N] an array index, a quoted one a string
+// key that may contain dots — and every other segment splits on dots. Only dots may
+// sit between tokens; on anything else the host THROWS, so the shim must too rather
+// than silently writing a path the host would have refused.
 function pathParts(path) {
   const parts = [];
-  const seg = /\[(\d+)\]|\["([^"]*)"\]|\['([^']*)'\]|([^.\[\]]+)/g;
+  const seg = /\[(\d+)\]|\["([^"]*)"\]|\['([^']*)'\]|\[([^\]]*)\]|([^.\[\]]+)/g;
+  let consumed = 0;
   let m;
   while ((m = seg.exec(path)) !== null) {
-    if (m[1] !== undefined) parts.push(Number(m[1]));
-    else parts.push(m[2] !== undefined ? m[2] : m[3] !== undefined ? m[3] : m[4]);
+    if (path.slice(consumed, m.index).replace(/\./g, "") !== "") break;
+    consumed = seg.lastIndex;
+    if (m[1] !== undefined) { parts.push(Number(m[1])); continue; }
+    const key = m[2] ?? m[3] ?? m[4] ?? m[5];
+    if (key === "") die("empty path segment in " + path);
+    parts.push(key);
+  }
+  if (parts.length === 0 || path.slice(consumed).replace(/\./g, "") !== "") {
+    die("unparseable config path " + path);
   }
   return parts;
 }
@@ -219,15 +228,6 @@ function setPath(obj, path, val) {
     cur = cur[k];
   }
   cur[parts[parts.length - 1]] = val;
-}
-
-function getPath(obj, path) {
-  let cur = obj;
-  for (const k of pathParts(path)) {
-    if (cur === null || typeof cur !== "object") return undefined;
-    cur = cur[k];
-  }
-  return cur;
 }
 
 const a0 = argv[0];
@@ -282,12 +282,6 @@ if (a0 === "config" && a1 === "set") {
   if (fails.includes("config-set-literal")) c[path] = val;
   else setPath(c, path, val);
   writeCfg(c);
-  process.exit(0);
-}
-
-if (a0 === "config" && a1 === "get") {
-  const v = getPath(readCfg(), argv[2]);
-  process.stdout.write(JSON.stringify(v === undefined ? null : v) + "\n");
   process.exit(0);
 }
 
@@ -1002,13 +996,9 @@ describe("collision — an agentId clash on the DERIVED id refuses without overw
 });
 
 // ===========================================================================
-// The 2026.8.1+ roster shape. Every test above drives the <=2026.7.1
-// `agents.list` ARRAY; `openclaw agents add` on a migrated host writes an
-// `agents.entries` MAP keyed by id instead, and the skill must attach at the
-// bracket-QUOTED `agents.entries["<id>"].skills` — a bare dot-path splits a
-// hyphenated id. The two shapes never coexist on a live host, so these runs
-// carry NO agents.list at all. Creation was fail-closed-broken on every 2026.8.1+
-// gateway until the bin read both shapes; nothing here re-drives the array.
+// The 2026.8.1+ roster shape: `openclaw agents add` writes an `agents.entries` MAP
+// keyed by id, never the `agents.list` ARRAY every test above drives. Creation was
+// fail-closed-broken on every migrated gateway until the bin read both shapes.
 // ===========================================================================
 
 /** A host whose `openclaw agents add` writes the 2026.8.1+ roster map. */
@@ -1017,8 +1007,6 @@ const ENTRIES_HOST = { OPENCLAW_SHIM_ROSTER: "entries" };
 describe("entries roster (2026.8.1+) — the skill lands where a migrated host looks", () => {
   it('attaches at agents.entries["<id>"].skills, never as a literal bracketed key', () => {
     writeConfig(freshConfig());
-    // A HYPHENATED id on purpose: it is the id a bare dot-path would split into
-    // `executive` / `shopper`, which is why the entries key is bracket-quoted.
     const spec = validSpec({ name: "Executive Shopper" });
     const r = runBin({ spec, env: ENTRIES_HOST });
 
@@ -1060,6 +1048,8 @@ describe("entries roster (2026.8.1+) — the skill lands where a migrated host l
     // one literal key and exits 0; every later gate — the allowlist merge, `config
     // validate` — passes over it, so WITHOUT the read-back this run declares `created`
     // with the skill attached nowhere. That is the failure the whole fix exists to stop.
+    // The verification reads openclaw.json, not the CLI: a single-parser host reads its
+    // OWN literal key back and confirms its own misattach.
     writeConfig(freshConfig());
     const preConfig = readFileSync(configPath, "utf8");
     const spec = validSpec({ name: "Executive Shopper" });
@@ -1070,8 +1060,9 @@ describe("entries roster (2026.8.1+) — the skill lands where a migrated host l
     const m = parseMarker(r.stderr);
     expect(m["status"]).toBe("persistence_failed");
     expect(r.stdout.includes("sil_shopper_created")).toBe(false);
-    // The read-back ran, and the cause names the skill that never stuck.
-    expect(shimLog()).toContain("config get");
+    // Writes had begun — the attach was issued and exited 0 — and the cause names the
+    // skill that never stuck.
+    expect(shimLog()).toContain("config set");
     expect(String(m["cause"])).toContain(SIL_SKILL);
     // Teardown reverted the literal key and everything else this run wrote.
     expect(readFileSync(configPath, "utf8")).toBe(preConfig);

--- a/src/__tests__/create-shopper.integration.test.ts
+++ b/src/__tests__/create-shopper.integration.test.ts
@@ -90,7 +90,7 @@ const SCRIPT = join(REPO_ROOT, "scripts", "create-shopper.mjs");
 const SIL_ID = "sil";
 /** The bundled skill's PUBLISHED name = the basename of the manifest's skills
  * ref (`./sil-shopping` → `sil-shopping`) — the key the host attaches a skill by
- * at `agents.list[i].skills`. Single-sourced from openclaw.plugin.json so a skill
+ * in the agent's `skills` array. Single-sourced from openclaw.plugin.json so a skill
  * rename tracks here automatically, and so this pins the create bin against the
  * manifest rather than a second literal. It is the skill NAME, NEVER the plugin
  * id `sil` — attaching the plugin id is the total skill-load failure this card
@@ -143,10 +143,16 @@ interface Spec {
  * Contract (matches what the bin actually needs — the bin reads `agents list`/
  * `agents add` only by exit code, then re-reads the config FILE):
  *   agents list --json     → exit 0 (empty output is fine)               [fail: agents-list]
- *   agents add <id> …      → append {id,skills:[]} to agents.list, mkdir
- *                            the --workspace dir + bootstrap SOUL.md/AGENTS.md, exit 0
+ *   agents add <id> …      → append {id,skills:[]} to agents.list — or, on an ENTRIES
+ *                            host (OPENCLAW_SHIM_ROSTER=entries), write
+ *                            agents.entries[<id>] = {skills:[]} instead; mkdir the
+ *                            --workspace dir + bootstrap SOUL.md/AGENTS.md, exit 0
  *                                                                        [fail: agents-add]
- *   config set <path> <v>  → apply the set to openclaw.json, exit 0      [fail: config-set]
+ *   config set <path> <v>  → apply the set to openclaw.json, exit 0      [fail: config-set;
+ *                            fail: config-set-literal ⇒ write the WHOLE path as ONE
+ *                            literal key and still exit 0 — the silent misattach a host
+ *                            that cannot parse the path performs]
+ *   config get <path> --json → the value at <path>, or `null`. The attach read-back.
  *   config validate --json → {valid:true,path}                          [fail: config-validate
  *                            ⇒ {valid:false,path,issues,error}, exit 0]
  *   agents bind --agent <id> --bind <ch> --json
@@ -188,15 +194,22 @@ function readCfg() { return JSON.parse(readFileSync(cfgPath, "utf8")); }
 function writeCfg(c) { writeFileSync(cfgPath, JSON.stringify(c, null, 2) + "\n"); }
 function die(msg) { process.stderr.write("shim: " + msg + "\n"); process.exit(1); }
 
-// Set a value at a dotted path that may contain "[N]" index segments, e.g.
-// "agents.list[0].skills" or "plugins.entries.sil.enabled".
-function setPath(obj, path, val) {
+// Split a config path into segments: dots, "[N]" indexes, and the bracket-QUOTED
+// keys 2026.8.1+ needs for hyphenated agent ids — "agents.list[0].skills",
+// "plugins.entries.sil.enabled", 'agents.entries["my-shopper"].skills'.
+function pathParts(path) {
   const parts = [];
-  for (const seg of path.split(".")) {
-    const m = seg.match(/^([^\[]+)\[(\d+)\]$/);
-    if (m) { parts.push(m[1]); parts.push(Number(m[2])); }
-    else { parts.push(seg); }
+  const seg = /\[(\d+)\]|\["([^"]*)"\]|\['([^']*)'\]|([^.\[\]]+)/g;
+  let m;
+  while ((m = seg.exec(path)) !== null) {
+    if (m[1] !== undefined) parts.push(Number(m[1]));
+    else parts.push(m[2] !== undefined ? m[2] : m[3] !== undefined ? m[3] : m[4]);
   }
+  return parts;
+}
+
+function setPath(obj, path, val) {
+  const parts = pathParts(path);
   let cur = obj;
   for (let i = 0; i < parts.length - 1; i++) {
     const k = parts[i];
@@ -208,14 +221,27 @@ function setPath(obj, path, val) {
   cur[parts[parts.length - 1]] = val;
 }
 
+function getPath(obj, path) {
+  let cur = obj;
+  for (const k of pathParts(path)) {
+    if (cur === null || typeof cur !== "object") return undefined;
+    cur = cur[k];
+  }
+  return cur;
+}
+
 const a0 = argv[0];
 const a1 = argv[1];
 
 if (a0 === "agents" && a1 === "list") {
   if (fails.includes("agents-list")) die("agents list forced failure");
-  let list = [];
-  try { const c = readCfg(); if (c.agents && Array.isArray(c.agents.list)) list = c.agents.list; } catch (e) {}
-  process.stdout.write(JSON.stringify({ agents: list.map((x) => ({ id: x && x.id })) }) + "\n");
+  let ids = [];
+  try {
+    const roster = readCfg().agents || {};
+    if (roster.entries && typeof roster.entries === "object") ids = Object.keys(roster.entries);
+    else if (Array.isArray(roster.list)) ids = roster.list.map((x) => x && x.id);
+  } catch (e) {}
+  process.stdout.write(JSON.stringify({ agents: ids.map((id) => ({ id: id })) }) + "\n");
   process.exit(0);
 }
 
@@ -226,8 +252,15 @@ if (a0 === "agents" && a1 === "add") {
   const ws = wsIdx >= 0 ? argv[wsIdx + 1] : null;
   const c = readCfg();
   if (!c.agents || typeof c.agents !== "object") c.agents = {};
-  if (!Array.isArray(c.agents.list)) c.agents.list = [];
-  c.agents.list.push({ id: id, skills: [] });
+  // 2026.8.1+ keeps the roster as a MAP keyed by id; <=2026.7.1 as an ARRAY. A live
+  // host has exactly one of the two, never both.
+  if (process.env.OPENCLAW_SHIM_ROSTER === "entries") {
+    if (!c.agents.entries || typeof c.agents.entries !== "object") c.agents.entries = {};
+    c.agents.entries[id] = { skills: [] };
+  } else {
+    if (!Array.isArray(c.agents.list)) c.agents.list = [];
+    c.agents.list.push({ id: id, skills: [] });
+  }
   writeCfg(c);
   if (ws) {
     mkdirSync(ws, { recursive: true });
@@ -245,8 +278,16 @@ if (a0 === "config" && a1 === "set") {
   let val;
   try { val = JSON.parse(rawVal); } catch (e) { val = rawVal; }
   const c = readCfg();
-  setPath(c, path, val);
+  // A host that cannot parse the path writes it as ONE literal key and still exits 0.
+  if (fails.includes("config-set-literal")) c[path] = val;
+  else setPath(c, path, val);
   writeCfg(c);
+  process.exit(0);
+}
+
+if (a0 === "config" && a1 === "get") {
+  const v = getPath(readCfg(), argv[2]);
+  process.stdout.write(JSON.stringify(v === undefined ? null : v) + "\n");
   process.exit(0);
 }
 
@@ -957,6 +998,85 @@ describe("collision — an agentId clash on the DERIVED id refuses without overw
     // Never overwrote the existing agent, never minted a shopper dir.
     expect(readFileSync(configPath, "utf8")).toBe(preConfig);
     expect(existsSync(shopperDir())).toBe(false);
+  });
+});
+
+// ===========================================================================
+// The 2026.8.1+ roster shape. Every test above drives the <=2026.7.1
+// `agents.list` ARRAY; `openclaw agents add` on a migrated host writes an
+// `agents.entries` MAP keyed by id instead, and the skill must attach at the
+// bracket-QUOTED `agents.entries["<id>"].skills` — a bare dot-path splits a
+// hyphenated id. The two shapes never coexist on a live host, so these runs
+// carry NO agents.list at all. Creation was fail-closed-broken on every 2026.8.1+
+// gateway until the bin read both shapes; nothing here re-drives the array.
+// ===========================================================================
+
+/** A host whose `openclaw agents add` writes the 2026.8.1+ roster map. */
+const ENTRIES_HOST = { OPENCLAW_SHIM_ROSTER: "entries" };
+
+describe("entries roster (2026.8.1+) — the skill lands where a migrated host looks", () => {
+  it('attaches at agents.entries["<id>"].skills, never as a literal bracketed key', () => {
+    writeConfig(freshConfig());
+    // A HYPHENATED id on purpose: it is the id a bare dot-path would split into
+    // `executive` / `shopper`, which is why the entries key is bracket-quoted.
+    const spec = validSpec({ name: "Executive Shopper" });
+    const r = runBin({ spec, env: ENTRIES_HOST });
+
+    expect(r.status).toBe(0);
+    expect(parseMarker(r.stdout)["status"]).toBe("created");
+
+    const c = readConfig();
+    expect(c.agents.entries["executive-shopper"].skills).toEqual([SIL_SKILL]);
+    // The silent misattach this pins shut: the path landing as ONE literal key
+    // (`agents['entries["executive-shopper"]']`, or the whole path at the root).
+    expect(Object.keys(c.agents).filter((k) => k.includes("["))).toEqual([]);
+    expect(Object.keys(c).filter((k) => k.includes("["))).toEqual([]);
+    // A migrated host grew no array — the bin must not have fabricated one.
+    expect(c.agents.list).toBeUndefined();
+  });
+
+  it("the DERIVED id already keys agents.entries ⇒ collision, existing agent untouched, never added over", () => {
+    // The list-shape twin of this test seeds `agents.list`; on a migrated host the
+    // clash source is the MAP's keys, and a bin reading only the array sees an empty
+    // roster and overwrites the operator's agent.
+    const cfg = freshConfig() as any;
+    cfg.agents = {
+      entries: { [deriveAgentId("My Shopper")]: { skills: ["other"], workspace: "/pre/existing" } },
+    };
+    writeConfig(cfg);
+    const preConfig = readFileSync(configPath, "utf8");
+
+    const r = runBin({ spec: validSpec({ name: "My Shopper" }), env: ENTRIES_HOST });
+
+    expect(r.status).not.toBe(0);
+    expect(parseMarker(r.stderr)["status"]).toBe("collision");
+    expect(shimLog()).not.toContain("agents add");
+    expect(readFileSync(configPath, "utf8")).toBe(preConfig);
+    expect(existsSync(shopperDir())).toBe(false);
+  });
+
+  it("a `config set` that exits 0 having written the WRONG key ⇒ persistence_failed, never created over an unattached skill", () => {
+    // The read-back's reason for existing. A host that cannot parse the path writes
+    // one literal key and exits 0; every later gate — the allowlist merge, `config
+    // validate` — passes over it, so WITHOUT the read-back this run declares `created`
+    // with the skill attached nowhere. That is the failure the whole fix exists to stop.
+    writeConfig(freshConfig());
+    const preConfig = readFileSync(configPath, "utf8");
+    const spec = validSpec({ name: "Executive Shopper" });
+
+    const r = runBin({ spec, env: ENTRIES_HOST, fail: ["config-set-literal"] });
+
+    expect(r.status).not.toBe(0);
+    const m = parseMarker(r.stderr);
+    expect(m["status"]).toBe("persistence_failed");
+    expect(r.stdout.includes("sil_shopper_created")).toBe(false);
+    // The read-back ran, and the cause names the skill that never stuck.
+    expect(shimLog()).toContain("config get");
+    expect(String(m["cause"])).toContain(SIL_SKILL);
+    // Teardown reverted the literal key and everything else this run wrote.
+    expect(readFileSync(configPath, "utf8")).toBe(preConfig);
+    expect(existsSync(shopperDir())).toBe(false);
+    expect(existsSync(spec.workspace)).toBe(false);
   });
 });
 

--- a/src/__tests__/create-shopper.integration.test.ts
+++ b/src/__tests__/create-shopper.integration.test.ts
@@ -195,9 +195,9 @@ function die(msg) { process.stderr.write("shim: " + msg + "\n"); process.exit(1)
 
 // Tokenize a config path as the host does (vendor/openclaw src/shared/dot-path.ts,
 // 2026.9.2): a bracket segment is ONE key — [N] an array index, a quoted one a string
-// key that may contain dots — and every other segment splits on dots. Only dots may
-// sit between tokens; on anything else the host THROWS, so the shim must too rather
-// than silently writing a path the host would have refused.
+// key that may contain dots — and every other segment splits on dots. The shim dies on
+// a path it cannot fully consume (the host throws there too); it is looser than the host
+// on malformed separators such as agents..list, which no path the bin emits contains.
 function pathParts(path) {
   const parts = [];
   const seg = /\[(\d+)\]|\["([^"]*)"\]|\['([^']*)'\]|\[([^\]]*)\]|([^.\[\]]+)/g;

--- a/src/__tests__/lib/host-wiring.test.ts
+++ b/src/__tests__/lib/host-wiring.test.ts
@@ -5,8 +5,8 @@
  * Card: self-upgrade-detect-host-wiring-advisory — **AC4, AC8, AC9** (+ the
  * `readHostVersion` seam AC2/AC10 depend on).
  *
- * This is the incident-#1 detector. A skill attaches per-agent at
- * `agents.list[i].skills` by its **published name** (`sil-shopping` = the skill-dir
+ * This is the incident-#1 detector. A skill attaches per-agent in the roster's
+ * `skills` array by its **published name** (`sil-shopping` = the skill-dir
  * basename); tools admit by **plugin id** (`sil` in `tools.alsoAllow`). They are two
  * different host keys, and conflating them is what seeded incident #1 — silently,
  * because the host fails a bad skill ref with a warning, not an error.
@@ -97,8 +97,8 @@ const only = (config: unknown, id: string, facts: SilWiringFacts = REAL) => {
   return found[0]!;
 };
 
-/** An agent entry as the host writes it (`openclaw agents add` → `{id, skills}`;
- * `create-shopper.mjs` then sets `agents.list[i].skills`). */
+/** An `agents.list` entry as a <=2026.7.1 host writes it (`openclaw agents add` →
+ * `{id, skills}`; `create-shopper.mjs` then sets that entry's `skills`). */
 const agent = (id: string, skills: unknown): Record<string, unknown> => ({ id, skills });
 
 /** A fully HEALTHY config for the given facts: skill attached by published name,
@@ -201,6 +201,19 @@ describe("detectWiringDrift — skill attached by ID instead of PUBLISHED NAME (
     expect(drift).toHaveLength(1);
     expect(drift[0]!.detected).toContain("shopper-a");
     expect(drift[0]!.detected).toContain("shopper-c");
+  });
+
+  it("reads the 2026.8.1+ `agents.entries` MAP too — otherwise the detector is blind on every migrated host", () => {
+    // 2026.8.1 renamed `agents.list` (array) to `agents.entries` (map keyed by id),
+    // and the two never coexist. A detector reading only the array sees NO agents
+    // there, so the drift it exists for goes silent on exactly the hosts that ran
+    // the migration — the failure mode that is invisible by construction.
+    const config = {
+      ...healthy(),
+      agents: { entries: { "beta-shopper": { skills: [REAL.id] } } },
+    };
+    expect(ids(config)).toEqual([SKILL_MISATTACHED]);
+    expect(only(config, SKILL_MISATTACHED).detected).toContain("beta-shopper");
   });
 
   it("NAMES NOTHING FROM THE MANIFEST ITSELF — the detector is fact-driven, never hardcoded", () => {

--- a/src/__tests__/lib/host-wiring.test.ts
+++ b/src/__tests__/lib/host-wiring.test.ts
@@ -563,15 +563,22 @@ describe("detectWiringDrift — pure, non-mutating, and unthrowable (AC8/AC12)",
     }
   });
 
-  it("an agent entry with a mis-attached skill but NO usable id still reports legibly", () => {
-    // `agents.list[i].id` is what the fix string points at. An entry without one is
-    // operator corruption — the finding must still fire (the drift is real) and
-    // must not print `undefined` at the operator.
-    const config = { agents: { list: [{ skills: [REAL.id] }] }, tools: { alsoAllow: [REAL.id] } };
-    const drift = detectWiringDrift(config, REAL).filter((f) => f.id === SKILL_MISATTACHED);
-    expect(drift).toHaveLength(1);
-    expect(drift[0]!.detected).not.toContain("undefined");
-    expect(drift[0]!.suggestedAction).not.toContain("undefined");
+  it("a mis-attached agent with NO usable id still reports legibly — in EITHER roster shape", () => {
+    // The label is what the fix string points at. A list entry with no `id`, and an
+    // entries key of "", are both operator corruption — the finding must still fire
+    // (the drift is real) and must name a path, never `undefined` or a blank where
+    // an agent name goes.
+    const corrupt: Array<[Record<string, unknown>, string]> = [
+      [{ list: [{ skills: [REAL.id] }] }, "agents.list[0]"],
+      [{ entries: { "": { skills: [REAL.id] } } }, `agents.entries[""]`],
+    ];
+    for (const [agents, label] of corrupt) {
+      const config = { agents, tools: { alsoAllow: [REAL.id] } };
+      const drift = detectWiringDrift(config, REAL).filter((f) => f.id === SKILL_MISATTACHED);
+      expect(drift, label).toHaveLength(1);
+      expect(drift[0]!.detected).toContain(label);
+      expect(drift[0]!.suggestedAction).not.toContain("undefined");
+    }
   });
 });
 

--- a/src/__tests__/tools/domain-create.test.ts
+++ b/src/__tests__/tools/domain-create.test.ts
@@ -99,11 +99,12 @@ describe("registration and schema", () => {
     expect(props()["specs"]["maxItems"]).toBe(50);
   });
 
-  it("a spec declares the route's seven fields, with `key`/`display_name`/`data_type` required", () => {
+  it("a spec declares the route's nine fields, with `key`/`display_name`/`data_type` required", () => {
     const item = props()["specs"]["items"] as Record<string, unknown>;
     const itemProps = item["properties"] as Record<string, Record<string, unknown>>;
     expect(Object.keys(itemProps).sort()).toEqual([
       "allowed_values",
+      "axis",
       "data_type",
       "description",
       "display_name",
@@ -113,6 +114,16 @@ describe("registration and schema", () => {
       "value_set",
     ]);
     expect((item["required"] as string[]).sort()).toEqual(["data_type", "display_name", "key"]);
+  });
+
+  it("`axis` is an optional boolean whose description says ONE and variant-level", () => {
+    // The route refuses a second axis and a product-level one; the agent's only warning is here.
+    const itemProps = (props()["specs"]["items"] as Record<string, unknown>)[
+      "properties"
+    ] as Record<string, Record<string, unknown>>;
+    expect(itemProps["axis"]["type"]).toBe("boolean");
+    expect(String(itemProps["axis"]["description"])).toMatch(/ONE variant-level key/);
+    expect(String(itemProps["axis"]["description"])).toMatch(/At most one/);
   });
 
   it("`data_type` stays a PLAIN STRING — a closed union would hide the offending spec key", () => {

--- a/src/lib/host-wiring.ts
+++ b/src/lib/host-wiring.ts
@@ -1,7 +1,7 @@
 /**
  * Host-wiring drift — is sil wired the way it thinks it is?
  *
- * A skill attaches per-agent at `agents.list[i].skills` by its PUBLISHED NAME
+ * A skill attaches per-agent in the roster's `skills` array by its PUBLISHED NAME
  * (`sil-shopping` = the skill-dir basename); tools admit by PLUGIN ID (`sil`).
  * Two different host keys, and conflating them seeded incident #1 — silently,
  * because the host fails a bad skill ref with a warning, not an error.
@@ -158,27 +158,45 @@ function findMisattachedAgents(
   config: Record<string, unknown>,
   facts: SilWiringFacts,
 ): string[] {
-  const agents = isRecord(config["agents"]) ? config["agents"] : undefined;
-  const list = Array.isArray(agents?.["list"]) ? agents["list"] : [];
-
   const labels: string[] = [];
+  for (const { label, skills: declared } of rosterAgents(config)) {
+    const skills = stringsOf(declared);
+    if (skills === null) continue;
+    if (!skills.includes(facts.id) || skills.includes(facts.skill)) continue;
+    labels.push(label);
+  }
+  return labels;
+}
+
+/**
+ * Every roster agent as `{ label, skills }`, from BOTH host shapes: the
+ * `agents.entries` map keyed by id (2026.8.1+) and the `agents.list` array
+ * (<=2026.7.1). Reading only the array left this detector blind on every
+ * migrated host. `label` is what the fix string points at, so a list entry with
+ * no usable id is reported positionally, never as `undefined`.
+ */
+function rosterAgents(
+  config: Record<string, unknown>,
+): Array<{ label: string; skills: unknown }> {
+  const agents = isRecord(config["agents"]) ? config["agents"] : undefined;
+  const found: Array<{ label: string; skills: unknown }> = [];
+
+  const entries = isRecord(agents?.["entries"]) ? agents["entries"] : undefined;
+  for (const [id, entry] of Object.entries(entries ?? {})) {
+    if (isRecord(entry)) found.push({ label: id, skills: entry["skills"] });
+  }
+
+  const list = Array.isArray(agents?.["list"]) ? agents["list"] : [];
   for (let i = 0; i < list.length; i += 1) {
     const entry: unknown = list[i];
     if (!isRecord(entry)) continue;
-
-    const skills = stringsOf(entry["skills"]);
-    if (skills === null) continue;
-    if (!skills.includes(facts.id) || skills.includes(facts.skill)) continue;
-
-    // The fix string points at this agent, so it must be legible. An entry with
-    // no usable id is operator corruption — the drift is still real, so report
-    // it positionally rather than printing `undefined` at the operator.
     const id = entry["id"];
-    labels.push(
-      typeof id === "string" && id.length > 0 ? id : `agents.list[${i}]`,
-    );
+    found.push({
+      label: typeof id === "string" && id.length > 0 ? id : `agents.list[${i}]`,
+      skills: entry["skills"],
+    });
   }
-  return labels;
+  return found;
 }
 
 /**

--- a/src/lib/host-wiring.ts
+++ b/src/lib/host-wiring.ts
@@ -172,8 +172,8 @@ function findMisattachedAgents(
  * Every roster agent as `{ label, skills }`, from BOTH host shapes: the
  * `agents.entries` map keyed by id (2026.8.1+) and the `agents.list` array
  * (<=2026.7.1). Reading only the array left this detector blind on every
- * migrated host. `label` is what the fix string points at, so a list entry with
- * no usable id is reported positionally, never as `undefined`.
+ * migrated host. `label` is what the fix string points at, so an entry with no
+ * usable id is reported by its path — never as `undefined` or a blank.
  */
 function rosterAgents(
   config: Record<string, unknown>,
@@ -183,7 +183,8 @@ function rosterAgents(
 
   const entries = isRecord(agents?.["entries"]) ? agents["entries"] : undefined;
   for (const [id, entry] of Object.entries(entries ?? {})) {
-    if (isRecord(entry)) found.push({ label: id, skills: entry["skills"] });
+    if (!isRecord(entry)) continue;
+    found.push({ label: id.length > 0 ? id : `agents.entries[""]`, skills: entry["skills"] });
   }
 
   const list = Array.isArray(agents?.["list"]) ? agents["list"] : [];

--- a/src/lib/host-wiring.ts
+++ b/src/lib/host-wiring.ts
@@ -169,11 +169,9 @@ function findMisattachedAgents(
 }
 
 /**
- * Every roster agent as `{ label, skills }`, from BOTH host shapes: the
- * `agents.entries` map keyed by id (2026.8.1+) and the `agents.list` array
- * (<=2026.7.1). Reading only the array left this detector blind on every
- * migrated host. `label` is what the fix string points at, so an entry with no
- * usable id is reported by its path — never as `undefined` or a blank.
+ * Every roster agent as `{ label, skills }`, from BOTH host shapes: the `agents.entries`
+ * map keyed by id (2026.8.1+) and the `agents.list` array (<=2026.7.1). `label` is what
+ * the fix string points at, so an entry with no usable id is reported by its path.
  */
 function rosterAgents(
   config: Record<string, unknown>,

--- a/src/lib/sil-client.ts
+++ b/src/lib/sil-client.ts
@@ -490,6 +490,7 @@ export type SpecDefinitionInput = {
   allowed_values?: string[];
   value_set?: string;
   level?: string;
+  axis?: boolean;
 };
 
 export type DomainMintParams = {

--- a/src/tools/catalog.ts
+++ b/src/tools/catalog.ts
@@ -543,6 +543,15 @@ function registerDomainCreate(api: PluginAPI): void {
                 "product or variant. Omit it where the category is not sure which.",
             }),
           ),
+          axis: Type.Optional(
+            Type.Boolean({
+              description:
+                "true on the ONE variant-level key merchants sell this category by — the"
+                + " size axis of a boot, never a colour. At most one per category, and it"
+                + " must be level variant; sil keys a size selector on it when a page"
+                + " names no key.",
+            }),
+          ),
         }),
         {
           maxItems: 50,


### PR DESCRIPTION
## sil v0 — four catalog tools 1:1 with the routes, and the skill driving the eight beats

**What changed.** `sil_search` · `sil_product_get` · `sil_stores` · `sil_domain_create`, each one route and never flags on another, validating responses against the shared schema artifact; the skill drives the eight beats and computes the three-state veto from `unset` / `applied` / maturity, never from prose; the shop leg reads back every ref a search returned, placed or held; the verified host is `openclaw/openclaw:2026.9.3`.

**Why.** `mission-control-sil/goals/sil-v0.md` SC6 — the agent surface of v0.

**Acceptance** (`log/sil-v0/2026-09-10-verify-run-4.md`): unit suite 64 files / 1614; `eval:host-round` 7/7 on a fresh creation boot with every `url:` ref echoed; the LIVE host-round e2e file 18/18; `eval:mint` PATH == G0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
